### PR TITLE
Scan: Add 'readback_value' to Set command

### DIFF
--- a/app/scan/model/src/main/java/org/csstudio/scan/command/ScanCommandProperty.java
+++ b/app/scan/model/src/main/java/org/csstudio/scan/command/ScanCommandProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 Oak Ridge National Laboratory.
+ * Copyright (c) 2012-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ public class ScanCommandProperty
     final public static String TAG_DEVICE = "device";
     final public static String TAG_VALUE = "value";
     final public static String TAG_READBACK = "readback";
+    final public static String TAG_READBACK_VALUE = "readback_value";
     final public static String TAG_COMPLETION = "completion";
     final public static String TAG_WAIT = "wait";
     final public static String TAG_TOLERANCE = "tolerance";

--- a/app/scan/model/src/main/java/org/csstudio/scan/command/SetCommand.java
+++ b/app/scan/model/src/main/java/org/csstudio/scan/command/SetCommand.java
@@ -253,12 +253,21 @@ public class SetCommand extends ScanCommand
                 command_element.appendChild(element);
             }
 
-            element = dom.createElement("readback_value");
             if (readback_value instanceof String)
-                element.appendChild(dom.createTextNode('"' + (String)readback_value + '"'));
+            {   // Skip when empty, otherwise persist as "text" ..
+                if (((String)readback_value).length() > 0)
+                {
+                    element = dom.createElement("readback_value");
+                    element.appendChild(dom.createTextNode('"' + (String)readback_value + '"'));
+                    command_element.appendChild(element);
+                }
+            }
             else
+            {   // .. or number
+                element = dom.createElement("readback_value");
                 element.appendChild(dom.createTextNode(readback_value.toString()));
-            command_element.appendChild(element);
+                command_element.appendChild(element);
+           }
         }
         if (tolerance > 0.0)
         {
@@ -284,7 +293,7 @@ public class SetCommand extends ScanCommand
         setCompletion(XMLUtil.getChildBoolean(element, ScanCommandProperty.TAG_COMPLETION).orElse(false));
         setWait(XMLUtil.getChildBoolean(element, ScanCommandProperty.TAG_WAIT).orElse(true));
         setReadback(XMLUtil.getChildString(element, ScanCommandProperty.TAG_READBACK).orElse(getDeviceName()));
-        setReadbackValue(StringOrDouble.parse(XMLUtil.getChildString(element, ScanCommandProperty.TAG_READBACK_VALUE).orElse("")));
+        setReadbackValue(StringOrDouble.parse(XMLUtil.getChildString(element, ScanCommandProperty.TAG_READBACK_VALUE).orElse("\"\"")));
         setTolerance(XMLUtil.getChildDouble(element, ScanCommandProperty.TAG_TOLERANCE).orElse(0.1));
         setTimeout(XMLUtil.getChildDouble(element, ScanCommandProperty.TAG_TIMEOUT).orElse(0.0));
         super.readXML(element);

--- a/app/scan/model/src/main/java/org/csstudio/scan/command/SetCommand.java
+++ b/app/scan/model/src/main/java/org/csstudio/scan/command/SetCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ public class SetCommand extends ScanCommand
     private volatile String device_name;
     private volatile Object value;
     private volatile String readback;
+    private volatile Object readback_value;
     private volatile boolean completion;
     private volatile boolean wait;
     private volatile double tolerance;
@@ -39,7 +40,7 @@ public class SetCommand extends ScanCommand
     /** Initialize empty set command */
     public SetCommand()
     {
-        this("device", 0.0, false, "", true, 0.1, 0.0);
+        this("device", 0.0, false, "", "", true, 0.1, 0.0);
     }
 
     /** Initialize for readback with default tolerance and timeout
@@ -48,7 +49,7 @@ public class SetCommand extends ScanCommand
      */
     public SetCommand(final String device_name, final Object value)
     {
-        this(device_name, value, false, device_name, true, 0.1, 0.0);
+        this(device_name, value, false, device_name, "", true, 0.1, 0.0);
     }
 
     /** Initialize with default tolerance and timeout
@@ -58,7 +59,7 @@ public class SetCommand extends ScanCommand
      */
     public SetCommand(final String device_name, final Object value, final boolean wait)
     {
-        this(device_name, value, false, device_name, wait, 0.1, 0.0);
+        this(device_name, value, false, device_name, "", wait, 0.1, 0.0);
     }
 
     /** Initialize
@@ -69,7 +70,7 @@ public class SetCommand extends ScanCommand
     public SetCommand(final String device_name, final Object value,
             final String readback)
     {
-        this(device_name, value, false, readback, true, 0.1, 0.0);
+        this(device_name, value, false, readback, "", true, 0.1, 0.0);
     }
 
     /** Initialize
@@ -77,13 +78,14 @@ public class SetCommand extends ScanCommand
      *  @param value Value to write to the device
      *  @param completion Wait for write completion?
      *  @param readback Readback device
+     *  @param readback_value Desired readback value ("" to use written value)
      *  @param wait Wait for readback to match?
      *  @param tolerance Numeric tolerance when checking value
      *  @param timeout Timeout in seconds, 0 as "forever"
      */
     public SetCommand(final String device_name, final Object value,
             final boolean completion,
-            final String readback, final boolean wait,
+            final String readback, final Object readback_value, final boolean wait,
             final double tolerance, final double timeout)
     {
         if (device_name == null)
@@ -94,6 +96,7 @@ public class SetCommand extends ScanCommand
         if (readback == null)
             throw new NullPointerException();
         this.readback = readback;
+        this.readback_value = readback_value;
         this.wait = wait;
         this.tolerance = tolerance;
         this.timeout = timeout;
@@ -108,6 +111,7 @@ public class SetCommand extends ScanCommand
         properties.add(ScanCommandProperty.COMPLETION);
         properties.add(ScanCommandProperty.WAIT);
         properties.add(ScanCommandProperty.READBACK);
+        properties.add(new ScanCommandProperty("readback_value", "Readback Value", Object.class));
         properties.add(ScanCommandProperty.TOLERANCE);
         properties.add(ScanCommandProperty.TIMEOUT);
         super.configureProperties(properties);
@@ -177,6 +181,18 @@ public class SetCommand extends ScanCommand
         this.readback = readback;
     }
 
+    /** @return Value to check from readback device */
+    public Object getReadbackValue()
+    {
+        return readback_value;
+    }
+
+    /** @param readback_value Value to check from readback device ("" for written value) */
+    public void setReadbackValue(final Object readback_value)
+    {
+        this.readback_value = readback_value;
+    }
+
     /** @return Tolerance */
     public double getTolerance()
     {
@@ -228,10 +244,20 @@ public class SetCommand extends ScanCommand
             element.appendChild(dom.createTextNode(Boolean.toString(wait)));
             command_element.appendChild(element);
         }
-        if (wait  &&  ! readback.isEmpty())
+        else
         {
-            element = dom.createElement("readback");
-            element.appendChild(dom.createTextNode(readback));
+            if (! readback.isEmpty())
+            {
+                element = dom.createElement("readback");
+                element.appendChild(dom.createTextNode(readback));
+                command_element.appendChild(element);
+            }
+
+            element = dom.createElement("readback_value");
+            if (readback_value instanceof String)
+                element.appendChild(dom.createTextNode('"' + (String)readback_value + '"'));
+            else
+                element.appendChild(dom.createTextNode(readback_value.toString()));
             command_element.appendChild(element);
         }
         if (tolerance > 0.0)
@@ -258,6 +284,7 @@ public class SetCommand extends ScanCommand
         setCompletion(XMLUtil.getChildBoolean(element, ScanCommandProperty.TAG_COMPLETION).orElse(false));
         setWait(XMLUtil.getChildBoolean(element, ScanCommandProperty.TAG_WAIT).orElse(true));
         setReadback(XMLUtil.getChildString(element, ScanCommandProperty.TAG_READBACK).orElse(getDeviceName()));
+        setReadbackValue(StringOrDouble.parse(XMLUtil.getChildString(element, ScanCommandProperty.TAG_READBACK_VALUE).orElse("")));
         setTolerance(XMLUtil.getChildDouble(element, ScanCommandProperty.TAG_TOLERANCE).orElse(0.1));
         setTimeout(XMLUtil.getChildDouble(element, ScanCommandProperty.TAG_TIMEOUT).orElse(0.0));
         super.readXML(element);
@@ -284,8 +311,12 @@ public class SetCommand extends ScanCommand
                 buf.append(device_name);
             else
                 buf.append(readback);
+            buf.append("'");
+
+            if (! readback_value.toString().isEmpty())
+                buf.append(" = ").append(StringOrDouble.quote(readback_value));
             if (tolerance > 0)
-                buf.append("' +-").append(tolerance);
+                buf.append(" +-").append(tolerance);
             if (timeout > 0  &&  !completion)
                 buf.append(", ").append(timeout).append(" sec timeout");
             buf.append(")");

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/ScanCommandUtil.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/ScanCommandUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2012-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,7 @@ public class ScanCommandUtil
             final boolean wait,
             final String readback_name, final double tolerance, final Duration timeout) throws Exception
     {
-        final WriteHelper write = new WriteHelper(context, device_name, value, completion, wait, readback_name, tolerance, timeout);
+        final WriteHelper write = new WriteHelper(context, device_name, value, completion, wait, readback_name, value, tolerance, timeout);
         write.perform();
     }
 }

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/ScanServerInstance.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/ScanServerInstance.java
@@ -41,7 +41,7 @@ public class ScanServerInstance
 
     private static final CountDownLatch done = new CountDownLatch(1);
 
-    public static final String VERSION = "4.5.4";
+    public static final String VERSION = "4.6.0";
 
     private static URL scan_config_file = ScanServerInstance.class.getResource("/examples/scan_config.xml");
 

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/WriteHelper.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/WriteHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,6 +58,7 @@ public class WriteHelper
      *  @param completion Await completion to the write?
      *  @param wait Wait for readback to match?
      *  @param readback_name Readback device name (default will be main device_name)
+     *  @param readback_value Readback value ("" to use written value)
      *  @param tolerance Numeric tolerance when checking value
      *  @param timeout Timeout for callback as well as readback; <code>null</code> as "forever"
      *  @throws Exception on error
@@ -66,7 +67,9 @@ public class WriteHelper
                        final String device_name, final Object value,
                        final boolean completion,
                        final boolean wait,
-                       final String readback_name, final double tolerance, final Duration timeout) throws Exception
+                       final String readback_name,
+                       Object readback_value,
+                       final double tolerance, final Duration timeout) throws Exception
     {
         this.context = context;
         this.completion = completion;
@@ -84,17 +87,21 @@ public class WriteHelper
         //  Wait for the device to reach the value?
         if (wait)
         {
+            if (readback_value == null  ||
+                readback_value.toString().isEmpty())
+                readback_value = value;
+
             // When using completion, readback needs to match "right away"
             final Duration check_timeout = completion ? Duration.ofSeconds(1) : timeout;
-            if (value instanceof Number)
+            if (readback_value instanceof Number)
             {
-                final double desired = ((Number)value).doubleValue();
+                final double desired = ((Number)readback_value).doubleValue();
                 condition = new NumericValueCondition(readback, Comparison.EQUALS, desired,
                                                       tolerance, check_timeout);
             }
             else
             {
-                final String desired = value.toString();
+                final String desired = readback_value.toString();
                 condition = new TextValueCondition(readback, Comparison.EQUALS, desired, check_timeout);
             }
         }

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/command/SetCommandImpl.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/command/SetCommandImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -103,6 +103,7 @@ public class SetCommandImpl extends ScanCommandImpl<SetCommand>
                                 command.getValue(),
                                 command.getCompletion(), command.getWait(),
                                 macros.resolveMacros(command.getReadback()),
+                                command.getReadbackValue(),
                                 command.getTolerance(),
                                 TimeDuration.ofSeconds(command.getTimeout()));
         try

--- a/services/scan-server/src/main/resources/webroot/index.html
+++ b/services/scan-server/src/main/resources/webroot/index.html
@@ -224,6 +224,7 @@ Only idle scans can be moved.
 <!-- Version number is in ScanServerInstance -->
 
 <dl>
+<dt>4.6.0</dt> <dd>Add 'readback_value' to Set command</dd>
 <dt>4.5.4</dt> <dd>Add 'UNEQUALS' to comparisons</dd>
 <dt>4.5.3</dt> <dd>Add 'If' command</dd>
 <dt>4.5.2</dt> <dd>Support scan/ID/move/+-1</dd>


### PR DESCRIPTION
Allows using 'set' when the value of the readback PV is different from the written value.
Typical example would be checking if some 'status' PV is 'OK' after a write completes.