### PR TITLE
CSSTUDIO-1298 Avoid changing value on secondary button click

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import javafx.scene.input.MouseButton;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -102,6 +103,14 @@ public class ComboRepresentation extends RegionBaseRepresentation<ComboBox<Strin
                 });
 
                 return cell;
+            });
+
+            combo.setOnMouseClicked(event -> {
+                // Secondary mouse button should bring up context menu,
+                // but not show selections (i.e. not expand drop-down).
+                if(event.getButton().equals(MouseButton.SECONDARY)){
+                    combo.hide();
+                }
             });
 
         }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
@@ -14,6 +14,7 @@ import static org.csstudio.display.builder.representation.ToolkitRepresentation.
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
+import javafx.scene.input.MouseButton;
 import org.controlsfx.control.ToggleSwitch;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
@@ -130,7 +131,11 @@ public class SlideButtonRepresentation extends RegionBaseRepresentation<HBox, Sl
         if (! toolkit.isEditMode() )
             button.addEventFilter(MouseEvent.MOUSE_RELEASED, event ->
             {
-                handleSlide();
+                // To avoid setting a new value when context menu is requested,
+                // slide only if primary button was pressed.
+                if(event.getButton().equals(MouseButton.PRIMARY)) {
+                    handleSlide();
+                }
                 event.consume();
             });
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
@@ -11,6 +11,7 @@ import static org.csstudio.display.builder.representation.ToolkitRepresentation.
 
 import java.util.logging.Level;
 
+import javafx.scene.input.MouseButton;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -124,7 +125,16 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
                 }
             });
             // Clicking into widget also activates
-            text.setOnMouseClicked(event -> setActive(true));
+            text.setOnMouseClicked(event -> {
+                // Secondary mouse button should bring up context menu
+                // but not enable editing.
+                if(event.getButton().equals(MouseButton.PRIMARY)){
+                    setActive(true);
+                }
+                else{
+                    text.setEditable(false);
+                }
+            });
             // While getting the focus does not activate the widget
             // (first need to type something or click),
             // _loosing_ focus de-activates the widget.


### PR DESCRIPTION
Right clicking on some widgets to get context menu has unwanted side effects. This commit fixes the following:

- Slide Button: right click shall not change the value.
- Text Entry: right click shall not make widget active or show cursor suggesting value can be edited.
- Combo Box: right click shall not expand choices (which also obscures part of the context menu).