### PR TITLE
Support alarm auth rules per alarm server

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.ui;
 
+import org.phoebus.applications.alarm.AlarmSystem;
 import org.phoebus.applications.alarm.model.SeverityLevel;
 import org.phoebus.security.authorization.AuthorizationService;
 import org.phoebus.ui.javafx.ImageCache;
@@ -79,6 +80,10 @@ public class AlarmUI
      */
     public static boolean mayAcknowledge()
     {
+	String authStr = "alarm_ack." + AlarmSystem.config_name;
+	boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+	if (hasAuthRule)
+	    return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_ack");
     }
 
@@ -87,7 +92,35 @@ public class AlarmUI
      */
     public static boolean mayConfigure()
     {
+	String authStr = "alarm_config." + AlarmSystem.config_name;
+	boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+	if (hasAuthRule)
+	    return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_config");
+    }
+
+    /** Verify modify mode action through authorization service.
+     *  @return <code>true</code> if the user has authorization to modify maintenance/normal mode.
+     */
+    public static boolean mayModifyMode()
+    {
+	String authStr = "alarm_mode." + AlarmSystem.config_name;
+	boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+	if (hasAuthRule)
+	    return AuthorizationService.hasAuthorization(authStr);
+        return AuthorizationService.hasAuthorization("alarm_mode");
+    }
+
+    /** Verify disable_notify action through authorization service.
+     *  @return <code>true</code> if the user has authorization to disable notifications.
+     */
+    public static boolean mayDisableNotify()
+    {
+	String authStr = "alarm_notify." + AlarmSystem.config_name;
+	boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+	if (hasAuthRule)
+	    return AuthorizationService.hasAuthorization(authStr);
+        return AuthorizationService.hasAuthorization("alarm_notify");
     }
 
     /** @return Label that indicates missing server connection */

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -80,10 +80,10 @@ public class AlarmUI
      */
     public static boolean mayAcknowledge()
     {
-	String authStr = "alarm_ack." + AlarmSystem.config_name;
-	boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
-	if (hasAuthRule)
-	    return AuthorizationService.hasAuthorization(authStr);
+        String authStr = "alarm_ack." + AlarmSystem.config_name;
+        boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+        if (hasAuthRule)
+            return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_ack");
     }
 
@@ -92,10 +92,10 @@ public class AlarmUI
      */
     public static boolean mayConfigure()
     {
-	String authStr = "alarm_config." + AlarmSystem.config_name;
-	boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
-	if (hasAuthRule)
-	    return AuthorizationService.hasAuthorization(authStr);
+        String authStr = "alarm_config." + AlarmSystem.config_name;
+        boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+        if (hasAuthRule)
+            return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_config");
     }
 
@@ -104,10 +104,10 @@ public class AlarmUI
      */
     public static boolean mayModifyMode()
     {
-	String authStr = "alarm_mode." + AlarmSystem.config_name;
-	boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
-	if (hasAuthRule)
-	    return AuthorizationService.hasAuthorization(authStr);
+        String authStr = "alarm_mode." + AlarmSystem.config_name;
+        boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+        if (hasAuthRule)
+            return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_mode");
     }
 
@@ -116,10 +116,10 @@ public class AlarmUI
      */
     public static boolean mayDisableNotify()
     {
-	String authStr = "alarm_notify." + AlarmSystem.config_name;
-	boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
-	if (hasAuthRule)
-	    return AuthorizationService.hasAuthorization(authStr);
+        String authStr = "alarm_notify." + AlarmSystem.config_name;
+        boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+        if (hasAuthRule)
+            return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_notify");
     }
 

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -260,11 +260,11 @@ public class AlarmTableUI extends BorderPane
     {
         setMaintenanceMode(false);
         server_mode.setOnAction(event ->  client.setMode(! client.isMaintenanceMode()));
-	server_mode.disableProperty().bind(new SimpleBooleanProperty(!AlarmUI.mayModifyMode()));
+        server_mode.disableProperty().bind(new SimpleBooleanProperty(!AlarmUI.mayModifyMode()));
 
 	setDisableNotify(false);
         server_notify.setOnAction(event ->  client.setNotify(! client.isDisableNotify()));
-	server_notify.disableProperty().bind(new SimpleBooleanProperty(!AlarmUI.mayDisableNotify()));
+        server_notify.disableProperty().bind(new SimpleBooleanProperty(!AlarmUI.mayDisableNotify()));
 
         final Button acknowledge = new Button("", ImageCache.getImageView(AlarmUI.class, "/icons/acknowledge.png"));
         acknowledge.disableProperty().bind(Bindings.isEmpty(active.getSelectionModel().getSelectedItems()));

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -34,6 +34,7 @@ import org.phoebus.util.text.CompareNatural;
 import org.phoebus.util.time.TimestampFormats;
 
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
@@ -259,9 +260,11 @@ public class AlarmTableUI extends BorderPane
     {
         setMaintenanceMode(false);
         server_mode.setOnAction(event ->  client.setMode(! client.isMaintenanceMode()));
+	server_mode.disableProperty().bind(new SimpleBooleanProperty(!AlarmUI.mayModifyMode()));
 
 	setDisableNotify(false);
         server_notify.setOnAction(event ->  client.setNotify(! client.isDisableNotify()));
+	server_notify.disableProperty().bind(new SimpleBooleanProperty(!AlarmUI.mayDisableNotify()));
 
         final Button acknowledge = new Button("", ImageCache.getImageView(AlarmUI.class, "/icons/acknowledge.png"));
         acknowledge.disableProperty().bind(Bindings.isEmpty(active.getSelectionModel().getSelectedItems()));

--- a/core/security/src/main/java/org/phoebus/security/authorization/Authorization.java
+++ b/core/security/src/main/java/org/phoebus/security/authorization/Authorization.java
@@ -17,4 +17,10 @@ public interface Authorization
      *  @return <code>true</code> if user holds that authorization
      */
     public boolean hasAuthorization(final String authorization);
+
+    /** Check if an authorization rule exists
+     *  @param auth_rule Name of the authorization rule
+     *  @return <code>true</code> if auth rule exists
+     */
+    public boolean hasAuthorizationRule(final String auth_rule);
 }

--- a/core/security/src/main/java/org/phoebus/security/authorization/AuthorizationService.java
+++ b/core/security/src/main/java/org/phoebus/security/authorization/AuthorizationService.java
@@ -105,4 +105,16 @@ public class AuthorizationService
             return false;
         return authorizations.hasAuthorization(authorization);
     }
+
+    /** Check if an authorization rule exists
+     *  @param auth_rule Name of the authorization rule
+     *  @return <code>true</code> if authorization rule exists
+     */
+    public static boolean hasAuthorizationRule(final String auth_rule)
+    {
+        final Authorization authorizations = instance.get();
+        if (authorizations == null)
+            return false;
+        return authorizations.hasAuthorizationRule(auth_rule);
+    }
 }

--- a/core/security/src/main/java/org/phoebus/security/authorization/FileBasedAuthorization.java
+++ b/core/security/src/main/java/org/phoebus/security/authorization/FileBasedAuthorization.java
@@ -30,6 +30,7 @@ public class FileBasedAuthorization implements Authorization
 {
     private final String user_name;
     private final Authorizations user_authorizations;
+    private List<String> rules = new ArrayList<String>();
 
     public FileBasedAuthorization(final InputStream config_stream, final String user_name) throws Exception
     {
@@ -48,6 +49,7 @@ public class FileBasedAuthorization implements Authorization
         for(Entry<String, List<Pattern>> rule : rules.entrySet())
         {
             final String permission = rule.getKey();
+	    this.rules.add(permission);
             final List<Pattern> patterns = rule.getValue();
             if (userMatchesPattern(patterns))
                 authorizations.add(permission);
@@ -99,5 +101,11 @@ public class FileBasedAuthorization implements Authorization
         if (null == user_authorizations)
             return false;
         return user_authorizations.haveAuthorization(authorization);
+    }
+
+     @Override
+    public boolean hasAuthorizationRule(String auth_rule)
+    {
+        return this.rules.contains(auth_rule);
     }
 }

--- a/core/security/src/main/java/org/phoebus/security/authorization/FileBasedAuthorization.java
+++ b/core/security/src/main/java/org/phoebus/security/authorization/FileBasedAuthorization.java
@@ -49,7 +49,7 @@ public class FileBasedAuthorization implements Authorization
         for(Entry<String, List<Pattern>> rule : rules.entrySet())
         {
             final String permission = rule.getKey();
-	    this.rules.add(permission);
+            this.rules.add(permission);
             final List<Pattern> patterns = rule.getValue();
             if (userMatchesPattern(patterns))
                 authorizations.add(permission);
@@ -103,7 +103,7 @@ public class FileBasedAuthorization implements Authorization
         return user_authorizations.haveAuthorization(authorization);
     }
 
-     @Override
+    @Override
     public boolean hasAuthorizationRule(String auth_rule)
     {
         return this.rules.contains(auth_rule);

--- a/core/security/src/main/resources/authorization.conf
+++ b/core/security/src/main/resources/authorization.conf
@@ -19,12 +19,22 @@ disable_save_restore = .*
 
 # Anybody can acknowledge alarms
 alarm_ack = .*
+# To set this rule per alarm server, use alarm_ack.CONFIG_NAME = fred
 
 # Specific users may configure alarms, including both "jane" and "janet"
 #alarm_config = fred, jane.*, egon, 
 
 # Anybody can configure alarms
 alarm_config = .*
+# To set this rule per alarm server, use alarm_config.CONFIG_NAME = fred
+
+# Anybody can put alarm server in maintenance mode
+alarm_mode = .*
+# To set this rule per alarm server, use alarm_mode.CONFIG_NAME = fred
+
+# Anybody can disable alarm email notifications
+alarm_notify = .*
+# To set this rule per alarm server, use alarm_notify.CONFIG_NAME = fred
 
 # Anybody can run Display Editor
 edit_display = .*


### PR DESCRIPTION
This PR is to support 2 tasks.
1. Alarm auth rules like alarm_config, alarm_ack etc. per alarm server. See the auth.conf changes to know how to set these rules per alarm server. This is an optional change which means the existing way of alarm rules continue to work as before.  
2. New authorization rules for maintenance mode (alarm_mode) and alarm email notify disabling mode (alarm_notify).