### PR TITLE
Scan debug

### DIFF
--- a/app/scan/model/src/main/java/org/csstudio/scan/device/DeviceInfo.java
+++ b/app/scan/model/src/main/java/org/csstudio/scan/device/DeviceInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ public class DeviceInfo
 {
     final private String name;
     final private String alias;
-    private String status;
+    final private String status;
 
     /** Initialize
      *  @param name Device name as understood by the control system
@@ -66,7 +66,7 @@ public class DeviceInfo
         return alias;
     }
 
-    /** @return Status of the device, for display purpose */
+    /** @return Status of the device, for display purpose. Must not be <code>null</code> */
     public String getStatus()
     {
         return status;

--- a/app/scan/model/src/main/java/org/csstudio/scan/device/VTypeHelper.java
+++ b/app/scan/model/src/main/java/org/csstudio/scan/device/VTypeHelper.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.scan.device;
+
+import static org.csstudio.scan.ScanSystem.logger;
+
+import java.util.logging.Level;
+
+
+/** Compatibility wrapper for legacy scripts
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class VTypeHelper extends org.phoebus.core.vtypes.VTypeHelper
+{
+    static
+    {
+        logger.log(Level.WARNING,
+                   "Legacy code accessed org.csstudio.scan.device.VTypeHelper, update to org.phoebus.core.vtypes.VTypeHelper",
+                   new Exception("Call stack"));
+    }
+}

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/ScanServerInstance.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/ScanServerInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -230,6 +230,7 @@ public class ScanServerInstance
                     iter.remove();
                     final String filename = iter.next();
                     iter.remove();
+                    logger.info("Loading log settings from " + filename);
                     LogManager.getLogManager().readConfiguration(new FileInputStream(filename));
                 }
                 else if (cmd.equals("-noshell"))

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/device/PVDevice.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/device/PVDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,10 +30,10 @@ import org.epics.vtype.Time;
 import org.epics.vtype.VByteArray;
 import org.epics.vtype.VString;
 import org.epics.vtype.VType;
+import org.phoebus.core.vtypes.VTypeHelper;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 import org.phoebus.util.time.TimeDuration;
-import org.phoebus.core.vtypes.VTypeHelper;
 
 import io.reactivex.disposables.Disposable;
 
@@ -124,7 +124,12 @@ public class PVDevice extends Device
         if (pv.get() == null)
             return "no PV";
         else
-            return VTypeHelper.toString(value.get());
+        {
+            final VType v = value.get();
+            if (PV.isDisconnected(v))
+                return Alarm.disconnected().getName();
+            return VTypeHelper.toString(v);
+        }
     }
 
     /** {@inheritDoc} */

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ScanServlet.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ScanServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2012-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,7 @@ public class ScanServlet extends HttpServlet
     {
         // Require XML: "text/xml", "text/xml; charset=UTF-8", ...
         final String format = request.getContentType();
+        logger.log(Level.FINE, () -> "POST scan " + format);
         if (! format.contains("/xml"))
         {
             logger.log(Level.WARNING, "POST /scan got format '" + format + "'");
@@ -87,6 +88,9 @@ public class ScanServlet extends HttpServlet
         // Submit scan
         try
         {
+            if (logger.isLoggable(Level.FINE))
+                logger.log(Level.FINE, "Scan '" + scan_name + "':\n" + scan_commands);
+
             final long scan_id = scan_server.submitScan(scan_name, scan_commands, queue, pre_post);
 
             // Return scan ID

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/SimulateServlet.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/SimulateServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2013-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,7 @@ public class SimulateServlet extends HttpServlet
     {
         // Require XML: "text/xml", "text/xml; charset=UTF-8", ...
         final String format = request.getContentType();
+        logger.log(Level.FINE, () -> "POST simulate " + format);
         if (! format.contains("/xml"))
         {
             logger.log(Level.WARNING, "POST /simulate got format '" + format + "'");
@@ -59,6 +60,9 @@ public class SimulateServlet extends HttpServlet
         // Simulate scan
         try
         {
+            if (logger.isLoggable(Level.FINE))
+                logger.log(Level.FINE, "Commands for simulation:\n" + scan_commands);
+
             final SimulationResult simulation = scan_server.simulateScan(scan_commands);
             // Return scan ID
             out.println("<simulation>");

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/internal/ScanServerImpl.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/internal/ScanServerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -199,11 +199,25 @@ public class ScanServerImpl implements ScanServer
             {
                 pre_commands = new ArrayList<>();
                 for (String path : ScanServerInstance.getScanConfig().getPreScanPaths())
-                    pre_commands.addAll(XMLCommandReader.readXMLStream(PathStreamTool.openStream(path)));
+                    try
+                    {
+                        pre_commands.addAll(XMLCommandReader.readXMLStream(PathStreamTool.openStream(path)));
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("Pre-scan parse errro in " + path, ex);
+                    }
 
                 post_commands = new ArrayList<>();
                 for (String path : ScanServerInstance.getScanConfig().getPostScanPaths())
-                    post_commands.addAll(XMLCommandReader.readXMLStream(PathStreamTool.openStream(path)));
+                    try
+                    {
+                        post_commands.addAll(XMLCommandReader.readXMLStream(PathStreamTool.openStream(path)));
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("Post-scan parse errro in " + path, ex);
+                    }
             }
             else
                 pre_commands = post_commands = Collections.emptyList();

--- a/services/scan-server/src/main/resources/debug_logging.properties
+++ b/services/scan-server/src/main/resources/debug_logging.properties
@@ -32,4 +32,4 @@ com.cosylab.epics.caj.level = WARNING
 org.phoebus.framework.rdb.level = WARNING
 org.phoebus.pv.level = WARNING
 
-org.csstudio.scan.server.level = CONFIG
+org.csstudio.scan.server.level = FINE

--- a/services/scan-server/src/main/resources/examples/simulationhookdemo.py
+++ b/services/scan-server/src/main/resources/examples/simulationhookdemo.py
@@ -1,5 +1,5 @@
 from org.csstudio.scan.server import SimulationHook
-from org.csstudio.scan.device import VTypeHelper
+from org.phoebus.core.vtypes import VTypeHelper
 
 class SimulationHookDemo(SimulationHook):
 


### PR DESCRIPTION
Extend logging at FINE level to show received commands.
Indicate if parse errors are in pre/post scan as opposed to main section.
Add wrapper for removed VTypeHelper to support older scripts.