### PR TITLE
Skip textupdate replace when pv_name is set from rule

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextUpdateWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextUpdateWidget.java
@@ -114,12 +114,11 @@ public class TextUpdateWidget extends PVWidget
 			 }
 		    }
 
-                    logger.log(Level.WARNING, "Replacing TextUpdate " + text_widget + " with 'text' but no 'pv_name' with a Label");
-
                     // Replace the widget type with "label"
                     final String type = xml.getAttribute("typeId");
                     if (type != null  &&  type.endsWith("TextUpdate") && pv_rule == false)
                     {
+			logger.log(Level.WARNING, "Replacing TextUpdate " + text_widget + " with 'text' but no 'pv_name' with a Label");
                         xml.setAttribute("typeId", "org.csstudio.opibuilder.widgets.Label");
                         // XMLUtil.dump(xml);
                         throw new ParseAgainException("Replace text update with label");


### PR DESCRIPTION
PR is for two fixes: 

1. Skip converting textupdate to label when pv_name is set as a rule
2. Support legacy textupdate rules/scripts that access 'enabled' property