### PR TITLE
Fix the bug which cannot handle settings file. 

### DIFF
--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -572,7 +572,7 @@ public class AlarmServerMain implements ServerModelListener
                         throw new Exception("Missing -server name");
                     iter.remove();
                     args_server = iter.next();
-		    use_args_server = true;
+                    use_args_server = true;
                     iter.remove();
                 }
                 else if (cmd.equals("-config"))
@@ -581,7 +581,7 @@ public class AlarmServerMain implements ServerModelListener
                         throw new Exception("Missing -config name");
                     iter.remove();
                     args_config = iter.next();
-		    use_args_config = true;
+                    use_args_config = true;
                     iter.remove();
                 }
                 else if (cmd.equals("-logging"))
@@ -649,21 +649,21 @@ public class AlarmServerMain implements ServerModelListener
                     throw new Exception("Unknown option " + cmd);
             }
 
-	    if ( use_args_server ) {
-		if ( use_settings ) {
-		    logger.log(Level.WARNING,"Found the conflicted configurations : -settings/server:" + server + " and -server:" + args_server);
-		    logger.log(Level.WARNING,"Force to use the argument -server instead of -settings");
-		    logger.log(Level.WARNING,"Server : " + args_server);
-		}
-		server = args_server;
+            if ( use_args_server ) {
+                if ( use_settings ) {
+                    logger.log(Level.WARNING,"Found the conflicted configurations : -settings/server:" + server + " and -server:" + args_server);
+                    logger.log(Level.WARNING,"Force to use the argument -server instead of -settings");
+                    logger.log(Level.WARNING,"Server : " + args_server);
+                }
+                server = args_server;
 	    }
-	    if ( use_args_config ) {
-		if ( use_settings ) {
-		    logger.log(Level.WARNING,"Found the conflicted configurations : -settings/config:" + config + " and -config:" + args_config);
-		    logger.log(Level.WARNING,"Force to use the argument -config instead of -settings");
-		    logger.log(Level.WARNING,"Config : " + args_config);
-		}
-		config = args_config;
+            if ( use_args_config ) {
+                if ( use_settings ) {
+                    logger.log(Level.WARNING,"Found the conflicted configurations : -settings/config:" + config + " and -config:" + args_config);
+                    logger.log(Level.WARNING,"Force to use the argument -config instead of -settings");
+                    logger.log(Level.WARNING,"Config : " + args_config);
+                }
+                config = args_config;
 	    }
 	    
 

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -603,12 +603,12 @@ public class AlarmServerMain implements ServerModelListener
                     logger.info("Loading settings from " + filename);
                     PropertyPreferenceLoader.load(new FileInputStream(filename));
 		    
-		    Preferences userPrefs  = Preferences.userRoot().node("org/phoebus/applications/alarm");
-		    String pref_server     = userPrefs.get("server", server);
-		    String pref_conf_names = userPrefs.get("config_names", config);
-		    server = pref_server;
-		    config = pref_conf_names;
-		    use_settings = true;
+                    Preferences userPrefs  = Preferences.userRoot().node("org/phoebus/applications/alarm");
+                    String pref_server     = userPrefs.get("server", server);
+                    String pref_conf_names = userPrefs.get("config_names", config);
+                    server = pref_server;
+                    config = pref_conf_names;
+                    use_settings = true;
 		    
 	        }
                 else if (cmd.equals("-noshell"))

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -547,11 +547,11 @@ public class AlarmServerMain implements ServerModelListener
         String server = "localhost:9092";
         String config = "Accelerator";
         boolean use_shell = true;
-	String  args_server = "";
-	String  args_config = "";
-	boolean use_args_server = false;
-	boolean use_args_config = false;
-	boolean use_settings = false;
+        String  args_server = "";
+        String  args_config = "";
+        boolean use_args_server = false;
+        boolean use_args_config = false;
+        boolean use_settings = false;
 	
 	// Handle arguments
         final List<String> args = new ArrayList<>(List.of(original_args));

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -610,7 +610,7 @@ public class AlarmServerMain implements ServerModelListener
                     config = pref_conf_names;
                     use_settings = true;
 		    
-	        }
+                }
                 else if (cmd.equals("-noshell"))
                 {
                     use_shell = false;

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -137,8 +137,8 @@ public class AlarmServerMain implements ServerModelListener
             restart.offer(false);
         else if (args.length == 1)
         {
-	    if (args[0].startsWith("shut"))
-		restart.offer(false);
+            if (args[0].startsWith("shut"))
+                restart.offer(false);
             else if (args[0].equals("restart"))
                 restart.offer(true);
             else if (args[0].equals("mode"))
@@ -561,8 +561,8 @@ public class AlarmServerMain implements ServerModelListener
             while (iter.hasNext())
             {
                 final String cmd = iter.next();
-		if ( cmd.equals("-h") || cmd.equals("-help")) 
-		{
+                if ( cmd.equals("-h") || cmd.equals("-help"))
+                {
                     help();
                     return;
                 }

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -137,8 +137,8 @@ public class AlarmServerMain implements ServerModelListener
             restart.offer(false);
         else if (args.length == 1)
         {
-            if (args[0].equals("shutdown"))
-                restart.offer(false);
+	    if (args[0].startsWith("shut"))
+		restart.offer(false);
             else if (args[0].equals("restart"))
                 restart.offer(true);
             else if (args[0].equals("mode"))
@@ -526,16 +526,16 @@ public class AlarmServerMain implements ServerModelListener
         System.out.println();
         System.out.println("Command-line arguments:");
         System.out.println();
-        System.out.println("-help                       - This text");
-        System.out.println("-server   localhost:9092    - Kafka server");
-        System.out.println("-config   Accelerator       - Alarm configuration");
+        System.out.println("-help                          - This text");
+        System.out.println("-server    localhost:9092      - Kafka server with port number");
+        System.out.println("-config    Accelerator         - Alarm configuration");
         // Don't mention this option, prefer examples/create_topics.sh
         // System.out.println("-create_topics              - Create Kafka topics for alarm configuration?");
-        System.out.println("-settings settings.xml      - Import preferences (PV connectivity) from property format file");
-        System.out.println("-noshell                    - Disable the command shell for running without a terminal");
-        System.out.println("-export   config.xml        - Export alarm configuration to file");
-        System.out.println("-import   config.xml        - Import alarm configruation from file");
-        System.out.println("-logging logging.properties -  Load log settings");
+        System.out.println("-settings  settings.{xml,ini}  - Import preferences (PV connectivity) from property format file");
+        System.out.println("-noshell                       - Disable the command shell for running without a terminal");
+        System.out.println("-export    config.xml          - Export alarm configuration to file");
+        System.out.println("-import    config.xml          - Import alarm configruation from file");
+        System.out.println("-logging   logging.properties  - Load log settings");
         System.out.println();
     }
 
@@ -561,8 +561,8 @@ public class AlarmServerMain implements ServerModelListener
             while (iter.hasNext())
             {
                 final String cmd = iter.next();
-                if (cmd.startsWith("-h"))
-                {
+		if ( cmd.equals("-h") || cmd.equals("-help")) 
+		{
                     help();
                     return;
                 }
@@ -651,7 +651,7 @@ public class AlarmServerMain implements ServerModelListener
 
 	    if ( use_args_server ) {
 		if ( use_settings ) {
-		    logger.log(Level.WARNING,"Found the conflicted configuration : -settings/server:" + server + " and -server:" + args_server);
+		    logger.log(Level.WARNING,"Found the conflicted configurations : -settings/server:" + server + " and -server:" + args_server);
 		    logger.log(Level.WARNING,"Force to use the argument -server instead of -settings");
 		    logger.log(Level.WARNING,"Server : " + args_server);
 		}
@@ -659,7 +659,7 @@ public class AlarmServerMain implements ServerModelListener
 	    }
 	    if ( use_args_config ) {
 		if ( use_settings ) {
-		    logger.log(Level.WARNING,"Found the conflicted configuration : -settings/server:" + config + " and -config:" + args_config);
+		    logger.log(Level.WARNING,"Found the conflicted configurations : -settings/config:" + config + " and -config:" + args_config);
 		    logger.log(Level.WARNING,"Force to use the argument -config instead of -settings");
 		    logger.log(Level.WARNING,"Config : " + args_config);
 		}


### PR DESCRIPTION
@kasemir and @shroffk,

Please check this request, and let me know. 

The current version cannot set `server` and `config` properly if we define them in *.ini file.  This request allows users to use `ini` file as the Kafka server and alarm config as well. However, these values are overridden by command line arguments `-config`, `-server`, or both. 

Moreover, use the "shutdown" instead of "start with shut".

@jeonghanlee 