### PR TITLE
Picture widget legacy prop

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PictureWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PictureWidget.java
@@ -83,7 +83,12 @@ public class PictureWidget extends MacroWidget
             }
 
             if (xml_version.getMajor() < 2)
+            {
+                final PictureWidget picture = (PictureWidget) widget;
                 MacroWidget.importPVName(model_reader, widget, widget_xml);
+                XMLUtil.getChildBoolean(widget_xml, "stretch_to_fit")
+                       .ifPresent(stretch -> picture.propStretch().setValue(stretch));
+            }
 
             // Parse updated XML
             return super.configureFromXML(model_reader, widget, widget_xml);


### PR DESCRIPTION
This PR is to fix an issue with picture widget where legacy property stretch_to_fit doesn't get assigned the original value from legacy image widget.