### PR TITLE
 Now when Phoebus opens .opi screen with menu widget which has empty …

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ActionButtonWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ActionButtonWidget.java
@@ -148,7 +148,8 @@ public class ActionButtonWidget extends PVWidget
                         the_text.appendChild(label_el.getFirstChild().cloneNode(true));
                     else
                     {
-                        Text the_label = doc.createTextNode(VALUE_LABEL);
+                        //If label is null, it should stay empty
+                        Text the_label = doc.createTextNode("");
                         the_text.appendChild(the_label);
                     }
                     xml.appendChild(the_text);


### PR DESCRIPTION
…string as a label, the new Active Button widget will show empty string as well.
