### PR TITLE
Issue_1162 Update Windows bat file to eliminate hard coded version

### DIFF
--- a/phoebus-product/phoebus.bat
+++ b/phoebus-product/phoebus.bat
@@ -23,14 +23,9 @@
 )
 
 @java -version
-
-@set V=4.6.1
-
-@IF EXIST product-%V%.jar (
-  SET JAR=product-%V%.jar
-) ELSE (
-  SET JAR=product-%V%-SNAPSHOT.jar
-)
+echo off
+FOR /F "tokens=* USEBACKQ" %%F IN (`dir /B product*.jar`) DO (SET JAR=%%F)
+echo on
 
 @REM To get one instance, use server mode
 @java -jar %JAR% -server 4918 %*


### PR DESCRIPTION
Decided to not use Maven filtering as that would also require a change in the assembly configuration. 
Modified the bat file to behave lite the *nix counterpart, i.e. set jar file identity based on dir (ls) command.

NOTE: Verified on Windows 10 only!