### PR TITLE
CSSTUDIO-1216 Embedded display always initiated to height=200

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -282,10 +282,6 @@ public class EmbeddedDisplayWidget extends VisibleWidget
         properties.add(embedded_model = runtimeModel.createProperty(this, null));
         properties.add(transparent = propTransparent.createProperty(this, false));
         BorderSupport.addBorderProperties(this, properties);
-
-        // Initial size
-        propWidth().setValue(300);
-        propHeight().setValue(200);
     }
 
     /** @return 'macros' property */


### PR DESCRIPTION
Removed setting size of embedded display widget as that overrides the default values.