### PR TITLE
Alarm UI: Track/update authorizations per instance of alarm table, tree

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,10 +58,11 @@ public class AlarmSystem
 
     /** Name of alarm tree root
      *
-     *  <p>Initial name from preferences,
-     *  potentially changed via UI to the last selected name.
+     *  <p>Default name from preferences.
+     *  UI instances may select different one at runtime,
+     *  but this remains unchanged.
      */
-    public static volatile String config_name;
+    public static final String config_name;
 
     /** Names of selectable alarm configurations */
     public static final List<String> config_names;
@@ -140,7 +141,7 @@ public class AlarmSystem
         automated_action_followup = getItems(prefs.get("automated_action_followup"));
         heartbeat_pv = prefs.get("heartbeat_pv");
         heartbeat_ms = prefs.getInt("heartbeat_secs") * 1000L;
-	disable_notify_visible = prefs.getBoolean("disable_notify_visible");
+        disable_notify_visible = prefs.getBoolean("disable_notify_visible");
 
         double secs = 0.0;
         try

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -74,7 +74,7 @@ public class AlarmClient
         consumer = KafkaHelper.connectConsumer(server, topics, topics);
         producer = KafkaHelper.connectProducer(server);
 
-        thread = new Thread(this::run, "AlarmClientModel");
+        thread = new Thread(this::run, "AlarmClientModel " + config_name);
         thread.setDaemon(true);
     }
 
@@ -541,9 +541,9 @@ public class AlarmClient
         }
         catch (final InterruptedException ex)
         {
-            logger.log(Level.WARNING, "Alarm client thread doesn't shut down", ex);
+            logger.log(Level.WARNING, thread.getName() + " thread doesn't shut down", ex);
         }
-        logger.info(thread.getName() + " shut down");
+        logger.log(Level.INFO, () -> thread.getName() + " shut down");
 
     }
 }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmConfigSelector.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmConfigSelector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,10 +30,6 @@ public class AlarmConfigSelector extends ChoiceBox<String>
     {
         getItems().setAll(AlarmSystem.config_names);
         setValue(initial_config_name);
-        setOnAction(event ->
-        {
-            AlarmSystem.config_name = getValue();
-            change_handler.accept(AlarmSystem.config_name);
-        });
+        setOnAction(event -> change_handler.accept(getValue()));
     }
 }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmContextMenuHelper.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmContextMenuHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -120,7 +120,7 @@ public class AlarmContextMenuHelper
         added.clear();
         count.set(0);
 
-        if (AlarmUI.mayAcknowledge())
+        if (AlarmUI.mayAcknowledge(model))
         {
             if (active.size() > 0)
                 menu_items.add(new AcknowledgeAction(model, active));

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.ui;
 
-import org.phoebus.applications.alarm.AlarmSystem;
+import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.model.SeverityLevel;
 import org.phoebus.security.authorization.AuthorizationService;
 import org.phoebus.ui.javafx.ImageCache;
@@ -76,52 +76,56 @@ public class AlarmUI
         return severity_icons[severity.ordinal()];
     }
 
+    /** Verify authorization, qualified by model's current config
+     *  @param model Alarm client model
+     *  @param auto Authorization name
+     *  @return <code>true</code> if the user has authorization
+     */
+    private static boolean haveQualifiedAuthorization(final AlarmClient model, final String authorization)
+    {
+        if (model != null)
+        {   // Check for authorization specific to this alarm model
+            final String qualified = authorization + "." + model.getRoot().getName();
+            if (AuthorizationService.isAuthorizationDefined(qualified))
+                return AuthorizationService.hasAuthorization(qualified);
+        }
+        return AuthorizationService.hasAuthorization(authorization);
+    }
+
     /** Verify acknowledge action through authorization service.
+     *  @param model Alarm client model
      *  @return <code>true</code> if the user has authorization to acknowledge.
      */
-    public static boolean mayAcknowledge()
+    public static boolean mayAcknowledge(final AlarmClient model)
     {
-        String authStr = "alarm_ack." + AlarmSystem.config_name;
-        boolean hasAuthRule = AuthorizationService.isAuthorizationDefined(authStr);
-        if (hasAuthRule)
-            return AuthorizationService.hasAuthorization(authStr);
-        return AuthorizationService.hasAuthorization("alarm_ack");
+        return haveQualifiedAuthorization(model, "alarm_ack");
     }
 
     /** Verify configure action through authorization service.
+     *  @param model Alarm client model
      *  @return <code>true</code> if the user has authorization to configure.
      */
-    public static boolean mayConfigure()
+    public static boolean mayConfigure(final AlarmClient model)
     {
-        String authStr = "alarm_config." + AlarmSystem.config_name;
-        boolean hasAuthRule = AuthorizationService.isAuthorizationDefined(authStr);
-        if (hasAuthRule)
-            return AuthorizationService.hasAuthorization(authStr);
-        return AuthorizationService.hasAuthorization("alarm_config");
+        return haveQualifiedAuthorization(model, "alarm_config");
     }
 
     /** Verify modify mode action through authorization service.
+     *  @param model Alarm client model
      *  @return <code>true</code> if the user has authorization to modify maintenance/normal mode.
      */
-    public static boolean mayModifyMode()
+    public static boolean mayModifyMode(final AlarmClient model)
     {
-        String authStr = "alarm_mode." + AlarmSystem.config_name;
-        boolean hasAuthRule = AuthorizationService.isAuthorizationDefined(authStr);
-        if (hasAuthRule)
-            return AuthorizationService.hasAuthorization(authStr);
-        return AuthorizationService.hasAuthorization("alarm_mode");
+        return haveQualifiedAuthorization(model, "alarm_mode");
     }
 
     /** Verify disable_notify action through authorization service.
+     *  @param model Alarm client model
      *  @return <code>true</code> if the user has authorization to disable notifications.
      */
-    public static boolean mayDisableNotify()
+    public static boolean mayDisableNotify(final AlarmClient model)
     {
-        String authStr = "alarm_notify." + AlarmSystem.config_name;
-        boolean hasAuthRule = AuthorizationService.isAuthorizationDefined(authStr);
-        if (hasAuthRule)
-            return AuthorizationService.hasAuthorization(authStr);
-        return AuthorizationService.hasAuthorization("alarm_notify");
+        return haveQualifiedAuthorization(model, "alarm_notify");
     }
 
     /** @return Label that indicates missing server connection */

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,6 @@ import org.phoebus.util.text.CompareNatural;
 import org.phoebus.util.time.TimestampFormats;
 
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
@@ -111,7 +110,7 @@ public class AlarmTableUI extends BorderPane
 
     private final Button server_notify = new Button();
 
-    private ToolBar toolbar = createToolbar();
+    private final ToolBar toolbar;
 
     /** Enable dragging the PV name from a table cell.
      *  @param cell Table cell
@@ -226,6 +225,8 @@ public class AlarmTableUI extends BorderPane
     {
         this.client = client;
 
+        toolbar = createToolbar();
+
         // When user resizes columns, update them in the 'other' table
         active.setColumnResizePolicy(new LinkedColumnResize(active, acknowledged));
         acknowledged.setColumnResizePolicy(new LinkedColumnResize(acknowledged, active));
@@ -260,11 +261,18 @@ public class AlarmTableUI extends BorderPane
     {
         setMaintenanceMode(false);
         server_mode.setOnAction(event ->  client.setMode(! client.isMaintenanceMode()));
-        server_mode.disableProperty().bind(new SimpleBooleanProperty(!AlarmUI.mayModifyMode()));
 
-	setDisableNotify(false);
+        // Could 'bind',
+        //   server_mode.disableProperty().bind(new SimpleBooleanProperty(!AlarmUI.mayModifyMode(client)));
+        // but mayModifyModel is not observable, plus setting it only when _disabled_
+        // means no actual property is created for the default value, enabled.
+        if (!AlarmUI.mayModifyMode(client))
+            server_mode.setDisable(true);
+
+        setDisableNotify(false);
         server_notify.setOnAction(event ->  client.setNotify(! client.isDisableNotify()));
-        server_notify.disableProperty().bind(new SimpleBooleanProperty(!AlarmUI.mayDisableNotify()));
+        if (!AlarmUI.mayDisableNotify(client))
+            server_notify.setDisable(true);
 
         final Button acknowledge = new Button("", ImageCache.getImageView(AlarmUI.class, "/icons/acknowledge.png"));
         acknowledge.disableProperty().bind(Bindings.isEmpty(active.getSelectionModel().getSelectedItems()));
@@ -285,12 +293,10 @@ public class AlarmTableUI extends BorderPane
         search.setTooltip(new Tooltip("Enter pattern ('vac', 'amp*trip')\nfor PV Name or Description,\npress RETURN to select"));
         search.textProperty().addListener(prop -> selectRows());
 
-	if (AlarmSystem.disable_notify_visible)
-	{
-	    return new ToolBar(active_count,ToolbarHelper.createStrut(), ToolbarHelper.createSpring(), server_mode, server_notify, acknowledge, unacknowledge, search);
-	}
+    	if (AlarmSystem.disable_notify_visible)
+    	    return new ToolBar(active_count,ToolbarHelper.createStrut(), ToolbarHelper.createSpring(), server_mode, server_notify, acknowledge, unacknowledge, search);
 
-	return new ToolBar(active_count,ToolbarHelper.createStrut(), ToolbarHelper.createSpring(), server_mode, acknowledge, unacknowledge, search);
+    	return new ToolBar(active_count,ToolbarHelper.createStrut(), ToolbarHelper.createSpring(), server_mode, acknowledge, unacknowledge, search);
     }
 
     /** Show if connected to server or not
@@ -335,7 +341,7 @@ public class AlarmTableUI extends BorderPane
 
         }
     }
-    
+
     private TableView<AlarmInfoRow> createTable(final ObservableList<AlarmInfoRow> rows,
                                                 final boolean active)
     {
@@ -454,7 +460,7 @@ public class AlarmTableUI extends BorderPane
             if (menu_items.size() > 0)
                 menu_items.add(new SeparatorMenuItem());
 
-            if (AlarmUI.mayConfigure()  &&   selection.size() == 1)
+            if (AlarmUI.mayConfigure(client)  &&   selection.size() == 1)
             {
                 menu_items.add(new ConfigureComponentAction(table, client, selection.get(0)));
                 menu_items.add(new SeparatorMenuItem());

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -418,7 +418,7 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
             if (menu_items.size() > 0)
                 menu_items.add(new SeparatorMenuItem());
 
-            if (AlarmUI.mayConfigure())
+            if (AlarmUI.mayConfigure(model))
             {
                 if (selection.size() <= 0)
                     // Add first item to empty config
@@ -461,7 +461,7 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
     {
         tree_view.setOnMouseClicked(event ->
         {
-            if (!AlarmUI.mayConfigure()       ||
+            if (!AlarmUI.mayConfigure(model)       ||
                 event.getClickCount() != 2    ||
                 tree_view.getSelectionModel().getSelectedItems().size() != 1)
                 return;


### PR DESCRIPTION
When updating authorization handling to support specific settings for each config, this was done based on a global config name, #1331.
Update tracks auth for each instance of an alarm table or tree, thus allowing multiple copies, each with a different config and correct authorization.
Also fixes issue where auth was correct when changing config at runtime, but not when restored after a restart.