### PR TITLE
Initial widget state incorrect if formula PV references disconnected PV

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/pv/RuntimePV.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/pv/RuntimePV.java
@@ -20,6 +20,7 @@ import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
 import io.reactivex.disposables.Disposable;
+import org.phoebus.pv.formula.FormulaPV;
 
 /** Process Variable, API for accessing life control system data.
  *
@@ -70,7 +71,8 @@ public class RuntimePV // TODO (Almost) remove. Use vtype.pv, only add setValue 
     {
         // If there is a known value, perform initial update
         final VType value = pv.read();
-        if (value != null)
+        // FormulaPVs should not trigger value change as PV inputs may be disconnected
+        if (value != null && !(pv instanceof FormulaPV))
             listener.valueChanged(this, value);
         listeners.add(listener);
     }


### PR DESCRIPTION
Given how formula PVs are constructed and evaluated, this is the least intrusive solution I could find. Root cause for the issue is that even if input PVs in a formula are off-line, the evaluated PV will not be treated as disconnected when OPI is launched. This fixes the issue such that widget is rendered correctly if any of the input PVs is off-line.