### PR TITLE
Databrowser - passing / using macros in databrowser

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -185,9 +185,6 @@ public class DataBrowserInstance implements AppInstance
             final Model new_model = new Model();
             try
             {
-                // Load model from file in background
-                XMLPersistence.load(new_model, ResourceParser.getContent(input));
-
                 // Check for macros
                 final Macros macros = new Macros();
                 ResourceParser.getQueryItemStream(input)
@@ -195,6 +192,9 @@ public class DataBrowserInstance implements AppInstance
                               .forEach(item -> macros.add(item.getKey(),
                                                           item.getValue()));
                 new_model.setMacros(macros);
+
+                // Load model from file in background
+                XMLPersistence.load(new_model, ResourceParser.getContent(new URI(input.getScheme() + "://" + input.getPath())));
 
                 Platform.runLater(() ->
                 {

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
@@ -432,7 +432,7 @@ public class Model
     public ModelItem getItem(final String name)
     {
         for (ModelItem item : items)
-            if (item.getName().equals(name))
+            if (item.getName().equals(name) || item.getResolvedName().equals(name))
                 return item;
         return null;
     }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/persistence/XMLPersistence.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/persistence/XMLPersistence.java
@@ -171,8 +171,8 @@ public class XMLPersistence
             // Ignore
         }
 
-        final String start = XMLUtil.getChildString(root_node, TAG_START).orElse("");
-        final String end = XMLUtil.getChildString(root_node, TAG_END).orElse("");
+        final String start = model.resolveMacros(XMLUtil.getChildString(root_node, TAG_START).orElse(""));
+        final String end = model.resolveMacros(XMLUtil.getChildString(root_node, TAG_END).orElse(""));
         if (start.length() > 0  &&  end.length() > 0)
         {
             final boolean scroll = XMLUtil.getChildBoolean(root_node, TAG_SCROLL).orElse(true);

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/TracesTab.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/TracesTab.java
@@ -401,7 +401,7 @@ public class TracesTab extends Tab
 
         // Trace PV/Formula Column ----------
         TableColumn<ModelItem, String> col = new TableColumn<>(Messages.ItemName);
-        col.setCellValueFactory(cell -> new SimpleStringProperty(cell.getValue().getName()));
+        col.setCellValueFactory(cell -> new SimpleStringProperty(cell.getValue().getResolvedName()));
         col.setCellFactory(TextFieldTableCell.forTableColumn());
         col.setOnEditCommit(event ->
         {
@@ -420,7 +420,7 @@ public class TracesTab extends Tab
 
         // Display Name Column ----------
         col = new TableColumn<>(Messages.TraceDisplayName);
-        col.setCellValueFactory(cell -> new SimpleStringProperty(cell.getValue().getDisplayName()));
+        col.setCellValueFactory(cell -> new SimpleStringProperty(cell.getValue().getResolvedDisplayName()));
         col.setCellFactory(TextFieldTableCell.forTableColumn());
         col.setOnEditCommit(event ->
         {
@@ -735,7 +735,7 @@ public class TracesTab extends Tab
             // Add PV-based entries
             final List<ProcessVariable> pvs = selection.stream()
                                                        .filter(item -> item instanceof PVItem)
-                                                       .map(item -> new ProcessVariable(item.getName()))
+                                                       .map(item -> new ProcessVariable(item.getResolvedName()))
                                                        .collect(Collectors.toList());
             if (pvs.size() > 0)
             {

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/sampleview/SampleView.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/sampleview/SampleView.java
@@ -143,7 +143,7 @@ public class SampleView extends VBox
 
     private void update()
     {
-        final List<String> model_items = model.getItems().stream().map(item -> item.getName()).collect(Collectors.toList());
+        final List<String> model_items = model.getItems().stream().map(item -> item.getResolvedName()).collect(Collectors.toList());
         if (! model_items.equals(items.getItems()))
         {
             items.getItems().setAll( model_items );
@@ -173,7 +173,7 @@ public class SampleView extends VBox
                 }
                 catch (Exception ex)
                 {
-                    Activator.logger.log(Level.WARNING, "Cannot access samples for " + item.getName(), ex);
+                    Activator.logger.log(Level.WARNING, "Cannot access samples for " + item.getResolvedName(), ex);
                 }
         }
         // Update UI

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/selection/DatabrowserSelection.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/selection/DatabrowserSelection.java
@@ -62,7 +62,7 @@ public class DatabrowserSelection {
      */
     public List<String> getPlotPVs()
     {
-        return model.getItems().stream().map(ModelItem::getName).collect(Collectors.toList());
+        return model.getItems().stream().map(ModelItem::getResolvedName).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
See #1420 
* Macros can be passed from URI
* Few basic UI changes to see resolved PV names (properties panel, samples panel)
* Macroized start/end time. At the moment ONLY when reading from PLT file -> suitable for fixed read-only PLT files (edited by hand).
