### PR TITLE
Databrowser AA Reader

### DIFF
--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
@@ -332,41 +332,41 @@ public abstract class ApplianceValueIterator implements ValueIterator {
             return "HIHI_ALARM";
         } else if (status == 4) {
             return "HIGH_ALARM";
-	} else if (status == 5) {
+        } else if (status == 5) {
             return "LOLO_ALARM";
-	} else if (status == 6) {
+        } else if (status == 6) {
             return "LOW_ALARM";
-	} else if (status == 7) {
+        } else if (status == 7) {
             return "STATE_ALARM";
-	} else if (status == 8) {
+        } else if (status == 8) {
             return "COS_ALARM";
-	} else if (status == 9) {
+        } else if (status == 9) {
             return "COMM_ALARM";
-	} else if (status == 10) {
+        } else if (status == 10) {
             return "TIMEOUT_ALARM";
-	} else if (status == 11) {
+        } else if (status == 11) {
             return "HW_LIMIT_ALARM";
-	} else if (status == 12) {
+        } else if (status == 12) {
             return "CALC_ALARM";
-	} else if (status == 13) {
+        } else if (status == 13) {
             return "SCAN_ALARM";
-	} else if (status == 14) {
+        } else if (status == 14) {
             return "LINK_ALARM";
-	} else if (status == 15) {
+        } else if (status == 15) {
             return "SOFT_ALARM";
-	} else if (status == 16) {
+        } else if (status == 16) {
             return "BAD_SUB_ALARM";
-	} else if (status == 17) {
+        } else if (status == 17) {
             return "UDF_ALARM";
-	} else if (status == 18) {
+        } else if (status == 18) {
             return "DISABLE_ALARM";
-	} else if (status == 19) {
+        } else if (status == 19) {
             return "SIMM_ALARM";
-	} else if (status == 20) {
+        } else if (status == 20) {
             return "READ_ACCESS_ALARM";
-	} else if (status == 21) {
+        } else if (status == 21) {
             return "WRITE_ACCESS_ALARM";
-	} else {
+        } else {
             return "UNKNOWN_ALARM";
         }
     }

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
@@ -39,6 +39,8 @@ import edu.stanford.slac.archiverappliance.PB.EPICSEvent.FieldValue;
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo;
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadType;
 
+import gov.aps.jca.dbr.Status;
+
 /**
  *
  * <code>ApplianceValueIterator</code> is the base class for different value iterators.
@@ -322,52 +324,9 @@ public abstract class ApplianceValueIterator implements ValueIterator {
      * @return alarm status
      */
     protected static String getStatus(int status) {
-        if (status == 0) {
-            return "NO_ALARM";
-        } else if (status == 1) {
-            return "READ_ALARM";
-        } else if (status == 2) {
-            return "WRITE_ALARM";
-        } else if (status == 3) {
-            return "HIHI_ALARM";
-        } else if (status == 4) {
-            return "HIGH_ALARM";
-        } else if (status == 5) {
-            return "LOLO_ALARM";
-        } else if (status == 6) {
-            return "LOW_ALARM";
-        } else if (status == 7) {
-            return "STATE_ALARM";
-        } else if (status == 8) {
-            return "COS_ALARM";
-        } else if (status == 9) {
-            return "COMM_ALARM";
-        } else if (status == 10) {
-            return "TIMEOUT_ALARM";
-        } else if (status == 11) {
-            return "HW_LIMIT_ALARM";
-        } else if (status == 12) {
-            return "CALC_ALARM";
-        } else if (status == 13) {
-            return "SCAN_ALARM";
-        } else if (status == 14) {
-            return "LINK_ALARM";
-        } else if (status == 15) {
-            return "SOFT_ALARM";
-        } else if (status == 16) {
-            return "BAD_SUB_ALARM";
-        } else if (status == 17) {
-            return "UDF_ALARM";
-        } else if (status == 18) {
-            return "DISABLE_ALARM";
-        } else if (status == 19) {
-            return "SIMM_ALARM";
-        } else if (status == 20) {
-            return "READ_ACCESS_ALARM";
-        } else if (status == 21) {
-            return "WRITE_ACCESS_ALARM";
-        } else {
-            return "UNKNOWN_ALARM";
-        }
+	String stat = String.valueOf(Status.forValue(status));
+	String key = stat.replace("gov.aps.jca.dbr.Status", "").replace("[", "").
+	    replace("]", "").replace("=", "").replaceAll("[0-9]", "");
+	return key;
     }
 }

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
@@ -324,9 +324,6 @@ public abstract class ApplianceValueIterator implements ValueIterator {
      * @return alarm status
      */
     protected static String getStatus(int status) {
-        String stat = String.valueOf(Status.forValue(status));
-        String key = stat.replace("gov.aps.jca.dbr.Status", "").replace("[", "").
-            replace("]", "").replace("=", "").replaceAll("[0-9]", "");
-        return key;
+        return Status.forValue(status).getName();
     }
 }

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
@@ -324,9 +324,9 @@ public abstract class ApplianceValueIterator implements ValueIterator {
      * @return alarm status
      */
     protected static String getStatus(int status) {
-	String stat = String.valueOf(Status.forValue(status));
-	String key = stat.replace("gov.aps.jca.dbr.Status", "").replace("[", "").
-	    replace("]", "").replace("=", "").replaceAll("[0-9]", "");
-	return key;
+        String stat = String.valueOf(Status.forValue(status));
+        String key = stat.replace("gov.aps.jca.dbr.Status", "").replace("[", "").
+            replace("]", "").replace("=", "").replaceAll("[0-9]", "");
+        return key;
     }
 }

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceValueIterator.java
@@ -148,7 +148,7 @@ public abstract class ApplianceValueIterator implements ValueIterator {
      */
     protected VType extractData(EpicsMessage dataMessage) {
         PayloadType type = mainStream.getPayLoadInfo().getType();
-        final Alarm alarm = Alarm.of(getSeverity(dataMessage.getSeverity()), AlarmStatus.CLIENT, String.valueOf(dataMessage.getStatus()));
+        final Alarm alarm = Alarm.of(getSeverity(dataMessage.getSeverity()), AlarmStatus.CLIENT, getStatus(dataMessage.getStatus()));
         final Time time = TimeHelper.fromInstant(TimestampHelper.fromSQLTimestamp(dataMessage.getTimestamp()));
 
         if (type == PayloadType.SCALAR_BYTE ||
@@ -311,6 +311,63 @@ public abstract class ApplianceValueIterator implements ValueIterator {
             return AlarmSeverity.INVALID;
         } else {
             return AlarmSeverity.UNDEFINED;
+        }
+    }
+
+    /**
+     * Determines alarm status from the given numerical representation.
+     *
+     * @param status numerical representation of alarm severity
+     *
+     * @return alarm status
+     */
+    protected static String getStatus(int status) {
+        if (status == 0) {
+            return "NO_ALARM";
+        } else if (status == 1) {
+            return "READ_ALARM";
+        } else if (status == 2) {
+            return "WRITE_ALARM";
+        } else if (status == 3) {
+            return "HIHI_ALARM";
+        } else if (status == 4) {
+            return "HIGH_ALARM";
+	} else if (status == 5) {
+            return "LOLO_ALARM";
+	} else if (status == 6) {
+            return "LOW_ALARM";
+	} else if (status == 7) {
+            return "STATE_ALARM";
+	} else if (status == 8) {
+            return "COS_ALARM";
+	} else if (status == 9) {
+            return "COMM_ALARM";
+	} else if (status == 10) {
+            return "TIMEOUT_ALARM";
+	} else if (status == 11) {
+            return "HW_LIMIT_ALARM";
+	} else if (status == 12) {
+            return "CALC_ALARM";
+	} else if (status == 13) {
+            return "SCAN_ALARM";
+	} else if (status == 14) {
+            return "LINK_ALARM";
+	} else if (status == 15) {
+            return "SOFT_ALARM";
+	} else if (status == 16) {
+            return "BAD_SUB_ALARM";
+	} else if (status == 17) {
+            return "UDF_ALARM";
+	} else if (status == 18) {
+            return "DISABLE_ALARM";
+	} else if (status == 19) {
+            return "SIMM_ALARM";
+	} else if (status == 20) {
+            return "READ_ACCESS_ALARM";
+	} else if (status == 21) {
+            return "WRITE_ACCESS_ALARM";
+	} else {
+            return "UNKNOWN_ALARM";
         }
     }
 }


### PR DESCRIPTION

![DataBrowser](https://user-images.githubusercontent.com/38105093/81442261-45501780-9141-11ea-8430-5ce2faf76a11.PNG)
This PR is to add numeric to string conversion for alarm status field in Archiver Appliance Reader. Currently, the status field in DataBrowser is displayed as a number which is not very user-friendly as most users don't know what numeric value stands for. Displaying the status as a string will be helpful to understand the alarm type. 