### PR TITLE
Databrowser setting to remove or keep failed datasources

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
@@ -48,14 +48,11 @@ public class Preferences
         UPDATE_PERIOD = "update_period",
         USE_AUTO_SCALE = "use_auto_scale",
         USE_DEFAULT_ARCHIVES = "use_default_archives",
+        DROP_FAILED_ARCHIVES = "drop_failed_archives",
         USE_TRACE_NAMES = "use_trace_names",
         PROMPT_FOR_RAW_DATA = "prompt_for_raw_data_request",
         PROMPT_FOR_VISIBILITY = "prompt_for_visibility",
-
-        // Later...
-        PROMPT_FOR_ERRORS = "prompt_for_errors",
-        TIME_SPAN_SHORTCUTS = "time_span_shortcuts",
-        EMAIL_DEFAULT_SENDER = "email_default_sender";
+        TIME_SPAN_SHORTCUTS = "time_span_shortcuts";
 
     public static class TimePreset
     {
@@ -86,6 +83,7 @@ public class Preferences
     public static double update_period;
     public static boolean use_auto_scale;
     public static boolean use_default_archives;
+    public static boolean drop_failed_archives;
     public static boolean use_trace_names;
     public static boolean prompt_for_raw_data_request;
     public static boolean prompt_for_visibility;
@@ -135,6 +133,7 @@ public class Preferences
         update_period = prefs.getDouble(UPDATE_PERIOD);
         use_auto_scale = prefs.getBoolean(USE_AUTO_SCALE);
         use_default_archives = prefs.getBoolean(USE_DEFAULT_ARCHIVES);
+        drop_failed_archives = prefs.getBoolean(DROP_FAILED_ARCHIVES);
         use_trace_names = prefs.getBoolean(USE_TRACE_NAMES);
 
         prompt_for_raw_data_request = prefs.getBoolean(PROMPT_FOR_RAW_DATA);
@@ -142,7 +141,7 @@ public class Preferences
 
 
         time_presets = new ArrayList<>();
-        for (String preset : prefs.get("time_span_shortcuts").split("\\|"))
+        for (String preset : prefs.get(TIME_SPAN_SHORTCUTS).split("\\|"))
         {
             final String[] label_span = preset.split(",");
             time_presets.add(new TimePreset(label_span[0], TimeRelativeInterval.startsAt(TimeParser.parseTemporalAmount(label_span[1]))));

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
@@ -122,13 +122,16 @@ public class Controller
         {
             logger.log(Level.WARNING, "No archived data for " + job.getPVItem().getDisplayName(), error);
             // Remove the problematic archive data source, but has to happen in UI thread
-            Platform.runLater(() ->  job.getPVItem().removeArchiveDataSource(archive));
+            if (Preferences.drop_failed_archives)
+                Platform.runLater(() ->  job.getPVItem().removeArchiveDataSource(archive));
         }
 
         @Override
         public void channelNotFound(final ArchiveFetchJob job, final boolean channelFoundAtLeastOnce,
                 final List<ArchiveDataSource> archivesThatFailed)
         {
+            logger.log(Level.INFO,
+                       () -> "Channel " + job.getPVItem().getResolvedDisplayName() + " not found in " + archivesThatFailed + ", removing data source.");
             // no need to reuse this source if the channel is not in it, but it has to happen in the UI thread, because
             // of the way the listeners of the pv item are implemented
             Platform.runLater(() ->  job.getPVItem().removeArchiveDataSource(archivesThatFailed));
@@ -137,7 +140,7 @@ public class Controller
             if (!channelFoundAtLeastOnce)
             {
                 logger.log(Level.INFO,
-                           "Channel " + job.getPVItem().getResolvedDisplayName() + " not found in any of the archived sources.");
+                           () -> "Channel " + job.getPVItem().getResolvedDisplayName() + " not found in any of the archived sources.");
             }
         }
     };

--- a/app/databrowser/src/main/resources/databrowser_preferences.properties
+++ b/app/databrowser/src/main/resources/databrowser_preferences.properties
@@ -85,10 +85,12 @@ archives=jdbc:mysql://localhost/archive|RDB*xnds://localhost/archive/cgi/Archive
 use_default_archives=false
 
 # If there is an error in retrieving archived data,
-# including that the channel is not found in the archive,
-# should this be displayed in a dialog box,
-# or logged as a WARNING (and thus visible on the console)?
-prompt_for_errors=false
+# should that archive data source be dropped from the channel?
+# This is meant to avoid needless queries to archives that cannot be accessed.
+# Note that archive data sources which clearly report a channel as "not found"
+# will still be dropped. This option only configures if data sources which
+# return an error (cannot connect, ...).
+drop_failed_archives=false
 
 # Re-scale behavior when archived data arrives: NONE, STAGGER
 archive_rescale=STAGGER
@@ -100,12 +102,6 @@ time_span_shortcuts=30 Minutes,-30 min|1 Hour,-1 hour|12 Hours,-12 hour|1 Day,-1
 
 #It is a path to the directory where the PLT files for WebDataBrowser are placed.
 plt_repository=/opt/codac/opi/databrowser/
-
-#SendEmailAction default sender
-# By defining a default email, users who select "Email.." from the context menu
-# do not need to enter an email address.
-# If left empty, elog dialog will require users to enter a "From:" address for the sender.
-email_default_sender=
 
 # Automatically refresh history data when the liver buffer is full
 # This will prevent the horizontal lines in the shown data when the buffer

--- a/app/databrowser/src/main/resources/databrowser_preferences.properties
+++ b/app/databrowser/src/main/resources/databrowser_preferences.properties
@@ -90,7 +90,7 @@ use_default_archives=false
 # Note that archive data sources which clearly report a channel as "not found"
 # will still be dropped. This option only configures if data sources which
 # return an error (cannot connect, ...).
-drop_failed_archives=false
+drop_failed_archives=true
 
 # Re-scale behavior when archived data arrives: NONE, STAGGER
 archive_rescale=STAGGER

--- a/app/databrowser/src/main/resources/databrowser_preferences.properties
+++ b/app/databrowser/src/main/resources/databrowser_preferences.properties
@@ -89,7 +89,7 @@ use_default_archives=false
 # This is meant to avoid needless queries to archives that cannot be accessed.
 # Note that archive data sources which clearly report a channel as "not found"
 # will still be dropped. This option only configures if data sources which
-# return an error (cannot connect, ...).
+# return an error (cannot connect, ...) should be queried again for the given channel.
 drop_failed_archives=true
 
 # Re-scale behavior when archived data arrives: NONE, STAGGER


### PR DESCRIPTION
When an archive cannot be accessed, it was removed from the channel's list of data sources.
This makes it configurable, allowing to keep such archives.
Unfortunate use case is people working from home over changing VPN and wireless connections that cause intermittent archive access issues. By keeping the data source, one can later 'retry'.