### PR TITLE
Authorization: 'isAuthorizationDefined' instead of 'rule'

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -24,6 +24,7 @@ import javafx.scene.paint.Color;
  *
  *  <p>Icons for {@link SeverityLevel}.
  *
+ *  @author Tanvi Ashwarya
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
@@ -81,7 +82,7 @@ public class AlarmUI
     public static boolean mayAcknowledge()
     {
         String authStr = "alarm_ack." + AlarmSystem.config_name;
-        boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+        boolean hasAuthRule = AuthorizationService.isAuthorizationDefined(authStr);
         if (hasAuthRule)
             return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_ack");
@@ -93,7 +94,7 @@ public class AlarmUI
     public static boolean mayConfigure()
     {
         String authStr = "alarm_config." + AlarmSystem.config_name;
-        boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+        boolean hasAuthRule = AuthorizationService.isAuthorizationDefined(authStr);
         if (hasAuthRule)
             return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_config");
@@ -105,7 +106,7 @@ public class AlarmUI
     public static boolean mayModifyMode()
     {
         String authStr = "alarm_mode." + AlarmSystem.config_name;
-        boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+        boolean hasAuthRule = AuthorizationService.isAuthorizationDefined(authStr);
         if (hasAuthRule)
             return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_mode");
@@ -117,7 +118,7 @@ public class AlarmUI
     public static boolean mayDisableNotify()
     {
         String authStr = "alarm_notify." + AlarmSystem.config_name;
-        boolean hasAuthRule = AuthorizationService.hasAuthorizationRule(authStr);
+        boolean hasAuthRule = AuthorizationService.isAuthorizationDefined(authStr);
         if (hasAuthRule)
             return AuthorizationService.hasAuthorization(authStr);
         return AuthorizationService.hasAuthorization("alarm_notify");

--- a/core/security/src/main/java/org/phoebus/security/authorization/Authorization.java
+++ b/core/security/src/main/java/org/phoebus/security/authorization/Authorization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,19 +8,35 @@
 package org.phoebus.security.authorization;
 
 /** Authorization support
+ *
+ *  <p>'authorization' describes something that a user may
+ *  be permitted to do.
+ *  Each application module can define its own authorizations.
+ *  For example, the alarm UI uses the 'alarm_ack' authorization
+ *  to determine if the current user may acknowledge alarms.
+ *
  *  @author Evan Smith
+ *  @author Tanvi Ashwarya
+ *  @author Kay Kasemir
  */
 public interface Authorization
 {
+    /** Check if an authorization has been defined,
+     *  i.e. if the authorization settings contain
+     *  a specific entry for this authorization.
+     *
+     *  <p>Note that authorizations that are not specifically
+     *  provided are not categorically denied.
+     *  Instead, they fall back to the "FULL" authorization.
+     *
+     *  @param authorization Name of the authorization rule
+     *  @return <code>true</code> if auth rule exists
+     */
+    public boolean isAuthorizationDefined(final String authorization);
+
     /** Check if current user is authorized to do something
      *  @param authorization Name of the authorization
      *  @return <code>true</code> if user holds that authorization
      */
     public boolean hasAuthorization(final String authorization);
-
-    /** Check if an authorization rule exists
-     *  @param auth_rule Name of the authorization rule
-     *  @return <code>true</code> if auth rule exists
-     */
-    public boolean hasAuthorizationRule(final String auth_rule);
 }

--- a/core/security/src/main/java/org/phoebus/security/authorization/AuthorizationService.java
+++ b/core/security/src/main/java/org/phoebus/security/authorization/AuthorizationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,8 @@ import org.phoebus.framework.workbench.Locations;
 import org.phoebus.security.PhoebusSecurity;
 
 /** Authorization Service
- *  @author Evan Smith
+ *  @author Tanvi Ashwarya
+ *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
 public class AuthorizationService
@@ -39,7 +40,7 @@ public class AuthorizationService
             final String filename = PhoebusSecurity.authorization_file;
             final String httpPrefix = "http://";
             final String httpsPrefix = "https://";
-            
+
             if (filename.isEmpty())
             {
                 logger.log(Level.CONFIG, "Using " + PhoebusSecurity.class.getResource("/authorization.conf"));
@@ -85,13 +86,26 @@ public class AuthorizationService
     }
 
     /** Initialize service with an existing instance of a custom class
-     *  implementing Authorization interface 
+     *  implementing Authorization interface
      *  @param auth custom Authorization object
      */
-    public static void init(Authorization auth)
+    public static void init(final Authorization auth)
     {
         if (instance.getAndSet(auth) != null)
             logger.log(Level.SEVERE, "Authorization is initialized more than once (" + auth.toString() + ")");
+    }
+
+
+    /** Check if an authorization is defined
+     *  @param authorization Name of the authorization
+     *  @return <code>true</code> if authorization is defined
+     */
+    public static boolean isAuthorizationDefined(final String authorization)
+    {
+        final Authorization authorizations = instance.get();
+        if (authorizations == null)
+            return false;
+        return authorizations.isAuthorizationDefined(authorization);
     }
 
     /** Check if current user is authorized to do something
@@ -104,17 +118,5 @@ public class AuthorizationService
         if (authorizations == null)
             return false;
         return authorizations.hasAuthorization(authorization);
-    }
-
-    /** Check if an authorization rule exists
-     *  @param auth_rule Name of the authorization rule
-     *  @return <code>true</code> if authorization rule exists
-     */
-    public static boolean hasAuthorizationRule(final String auth_rule)
-    {
-        final Authorization authorizations = instance.get();
-        if (authorizations == null)
-            return false;
-        return authorizations.hasAuthorizationRule(auth_rule);
     }
 }

--- a/core/security/src/main/java/org/phoebus/security/authorization/FileBasedAuthorization.java
+++ b/core/security/src/main/java/org/phoebus/security/authorization/FileBasedAuthorization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 
 /** File Based Authorization Implementation
  *  @author Evan Smith
+ *  @author Tanvi Ashwarya
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
@@ -30,7 +31,7 @@ public class FileBasedAuthorization implements Authorization
 {
     private final String user_name;
     private final Authorizations user_authorizations;
-    private List<String> rules = new ArrayList<String>();
+    private final List<String> rules = new ArrayList<>();
 
     public FileBasedAuthorization(final InputStream config_stream, final String user_name) throws Exception
     {
@@ -96,16 +97,16 @@ public class FileBasedAuthorization implements Authorization
     }
 
     @Override
-    public boolean hasAuthorization(String authorization)
+    public boolean isAuthorizationDefined(final String authorization)
+    {
+        return this.rules.contains(authorization);
+    }
+
+    @Override
+    public boolean hasAuthorization(final String authorization)
     {
         if (null == user_authorizations)
             return false;
         return user_authorizations.haveAuthorization(authorization);
-    }
-
-    @Override
-    public boolean hasAuthorizationRule(String auth_rule)
-    {
-        return this.rules.contains(auth_rule);
     }
 }

--- a/core/security/src/main/resources/authorization.conf
+++ b/core/security/src/main/resources/authorization.conf
@@ -19,25 +19,38 @@ disable_save_restore = .*
 
 # Anybody can acknowledge alarms
 alarm_ack = .*
-# To set this rule per alarm server, use alarm_ack.CONFIG_NAME = fred
 
 # Specific users may configure alarms, including both "jane" and "janet"
 #alarm_config = fred, jane.*, egon, 
 
 # Anybody can configure alarms
 alarm_config = .*
-# To set this rule per alarm server, use alarm_config.CONFIG_NAME = fred
 
 # Anybody can put alarm server in maintenance mode
 alarm_mode = .*
-# To set this rule per alarm server, use alarm_mode.CONFIG_NAME = fred
 
 # Anybody can disable alarm email notifications
 alarm_notify = .*
-# To set this rule per alarm server, use alarm_notify.CONFIG_NAME = fred
+
+# The alarm UI also supports further qualification by CONFIG_NAME,
+# where CONFIG_NAME would for example be "Accelerator".
+# To allow a specific user to acknowledge, configure, ..
+# alarms for a specific CONFIG_NAME, use
+#
+#   alarm_ack.CONFIG_NAME = fred
+#   alarm_config.CONFIG_NAME = fred
+#   alarm_mode.CONFIG_NAME = fred
+#   alarm_notify.CONFIG_NAME = fred
+#
+# If there is no alarm_*.CONFIG_NAME setting defined for a specific
+# CONFIG_NAME, the plain alarm_* setting is used.
+
 
 # Anybody can run Display Editor
 edit_display = .*
 
+
 # Full authorization.
+# Users listed for "FULL" authorization are granted
+# all authorizations, no matter if they are listed above or not.
 FULL = root

--- a/core/security/src/test/java/org/phoebus/security/authorization/AuthorizationServiceTest.java
+++ b/core/security/src/test/java/org/phoebus/security/authorization/AuthorizationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,9 +48,17 @@ public class AuthorizationServiceTest
             assertTrue(as.hasAuthorization("alarm_config"));
         }
 
+        assertTrue(as.isAuthorizationDefined("alarm_ack"));
+        // 'bogus' is not defined, and not granted
+        assertFalse(as.isAuthorizationDefined("bogus"));
+        assertFalse(as.hasAuthorization("bogus"));
+
         // FULL
         as = createAuthorization("root");
         assertTrue(as.hasAuthorization("alarm_ack"));
         assertTrue(as.hasAuthorization("alarm_config"));
+        // 'bogus' is not defined, but covered by FULL=root
+        assertFalse(as.isAuthorizationDefined("bogus"));
+        assertTrue(as.hasAuthorization("bogus"));
     }
 }


### PR DESCRIPTION
 #1320 added to the authorization API so that the alarm UI could handle specific alarm configurations different from others.
No change to functionality, but clarifying the new API by calling it 'isAuthorizationDefined',  avoiding use of 'rule' which might promise too much or get confused with display rules.
Adding comments and test.
