### PR TITLE
Data browser filename fix

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -194,7 +194,13 @@ public class DataBrowserInstance implements AppInstance
                 new_model.setMacros(macros);
 
                 // Load model from file in background
-                XMLPersistence.load(new_model, ResourceParser.getContent(new URI(input.getScheme() + "://" + input.getPath())));
+                // (strip 'query' from input)
+                XMLPersistence.load(new_model, ResourceParser.getContent(
+                        new URI(input.getScheme(),
+                                input.getAuthority(),
+                                input.getPath(),
+                                "",
+                                "")));
 
                 Platform.runLater(() ->
                 {


### PR DESCRIPTION
#1422 added support for macros, but because it used plain string
manipulations to remove the "..?MACRO=value" query from the input URL,
it created problems with spaces in filenames, as reported in #1435.

This rewrites the URI using API that will properly escape spaces in the
file name.