### PR TITLE
Display Builder Editor: Open in external editor actions

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Messages.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Messages.java
@@ -60,6 +60,7 @@ public class Messages
     public static String MoveToFront;
     public static String MoveUp;
     public static String NewDisplay;
+    public static String OpenInExternalEditor;
     public static String Order;
     public static String Paste;
     public static String PointCount_Fmt;

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/actions/ActionDescription.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/actions/ActionDescription.java
@@ -7,11 +7,16 @@
  *******************************************************************************/
 package org.csstudio.display.builder.editor.actions;
 
+import static org.csstudio.display.builder.editor.Plugin.logger;
+
+import java.io.File;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.logging.Level;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 
@@ -21,8 +26,12 @@ import org.csstudio.display.builder.editor.app.DisplayEditorInstance;
 import org.csstudio.display.builder.editor.undo.SetWidgetPropertyAction;
 import org.csstudio.display.builder.editor.undo.UpdateWidgetOrderAction;
 import org.csstudio.display.builder.model.ChildrenProperty;
+import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.Widget;
 import org.phoebus.framework.preferences.PhoebusPreferenceService;
+import org.phoebus.framework.spi.AppResourceDescriptor;
+import org.phoebus.framework.util.ResourceParser;
+import org.phoebus.ui.application.ApplicationLauncherService;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.dialog.NumericInputDialog;
 import org.phoebus.ui.javafx.PlatformInfo;
@@ -30,6 +39,7 @@ import org.phoebus.ui.undo.CompoundUndoableAction;
 import org.phoebus.ui.undo.UndoableActionManager;
 
 import javafx.geometry.Point2D;
+import javafx.stage.Stage;
 
 /** Description of an action
  *
@@ -787,6 +797,28 @@ public abstract class ActionDescription
                 location += height + offset;
                 undo.execute(new SetWidgetPropertyAction<>(widget.propY(), location));
                 height = widget.propHeight().getValue();
+            }
+        }
+    };
+
+    /** Open in external Editor */
+    public static final ActionDescription OPEN_EXTERNAL =
+        new ActionDescription("icons/file.png", Messages.OpenInExternalEditor)
+    {
+        @Override
+        public void run(final DisplayEditor editor, final boolean selected)
+        {
+            String resource = editor.getModel().getUserData(DisplayModel.USER_DATA_INPUT_FILE);
+            try {
+                AppResourceDescriptor application = ApplicationLauncherService.findApplication(new URI("display.xml"), true, (Stage)editor.getContextMenuNode().getScene().getWindow());
+                if (application == null)
+                    return;
+                logger.log(Level.INFO, "Opening " + resource + " with " + application.getName());
+                application.create(ResourceParser.getURI(new File(resource)));
+            }
+            catch (Exception e)
+            {
+                logger.log(Level.WARNING, "Opening " + resource + " failed.", e);
             }
         }
     };

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
@@ -40,6 +40,7 @@ import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.framework.spi.AppResourceDescriptor;
 import org.phoebus.framework.util.ResourceParser;
+import org.phoebus.ui.application.ApplicationLauncherService;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
@@ -72,6 +73,7 @@ public class DisplayEditorInstance implements AppInstance
     private final AppResourceDescriptor app;
     private DockItemWithInput dock_item;
     private final EditorGUI editor_gui;
+    private final boolean external_editor_exists = null != ApplicationLauncherService.findApplication(ResourceParser.getURI(new File("x.xml")), false, null);
 
     private final WidgetPropertyListener<String> model_name_listener = (property, old_value, new_value) ->
     {
@@ -159,6 +161,7 @@ public class DisplayEditorInstance implements AppInstance
             final MenuItem morph = new MorphWidgetsMenu(editor_gui.getDisplayEditor());
             final MenuItem back = new ActionWapper(ActionDescription.TO_BACK);
             final MenuItem front = new ActionWapper(ActionDescription.TO_FRONT);
+            final ActionWapper open_external = new ActionWapper(ActionDescription.OPEN_EXTERNAL);
             if (selection.size() <= 0)
             {
                 delete.setDisable(true);
@@ -171,6 +174,7 @@ public class DisplayEditorInstance implements AppInstance
                 morph.setDisable(true);
                 back.setDisable(true);
                 front.setDisable(true);
+                open_external.setDisable(!external_editor_exists);
             }
 
             final MenuItem ungroup;
@@ -242,6 +246,7 @@ public class DisplayEditorInstance implements AppInstance
                                        new SetDisplaySize(editor_gui.getDisplayEditor()),
                                        new SeparatorMenuItem(),
                                        ExecuteDisplayAction.asMenuItem(this),
+                                       open_external,
                                        new ReloadDisplayAction(this),
                                        reload_classes,
                                        new SeparatorMenuItem(),

--- a/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/messages.properties
+++ b/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/messages.properties
@@ -43,6 +43,7 @@ MoveToBack=Move widget to back [Alt-Shift-B]
 MoveToFront=Move widget to front [Alt-Shift-F]
 MoveUp=Move widget backward [Alt-B]
 NewDisplay=New Display
+OpenInExternalEditor=Open as XML in external editor
 Order=Order
 Paste=Paste
 PointCount_Fmt={0} Points

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/Messages.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/Messages.java
@@ -80,6 +80,7 @@ public class Messages
     public static String MacrosTable_ValueHint;
     public static String MoveDown;
     public static String MoveUp;
+    public static String OpenInExternalEditor;
     public static String Password;
     public static String Password_Caption;
     public static String Password_Error;

--- a/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/messages.properties
+++ b/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/messages.properties
@@ -63,6 +63,7 @@ MacrosTable_ToolTip=Edit names or values. Add new macro in last row
 MacrosTable_ValueHint=<Enter value>
 MoveDown=Down
 MoveUp=Up
+OpenInExternalEditor=Open in external editor
 Password=Password
 Password_Caption=Password:
 Password_Error=Incorrect password


### PR DESCRIPTION
Display Builder Editor: Open in external editor actions added for Script dialog ("Select" Menu Button) and Editor Pane (Context menu).
Opens the Script file, if an external application is registered for handling .py or .js files, if script is configured as file (not embedded).
Opens the Display file, if an external application is registered for handling .xml files.
See #679