### PR TITLE
Embedded display: $(LCID)

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -33,6 +33,7 @@ import org.csstudio.display.builder.model.persist.XMLTags;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.model.properties.EnumWidgetProperty;
 import org.csstudio.display.builder.model.widgets.GroupWidget.Style;
+import org.phoebus.framework.macros.Macros;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -286,9 +287,6 @@ public class EmbeddedDisplayWidget extends MacroWidget
         properties.add(embedded_model = runtimeModel.createProperty(this, null));
         properties.add(transparent = propTransparent.createProperty(this, false));
         BorderSupport.addBorderProperties(this, properties);
-
-        // Legacy "Linking Container" defined a "Linking Container ID" macro.
-        propMacros().getValue().add("LCID", getID());
     }
 
     @Override
@@ -298,6 +296,17 @@ public class EmbeddedDisplayWidget extends MacroWidget
         if (name.equals("opi_file"))
             return propFile();
         return super.getProperty(name);
+    }
+
+    @Override
+    public Macros getEffectiveMacros()
+    {
+        final Macros macros = new Macros(super.getEffectiveMacros());
+
+        // Legacy "Linking Container" defined a "Linking Container ID" macro.
+        macros.add("LCID", getID());
+
+        return macros;
     }
 
     /** @return 'file' property */


### PR DESCRIPTION
#1405 didn't quite work out.
It would always define $(LCID), but then all macros are replaced from the parsed XML.

Now $(LCID) is added to the 'effective' macros:
It doesn't show in the editor, you cannot assign a value.

![Screen Shot 2020-07-01 at 12 22 43 PM](https://user-images.githubusercontent.com/1932421/86268101-b1755780-bb95-11ea-87c7-c2004dc6c47c.png)
At runtime, however, it's available.


![Screen Shot 2020-07-01 at 12 23 05 PM](https://user-images.githubusercontent.com/1932421/86268122-b6d2a200-bb95-11ea-97bd-5c57a236653f.png)
