### PR TITLE
CSSTUDIO-1316 Some widgets initially disabled when PV disconnected

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
@@ -353,8 +353,7 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
         }
         if (dirty_enablement.checkAndClear())
         {
-            final boolean enabled = model_widget.propEnabled().getValue()  &&
-                                    model_widget.runtimePropPVWritable().getValue();
+            final boolean enabled = model_widget.propEnabled().getValue();
             jfx_node.setDisable(! enabled);
             Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
         }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
@@ -227,8 +227,7 @@ public class CheckBoxRepresentation extends RegionBaseRepresentation<CheckBox, C
             // Don't disable the widget, because that would also remove the
             // context menu etc.
             // Just apply a style that matches the disabled look.
-            enabled = model_widget.propEnabled().getValue() &&
-                      model_widget.runtimePropPVWritable().getValue();
+            enabled = model_widget.propEnabled().getValue();
             Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
             if (model_widget.propAutoSize().getValue())
                 sizeChanged(null, null, null);

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
@@ -274,12 +274,7 @@ public class ComboRepresentation extends RegionBaseRepresentation<ComboBox<Strin
         }
         if (dirty_enable.checkAndClear()  &&  !toolkit.isEditMode())
         {
-            final boolean enabled = model_widget.propEnabled().getValue()  &&
-                                    model_widget.runtimePropPVWritable().getValue();
-            // When truly disabled, the widget no longer reacts to context menu,
-            // and the cursor will be ignored
-            //  jfx_node.setDisable(! enabled);
-            // So keep enabled, but indicate that trying to operate the widget is futile
+            final boolean enabled = model_widget.propEnabled().getValue();
             Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
             jfx_node.setCursor(enabled ? Cursor.DEFAULT : Cursors.NO_WRITE);
         }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
@@ -243,8 +243,7 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
 
     private void enablementChanged(final WidgetProperty<Boolean> property, final Boolean old_value, final Boolean new_value)
     {
-        enabled = model_widget.propEnabled().getValue()  &&
-                  model_widget.runtimePropPVWritable().getValue();
+        enabled = model_widget.propEnabled().getValue();
         dirty_enablement.mark();
         toolkit.scheduleUpdate(this);
     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
@@ -97,7 +97,7 @@ public class SlideButtonRepresentation extends RegionBaseRepresentation<HBox, Sl
 
             // Don't disable the widget, because that would also remove the context menu etc.
             // Just apply a style that matches the disabled look.
-            enabled = model_widget.propEnabled().getValue() && model_widget.runtimePropPVWritable().getValue();
+            enabled = model_widget.propEnabled().getValue();
 
             Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
@@ -367,8 +367,7 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
             jfx_node.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
 
             // Enable if enabled by user and there's write access
-            final boolean enabled = model_widget.propEnabled().getValue()  &&
-                                    model_widget.runtimePropPVWritable().getValue();
+            final boolean enabled = model_widget.propEnabled().getValue();
             // Don't disable the widget, because that would also remove the
             // context menu etc.
             // Just apply a style that matches the disabled look.


### PR DESCRIPTION
Fixes issue where some widgets are initially disabled if associated PV is disconnected. With this change the behavior is more consistent across all widgets. 