### PR TITLE
CoreUI: JFX dialogs: set dialog Owner to get correct dialog icons on Windows

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/dialog/DialogHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/dialog/DialogHelper.java
@@ -59,6 +59,7 @@ public class DialogHelper
      */
     public static void positionDialog(final Dialog<?> dialog, final Node node, final int x_offset, final int y_offset)
     {
+        dialog.initOwner(node.getScene().getWindow());
         // Must runLater due to dialog Width/Height are initialized after dialog shows up
         Platform.runLater(new Runnable() {
             @Override


### PR DESCRIPTION
See #896 #897 for motivation, this PR is targeted to Core UI. Usage example: `org.csstudio.trends.databrowser3.ui.AddPVDialog`