### PR TITLE
Legacy tank widget prop support

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/RulesWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/RulesWidgetProperty.java
@@ -58,7 +58,7 @@ public class RulesWidgetProperty extends WidgetProperty<List<RuleInfo>>
     public static WidgetProperty<?> propIDToNewProp(final Widget widget,
             final String prop_id, final String dbg_tag)
     {
-	try
+        try
         {
 	    // Check for plain property (including re-mapped legacy properties)
             return widget.getProperty(prop_id).clone();

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/RulesWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/RulesWidgetProperty.java
@@ -58,6 +58,16 @@ public class RulesWidgetProperty extends WidgetProperty<List<RuleInfo>>
     public static WidgetProperty<?> propIDToNewProp(final Widget widget,
             final String prop_id, final String dbg_tag)
     {
+	try
+        {
+	    // Check for plain property (including re-mapped legacy properties)
+            return widget.getProperty(prop_id).clone();
+        }
+        catch (Throwable ex)
+        {
+            // Ignore, fall through to getPropertyByPath
+        }
+
         try
         {
             return widget.getPropertyByPath(prop_id, true).clone();

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TankWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TankWidget.java
@@ -147,6 +147,15 @@ public class TankWidget extends PVWidget
         properties.add(maximum = propMaximum.createProperty(this, 100.0));
     }
 
+    @Override
+    public WidgetProperty<?> getProperty(String name) throws IllegalArgumentException, IndexOutOfBoundsException
+    {
+        // Support legacy scripts/rules that access color_fillbackground
+        if (name.equals("color_fillbackground"))
+            return propEmptyColor();
+        return super.getProperty(name);
+    }
+
     /** @return 'font' property */
     public WidgetProperty<WidgetFont> propFont()
     {


### PR DESCRIPTION
This PR is to support legacy property color_fillbackground for tank widget. It also modifies function propIdToNew() to first check getProperty() that supports legacy rules/scripts using legacy props.