### PR TITLE
Scan server: 'Parallel' cmd error uses message of failed sub-command

### DIFF
--- a/services/scan-server/src/main/java/org/csstudio/scan/server/SimulationContext.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/SimulationContext.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 import org.csstudio.scan.device.DeviceInfo;
@@ -53,6 +54,8 @@ public class SimulationContext
 
     private double simulation_seconds = 0.0;
 
+    private final AtomicInteger parallel_level = new AtomicInteger();
+
     /** Initialize
      *  @param jython {@link JythonSupport}
      *  @param log_stream Stream for simulation progress log
@@ -82,6 +85,20 @@ public class SimulationContext
     public MacroContext getMacros()
     {
         return macros;
+    }
+
+    /** Increment level of 'Parallel' commands
+     *  @return Incremented parallel command level
+     */
+    public int incParallelLevel()
+    {
+        return parallel_level.incrementAndGet();
+    }
+
+    /** Decrement level of 'Parallel' commands */
+    public void decParallelLevel()
+    {
+        parallel_level.decrementAndGet();
     }
 
     /** @return Current time of simulation in seconds */

--- a/services/scan-server/src/test/java/org/csstudio/scan/server/log/derby/DerbyLogDemo.java
+++ b/services/scan-server/src/test/java/org/csstudio/scan/server/log/derby/DerbyLogDemo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ public class DerbyLogDemo
     @Test
     public void demoDerbyLog() throws Exception
     {
-        LogManager.getLogManager().readConfiguration(ScanServerInstance.class.getResourceAsStream("/logging.properties"));
+        LogManager.getLogManager().readConfiguration(ScanServerInstance.class.getResourceAsStream("/debug_logging.properties"));
         DerbyDataLogger.startup("/tmp/scan_log_db");
 
         final RDBDataLogger datalog = new DerbyDataLogger();


### PR DESCRIPTION
.. since end user is mostly interested in what actually failed, not the
fact that it was wrapped in a parallel command