### PR TITLE
Progressbar: Revert to 'managed' mode

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ProgressBarWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ProgressBarWidget.java
@@ -87,30 +87,30 @@ public class ProgressBarWidget extends PVWidget
                 final Element el = XMLUtil.getChildElement(xml, "color_fillbackground");
                 if (el != null)
                     bar.propBackgroundColor().readFromXML(model_reader, el);
-            }
 
-            // Create text update for the value indicator
-            if (XMLUtil.getChildBoolean(xml, "show_label").orElse(true))
-            {
-                final Document doc = xml.getOwnerDocument();
-                final Element text = doc.createElement(XMLTags.WIDGET);
-                text.setAttribute(XMLTags.TYPE, TextUpdateWidget.WIDGET_DESCRIPTOR.getType());
-                XMLUtil.updateTag(text, XMLTags.NAME, widget.getName() + " Label");
-                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.X), true));
-                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.Y), true));
-                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.WIDTH), true));
-                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.HEIGHT), true));
-                text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.PV_NAME), true));
+                // Create text update for the value indicator
+                if (XMLUtil.getChildBoolean(xml, "show_label").orElse(true))
+                {
+                    final Document doc = xml.getOwnerDocument();
+                    final Element text = doc.createElement(XMLTags.WIDGET);
+                    text.setAttribute(XMLTags.TYPE, TextUpdateWidget.WIDGET_DESCRIPTOR.getType());
+                    XMLUtil.updateTag(text, XMLTags.NAME, widget.getName() + " Label");
+                    text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.X), true));
+                    text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.Y), true));
+                    text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.WIDTH), true));
+                    text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.HEIGHT), true));
+                    text.appendChild(doc.importNode(XMLUtil.getChildElement(xml, XMLTags.PV_NAME), true));
 
-                Element e = doc.createElement(CommonWidgetProperties.propTransparent.getName());
-                e.appendChild(doc.createTextNode(Boolean.TRUE.toString()));
-                text.appendChild(e);
+                    Element e = doc.createElement(CommonWidgetProperties.propTransparent.getName());
+                    e.appendChild(doc.createTextNode(Boolean.TRUE.toString()));
+                    text.appendChild(e);
 
-                e = doc.createElement(CommonWidgetProperties.propHorizontalAlignment.getName());
-                e.appendChild(doc.createTextNode(Integer.toString(HorizontalAlignment.CENTER.ordinal())));
-                text.appendChild(e);
+                    e = doc.createElement(CommonWidgetProperties.propHorizontalAlignment.getName());
+                    e.appendChild(doc.createTextNode(Integer.toString(HorizontalAlignment.CENTER.ordinal())));
+                    text.appendChild(e);
 
-                xml.getParentNode().appendChild(text);
+                    xml.getParentNode().appendChild(text);
+                }
             }
 
             return true;

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
@@ -19,7 +19,6 @@ import org.epics.vtype.VType;
 import org.phoebus.ui.javafx.Styles;
 
 import javafx.scene.control.ProgressBar;
-import javafx.scene.paint.Color;
 import javafx.scene.transform.Rotate;
 import javafx.scene.transform.Translate;
 
@@ -41,10 +40,6 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
     public ProgressBar createJFXNode() throws Exception
     {
         final ProgressBar bar = new ProgressBar();
-        // This code manages layout,
-        // because otherwise for example border changes would trigger
-        // expensive Node.notifyParentOfBoundsChange() recursing up the scene graph
-        bar.setManaged(false);
         return bar;
     }
 
@@ -128,7 +123,7 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
         final double value = VTypeUtil.getValueNumber(vtype).doubleValue();
         final double percentage = (value - min_val) / (max_val - min_val);
         // Limit to 0.0 .. 1.0
-        if (percentage < 0.0)
+        if (percentage < 0.0  ||  !Double.isFinite(percentage))
             this.percentage = 0.0;
         else if (percentage > 1.0)
             this.percentage = 1.0;
@@ -152,12 +147,12 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
                 jfx_node.getTransforms().setAll(
                         new Translate(0, height),
                         new Rotate(-90, 0, 0));
-                jfx_node.resize(height, width);
+                jfx_node.setPrefSize(height, width);
             }
             else
             {
                 jfx_node.getTransforms().clear();
-                jfx_node.resize(width, height);
+                jfx_node.setPrefSize(width, height);
             }
 
             // Default 'inset' of .bar uses 7 pixels.
@@ -178,13 +173,4 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
         if (dirty_value.checkAndClear())
             jfx_node.setProgress(percentage);
     }
-
-    public static void main(String[] args)
-    {
-        final Color color = Color.rgb(236, 236, 236).deriveColor(0, 1.0, 0.9254*0.8, 1.0);
-        System.out.println(color.getBrightness());
-        System.out.println(color.getRed() * 255);
-        System.out.println(color.getGreen() * 255);
-        System.out.println(color.getBlue() * 255);
-           }
 }


### PR DESCRIPTION
At some point, several widgets were switched to 'non-managed' mode to optimize redraws.
Turns out non-managed mode requires calling 'layout' after resize and even value
changes of the progress bar to reliably get the bar to update. Simply using the default
'managed' mode is more straight forward, so going back.

#1272 ended up adding the label over and over, now only adding it for initial *.opi import