### PR TITLE
Channel Archiver: Fix communication errors, content type

### DIFF
--- a/phoebus-product/phoebus.sh
+++ b/phoebus-product/phoebus.sh
@@ -5,8 +5,7 @@
 # When deploying, change "TOP"
 # to the absolute installation path
 # TOP="."
-THIS_SCRIPT="$(realpath "$0")";
-TOP="${THIS_SCRIPT%/*}";
+TOP="$( cd "$(dirname "$0")" ; pwd -P )"
 
 # Ideally, assert that Java is found
 # export JAVA_HOME=/opt/jdk-9


### PR DESCRIPTION
Explicitly sends data as "text/xml" for  #1415
Sets some more detail and displays received errors.