### PR TITLE
Display Editor: Copy / Paste Properties enabled for DisplayModel (dis…

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/CopyPropertiesAction.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/CopyPropertiesAction.java
@@ -111,6 +111,8 @@ public class CopyPropertiesAction extends MenuItem
         super("Copy Properties", ImageCache.getImageView(ImageCache.class, "/icons/copy_edit.png"));
         if (selection.size() == 1)
             setOnAction(event -> selectPropertiesToCopy(editor.getContextMenuNode(), selection.get(0)));
+        else if (selection.size() == 0)
+            setOnAction(event -> selectPropertiesToCopy(editor.getContextMenuNode(), editor.getModel()));
         else
             setDisable(true);
     }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/PastePropertiesAction.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/PastePropertiesAction.java
@@ -38,6 +38,8 @@ public class PastePropertiesAction extends MenuItem
         super("Paste Properties", ImageCache.getImageView(ImageCache.class, "/icons/paste.png"));
         if (selection.size() >= 1  &&  clipboardHasProperties())
             setOnAction(event -> pasteProperties(editor, selection));
+        else if (selection.size() == 0  &&  clipboardHasProperties())
+            setOnAction(event -> pasteProperties(editor, List.of(editor.getModel())));
         else
             setDisable(true);
     }


### PR DESCRIPTION
…play "background") in Editor
Useful for Scripts / Rules etc. copied and pasted for example between displays
See #679 