### PR TITLE
Update Jetty

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -66,12 +66,12 @@
     <classpathentry exported="true" kind="lib" path="target/lib/jersey-core-1.19.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jersey-multipart-1.19.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jersey-server-1.19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jetty-http-9.4.9.v20180320.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jetty-io-9.4.9.v20180320.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jetty-security-9.4.9.v20180320.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jetty-server-9.4.9.v20180320.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jetty-servlet-9.4.9.v20180320.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jetty-util-9.4.9.v20180320.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jetty-http-9.4.30.v20200611.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jetty-io-9.4.30.v20200611.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jetty-security-9.4.30.v20200611.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jetty-server-9.4.30.v20200611.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jetty-servlet-9.4.30.v20200611.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jetty-util-9.4.30.v20200611.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jfxtras-agenda-9.0-r1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jfxtras-common-9.0-r1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jfxtras-controls-9.0-r1.jar"/>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -242,22 +242,21 @@
       <version>${jackson.version}</version>
     </dependency>
 
-    <!-- Jetty, web server used by scan server, archive engine, .. For versions 
-      check http://central.maven.org/maven2/org/eclipse/jetty/jetty-maven-plugin/ -->
+    <!-- Jetty, web server used by scan server, archive engine, .. -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.9.v20180320</version>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.9.v20180320</version>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
-      <version>9.4.9.v20180320</version>
+      <version>${jetty.version}</version>
     </dependency>
 
     <!-- Derby, database used by scan server -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <mockito.version>2.23.4</mockito.version>
     <postgresql.driver.version>42.2.9</postgresql.driver.version>
     <lombok.version>1.18.12</lombok.version>
+    <jetty.version>9.4.30.v20200611</jetty.version>
     <!--<maven.repo.local>${project.build.directory}/.m2</maven.repo.local> -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/services/archive-engine/pom.xml
+++ b/services/archive-engine/pom.xml
@@ -44,17 +44,17 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.9.v20180320</version>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.9.v20180320</version>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
-      <version>9.4.9.v20180320</version>
+      <version>${jetty.version}</version>
     </dependency>
 
     <dependency>

--- a/services/scan-server/pom.xml
+++ b/services/scan-server/pom.xml
@@ -28,17 +28,17 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.9.v20180320</version>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.9.v20180320</version>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
-      <version>9.4.9.v20180320</version>
+      <version>${jetty.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
'dependabot' warned about outdated version 9.4.9.v20180320, suggesting
at least 9.4.17.
Moving to latest release at this time, 9.4.30.v20200611