### PR TITLE
Csstudio 1120 Fix for space characters in file paths

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
@@ -195,13 +195,15 @@ public class DisplayInfo
         {
             buf.append("file:");
             // Windows platform tweak
-            if (path.contains(":"))
+            if (path.contains(":/"))
+                buf.append("//");
+            else if (path.contains(":"))
                 buf.append("///");
         }
 
         // In path, keep ':' and '/', but replace spaces
         // Windows platform tweak replace \ with /
-        buf.append(path.replace(' ', '+').replace('\\', '/'));
+        buf.append(path.replace(" ", "%20").replace('\\', '/'));
 
         // Add macros as path parameters
         boolean first = true;

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeApplication.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeApplication.java
@@ -7,12 +7,16 @@
  ******************************************************************************/
 package org.csstudio.display.builder.runtime.app;
 
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
 
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.ModelPlugin;
+import org.csstudio.display.builder.model.persist.ModelReader;
 import org.phoebus.framework.spi.AppResourceDescriptor;
 import org.phoebus.framework.util.ResourceParser;
 import org.phoebus.ui.docking.DockItemWithInput;
@@ -77,6 +81,17 @@ public class DisplayRuntimeApplication implements AppResourceDescriptor
 
         // Check for existing instance with that input, i.e. path & macros
         final DisplayRuntimeInstance instance;
+        String s = "";
+        try(InputStream inputStream = input.toURL().openStream()){
+            ModelReader modelReader = new ModelReader(inputStream, input.toURL().getFile());
+            final DisplayModel model = modelReader.readModel();
+
+            System.out.println();
+        }
+        catch(Exception e){
+            e.printStackTrace();
+        }
+
         final DockItemWithInput existing = DockStage.getDockItemWithInput(NAME, input);
         if (existing != null)
         {   // Found one, raise it

--- a/core/framework/src/main/java/org/phoebus/framework/macros/Macros.java
+++ b/core/framework/src/main/java/org/phoebus/framework/macros/Macros.java
@@ -10,6 +10,7 @@ package org.phoebus.framework.macros;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -332,5 +333,36 @@ public class Macros implements MacroValueProvider
                                    .collect(Collectors.joining(", ")) +
                    "]";
         }
+    }
+
+    public String getAsSortedQueryParameters(){
+        StringBuilder stringBuilder = new StringBuilder();
+        Map<String, String> sorted = new HashMap(macros.size());
+        macros
+            .entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEachOrdered(x -> sorted.put(x.getKey(), x.getValue()));
+
+        sorted
+                .entrySet()
+                .stream()
+                .forEach(macro -> stringBuilder.append(macro.getKey()).append("=").append(macro.getValue()).append("&"));
+
+        String queryString = stringBuilder.toString();
+
+        return queryString.substring(0, queryString.length() - 1);
+    }
+
+    public String toQueryParameters(){
+        StringBuilder stringBuilder = new StringBuilder();
+        macros
+                .entrySet()
+                .stream()
+                .forEach(macro -> stringBuilder.append(macro.getKey()).append("=").append(macro.getValue()).append("&"));
+
+        String queryString = stringBuilder.toString();
+
+        return queryString.substring(0, queryString.length() - 1);
     }
 }

--- a/core/framework/src/test/java/org/phoebus/framework/macros/MacrosUnitTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/macros/MacrosUnitTest.java
@@ -11,8 +11,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 


### PR DESCRIPTION
This is contributed by @shroffk . It partially fixes #1210 as space characters in file paths/URIs are treated consistently. Issue with top level macros causing a display to always run in new tab remains.