### PR TITLE
Display 'pv_name' macros on graphics

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArcWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArcWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2016-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ import org.w3c.dom.Element;
  *  @author Megan Grodowitz
  */
 @SuppressWarnings("nls")
-public class ArcWidget extends VisibleWidget
+public class ArcWidget extends MacroWidget
 {
     /** Widget descriptor */
     public static final WidgetDescriptor WIDGET_DESCRIPTOR =
@@ -79,6 +79,8 @@ public class ArcWidget extends VisibleWidget
                 // 'Fill' is similar to the new 'transparent' option
                 XMLUtil.getChildBoolean(xml, "fill")
                        .ifPresent(fill -> arc.propTransparent().setValue(! fill));
+
+                MacroWidget.importPVName(model_reader, widget, xml);
             }
             return true;
         }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArrayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArrayWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,6 @@ package org.csstudio.display.builder.model.widgets;
 
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMacros;
 import static org.csstudio.display.builder.model.properties.InsetsWidgetProperty.runtimePropInsets;
 
 import java.util.Arrays;
@@ -27,7 +26,6 @@ import org.csstudio.display.builder.model.persist.ModelWriter;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.properties.WidgetColor;
-import org.phoebus.framework.macros.Macros;
 
 /**
  * An Array Widget contains copies of a child widget. Each copy is assigned the
@@ -36,7 +34,7 @@ import org.phoebus.framework.macros.Macros;
  * @author Amanda Carpenter
  */
 @SuppressWarnings("nls")
-public class ArrayWidget extends PVWidget
+public class ArrayWidget extends MacroWidget
 {
     /** Widget descriptor */
     public static final WidgetDescriptor WIDGET_DESCRIPTOR =
@@ -69,7 +67,6 @@ public class ArrayWidget extends PVWidget
         }
     }
 
-    private volatile WidgetProperty<Macros> macros;
     private volatile ChildrenProperty children;
     private volatile WidgetProperty<WidgetColor> foreground;
     private volatile WidgetProperty<WidgetColor> background;
@@ -84,32 +81,12 @@ public class ArrayWidget extends PVWidget
     protected void defineProperties(final List<WidgetProperty<?>> properties)
     {
         super.defineProperties(properties);
-        properties.add(macros = propMacros.createProperty(this, new Macros()));
         properties.add(children = new ArrayWidgetChildrenProperty(this));
         properties.add(foreground = propForegroundColor.createProperty(this,
                 WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(background = propBackgroundColor.createProperty(this,
                 WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(insets = runtimePropInsets.createProperty(this, new int[] { 0, 0 }));
-    }
-
-    /**
-     * Array widget extends parent macros
-     *
-     * @return {@link Macros}
-     */
-    @Override
-    public Macros getEffectiveMacros()
-    {
-        final Macros base = super.getEffectiveMacros();
-        final Macros my_macros = propMacros().getValue();
-        return Macros.merge(base, my_macros);
-    }
-
-    /** @return 'macros' property */
-    public WidgetProperty<Macros> propMacros()
-    {
-        return macros;
     }
 
     /** @return Runtime 'children' property*/

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArrayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArrayWidget.java
@@ -106,7 +106,7 @@ public class ArrayWidget extends PVWidget
         return Macros.merge(base, my_macros);
     }
 
-     /** @return 'macros' property */
+    /** @return 'macros' property */
     public WidgetProperty<Macros> propMacros()
     {
         return macros;

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArrayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArrayWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@ package org.csstudio.display.builder.model.widgets;
 
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMacros;
 import static org.csstudio.display.builder.model.properties.InsetsWidgetProperty.runtimePropInsets;
 
 import java.util.Arrays;
@@ -26,6 +27,7 @@ import org.csstudio.display.builder.model.persist.ModelWriter;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.properties.WidgetColor;
+import org.phoebus.framework.macros.Macros;
 
 /**
  * An Array Widget contains copies of a child widget. Each copy is assigned the
@@ -34,7 +36,7 @@ import org.csstudio.display.builder.model.properties.WidgetColor;
  * @author Amanda Carpenter
  */
 @SuppressWarnings("nls")
-public class ArrayWidget extends MacroWidget
+public class ArrayWidget extends PVWidget
 {
     /** Widget descriptor */
     public static final WidgetDescriptor WIDGET_DESCRIPTOR =
@@ -67,6 +69,7 @@ public class ArrayWidget extends MacroWidget
         }
     }
 
+    private volatile WidgetProperty<Macros> macros;
     private volatile ChildrenProperty children;
     private volatile WidgetProperty<WidgetColor> foreground;
     private volatile WidgetProperty<WidgetColor> background;
@@ -81,12 +84,32 @@ public class ArrayWidget extends MacroWidget
     protected void defineProperties(final List<WidgetProperty<?>> properties)
     {
         super.defineProperties(properties);
+        properties.add(macros = propMacros.createProperty(this, new Macros()));
         properties.add(children = new ArrayWidgetChildrenProperty(this));
         properties.add(foreground = propForegroundColor.createProperty(this,
                 WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(background = propBackgroundColor.createProperty(this,
                 WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(insets = runtimePropInsets.createProperty(this, new int[] { 0, 0 }));
+    }
+
+    /**
+     * Array widget extends parent macros
+     *
+     * @return {@link Macros}
+     */
+    @Override
+    public Macros getEffectiveMacros()
+    {
+        final Macros base = super.getEffectiveMacros();
+        final Macros my_macros = propMacros().getValue();
+        return Macros.merge(base, my_macros);
+    }
+
+     /** @return 'macros' property */
+    public WidgetProperty<Macros> propMacros()
+    {
+        return macros;
     }
 
     /** @return Runtime 'children' property*/

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EllipseWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EllipseWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,10 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import java.util.Arrays;
 import java.util.List;
 
+import org.csstudio.display.builder.model.Version;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetCategory;
+import org.csstudio.display.builder.model.WidgetConfigurator;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.properties.WidgetColor;
@@ -25,7 +27,7 @@ import org.csstudio.display.builder.model.properties.WidgetColor;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class EllipseWidget extends VisibleWidget
+public class EllipseWidget extends MacroWidget
 {
     /** Widget descriptor */
     public static final WidgetDescriptor WIDGET_DESCRIPTOR =
@@ -60,6 +62,13 @@ public class EllipseWidget extends VisibleWidget
         properties.add(line_color = propLineColor.createProperty(this, new WidgetColor(0, 0, 255)));
         properties.add(background = propBackgroundColor.createProperty(this, new WidgetColor(30, 144, 255)));
         properties.add(transparent = propTransparent.createProperty(this, false));
+    }
+
+    @Override
+    public WidgetConfigurator getConfigurator(final Version persisted_version)
+            throws Exception
+    {
+        return new MacroWidget.LegacyWidgetConfigurator(persisted_version);
     }
 
     /** @return 'background_color' property */

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -9,7 +9,6 @@ package org.csstudio.display.builder.model.widgets;
 
 import static org.csstudio.display.builder.model.ModelPlugin.logger;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFile;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMacros;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propTransparent;
 
 import java.util.Arrays;
@@ -34,7 +33,6 @@ import org.csstudio.display.builder.model.persist.XMLTags;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.model.properties.EnumWidgetProperty;
 import org.csstudio.display.builder.model.widgets.GroupWidget.Style;
-import org.phoebus.framework.macros.Macros;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -44,7 +42,7 @@ import org.w3c.dom.Node;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class EmbeddedDisplayWidget extends VisibleWidget
+public class EmbeddedDisplayWidget extends MacroWidget
 {
     public static final int DEFAULT_WIDTH = 400,
                             DEFAULT_HEIGHT = 300;
@@ -259,7 +257,6 @@ public class EmbeddedDisplayWidget extends VisibleWidget
         }
     }
 
-    private volatile WidgetProperty<Macros> macros;
     private volatile WidgetProperty<String> file;
     private volatile WidgetProperty<Resize> resize;
     private volatile WidgetProperty<String> group_name;
@@ -276,18 +273,11 @@ public class EmbeddedDisplayWidget extends VisibleWidget
     {
         super.defineProperties(properties);
         properties.add(file = propFile.createProperty(this, ""));
-        properties.add(macros = propMacros.createProperty(this, new Macros()));
         properties.add(resize = propResize.createProperty(this, Resize.None));
         properties.add(group_name = propGroupName.createProperty(this, ""));
         properties.add(embedded_model = runtimeModel.createProperty(this, null));
         properties.add(transparent = propTransparent.createProperty(this, false));
         BorderSupport.addBorderProperties(this, properties);
-    }
-
-    /** @return 'macros' property */
-    public WidgetProperty<Macros> propMacros()
-    {
-        return macros;
     }
 
     /** @return 'file' property */
@@ -325,16 +315,5 @@ public class EmbeddedDisplayWidget extends VisibleWidget
             throws Exception
     {
         return new EmbeddedDisplayWidgetConfigurator(persisted_version);
-    }
-
-    /** Embedded widget adds/replaces parent macros
-     *  @return {@link Macros}
-     */
-    @Override
-    public Macros getEffectiveMacros()
-    {
-        final Macros base = super.getEffectiveMacros();
-        final Macros my_macros = propMacros().getValue();
-        return base == null ? my_macros : Macros.merge(base, my_macros);
     }
 }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/GroupWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/GroupWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@ package org.csstudio.display.builder.model.widgets;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMacros;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propTransparent;
 import static org.csstudio.display.builder.model.properties.InsetsWidgetProperty.runtimePropExtendedInsets;
 
@@ -35,7 +34,6 @@ import org.csstudio.display.builder.model.persist.WidgetFontService;
 import org.csstudio.display.builder.model.properties.EnumWidgetProperty;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.properties.WidgetFont;
-import org.phoebus.framework.macros.Macros;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Element;
 
@@ -55,7 +53,7 @@ import org.w3c.dom.Element;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class GroupWidget extends VisibleWidget
+public class GroupWidget extends MacroWidget
 {
     /** Widget descriptor */
     public static final WidgetDescriptor WIDGET_DESCRIPTOR =
@@ -96,14 +94,14 @@ public class GroupWidget extends VisibleWidget
 
     /** 'style' property */
     static final WidgetPropertyDescriptor<Style> propStyle =
-        new WidgetPropertyDescriptor<Style>(
+        new WidgetPropertyDescriptor<>(
             WidgetPropertyCategory.DISPLAY, "style", Messages.Style)
     {
         @Override
         public EnumWidgetProperty<Style> createProperty(final Widget widget,
                                                         final Style default_value)
         {
-            return new EnumWidgetProperty<Style>(this, widget, default_value);
+            return new EnumWidgetProperty<>(this, widget, default_value);
         }
     };
 
@@ -178,7 +176,6 @@ public class GroupWidget extends VisibleWidget
         }
     }
 
-    private volatile WidgetProperty<Macros> macros;
     private volatile ChildrenProperty children;
     private volatile WidgetProperty<Style> style;
     private volatile WidgetProperty<WidgetColor> foreground;
@@ -196,7 +193,6 @@ public class GroupWidget extends VisibleWidget
     protected void defineProperties(final List<WidgetProperty<?>> properties)
     {
         super.defineProperties(properties);
-        properties.add(macros = propMacros.createProperty(this, new Macros()));
         properties.add(children = new ChildrenProperty(this));
         properties.add(style = propStyle.createProperty(this, Style.GROUP));
         properties.add(font = propFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.DEFAULT)));
@@ -211,12 +207,6 @@ public class GroupWidget extends VisibleWidget
             throws Exception
     {
         return new GroupWidgetConfigurator(persisted_version);
-    }
-
-    /** @return 'macros' property */
-    public WidgetProperty<Macros> propMacros()
-    {
-        return macros;
     }
 
     /** @return Runtime 'children' property */
@@ -247,17 +237,6 @@ public class GroupWidget extends VisibleWidget
     public WidgetProperty<Boolean> propTransparent()
     {
         return transparent;
-    }
-
-    /** Group widget extends parent macros
-     *  @return {@link Macros}
-     */
-    @Override
-    public Macros getEffectiveMacros()
-    {
-        final Macros base = super.getEffectiveMacros();
-        final Macros my_macros = propMacros().getValue();
-        return Macros.merge(base, my_macros);
     }
 
     /** @return 'font' property */

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/LabelWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/LabelWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,7 +44,7 @@ import org.w3c.dom.Element;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class LabelWidget extends VisibleWidget
+public class LabelWidget extends MacroWidget
 {
     /** Widget descriptor */
     public static final WidgetDescriptor WIDGET_DESCRIPTOR =
@@ -78,7 +78,10 @@ public class LabelWidget extends VisibleWidget
 
             // Default used to be 'middle'
             if (is_legacy)
+            {
                 widget.getProperty(propVerticalAlignment).setValue(VerticalAlignment.MIDDLE);
+                MacroWidget.importPVName(model_reader, widget, xml);
+            }
 
             if (! super.configureFromXML(model_reader, widget, xml))
                 return false;

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MacroWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MacroWidget.java
@@ -11,7 +11,9 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 
 import java.util.List;
 
+import org.csstudio.display.builder.model.Version;
 import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.WidgetConfigurator;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.persist.ModelReader;
 import org.phoebus.framework.macros.Macros;
@@ -21,6 +23,7 @@ import org.w3c.dom.Element;
 /** Base for widget with 'macros'
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class MacroWidget extends VisibleWidget
 {
     private volatile WidgetProperty<Macros> macros;
@@ -31,7 +34,7 @@ public class MacroWidget extends VisibleWidget
      *  even though those widgets didn't have an actual PV.
      *  The 'pv_name' property was simply treated as a macro,
      *  allowing for example scripts to then refer to '$(pv_name)'.
-     *  
+     *
      *  <p>This imports it as an actual macro.
      */
     public static void importPVName(final ModelReader model_reader, final Widget widget, final Element widget_xml)
@@ -42,6 +45,23 @@ public class MacroWidget extends VisibleWidget
             final MacroWidget mw = (MacroWidget) widget;
             mw.propMacros().getValue().add("pv_name", value);
         });
+    }
+
+    /** Handle legacy XML format: Import 'pv_name' */
+    static class LegacyWidgetConfigurator extends WidgetConfigurator
+    {
+        public LegacyWidgetConfigurator(final Version xml_version)
+        {
+            super(xml_version);
+        }
+
+        @Override
+        public boolean configureFromXML(final ModelReader model_reader, final Widget widget, final Element widget_xml) throws Exception
+        {
+            if (xml_version.getMajor() < 2)
+                MacroWidget.importPVName(model_reader, widget, widget_xml);
+            return super.configureFromXML(model_reader, widget, widget_xml);
+        }
     }
 
     /** Widget constructor.

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MacroWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MacroWidget.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.csstudio.display.builder.model.widgets;
+
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMacros;
+
+import java.util.List;
+
+import org.csstudio.display.builder.model.WidgetProperty;
+import org.phoebus.framework.macros.Macros;
+
+/** Base for widget with 'macros'
+ *  @author Kay Kasemir
+ */
+public class MacroWidget extends VisibleWidget
+{
+    private volatile WidgetProperty<Macros> macros;
+
+    /** Widget constructor.
+     *  @param type Widget type
+     */
+    public MacroWidget(final String type)
+    {
+        super(type);
+    }
+
+    /** Widget constructor.
+     *  @param type Widget type
+     *  @param default_width Default width
+     *  @param default_height .. and height
+     */
+    public MacroWidget(final String type, final int default_width, final int default_height)
+    {
+        super(type, default_width, default_height);
+    }
+
+    @Override
+    protected void defineProperties(final List<WidgetProperty<?>> properties)
+    {
+        super.defineProperties(properties);
+        properties.add(macros = propMacros.createProperty(this, new Macros()));
+    }
+
+    /** @return 'macros' property */
+    public WidgetProperty<Macros> propMacros()
+    {
+        return macros;
+    }
+
+    /** Widget extends parent macros
+     *  @return {@link Macros}
+     */
+    @Override
+    public Macros getEffectiveMacros()
+    {
+        final Macros base = super.getEffectiveMacros();
+        final Macros my_macros = propMacros().getValue();
+        return Macros.merge(base, my_macros);
+    }
+}

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MacroWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MacroWidget.java
@@ -11,8 +11,12 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 
 import java.util.List;
 
+import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.persist.ModelReader;
 import org.phoebus.framework.macros.Macros;
+import org.phoebus.framework.persistence.XMLUtil;
+import org.w3c.dom.Element;
 
 /** Base for widget with 'macros'
  *  @author Kay Kasemir
@@ -20,6 +24,25 @@ import org.phoebus.framework.macros.Macros;
 public class MacroWidget extends VisibleWidget
 {
     private volatile WidgetProperty<Macros> macros;
+
+    /** Helper for WidgetConfigurator that imports 'pv_name' as macro
+     *
+     *  <p>Legacy displays had a 'pv_name' property on static widgets
+     *  even though those widgets didn't have an actual PV.
+     *  The 'pv_name' property was simply treated as a macro,
+     *  allowing for example scripts to then refer to '$(pv_name)'.
+     *  
+     *  <p>This imports it as an actual macro.
+     */
+    public static void importPVName(final ModelReader model_reader, final Widget widget, final Element widget_xml)
+    {
+        XMLUtil.getChildString(widget_xml, "pv_name")
+               .ifPresent(value ->
+        {
+            final MacroWidget mw = (MacroWidget) widget;
+            mw.propMacros().getValue().add("pv_name", value);
+        });
+    }
 
     /** Widget constructor.
      *  @param type Widget type

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PictureWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PictureWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ import org.w3c.dom.Text;
  *  @author Megan Grodowitz
  */
 @SuppressWarnings("nls")
-public class PictureWidget extends VisibleWidget
+public class PictureWidget extends MacroWidget
 {
     public final static String default_pic = "examples:/icons/default_picture.png";
 
@@ -64,7 +64,6 @@ public class PictureWidget extends VisibleWidget
         public boolean configureFromXML(final ModelReader model_reader, final Widget widget, final Element widget_xml)
                 throws Exception
         {
-            // Legacy used background color for the line
             Element xml = XMLUtil.getChildElement(widget_xml, "image_file");
             if (xml != null)
             {
@@ -82,6 +81,9 @@ public class PictureWidget extends VisibleWidget
                 }
                 widget_xml.appendChild(fname);
             }
+
+            if (xml_version.getMajor() < 2)
+                MacroWidget.importPVName(model_reader, widget, widget_xml);
 
             // Parse updated XML
             return super.configureFromXML(model_reader, widget, widget_xml);

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolygonWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolygonWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ import org.w3c.dom.Element;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class PolygonWidget extends VisibleWidget
+public class PolygonWidget extends MacroWidget
 {
     /** Legacy polygon used 1.0.0 */
     private static final Version version = new Version(2, 0, 0);
@@ -96,6 +96,8 @@ public class PolygonWidget extends VisibleWidget
                 // In case a re-parse is triggered, prevent another XMLPoints adjustment
                 // by marking as current version
                 widget_xml.setAttribute(XMLTags.VERSION, version.toString());
+
+                MacroWidget.importPVName(model_reader, widget, widget_xml);
             }
             // Parse updated XML
             return super.configureFromXML(model_reader, widget, widget_xml);

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolylineWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolylineWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,7 +41,7 @@ import org.w3c.dom.Element;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class PolylineWidget extends VisibleWidget
+public class PolylineWidget extends MacroWidget
 {
     /** Legacy polyline used 1.0.0 */
     private static final Version version = new Version(2, 0, 0);
@@ -88,14 +88,14 @@ public class PolylineWidget extends VisibleWidget
 
     /** Display 'arrows' */
     private static final WidgetPropertyDescriptor<Arrows> propArrows =
-        new WidgetPropertyDescriptor<Arrows>(
+        new WidgetPropertyDescriptor<>(
             WidgetPropertyCategory.DISPLAY, "arrows", Messages.Arrows)
     {
         @Override
         public EnumWidgetProperty<Arrows> createProperty(final Widget widget,
                                                         final Arrows default_value)
         {
-            return new EnumWidgetProperty<Arrows>(this, widget, default_value);
+            return new EnumWidgetProperty<>(this, widget, default_value);
         }
     };
 
@@ -127,6 +127,8 @@ public class PolylineWidget extends VisibleWidget
                     line.appendChild(c.cloneNode(true));
                     widget_xml.appendChild(line);
                     widget_xml.removeChild(xml);
+
+                    MacroWidget.importPVName(model_reader, widget, widget_xml);
                 }
                 // In case a re-parse is triggered, prevent another XMLPoints adjustment
                 // by marking as current version

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/RectangleWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/RectangleWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,8 +16,10 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.csstudio.display.builder.model.Messages;
+import org.csstudio.display.builder.model.Version;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetCategory;
+import org.csstudio.display.builder.model.WidgetConfigurator;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyCategory;
@@ -29,7 +31,7 @@ import org.csstudio.display.builder.model.properties.WidgetColor;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class RectangleWidget extends VisibleWidget
+public class RectangleWidget extends MacroWidget
 {
     /** Widget descriptor */
     public static final WidgetDescriptor WIDGET_DESCRIPTOR =
@@ -75,6 +77,13 @@ public class RectangleWidget extends VisibleWidget
         properties.add(transparent = propTransparent.createProperty(this, false));
         properties.add(corner_width = propCornerWidth.createProperty(this, 0));
         properties.add(corner_height = propCornerHeight.createProperty(this, 0));
+    }
+
+    @Override
+    public WidgetConfigurator getConfigurator(final Version persisted_version)
+            throws Exception
+    {
+        return new MacroWidget.LegacyWidgetConfigurator(persisted_version);
     }
 
     /** @return 'background_color' property */

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TabsWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TabsWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@ import static org.csstudio.display.builder.model.ModelPlugin.logger;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propDirection;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMacros;
 import static org.csstudio.display.builder.model.properties.InsetsWidgetProperty.runtimePropInsets;
 
 import java.text.MessageFormat;
@@ -41,7 +40,6 @@ import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.model.properties.Direction;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.properties.WidgetFont;
-import org.phoebus.framework.macros.Macros;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Element;
 
@@ -56,7 +54,7 @@ import org.w3c.dom.Element;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class TabsWidget extends VisibleWidget
+public class TabsWidget extends MacroWidget
 {
     /** Widget descriptor */
     public static final WidgetDescriptor WIDGET_DESCRIPTOR =
@@ -97,7 +95,7 @@ public class TabsWidget extends VisibleWidget
             final WidgetProperty<List<Widget>> c = getElement(1);
             return (ChildrenProperty)c;
         }
-    };
+    }
 
     private static final ArrayWidgetProperty.Descriptor<TabItemProperty> propTabs =
         new ArrayWidgetProperty.Descriptor<>(WidgetPropertyCategory.WIDGET, "tabs", Messages.TabsWidget_Name,
@@ -173,7 +171,6 @@ public class TabsWidget extends VisibleWidget
         }
     }
 
-    private volatile WidgetProperty<Macros> macros;
     private volatile WidgetProperty<WidgetColor> background;
     private volatile WidgetProperty<WidgetFont> font;
     private volatile WidgetProperty<Integer> active;
@@ -191,7 +188,6 @@ public class TabsWidget extends VisibleWidget
     protected void defineProperties(final List<WidgetProperty<?>> properties)
     {
         super.defineProperties(properties);
-        properties.add(macros = propMacros.createProperty(this, new Macros()));
         properties.add(font = propFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.DEFAULT)));
         properties.add(background = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(active = propActiveTab.createProperty(this, 0));
@@ -212,23 +208,6 @@ public class TabsWidget extends VisibleWidget
             throws Exception
     {
         return new TabsWidgetConfigurator(persisted_version);
-    }
-
-    /** @return Widget 'macros' */
-    public WidgetProperty<Macros> widgetMacros()
-    {
-        return macros;
-    }
-
-    /** Group widget extends parent macros
-     *  @return {@link Macros}
-     */
-    @Override
-    public Macros getEffectiveMacros()
-    {
-        final Macros base = super.getEffectiveMacros();
-        final Macros my_macros = widgetMacros().getValue();
-        return Macros.merge(base, my_macros);
     }
 
     /** @return 'background_color' property */

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/DataBrowserWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/DataBrowserWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,6 @@ package org.csstudio.display.builder.model.widgets.plots;
 
 import static org.csstudio.display.builder.model.ModelPlugin.logger;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFile;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMacros;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.runtimePropConfigure;
 import static org.csstudio.display.builder.model.widgets.plots.PlotWidgetProperties.propToolbar;
 
@@ -32,9 +31,8 @@ import org.csstudio.display.builder.model.WidgetPropertyDescriptor;
 import org.csstudio.display.builder.model.persist.ModelReader;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.model.properties.RuntimeEventProperty;
-import org.csstudio.display.builder.model.widgets.VisibleWidget;
+import org.csstudio.display.builder.model.widgets.MacroWidget;
 import org.epics.vtype.VType;
-import org.phoebus.framework.macros.Macros;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Element;
 
@@ -45,7 +43,7 @@ import org.w3c.dom.Element;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class DataBrowserWidget extends VisibleWidget
+public class DataBrowserWidget extends MacroWidget
 {
     /** Widget descriptor */
     public static final WidgetDescriptor WIDGET_DESCRIPTOR =
@@ -97,7 +95,6 @@ public class DataBrowserWidget extends VisibleWidget
 
     private volatile WidgetProperty<Boolean> show_toolbar;
     private volatile WidgetProperty<String> file;
-    private volatile WidgetProperty<Macros> macros;
     private volatile RuntimeEventProperty configure;
     private volatile WidgetProperty<String> selection_value_pv;
     private volatile WidgetProperty<VType> selection_value;
@@ -114,7 +111,6 @@ public class DataBrowserWidget extends VisibleWidget
         super.defineProperties(properties);
         properties.add(file = propFile.createProperty(this, ""));
         properties.add(show_toolbar = propToolbar.createProperty(this, false));
-        properties.add(macros = propMacros.createProperty(this, new Macros()));
         properties.add(configure = (RuntimeEventProperty) runtimePropConfigure.createProperty(this, null));
         properties.add(selection_value_pv = propSelectionValuePV.createProperty(this, ""));
         properties.add(selection_value = propSelectionValue.createProperty(this, null));
@@ -152,23 +148,6 @@ public class DataBrowserWidget extends VisibleWidget
             logger.log(Level.WARNING, "Cannot obtain data browser model", ex);
         }
         return null;
-    }
-
-    /** Databrowser widget extends parent macros
-     *  @return {@link Macros}
-     */
-    @Override
-    public Macros getEffectiveMacros()
-    {
-        final Macros base = super.getEffectiveMacros();
-        final Macros my_macros = propMacros().getValue();
-        return Macros.merge(base, my_macros);
-    }
-
-    /** @return 'macros' property */
-    public WidgetProperty<Macros> propMacros()
-    {
-        return macros;
     }
 
     /** @return 'file' property */


### PR DESCRIPTION
Unlike 'Monitor' or 'Control' widgets, 'Graphics' widgets are meant to be static in nature, they don't have a PV. Still, legacy *.opi files sometimes contain a "pv_name" property which is then basically used as a macro in attached scripts or rules. At least that's how FRIB decided to use it. To allow import, adding macro to all 'Graphics', and importing legacy "pv_name" property into the macros.