### PR TITLE
app-nav cleanup unnecessary code

### DIFF
--- a/app/display/navigation/src/main/java/org/phoebus/applications/display/navigation/DisplayNavigationViewController.java
+++ b/app/display/navigation/src/main/java/org/phoebus/applications/display/navigation/DisplayNavigationViewController.java
@@ -153,7 +153,6 @@ public class DisplayNavigationViewController {
 
         private ObservableList<TreeItem<File>> buildChildren(TreeItem<File> treeItem) {
             File item = treeItem.getValue();
-            Set<File> childrens = ProcessOPI.getLinkedFiles(item);
             ObservableList<TreeItem<File>> children = FXCollections.observableArrayList();
             for (File child : ProcessOPI.getLinkedFiles(item)) {
                 children.add(new DisplayNavigationTreeItem(child));


### PR DESCRIPTION
Patch: removing a mistakenly included 'getchildren' computation