### PR TITLE
JavaFX 14

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -140,36 +140,53 @@
     <classpathentry exported="true" kind="lib" path="target/lib/xmlgraphics-commons-2.4.jar"/>
 
     <!-- On Windows, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-13.0.1-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-13.0.1-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-13.0.1-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-13.0.1-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-13.0.1-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14-win.jar"/>
     -->
     <!-- On Linux, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-13.0.1-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-13.0.1-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-13.0.1-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-13.0.1-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-13.0.1-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-13.0.1-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-13.0.1-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14-linux.jar"/>
     -->
+    <!-- On Mac, need to add this:
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14.jar"/>
+    -->
+
     <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <epics.version>7.0.4</epics.version>
     <vtype.version>1.0.1</vtype.version>
-    <openjfx.version>13.0.1</openjfx.version>
+    <openjfx.version>14</openjfx.version>
     <jackson.version>2.10.1</jackson.version>
     <batik.version>1.12</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
We’re on 13.0.1, while the latest regular release is 14.
Still compatible with openjdk 11, i.e. don’t need to change JRE at the same time.

https://github.com/openjdk/jfx/blob/jfx14/doc-files/release-notes-14.md
has list of fixed issues, though not clear if we suffered from a specific one.

So this is mostly about staying up to date.