### PR TITLE
Csstudio 834

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
@@ -155,6 +155,7 @@ public class Messages
     public static String WidgetProperties_BarBackgroundColor;
     public static String WidgetProperties_BarColor;
     public static String WidgetProperties_Bit;
+    public static String WidgetProperties_ReadbackBit;
     public static String WidgetProperties_BorderAlarmSensitive;
     public static String WidgetProperties_BorderColor;
     public static String WidgetProperties_BorderWidth;

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/BoolButtonWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/BoolButtonWidget.java
@@ -7,22 +7,6 @@
  *******************************************************************************/
 package org.csstudio.display.builder.model.widgets;
 
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newBooleanPropertyDescriptor;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newFilenamePropertyDescriptor;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBit;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propConfirmDialogOptions;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propConfirmMessage;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propEnabled;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLabelsFromPV;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propOffColor;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propOffLabel;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propOnColor;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propOnLabel;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPassword;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,15 +24,16 @@ import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.NamedWidgetFonts;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.persist.WidgetFontService;
-import org.csstudio.display.builder.model.properties.ConfirmDialog;
-import org.csstudio.display.builder.model.properties.EnumWidgetProperty;
-import org.csstudio.display.builder.model.properties.WidgetColor;
-import org.csstudio.display.builder.model.properties.WidgetFont;
+import org.csstudio.display.builder.model.properties.*;
+import org.epics.vtype.VType;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Element;
 
-/** Widget that provides button for making a binary change
- *  @author Megan Grodowitz
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.*;
+
+/**
+ * Widget that provides button for making a binary change.
+ * @author Megan Grodowitz
  */
 @SuppressWarnings("nls")
 public class BoolButtonWidget extends WritablePVWidget
@@ -124,6 +109,13 @@ public class BoolButtonWidget extends WritablePVWidget
         newFilenamePropertyDescriptor(WidgetPropertyCategory.DISPLAY, "on_image", Messages.WidgetProperties_OnImage);
     private static final WidgetPropertyDescriptor<Boolean> propShowLED =
         newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "show_led", Messages.WidgetProperties_ShowLED);
+    public static final WidgetPropertyDescriptor<String> propReadbackPVName =
+            CommonWidgetProperties.newPVNamePropertyDescriptor(WidgetPropertyCategory.WIDGET, "readback_pv_name", Messages.WidgetProperties_ReadbackPVName);
+    public static final WidgetPropertyDescriptor<VType> propReadbackPVValue =
+            CommonWidgetProperties.newRuntimeValue("readback_pv_value", Messages.WidgetProperties_ReadbackPVValue);
+    public static final WidgetPropertyDescriptor<Integer> propReadbackBit =
+            newIntegerPropertyDescriptor(WidgetPropertyCategory.WIDGET, "readback_bit", Messages.WidgetProperties_ReadbackBit);
+
     public static final WidgetPropertyDescriptor<Mode> propMode =
         new WidgetPropertyDescriptor<>(WidgetPropertyCategory.BEHAVIOR, "mode", Messages.BoolWidget_Mode)
     {
@@ -141,6 +133,9 @@ public class BoolButtonWidget extends WritablePVWidget
     private volatile WidgetProperty<String> on_label;
     private volatile WidgetProperty<WidgetColor> on_color;
     private volatile WidgetProperty<String> on_image;
+    private volatile WidgetProperty<String> readbackPVName;
+    private volatile WidgetProperty<VType> readbackPVValue;
+    private volatile WidgetProperty<Integer> readbackBit;
     private volatile WidgetProperty<Boolean> show_LED;
     private volatile WidgetProperty<WidgetFont> font;
     private volatile WidgetProperty<WidgetColor> background;
@@ -185,6 +180,9 @@ public class BoolButtonWidget extends WritablePVWidget
         properties.add(confirm_dialog = propConfirmDialogOptions.createProperty(this, ConfirmDialog.NONE));
         properties.add(confirm_message = propConfirmMessage.createProperty(this, "Are your sure you want to do this?"));
         properties.add(password = propPassword.createProperty(this, ""));
+        properties.add(readbackPVName = propReadbackPVName.createProperty(this, ""));
+        properties.add(readbackPVValue = propReadbackPVValue.createProperty(this, RUNTIME_VALUE_NO_PV));
+        properties.add(readbackBit = propReadbackBit.createProperty(this, 0));
     }
 
     /** @return 'bit' property */
@@ -287,5 +285,25 @@ public class BoolButtonWidget extends WritablePVWidget
     public WidgetProperty<String> propPassword()
     {
         return password;
+    }
+
+    /**
+         * @return The PV name associated with the 'On' state.
+         */
+        public WidgetProperty<String> propReadbackPVName(){
+            return readbackPVName;
+        }
+
+        /**
+         *
+         * @return The PV value associated with the 'On' state.
+         */
+        public WidgetProperty<VType> propReadbackPVValue(){
+            return readbackPVValue;
+        }
+
+
+        public WidgetProperty<Integer> propReadbackBit(){
+            return readbackBit;
     }
 }

--- a/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
+++ b/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
@@ -139,6 +139,7 @@ WidgetProperties_BackgroundColor=Background Color
 WidgetProperties_BarBackgroundColor=Bar Background Color
 WidgetProperties_BarColor=Bar Color
 WidgetProperties_Bit=Bit
+WidgetProperties_ReadbackBit=Readback Bit
 WidgetProperties_BorderAlarmSensitive=Alarm Border
 WidgetProperties_BorderColor=Border Color
 WidgetProperties_BorderWidth=Border Width

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/BaseWidgetRuntimes.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/BaseWidgetRuntimes.java
@@ -13,15 +13,7 @@ import java.util.function.Supplier;
 
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.Widget;
-import org.csstudio.display.builder.model.widgets.ArrayWidget;
-import org.csstudio.display.builder.model.widgets.EmbeddedDisplayWidget;
-import org.csstudio.display.builder.model.widgets.GroupWidget;
-import org.csstudio.display.builder.model.widgets.KnobWidget;
-import org.csstudio.display.builder.model.widgets.NavigationTabsWidget;
-import org.csstudio.display.builder.model.widgets.ScaledSliderWidget;
-import org.csstudio.display.builder.model.widgets.ScrollBarWidget;
-import org.csstudio.display.builder.model.widgets.TableWidget;
-import org.csstudio.display.builder.model.widgets.TabsWidget;
+import org.csstudio.display.builder.model.widgets.*;
 import org.csstudio.display.builder.model.widgets.plots.DataBrowserWidget;
 import org.csstudio.display.builder.model.widgets.plots.ImageWidget;
 import org.csstudio.display.builder.model.widgets.plots.StripchartWidget;
@@ -51,7 +43,8 @@ public class BaseWidgetRuntimes implements WidgetRuntimesService
             entry(TableWidget.WIDGET_DESCRIPTOR.getType(),           () -> new TableWidgetRuntime()),
             entry(TabsWidget.WIDGET_DESCRIPTOR.getType(),            () -> new TabsWidgetRuntime()),
             entry(DataBrowserWidget.WIDGET_DESCRIPTOR.getType(),     () -> new DataBrowserWidgetRuntime()),
-            entry(XYPlotWidget.WIDGET_DESCRIPTOR.getType(),          () -> new XYPlotWidgetRuntime())
+            entry(XYPlotWidget.WIDGET_DESCRIPTOR.getType(),          () -> new XYPlotWidgetRuntime()),
+            entry(BoolButtonWidget.WIDGET_DESCRIPTOR.getType(), BoolButtonWidgetRuntime::new)
         );
     }
 }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/BoolButtonWidgetRuntime.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/internal/BoolButtonWidgetRuntime.java
@@ -1,0 +1,42 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * Copyright (C) 2016 European Spallation Source ERIC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.csstudio.display.builder.runtime.internal;
+
+
+import org.csstudio.display.builder.model.widgets.BoolButtonWidget;
+import org.csstudio.display.builder.model.widgets.KnobWidget;
+import org.csstudio.display.builder.runtime.PVNameToValueBinding;
+import org.csstudio.display.builder.runtime.WidgetRuntime;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Runtime for a {@link org.csstudio.display.builder.model.widgets.BoolButtonWidget} which supports
+ * an optional read-back PV used to set the visual status of the button.
+ */
+public class BoolButtonWidgetRuntime extends WidgetRuntime<BoolButtonWidget> {
+
+    private final List<PVNameToValueBinding> bindings = new ArrayList<>();
+
+    @Override
+    public void start()
+    {
+        super.start();
+        if(!widget.propReadbackPVName().getValue().isEmpty()){
+            bindings.add(new PVNameToValueBinding(this, widget.propReadbackPVName(), widget.propReadbackPVValue()));
+        }
+    }
+
+    @Override
+    public void stop ( ) {
+        bindings.stream().forEach(PVNameToValueBinding::dispose);
+        super.stop();
+    }
+}


### PR DESCRIPTION
Added a read-back PV property to the BoolButtonWidget. The idea is to set the state of the button (LED, background and image, as configured) based on a read-back PV rather than on the primary PV.  If the read-back PV name is blank, the behavior is as before.
The label of the button is however always set by the primary PV value.
