### PR TITLE
Support legacy rules for prop opi_file for embedded widget

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -280,6 +280,15 @@ public class EmbeddedDisplayWidget extends MacroWidget
         BorderSupport.addBorderProperties(this, properties);
     }
 
+    @Override
+    public WidgetProperty<?> getProperty(String name) throws IllegalArgumentException, IndexOutOfBoundsException
+    {
+        // Support legacy scripts/rules that access opi_file
+        if (name.equals("opi_file"))
+            return propFile();
+        return super.getProperty(name);
+    }
+
     /** @return 'file' property */
     public WidgetProperty<String> propFile()
     {


### PR DESCRIPTION
This PR is to support legacy rules that use property "opi_file" for embedded (linking container) widgets.