### PR TITLE
Update config_name when change_handler is invoked

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
@@ -57,7 +57,7 @@ public class AlarmSystem
     public static final String server;
 
     /** Name of alarm tree root */
-    public static final String config_name;
+    public static String config_name;
 
     /** Names of selectable alarm configurations */
     public static final List<String> config_names;

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
@@ -56,8 +56,12 @@ public class AlarmSystem
     /** Kafka Server host:port */
     public static final String server;
 
-    /** Name of alarm tree root */
-    public static String config_name;
+    /** Name of alarm tree root
+     *
+     *  <p>Initial name from preferences,
+     *  potentially changed via UI to the last selected name.
+     */
+    public static volatile String config_name;
 
     /** Names of selectable alarm configurations */
     public static final List<String> config_names;

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmConfigSelector.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmConfigSelector.java
@@ -30,6 +30,10 @@ public class AlarmConfigSelector extends ChoiceBox<String>
     {
         getItems().setAll(AlarmSystem.config_names);
         setValue(initial_config_name);
-        setOnAction(event -> change_handler.accept(getValue()));
+        setOnAction(event ->
+        {
+            AlarmSystem.config_name = getValue();
+            change_handler.accept(AlarmSystem.config_name);
+        });
     }
 }


### PR DESCRIPTION
Currently AlarmSystem.config_name is final string, this PR updates config_name when change_handler is invoked so auth functions mayAcknowledge(), mayConfigure() etc. gets the current config name when it is changed from the default value.