### PR TITLE
Resize crop

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -95,6 +95,7 @@ public class Messages
     public static String PointType_X;
     public static String Resize_Container;
     public static String Resize_Content;
+    public static String Resize_Crop;
     public static String Resize_None;
     public static String Resize_Stretch;
     public static String Right;

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -77,7 +77,10 @@ public class EmbeddedDisplayWidget extends MacroWidget
         /** Stretch the embedded content to fit the container,
          *  separately scaling the horizontal and vertical size
          */
-        StretchContent(Messages.Resize_Stretch);
+        StretchContent(Messages.Resize_Stretch),
+
+        /** No resize, but also no scroll bars. Oversized content is cropped */
+        Crop(Messages.Resize_Crop);
 
         private final String label;
 
@@ -160,13 +163,18 @@ public class EmbeddedDisplayWidget extends MacroWidget
                 {
                     try
                     {   // 0=SIZE_OPI_TO_CONTAINER, 1=SIZE_CONTAINER_TO_OPI, 2=CROP_OPI, 3=SCROLL_OPI
+                        // Problem with any resize is that we now use the content's connfigured width x height
+                        // as size, while the legacy implementation self-determined the size and
+                        // width x height were usually not configured.
+                        // This likely results in unexpected resizing until the size of the legacy display file
+                        // (which doesn't matter to the legacy tool) gets configured.
                         final int old_resize = Integer.parseInt(XMLUtil.getString(element));
                         if (old_resize == 0)
                             widget.setPropertyValue(propResize, Resize.ResizeContent);
                         else if (old_resize == 1)
                             widget.setPropertyValue(propResize, Resize.SizeToContent);
-                        else
-                            widget.setPropertyValue(propResize, Resize.None);
+                        else // 'scroll' or 'crop' -> crop
+                            widget.setPropertyValue(propResize, Resize.Crop);
                     }
                     catch (NumberFormatException ex)
                     {

--- a/app/display/model/src/main/resources/examples/embedded/structure_embedded.bob
+++ b/app/display/model/src/main/resources/examples/embedded/structure_embedded.bob
@@ -4,8 +4,8 @@
   <macros>
     <groupname>MacroGroupName</groupname>
   </macros>
-  <width>1200</width>
-  <height>1000</height>
+  <width>1260</width>
+  <height>980</height>
   <widget type="label" version="2.0.0">
     <name>Label</name>
     <class>TITLE</class>
@@ -39,10 +39,10 @@ are always a compromise that often results in inconsistent widget sizes.</text>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>Embedded</name>
-    <file>embedded.bob</file>
     <macros>
       <X>No resize</X>
     </macros>
+    <file>embedded.bob</file>
     <x>1</x>
     <y>217</y>
     <width>140</width>
@@ -58,10 +58,10 @@ are always a compromise that often results in inconsistent widget sizes.</text>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>Embedded</name>
-    <file>embedded.bob</file>
     <macros>
       <X>Content shrinks</X>
     </macros>
+    <file>embedded.bob</file>
     <x>181</x>
     <y>217</y>
     <width>140</width>
@@ -78,10 +78,10 @@ are always a compromise that often results in inconsistent widget sizes.</text>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>Embedded</name>
-    <file>embedded.bob</file>
     <macros>
       <X>Widget grows</X>
     </macros>
+    <file>embedded.bob</file>
     <x>361</x>
     <y>217</y>
     <width>180</width>
@@ -98,10 +98,10 @@ are always a compromise that often results in inconsistent widget sizes.</text>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>Embedded_1</name>
-    <file>embedded.bob</file>
     <macros>
       <X>Content gets distorted</X>
     </macros>
+    <file>embedded.bob</file>
     <x>570</x>
     <y>217</y>
     <width>460</width>
@@ -126,20 +126,20 @@ then shows several motors via the Embedded Display Widget:</text>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>Embedded Display_1</name>
-    <file>motor.bob</file>
     <macros>
       <M>XPos</M>
     </macros>
+    <file>motor.bob</file>
     <y>481</y>
     <width>320</width>
     <height>210</height>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>Embedded Display_1</name>
-    <file>motor.bob</file>
     <macros>
       <M>YPos</M>
     </macros>
+    <file>motor.bob</file>
     <x>310</x>
     <y>481</y>
     <width>320</width>
@@ -167,10 +167,10 @@ This example updates the display file name from a script.</text>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>group_name_ex_1</name>
-    <file>template.bob</file>
     <macros>
       <pv_name>sim://sine</pv_name>
     </macros>
+    <file>template.bob</file>
     <x>651</x>
     <y>481</y>
     <width>160</width>
@@ -188,10 +188,10 @@ template or master display, possibly setting different macros.</text>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>group_name_ex_2</name>
-    <file>template.bob</file>
     <macros>
       <pv_name>sim://sine</pv_name>
     </macros>
+    <file>template.bob</file>
     <x>821</x>
     <y>481</y>
     <width>160</width>
@@ -200,10 +200,10 @@ template or master display, possibly setting different macros.</text>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>group_name_ex_3</name>
-    <file>template.bob</file>
     <macros>
       <pv_name>sim://ramp(1,5,.5)</pv_name>
     </macros>
+    <file>template.bob</file>
     <x>981</x>
     <y>481</y>
     <width>160</width>
@@ -212,10 +212,10 @@ template or master display, possibly setting different macros.</text>
   </widget>
   <widget type="embedded" version="2.0.0">
     <name>group_name_ex_4</name>
-    <file>template.bob</file>
     <macros>
       <pv_name>sim://ramp(1,5,.5)</pv_name>
     </macros>
+    <file>template.bob</file>
     <x>651</x>
     <y>701</y>
     <width>170</width>
@@ -251,5 +251,25 @@ the display provided in the macro.</text>
     <y>701</y>
     <width>250</width>
     <height>119</height>
+  </widget>
+  <widget type="embedded" version="2.0.0">
+    <name>Embedded_2</name>
+    <macros>
+      <X>Content gets cropped</X>
+    </macros>
+    <file>embedded.bob</file>
+    <x>1060</x>
+    <y>217</y>
+    <width>200</width>
+    <height>123</height>
+    <resize>4</resize>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_8</name>
+    <text>Crop</text>
+    <x>1060</x>
+    <y>187</y>
+    <width>180</width>
+    <height>26</height>
   </widget>
 </display>

--- a/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
+++ b/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
@@ -79,6 +79,7 @@ PointType_Triangles=Triangles
 PointType_X=X
 Resize_Container=Size widget to match content
 Resize_Content=Size content to fit widget
+Resize_Crop=Crop content
 Resize_None=No Resize
 Resize_Stretch=Stretch content to fit widget
 Right=Right

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -364,6 +364,13 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
                 zoom.setY(1.0);
                 scroll.setHbarPolicy(ScrollBarPolicy.AS_NEEDED);
                 scroll.setVbarPolicy(ScrollBarPolicy.AS_NEEDED);
+            }
+            else if (resize == Resize.Crop)
+            {
+                zoom.setX(1.0);
+                zoom.setY(1.0);
+                scroll.setHbarPolicy(ScrollBarPolicy.NEVER);
+                scroll.setVbarPolicy(ScrollBarPolicy.NEVER);
             }
             else if (resize == Resize.ResizeContent  ||  resize == Resize.StretchContent )
             {


### PR DESCRIPTION
@tanviash  had reported issues with the original *.opi import where `Resize: None` resulted in too many scrollbars.
This adds a new `Resize: Crop` option to embedded display widget and uses that when importing *.opi files.
