### PR TITLE
Byte monitor: Handle all 32 bits

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
@@ -219,9 +219,9 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
         final boolean save_bitRev = bitReverse;
 
         final int [] colorIndices = new int [nBits];
-        final int number = VTypeUtil.getValueNumber(value).intValue();
+        final long number = Integer.toUnsignedLong(VTypeUtil.getValueNumber(value).intValue());
         for (int i = 0; i < nBits; i++)
-            colorIndices[ save_bitRev ? i : nBits-1-i] = number & (1 << (sBit+i));
+            colorIndices[ save_bitRev ? i : nBits-1-i] = (number & (1L << (sBit+i))) == 0 ? 0 : 1;
         return colorIndices;
     }
 
@@ -354,10 +354,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
         final Color[] new_colorVals = new Color[value_indices.length];
         final Color[] save_colors = colors;
         for (int i = 0; i < value_indices.length; i++)
-        {
-            value_indices[i] = value_indices[i] <= 0 ? 0 : 1;
             new_colorVals[i] = save_colors[value_indices[i]];
-        }
         value_colors = new_colorVals;
 
         dirty_content.mark();


### PR DESCRIPTION
The byte monitor widget didn't properly handle the highest bit of a 32 bit number.

Note how the hex number and the byte monitor don't match regarding bit 31:
![Screen Shot 2020-07-27 at 2 50 13 PM](https://user-images.githubusercontent.com/1932421/88581861-c8378e80-d01b-11ea-9850-a68f7daa4d63.png)

Reason was using 32 bit _signed_ int. With fix, hex readback and byte monitor match:

![Screen Shot 2020-07-27 at 2 57 45 PM](https://user-images.githubusercontent.com/1932421/88581872-ccfc4280-d01b-11ea-92c5-50f37feb39af.png)
