### PR TITLE
Linux launcher shell script bug, and improvement

### DIFF
--- a/phoebus-product/phoebus.sh
+++ b/phoebus-product/phoebus.sh
@@ -4,13 +4,15 @@
 
 # When deploying, change "TOP"
 # to the absolute installation path
-TOP="."
+# TOP="."
+THIS_SCRIPT="$(realpath "$0")";
+TOP="${THIS_SCRIPT%/*}";
 
 # Ideally, assert that Java is found
 # export JAVA_HOME=/opt/jdk-9
 # export PATH="$JAVA_HOME/bin:$PATH"
 
-if [ -d $TOP/target ]
+if [ -d "${TOP}/target" ]
 then
   TOP="$TOP/target"
 fi
@@ -31,10 +33,17 @@ JAR=`echo ${TOP}/product-*.jar`
 # To get one instance, use server mode
 OPT="-server 4918"
 
-if [ "x$1" == "x-main" ]
-then
+
+filter1="-help"
+filter2="-main"
+
+firstarg=$1;
+
+if test "${firstarg#*$filter1}" != "$firstarg"; then
   # Run MEDM converter etc. in foreground
   java -jar $JAR $OPT "$@"
+elif test "${firstarg#*$filter2}" != "$firstarg"; then
+    java -jar $JAR $OPT "$@"
 else
   # Run UI as separate thread
   java -jar $JAR $OPT "$@" &


### PR DESCRIPTION
@kasemir, 

  Please look at this pull request, which is a simple, and tiny update on phoebus.sh in order 
1) to remove the following like error 
```
./phoebus.sh --help
./phoebus.sh: 34: [: x--help: unexpected operator
```
2) to put `-help` as the foreground instead of background. 

In addition, I added two more lines to allow the script know where it is. So, one can run this script outside the directory. 

Best,
Han

