### PR TITLE
Issue 683

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/actions/ContextMenuNodeAlarmHistory.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/actions/ContextMenuNodeAlarmHistory.java
@@ -27,7 +27,7 @@ import javafx.scene.image.Image;
 @SuppressWarnings("rawtypes")
 public class ContextMenuNodeAlarmHistory implements ContextMenuEntry {
 
-    private static final List<Class<?>> supportedTypes = List.of(AlarmTreeItem.class);
+    private static final Class<?> supportedType = AlarmTreeItem.class;
     private static final String NAME = "Alarm History";
 
     @Override
@@ -49,8 +49,8 @@ public class ContextMenuNodeAlarmHistory implements ContextMenuEntry {
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes() {
-        return supportedTypes;
+    public Class<?> getSupportedType() {
+        return supportedType;
     }
 
     @Override

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/actions/ContextMenuPVAlarmHistory.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/actions/ContextMenuPVAlarmHistory.java
@@ -18,15 +18,14 @@ import javafx.scene.image.Image;
 
 /**
  * A headless context menu entry for creating log entries from adaptable
- * selections. TODO this temporary headless action needs to removed once the
- * create log entry dialog is complete.
+ * selections.
  *
  * @author Kunal Shroff
  *
  */
 public class ContextMenuPVAlarmHistory implements ContextMenuEntry {
 
-    private static final List<Class<?>> supportedTypes = List.of(ProcessVariable.class);
+    private static final Class<?> supportedType = ProcessVariable.class;
     private static final String NAME = "Alarm History";
 
     @Override
@@ -48,8 +47,8 @@ public class ContextMenuPVAlarmHistory implements ContextMenuEntry {
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes() {
-        return supportedTypes;
+    public Class<?> getSupportedType() {
+        return supportedType;
     }
 
     @Override

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ChannelInfo.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ChannelInfo.java
@@ -34,7 +34,7 @@ public class ChannelInfo implements ContextMenuEntry {
     private static final String NAME = "Channel Info";
     private static final Image icon = ImageCache.getImage(ChannelTableApp.class, "/icons/channel_info.png");
 
-    private static final List<Class<?>> supportedTypes = Arrays.asList(ProcessVariable.class, Channel.class);
+    private static final Class<?> supportedTypes = Channel.class;
 
     @Override
     public String getName()
@@ -49,12 +49,11 @@ public class ChannelInfo implements ContextMenuEntry {
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes()
+    public Class<?> getSupportedType()
     {
         return supportedTypes;
     }
 
-    private ExecutorService executor = Executors.newFixedThreadPool(5);
     private ChannelFinderClient client = ChannelFinderService.getInstance().getClient();
 
     @Override
@@ -62,12 +61,9 @@ public class ChannelInfo implements ContextMenuEntry {
     {
         List<ProcessVariable> pvs = new ArrayList<>();
         List<Channel> channels = new ArrayList<>();
-        List<Object> ss = SelectionService.getInstance().getSelection().getSelections();
         SelectionService.getInstance().getSelection().getSelections().stream().forEach(s -> {
-            System.out.println(s);
             if (s instanceof Channel)
             {
-                System.out.println(((Channel)s).toString());
                 channels.add((Channel)s);
             } else if (s instanceof ProcessVariable)
             {

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
@@ -204,7 +204,7 @@ public class ChannelTableController extends ChannelFinderController {
                     ObservableList<Channel> old = tableView.getSelectionModel().getSelectedItems();
 
                     List<Object> pvs = SelectionService.getInstance().getSelection().getSelections().stream().map(s -> {
-                        return AdapterService.adapt(s, (Class)entry.getSupportedTypes().get(0)).get();
+                        return AdapterService.adapt(s, entry.getSupportedType()).get();
                     }).collect(Collectors.toList());
                     // set the selection 
                     SelectionService.getInstance().setSelection(tableView, pvs);

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeController.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTreeController.java
@@ -168,7 +168,7 @@ public class ChannelTreeController extends ChannelFinderController {
 
                     List<Object> supportedTypes = SelectionService.getInstance().getSelection().getSelections().stream()
                             .map(s -> {
-                                return AdapterService.adapt(s, (Class) entry.getSupportedTypes().get(0)).get();
+                                return AdapterService.adapt(s, entry.getSupportedType()).get();
                             }).collect(Collectors.toList());
                     // set the selection
                     SelectionService.getInstance().setSelection(treeTableView, supportedTypes);

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ContextMenuDataBrowserLauncher.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ContextMenuDataBrowserLauncher.java
@@ -24,7 +24,7 @@ import javafx.scene.image.Image;
 @SuppressWarnings("nls")
 public class ContextMenuDataBrowserLauncher implements ContextMenuEntry
 {
-    private static final List<Class<?>> supportedTypes = List.of(ProcessVariable.class);
+    private static final Class<?> supportedType = ProcessVariable.class;
 
     @Override
     public String getName()
@@ -39,9 +39,9 @@ public class ContextMenuDataBrowserLauncher implements ContextMenuEntry
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes()
+    public Class<?> getSupportedType()
     {
-        return supportedTypes;
+        return supportedType;
     }
 
     @Override

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ProbeDisplayContextMenuEntry.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ProbeDisplayContextMenuEntry.java
@@ -8,7 +8,6 @@
 package org.csstudio.display.builder.runtime.app;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 
 import org.csstudio.display.builder.model.DisplayModel;
@@ -33,14 +32,13 @@ import javafx.scene.image.Image;
 @SuppressWarnings("nls")
 public class ProbeDisplayContextMenuEntry implements ContextMenuEntry
 {
-    private static final List<Class<?>> types;
+    private static final Class<?> type;
 
     static
-    {
-        // Enable/disable the context menu entry by associating it with PV or nothing
-        types = Preferences.probe_display.isBlank()
-              ? Collections.emptyList()
-              : List.of(ProcessVariable.class);
+    {   // Enable/disable the context menu entry by associating it with PV or nothing
+        type = Preferences.probe_display.isBlank()
+              ? null
+              : ProcessVariable.class;
     }
 
     @Override
@@ -50,9 +48,9 @@ public class ProbeDisplayContextMenuEntry implements ContextMenuEntry
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes()
+    public Class<?> getSupportedType()
     {
-        return types;
+        return type;
     }
 
     @Override

--- a/app/email/src/main/java/org/phoebus/applications/email/actions/ContextCreateEmail.java
+++ b/app/email/src/main/java/org/phoebus/applications/email/actions/ContextCreateEmail.java
@@ -1,8 +1,5 @@
 package org.phoebus.applications.email.actions;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.phoebus.applications.email.EmailApp;
 import org.phoebus.framework.selection.Selection;
 import org.phoebus.framework.workbench.ApplicationService;
@@ -16,7 +13,7 @@ import org.phoebus.ui.spi.ContextMenuEntry;
  */
 public class ContextCreateEmail implements ContextMenuEntry {
 
-    private static final List<Class<?>> supportedTypes = Arrays.asList(String.class);
+    private static final Class<?> supportedType = String.class;
 
     @Override
     public String getName() {
@@ -29,7 +26,7 @@ public class ContextCreateEmail implements ContextMenuEntry {
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes() {
-        return supportedTypes;
+    public Class<?> getSupportedType() {
+        return supportedType;
     }
 }

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/ContextMenuLogging.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/ContextMenuLogging.java
@@ -20,7 +20,7 @@ import org.phoebus.ui.spi.ContextMenuEntry;
 public class ContextMenuLogging implements ContextMenuEntry {
 
     private static final String NAME = "Create Log";
-    private static final List<Class<?>> supportedTypes = Arrays.asList(LogEntry.class);
+    private static final Class<?> supportedType = LogEntry.class;
 
     @Override
     public String getName() {
@@ -41,8 +41,8 @@ public class ContextMenuLogging implements ContextMenuEntry {
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes() {
-        return supportedTypes;
+    public Class<?> getSupportedType() {
+        return supportedType;
     }
 
 }

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ContextLaunchProbe.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ContextLaunchProbe.java
@@ -1,6 +1,5 @@
 package org.phoebus.applications.probe;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.phoebus.core.types.ProcessVariable;
@@ -20,7 +19,7 @@ import javafx.scene.image.Image;
 @SuppressWarnings("nls")
 public class ContextLaunchProbe implements ContextMenuEntry {
 
-    private static final List<Class<?>> supportedTypes = Arrays.asList(ProcessVariable.class);
+    private static final Class<?> supportedTypes = ProcessVariable.class;
 
     @Override
     public String getName() {
@@ -53,7 +52,7 @@ public class ContextLaunchProbe implements ContextMenuEntry {
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes() {
+    public Class<?> getSupportedType() {
         return supportedTypes;
     }
 

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvToClipboard.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvToClipboard.java
@@ -30,7 +30,7 @@ import javafx.scene.input.ClipboardContent;
 @SuppressWarnings("nls")
 public class ContextMenuPvToClipboard implements ContextMenuEntry
 {
-    private static final List<Class<?>> supportedTypes = Arrays.asList(ProcessVariable.class);
+    private static final Class<?> supportedTypes = ProcessVariable.class;
 
     private static final Image icon = ImageCache.getImage(ImageCache.class, "/icons/copy.png");
 
@@ -47,7 +47,7 @@ public class ContextMenuPvToClipboard implements ContextMenuEntry
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes()
+    public Class<?> getSupportedType()
     {
         return supportedTypes;
     }

--- a/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
@@ -153,7 +153,10 @@ public class ProbeController {
         {
 
             menu.getItems().clear();
-            SelectionService.getInstance().setSelection("Probe", List.of(new ProcessVariable(txtPVName.getText().trim())));
+            if (!txtPVName.getText().isBlank()) {
+                SelectionService.getInstance().setSelection("Probe",
+                        List.of(new ProcessVariable(txtPVName.getText().trim())));
+            }
             ContextMenuHelper.addSupportedEntries(txtPVName, menu);
             menu.show(txtPVName.getScene().getWindow(), event.getScreenX(), event.getScreenY());
         });

--- a/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ContextMenuPVTableLauncher.java
+++ b/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ContextMenuPVTableLauncher.java
@@ -23,7 +23,7 @@ import javafx.scene.image.Image;
 @SuppressWarnings("nls")
 public class ContextMenuPVTableLauncher implements ContextMenuEntry
 {
-    private static final List<Class<?>> supportedTypes = List.of(ProcessVariable.class);
+    private static final Class<?> supportedType = ProcessVariable.class;
 
     static final Image icon = ImageCache.getImage(PVTableApplication.class, "/icons/pvtable.png");
 
@@ -40,9 +40,9 @@ public class ContextMenuPVTableLauncher implements ContextMenuEntry
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes()
+    public Class<?> getSupportedType()
     {
-        return supportedTypes;
+        return supportedType;
     }
 
     @Override

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/ContextMenuPVTreeLauncher.java
@@ -24,7 +24,7 @@ import javafx.scene.image.Image;
 @SuppressWarnings("nls")
 public class ContextMenuPVTreeLauncher implements ContextMenuEntry
 {
-    private static final List<Class<?>> supportedTypes = List.of(ProcessVariable.class);
+    private static final Class<?> supportedType = ProcessVariable.class;
 
     private static final Image icon = ImageCache.getImage(ContextMenuPVTreeLauncher.class, "/icons/pvtree.png");
 
@@ -41,9 +41,9 @@ public class ContextMenuPVTreeLauncher implements ContextMenuEntry
     }
 
     @Override
-    public List<Class<?>> getSupportedTypes()
+    public Class<?> getSupportedType()
     {
-        return supportedTypes;
+        return supportedType;
     }
 
     @Override

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuService.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuService.java
@@ -63,11 +63,9 @@ public class ContextMenuService {
             Class sc = s;
             do
             {
-                // System.out.println("Selection is of type " + sc);
                 allAdaptableSelectionType.add(sc);
                 for (Class inter : sc.getInterfaces())
                 {
-                    // System.out.println(".. and interface " + inter);
                     allAdaptableSelectionType.add(inter);
                 }
                 sc = sc.getSuperclass();
@@ -79,11 +77,12 @@ public class ContextMenuService {
             });
         });
 
-        //
+        // Return the context menu entries that can handle the given selection type,
+        // either directly or by adapting it to a supported type.
         final List<ContextMenuEntry> result = contextMenuEntries
             .stream()
             .filter(p -> {
-                  return !Collections.disjoint(p.getSupportedTypes(), allAdaptableSelectionType);
+                return allAdaptableSelectionType.contains(p.getSupportedType());
             })
             .collect(Collectors.toList());
         result.sort((a, b) -> a.getName().compareTo(b.getName()));

--- a/core/ui/src/main/java/org/phoebus/ui/spi/ContextMenuEntry.java
+++ b/core/ui/src/main/java/org/phoebus/ui/spi/ContextMenuEntry.java
@@ -44,9 +44,9 @@ public interface ContextMenuEntry {
     }
 
     /**
-     * @return Selection types for which this entry should be displayed
+     * @return Selection type for which this entry should be displayed
      */
-    public List<Class<?>> getSupportedTypes();
+    public Class<?> getSupportedType();
 
     /**
      * Invoke the context menu


### PR DESCRIPTION
I am making a change to the ContextMenuEntry Interface.
Instead of having a list of supported types each context menu entry only specifies a single supported type. This is keeping with all the examples (except 1) where the actions were associated with a single type.

This change to the Interface simplifies the ContextMenuService. 
We can still use the adapter framework to ensure that the selection can be adapted to multiple types and then used by their associated actions.

P.S. small clean up in conditional launching of probe context menu