### PR TITLE
Rules jython: Adjust math functions

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
@@ -176,6 +176,10 @@ public class RuleToScript
             }
             else if (text.charAt(i) == '=' && i > 0 && !(text.charAt(i-1)=='<' || text.charAt(i-1)=='>')) // and neither "==" nor "!=" nor "<=", ">="
                 result.append("==");
+	    else if (matches(text, i, "Math."))
+            {
+		i += 4;
+            }
             else
                 result.append(text.charAt(i));
         }


### PR DESCRIPTION
OPI rules that use javascript Math functions do not cleanly convert to Jython code used by Display Builder. The fix is to handle this conversion. 