### PR TITLE
Display scripts: Replace 'nashorn'

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/ScriptInfo.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/ScriptInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -46,8 +46,9 @@ public class ScriptInfo
     /** Example java script */
     public static final String EXAMPLE_JAVASCRIPT =
         "/* Embedded javascript */\n" +
-        "PVUtil = org.csstudio.display.builder.runtime.script.PVUtil;\n" +
-        "logger = org.csstudio.display.builder.runtime.script.ScriptUtil.getLogger();\n" +
+        "importClass(org.csstudio.display.builder.runtime.script.PVUtil);\n" +
+        "importClass(org.csstudio.display.builder.runtime.script.ScriptUtil);\n" +
+        "logger = ScriptUtil.getLogger();\n" +
         "logger.info(\"Hello\");\n" +
         "/* widget.setPropertyValue(\"text\", PVUtil.getString(pvs[0])); */";
 

--- a/app/display/runtime/pom.xml
+++ b/app/display/runtime/pom.xml
@@ -30,6 +30,11 @@
       <version>0.10.2.1</version>
     </dependency>
     <dependency>
+      <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
+      <version>1.7.12</version>
+    </dependency>
+    <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
       <version>4.6.4-SNAPSHOT</version>

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JavaScript.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JavaScript.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,8 +8,6 @@
 package org.csstudio.display.builder.runtime.script.internal;
 
 import java.util.concurrent.Future;
-
-import javax.script.CompiledScript;
 
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.runtime.pv.RuntimePV;
@@ -22,7 +20,7 @@ class JavaScript implements Script
 {
     private final JavaScriptSupport support;
     private final String name;
-    private final CompiledScript code;
+    private final org.mozilla.javascript.Script code;
 
     /** Parse and compile script file
      *
@@ -30,7 +28,7 @@ class JavaScript implements Script
      *  @param name Name of script (file name, URL)
      *  @param code Compiled code
      */
-    public JavaScript(final JavaScriptSupport support, final String name, final CompiledScript code)
+    public JavaScript(final JavaScriptSupport support, final String name, final org.mozilla.javascript.Script code)
     {
         this.support = support;
         this.name = name;
@@ -44,7 +42,7 @@ class JavaScript implements Script
     }
 
     /** @return Compiled code */
-    public CompiledScript getCode()
+    public org.mozilla.javascript.Script getCode()
     {
         return code;
     }

--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -113,6 +113,7 @@
     <classpathentry exported="true" kind="lib" path="target/lib/py4j-0.10.2.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/rank-eval-client-6.4.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/reactive-streams-1.0.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/rhino-1.7.12.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/rxjava-2.1.14.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/slf4j-api-1.7.25.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/spring-aop-5.1.7.RELEASE.jar"/>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -167,6 +167,13 @@
       <version>1.2</version>
     </dependency>
 
+    <!-- JavaScript (replacement for nashorn) -->
+    <dependency>
+      <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
+      <version>1.7.12</version>
+    </dependency>
+
     <!-- Dependency for olog, channelfinde, and other rest clients. https://mvnrepository.com/artifact/com.sun.jersey/jersey-core -->
     <dependency>
       <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
For display scripts, Jython has been promoted over JavaScript. Details of JS when it comes to accessing Java classes have in fact changed as the scripting engine moved from Rhino to Nashorn. Nashorn has been deprecated and will soon be removed in Java 15, https://openjdk.java.net/jeps/372.
Turns out Rhino is still being maintained, last release in January, last commit yesterday,  https://github.com/mozilla/rhino  ,  so changing back to Rhino is quite easy and for those who liked to use JS, it's back to where we started.
