### PR TITLE
Display text-update: In interactive mode, bottom-aligned, scroll to bot.

### DIFF
--- a/app/display/model/src/main/resources/examples/monitors_textupdate.bob
+++ b/app/display/model/src/main/resources/examples/monitors_textupdate.bob
@@ -355,7 +355,7 @@ while the DMS specialization maps 2 pi to 360 degrees.
     <text>By default, Text Update widgets simply display the value of a PV.
 They allow no interaction.
 
-When you set the  'interactive' property to true, the widget allows selecting the current value so users and 'copy' it.
+When you set the  'interactive' property to true, the widget allows selecting the current value so users can 'copy' it.
 In addition, a scrollbar appears when the text exceeds the widget area.
 </text>
     <x>450</x>

--- a/app/display/model/src/main/resources/examples/monitors_textupdate.bob
+++ b/app/display/model/src/main/resources/examples/monitors_textupdate.bob
@@ -2,7 +2,7 @@
 <display version="2.0.0">
   <name>Text Update</name>
   <width>1060</width>
-  <height>960</height>
+  <height>1000</height>
   <widget type="label" version="2.0.0">
     <name>Label</name>
     <class>TITLE</class>
@@ -357,11 +357,12 @@ They allow no interaction.
 
 When you set the  'interactive' property to true, the widget allows selecting the current value so users can 'copy' it.
 In addition, a scrollbar appears when the text exceeds the widget area.
+With vertical alignment set to 'bottom', the scrollbar will default to the bottom as well.
 </text>
     <x>450</x>
     <y>800</y>
     <width>350</width>
-    <height>160</height>
+    <height>200</height>
     <font>
       <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
       </font>

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
@@ -283,7 +283,7 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
                 {
                     // For bottom-aligned widget, scroll to bottom
                     area.selectPositionCaret(area.getLength());
-                    area.deselect(); //re
+                    area.deselect();
                 }
             }
             if (! jfx_node.isManaged())

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.properties.RotationStep;
+import org.csstudio.display.builder.model.properties.VerticalAlignment;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.widgets.PVWidget;
 import org.csstudio.display.builder.model.widgets.TextUpdateWidget;
@@ -82,12 +83,12 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
         {
             final Label label = new Label();
             label.getStyleClass().add("text_update");
-    
+
             // This code manages layout,
             // because otherwise for example border changes would trigger
             // expensive Node.notifyParentOfBoundsChange() recursing up the scene graph
             label.setManaged(false);
-    
+
             return label;
         }
     }
@@ -275,7 +276,16 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
             if (jfx_node instanceof Label)
                 ((Label)jfx_node).setText(value_text);
             else
-                ((TextArea)jfx_node).setText(value_text);
+            {
+                final TextArea area = (TextArea)jfx_node;
+                area.setText(value_text);
+                if (model_widget.propVerticalAlignment().getValue() == VerticalAlignment.BOTTOM)
+                {
+                    // For bottom-aligned widget, scroll to bottom
+                    area.selectPositionCaret(area.getLength());
+                    area.deselect(); //re
+                }
+            }
             if (! jfx_node.isManaged())
                 jfx_node.layout();
         }


### PR DESCRIPTION
TextUpdate has an 'interactive' mode where the read-only widget gets a scrollbar and allows selecting & copying text out. Useful to for example show log messages that span a few lines.

By default, the text is top/left aligned, and when the value updates, the scrollbar is at the top.

When selecting 'bottom' for the vertical alignment, the scrollbar will now be at the bottom, useful to 'tail' a short list of messages.