### PR TITLE
Image widget: Allow runtime changes of `roi[0].interactive`

### DIFF
--- a/app/display/model/src/main/resources/examples/plots_image.bob
+++ b/app/display/model/src/main/resources/examples/plots_image.bob
@@ -72,8 +72,6 @@
     <interpolation>0</interpolation>
     <minimum>-1.0</minimum>
     <maximum>1.0</maximum>
-    <rois>
-    </rois>
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label_2</name>
@@ -168,8 +166,6 @@ impacts on overall perception. </text>
     <interpolation>1</interpolation>
     <minimum>-1.0</minimum>
     <maximum>1.0</maximum>
-    <rois>
-    </rois>
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label_4</name>
@@ -231,6 +227,14 @@ the value range.</text>
         </font>
       </scale_font>
     </y_axis>
+    <rules>
+      <rule name="interactive" prop_id="rois[0].interactive" out_exp="false">
+        <exp bool_exp="pv0&lt;1">
+          <value>false</value>
+        </exp>
+        <pv_name>loc://roi_interactive(1)</pv_name>
+      </rule>
+    </rules>
     <autoscale>false</autoscale>
     <minimum>-1.0</minimum>
     <maximum>1.0</maximum>
@@ -447,36 +451,26 @@ or used in a script for customized formatting.</text>
         <name>X</name>
         <width>80</width>
         <editable>true</editable>
-        <options>
-        </options>
       </column>
       <column>
         <name>Y</name>
         <width>80</width>
         <editable>true</editable>
-        <options>
-        </options>
       </column>
       <column>
         <name>Value</name>
         <width>100</width>
         <editable>true</editable>
-        <options>
-        </options>
       </column>
       <column>
         <name>Xi</name>
         <width>80</width>
         <editable>true</editable>
-        <options>
-        </options>
       </column>
       <column>
         <name>Yi</name>
         <width>80</width>
         <editable>true</editable>
-        <options>
-        </options>
       </column>
     </columns>
     <editable>false</editable>
@@ -649,5 +643,12 @@ via PVs.</text>
     <y>802</y>
     <format>1</format>
     <precision>2</precision>
+  </widget>
+  <widget type="checkbox" version="2.0.0">
+    <name>Check Box</name>
+    <pv_name>loc://roi_interactive(1)</pv_name>
+    <label>interactive</label>
+    <x>960</x>
+    <y>672</y>
   </widget>
 </display>

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -193,7 +193,15 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
             image_plot.requestUpdate();
         });
 
-        // For now _not_ listening to runtime changes of roi.interactive() or roi.file() ...
+        // Allow interactive adjustment of ROI?
+        model_roi.interactive().addPropertyListener((prop, old, interactive) ->
+        {
+            plot_roi.setInteractive(interactive);
+            // Cancel tracker which might have been active
+            if (! interactive)
+                Platform.runLater(() -> image_plot.removeROITracker());
+        });
+        // For now _not_ listening to runtime changes of roi.file() ...
 
         // Listen to roi.x_value(), .. and update plot_roi
         final WidgetPropertyListener<Double> model_roi_listener = (o, old, value) ->

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RegionOfInterest.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RegionOfInterest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import javafx.scene.paint.Color;
  *
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class RegionOfInterest
 {
     private final String name;
@@ -77,6 +78,12 @@ public class RegionOfInterest
         // Caller needs to request update of image
     }
 
+    /** @param interactive Should region be movable? */
+    public void setInteractive(final boolean interactive)
+    {
+        this.interactive = interactive;
+    }
+
     /** @return Is region interactive? */
     public boolean isInteractive()
     {
@@ -94,5 +101,11 @@ public class RegionOfInterest
     {
         this.region = region;
         // Caller needs to request update of image
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ROI '" + name + "': interactive=" + interactive;
     }
 }


### PR DESCRIPTION
In 'interactive' mode, a region of interest can be moved/resized inside the plot.
When not 'interactive', a ROI is only shown, but cannot be moved directly inside the plot.
This change allows changing that option at runtime, for example via a rule.