### PR TITLE
ctrl+mouse scroll to zoom in fix #1194

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -299,6 +299,8 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     private void doWheelZoom(final double delta, final double x, final double y)
     {
         final double zoom = getZoom();
+	if (delta == 0)
+	    return;
         if (zoom >= ZOOM_MAX && delta > 0)
             return;
         if (zoom <= ZOOM_MIN && delta < 0)


### PR DESCRIPTION
#1194 On some linux setups, an extra scrollwheel event is seen with delta = 0 which causes zoom to work in just one direction. The fix is to ignore such erroneous scrollwheel events.