### PR TITLE
Csstudio 1204 Tanks scale not computed correctly if PV has invalid display limit

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TankRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TankRepresentation.java
@@ -97,7 +97,7 @@ public class TankRepresentation extends RegionBaseRepresentation<Pane, TankWidge
         {
             // Try display range from PV
             final org.epics.vtype.Display display_info = Display.displayOf(vtype);
-            if (display_info != null)
+            if (display_info != null && display_info.getDisplayRange().isFinite())
             {
                 min_val = display_info.getDisplayRange().getMinimum();
                 max_val = display_info.getDisplayRange().getMaximum();


### PR DESCRIPTION
Due to changes in the vtype lib, a PV where the display limit is not set will now result in a non-null Display object when calling Display.displayOf(vtype). An additional check is needed to determine if the display range is valid.