### PR TITLE
Slidebutton: Fix size

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
@@ -14,7 +14,6 @@ import static org.csstudio.display.builder.representation.ToolkitRepresentation.
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
-import javafx.scene.input.MouseButton;
 import org.controlsfx.control.ToggleSwitch;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
@@ -29,6 +28,7 @@ import org.phoebus.ui.javafx.Styles;
 import javafx.application.Platform;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -77,15 +77,14 @@ public class SlideButtonRepresentation extends RegionBaseRepresentation<HBox, Sl
         super.updateChanges();
 
         if ( dirty_size.checkAndClear() ) {
-
-            jfx_node.resize(model_widget.propWidth().getValue(), model_widget.propHeight().getValue());
-
             if ( model_widget.propAutoSize().getValue() ) {
+                jfx_node.setPrefSize(-1, -1);
                 jfx_node.autosize();
                 model_widget.propWidth().setValue((int) jfx_node.getWidth());
                 model_widget.propHeight().setValue((int) jfx_node.getHeight());
             }
-
+            else
+                jfx_node.setPrefSize(model_widget.propWidth().getValue(), model_widget.propHeight().getValue());
         }
 
         if ( dirty_style.checkAndClear() ) {
@@ -147,7 +146,7 @@ public class SlideButtonRepresentation extends RegionBaseRepresentation<HBox, Sl
         HBox hbox = new HBox(6, button, label);
         hbox.setAlignment(Pos.CENTER_RIGHT);
         return hbox;
-        
+
     }
 
     @Override


### PR DESCRIPTION
As a result of #1434, the slide button would always show but not properly respond to resizes.

Note the label that's larger than the widget, which simply overflows:
![Screen Shot 2020-07-29 at 8 51 39 AM](https://user-images.githubusercontent.com/1932421/88802217-c2a38b00-d178-11ea-852f-d0c62eb7a16a.png)

With this fix, the widget honors the assigned space:
![Screen Shot 2020-07-29 at 8 50 35 AM](https://user-images.githubusercontent.com/1932421/88802292-dc44d280-d178-11ea-920a-d0d5ee71c615.png)

![Screen Shot 2020-07-29 at 8 50 41 AM](https://user-images.githubusercontent.com/1932421/88802300-dfd85980-d178-11ea-8870-d67667a06a41.png)

Of course one can still enable 'auto-size':
![Screen Shot 2020-07-29 at 8 50 48 AM](https://user-images.githubusercontent.com/1932421/88802324-e8309480-d178-11ea-99bd-cbc0391fdd90.png)

