### PR TITLE
Data browser connections

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/Activator.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.csstudio.trends.databrowser3;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -30,30 +31,27 @@ public class Activator
 
     /** Dedicated timer for scrolling/updating plots.
      *
-     *  <p>The {@link #thread_pool} can be used to <code>schedule</code> tasks,
-     *  but long running tasks may be scheduled on the same thread and thus delay each other.
-     *
      *  <p>This timer is to be used for short-running tasks.
      */
     public static final ScheduledExecutorService timer;
 
 
-    /** Thread pool, mostly for fetching archived data
+    /** Thread pool, mostly for long running tasks like fetching archived data.
      *
      *  <p>No upper limit for threads.
      *  Removes all threads after 10 seconds
      */
-    public static final ScheduledExecutorService thread_pool;
+    public static final ExecutorService thread_pool;
 
     static
     {
         // Up to 1 timer thread, delete when more than 10 seconds idle
-        timer = Executors.newScheduledThreadPool(0, new NamedThreadFactory("DataBrowserScroll"));
+        timer = Executors.newScheduledThreadPool(0, new NamedThreadFactory("DataBrowserTimer"));
         ((ThreadPoolExecutor)timer).setKeepAliveTime(10, TimeUnit.SECONDS);
         ((ThreadPoolExecutor)timer).setMaximumPoolSize(1);
 
         // After 10 seconds, delete all idle threads
-        thread_pool = Executors.newScheduledThreadPool(0, new NamedThreadFactory("DataBrowser"));
+        thread_pool = Executors.newCachedThreadPool(new NamedThreadFactory("DataBrowserPool"));
        ((ThreadPoolExecutor)thread_pool).setKeepAliveTime(10, TimeUnit.SECONDS);
     }
 

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/archive/ArchiveFetchJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/archive/ArchiveFetchJob.java
@@ -76,7 +76,7 @@ public class ArchiveFetchJob implements JobRunnable
      */
     class WorkerThread implements Runnable
     {
-        private volatile String message = "";
+        private volatile String message = "Queued";
         private volatile boolean cancelled = false;
 
         /** Archive reader that's currently queried */

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -522,7 +522,7 @@ public class Controller
         // Compiler error "schedule(Runnable, long, TimeUnit) is ambiguous"
         // unless specifically casting getArchivedData to Runnable.
         final Runnable fetch = this::getArchivedData;
-        archive_fetch_delay_task = Activator.thread_pool.schedule(fetch, archive_fetch_delay, TimeUnit.MILLISECONDS);
+        archive_fetch_delay_task = Activator.timer.schedule(fetch, archive_fetch_delay, TimeUnit.MILLISECONDS);
     }
 
     /** Start model items and initiate scrolling/updates

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/waveformview/WaveformView.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/waveformview/WaveformView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -133,7 +133,7 @@ public class WaveformView extends VBox
             if (pending_move != null)
                 pending_move.cancel(false);
 
-            pending_move = Activator.thread_pool.schedule(WaveformView.this::userMovedAnnotation, 500, TimeUnit.MILLISECONDS);
+            pending_move = Activator.timer.schedule(WaveformView.this::userMovedAnnotation, 500, TimeUnit.MILLISECONDS);
         }
 
         @Override

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RawSampleIterator.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RawSampleIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,10 @@ public class RawSampleIterator extends AbstractRDBValueIterator
         catch (Exception ex)
         {
             if (! RDBArchiveReader.isCancellation(ex))
+            {   // Caller won't get valid iterator, close here
+                close();
                 throw ex;
+            }
             // Else: Not a real error; return empty iterator
             value = null;
         }

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/StoredProcedureValueIterator.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/StoredProcedureValueIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,7 +67,17 @@ public class StoredProcedureValueIterator extends AbstractRDBValueIterator
     {
         super(reader, channel_id);
         this.stored_procedure = stored_procedure;
-        executeProcedure(start, end, count);
+
+        try
+        {
+            executeProcedure(start, end, count);
+        }
+        catch (Exception ex)
+        {
+            // Caller won't get a valid iterator, so close here
+            super.close();
+            throw ex;
+        }
     }
 
     /** Invoke stored procedure

--- a/core/framework/src/main/java/org/phoebus/framework/rdb/RDBConnectionPool.java
+++ b/core/framework/src/main/java/org/phoebus/framework/rdb/RDBConnectionPool.java
@@ -157,7 +157,7 @@ public class RDBConnectionPool
             {
                 // Ignore, closing anyway
             }
-            logger.log(Level.WARNING, this + " is closed", new Exception("Call stack"));
+            logger.log(Level.INFO, this + " is closed", new Exception("Call stack"));
         }
         push(connection);
         logger.log(Level.FINER, "Released connection into " + this);

--- a/core/framework/src/main/java/org/phoebus/framework/rdb/RDBInfo.java
+++ b/core/framework/src/main/java/org/phoebus/framework/rdb/RDBInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,6 +73,12 @@ public class RDBInfo
         return dialect;
     }
 
+    /** @return user */
+    public String getUser()
+    {
+        return user;
+    }
+
     /** Create a new {@link Connection} */
     public Connection connect() throws Exception
     {
@@ -118,7 +124,16 @@ public class RDBInfo
         // Unless connection was created by dialect-specific code,
         // use generic driver manager
         if (connection == null)
-            connection = DriverManager.getConnection(url, prop);
+        {
+            try
+            {
+                connection = DriverManager.getConnection(url, prop);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Cannot connect to " + url + " as " + user, ex);
+            }
+        }
 
         // Basic database info
         if (logger.isLoggable(Level.FINE))


### PR DESCRIPTION
Fixes handling of RDB archive connections

 * RDB errors could lead to connections that weren't closed.
 * Only the statements for fetching samples could be canceled. Now also auxiliary statements can be canceled.
 * Separate 'timer' (one thread, scheduled) from 'pool' (many threads, but can't schedule)
 * At FINE level, log call stack of connection's last user to help debug leftover connections