### PR TITLE
minor issues on alarm-logger and alarm-config-logger (arguments)

### DIFF
--- a/services/alarm-config-logger/alarm-config-logger.sh
+++ b/services/alarm-config-logger/alarm-config-logger.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Alarm Config Logger launcher for Linux or Mac OS X
+
+# When deploying, change "TOP"
+# to the absolute installation path
+TOP="."
+
+# Ideally, assert that Java is found
+# export JAVA_HOME=/opt/jdk-9
+# export PATH="$JAVA_HOME/bin:$PATH"
+
+if [ -d $TOP/target ]
+then
+  TOP="$TOP/target"
+fi
+
+JAR=`echo "${TOP}/service-alarm-config-logger-*.jar"`
+
+java -jar $JAR "$@"

--- a/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLoggingService.java
+++ b/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLoggingService.java
@@ -43,7 +43,7 @@ public class AlarmConfigLoggingService {
         System.out.println("-help                                      - This text");
         System.out.println("-topics   Accelerator                      - Alarm topics whoes assocaited configuration is to be logged, they can be defined as a comma separated list");
         System.out.println("-bootstrap.servers localhost:9092          - Kafka server address");
-        System.out.println("-repo.location /etc/var/alarm_repo         - Location of the alarm configuration repository");
+        System.out.println("-repo.location /tmp/alarm_repo             - Location of the alarm configuration repository");
         System.out.println("-remote.location https://remote.git/repo   - Location of the remote git alarm configuration repository");
         System.out.println("-username username                         - username for remote git repo");
         System.out.println("-password password                         - password for remote git repo");
@@ -68,7 +68,7 @@ public class AlarmConfigLoggingService {
 
     public static void main(String[] original_args) throws InterruptedException {
 	SpringApplication.run(AlarmConfigLoggingService.class, original_args);
-        logger.info("Starting the AlarmConfigLoggingService....");
+        logger.info("Starting the AlarmConfigLoggerService....");
 
         Properties properties = PropertiesHelper.getProperties();
 
@@ -79,8 +79,8 @@ public class AlarmConfigLoggingService {
             while (iter.hasNext()) {
 
                 final String cmd = iter.next();
-                if (cmd.startsWith("-h")) {
-                    help();
+		if ( cmd.equals("-h") || cmd.equals("-help")) {
+		    help();
                     return;
                 } else if (cmd.equals("-properties")) {
                     if (!iter.hasNext())
@@ -140,9 +140,11 @@ public class AlarmConfigLoggingService {
                     throw new Exception("Unknown option " + cmd);
             }
         } catch (Exception ex) {
-            help();
             System.out.println();
+	    System.out.println("\n>>>> Print StackTrace ....");
             ex.printStackTrace();
+	    System.out.println("\n>>>> Please check available arguments of alarm-config-logger as follows:");
+	    help();
             return;
         }
 

--- a/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/PropertiesHelper.java
+++ b/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/PropertiesHelper.java
@@ -12,7 +12,7 @@ public class PropertiesHelper {
     static Properties prop = new Properties();
 
     static {
-        String filename = "alarm_config_logging_service.properties";
+        String filename = "alarm_config_logger.properties";
 
         try (InputStream input = PropertiesHelper.class.getClassLoader().getResourceAsStream(filename);) {
             if (input != null) {

--- a/services/alarm-config-logger/src/main/resources/alarm_config_logger.properties
+++ b/services/alarm-config-logger/src/main/resources/alarm_config_logger.properties
@@ -3,11 +3,11 @@ bootstrap.servers=localhost:9092
 alarm_topics=Accelerator
 
 # Location of the git repo
-local.location=C:\\AlarmConfig
+local.location=/tmp/alarm_repo
 
 # location of the remote git repo, 
 # The complete URI of the remote is created using the remote.location
 # it is recomended that your remote url end in the alarm topic assigned to this config service alarm_topic
-remote.location=
+remote.location=https://remote.git/repo
 username=username
 password=password

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
@@ -53,7 +53,7 @@ public class AlarmLoggingService {
         System.out.println("-es_port  9200                           - elastic server port");
         System.out.println("-es_sniff  false                         - elastic server sniff feature");
         System.out.println("-bootstrap.servers localhost:9092        - Kafka server address");
-        System.out.println("-properties /opt/alarm_logger.propertier - Properties file to be used (instead of command line arguments)");
+        System.out.println("-properties /opt/alarm_logger.properties - Properties file to be used (instead of command line arguments)");
         System.out.println("-date_span_units M                       - Date units for the time based index to span.");
         System.out.println("-date_span_value 1                       - Date value for the time based index to span.");
         System.out.println("-logging logging.properties              - Load log settings");
@@ -94,9 +94,11 @@ public class AlarmLoggingService {
             while (iter.hasNext()) {
 
                 final String cmd = iter.next();
-                if (cmd.startsWith("-h")) {
+		if ( cmd.equals("-h") || cmd.equals("-help")) {
+		    use_shell = false;
                     help();
-                    close();
+		    // Do we need the exit code for help?
+		    System.exit(SpringApplication.exit(context));
                     return;
                 } else if (cmd.equals("-noshell")) {
                     use_shell = false;

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
@@ -188,11 +188,12 @@ public class AlarmLoggingService {
                     throw new Exception("Unknown option " + cmd);
             }
         } catch (Exception ex) {
-            help();
-            System.out.println();
-            ex.printStackTrace();
-            close();
-            return;
+	    System.out.println("\n>>>> Print StackTrace ....");
+	    ex.printStackTrace();
+	    System.out.println("\n>>>> Please check available arguments of alarm-logger as follows:");
+	    help();
+	    System.exit(SpringApplication.exit(context));
+	    return;
         }
 
         logger.info("Alarm Logging Service (PID " + ProcessHandle.current().pid() + ")");


### PR DESCRIPTION
@kasemir and @shroffk , please look at this pull request. Alarm-logger and alarm-config-logger have the mixed programming logic between standard java and springboot. So, the workflow in main function is not quite well organized. 

I only touched  minimum source files to minimize any impact on these application, since I also have limited knowledge on JAVA and SpringBoot programming. 

Now, `-h` option and `-help` option work, it terminates the main applications well.  And I remove "arbitrary" option `-h*`, because it may create potential issues  in near future. 

For `alarm-config-logger`, now the consistent properties options and the input arguments, and rename the properties file also. In addition, add the sh script for `alarm-config-logger`. 

Please let me know what you think, and feel free to change or reject them according to what you would like to do. 
