### PR TITLE
ProgressBar: When importing *.opi, add Text Update for label

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ProgressBarWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ProgressBarWidget.java
@@ -24,8 +24,12 @@ import org.csstudio.display.builder.model.WidgetConfigurator;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.persist.ModelReader;
+import org.csstudio.display.builder.model.persist.XMLTags;
+import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
+import org.csstudio.display.builder.model.properties.HorizontalAlignment;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.phoebus.framework.persistence.XMLUtil;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Widget that displays a progress bar
@@ -83,6 +87,30 @@ public class ProgressBarWidget extends PVWidget
                 final Element el = XMLUtil.getChildElement(xml, "color_fillbackground");
                 if (el != null)
                     bar.propBackgroundColor().readFromXML(model_reader, el);
+            }
+
+            // Create text update for the value indicator
+            if (XMLUtil.getChildBoolean(xml, "show_label").orElse(true))
+            {
+                final Document doc = xml.getOwnerDocument();
+                final Element text = doc.createElement(XMLTags.WIDGET);
+                text.setAttribute(XMLTags.TYPE, TextUpdateWidget.WIDGET_DESCRIPTOR.getType());
+                XMLUtil.updateTag(text, XMLTags.NAME, widget.getName() + " Label");
+                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.X), true));
+                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.Y), true));
+                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.WIDTH), true));
+                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.HEIGHT), true));
+                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.PV_NAME), true));
+
+                Element e = doc.createElement(CommonWidgetProperties.propTransparent.getName());
+                e.appendChild(doc.createTextNode(Boolean.TRUE.toString()));
+                text.appendChild(e);
+
+                e = doc.createElement(CommonWidgetProperties.propHorizontalAlignment.getName());
+                e.appendChild(doc.createTextNode(Integer.toString(HorizontalAlignment.CENTER.ordinal())));
+                text.appendChild(e);
+
+                xml.getParentNode().appendChild(text);
             }
 
             return true;


### PR DESCRIPTION
BOY had a label with somewhat limited configuration options.
On import, if label is enabled, create Text Update which is then fully configurable (units? format?...)

![Screen Shot 2020-04-16 at 3 44 21 PM](https://user-images.githubusercontent.com/1932421/79499776-7aad8d80-7ff9-11ea-82a5-f671134309c3.png)
