### PR TITLE
Handle ConsoleUtil warnings

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/ScriptSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/ScriptSupport.java
@@ -120,7 +120,33 @@ public class ScriptSupport
                     warned = true;
                 }
                 line = line.replace("org.csstudio.opibuilder.scriptUtil", "org.csstudio.display.builder.runtime.script");
+		if (line.contains("ConsoleUtil"))
+		{
+		    // Handle "from org.csstudio.opibuilder.scriptUtil.ConsoleUtil import writeInfo"
+		    if (line.contains("org.csstudio.display.builder.runtime.script.ConsoleUtil") && line.contains("writeInfo"))
+		    {
+			line.replace("writeInfo", "ScriptUtil");
+			line.replace("org.csstudio.display.builder.runtime.script.ConsoleUtil", "org.csstudio.display.builder.runtime.script");
+		    }
+		    else
+		    {
+			// Handle "from org.csstudio.opibuilder.scriptUtil import ConsoleUtil"
+		        line = line.replace("ConsoleUtil", "ScriptUtil");
+		    }
+		}
             }
+	    if (line.contains("ConsoleUtil.writeInfo"))
+	    {
+		line.replace("ConsoleUtil.writeInfo", "ScriptUtil.getLogger().info");
+	    }
+	    if (line.contains("writeInfo"))
+	    {
+		line.replace("writeInfo", "ScriptUtil.getLogger().info");
+	    }
+	    if (line.contains("ConsoleUtil.writeString"))
+	    {
+		line.replace("ConsoleUtil.writeString", "ScriptUtil.getLogger().info");
+	    }	
             buf.append(line).append('\n');
         }
         stream.close();


### PR DESCRIPTION
Legacy scripts that use ConsoleUtil class throw warnings like below. This PR is to address ConsoleUtil class and its function writeInfo by patching the script lines to use already available ScriptUtil class and its APIs.

2020-03-18 11:43:03 WARNING [org.csstudio.display.builder.runtime] Script execution failed
Display 'EmbeddedDisplay _table.opi', Widget 'Wrk_State_Set' (textupdate), JythonScript embed_read.py
Traceback (most recent call last):
  File "embed_read.py", line 2, in <module>
ImportError: cannot import name ConsoleUtil

	at org.python.core.Py.ImportError(Py.java:334)
	at org.python.core.imp.importFromAs(imp.java:1161)
	at org.python.core.imp.importFrom(imp.java:1124)
	at org.python.pycode._pyx486.f$0(embed_read.py:26)
	at org.python.pycode._pyx486.call_function(embed_read.py)
	at org.python.core.PyTableCode.call(PyTableCode.java:171)
	at org.python.core.PyCode.call(PyCode.java:18)
	at org.python.core.Py.runCode(Py.java:1614)
	at org.python.core.Py.exec(Py.java:1658)
	at org.python.util.PythonInterpreter.exec(PythonInterpreter.java:276)
	at org.csstudio.display.builder.runtime.script.internal.JythonScriptSupport.lambda$submit$0(JythonScriptSupport.java:234)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
  