### PR TITLE
Run else branch of rule when PV disconnects

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
@@ -234,6 +234,7 @@ public class RuleToScript
         final StringBuilder script = new StringBuilder();
         script.append("## Script for Rule: ").append(rule.getName()).append("\n\n");
         script.append("from org.csstudio.display.builder.runtime.script import PVUtil\n");
+        script.append("from java import lang\n");
         if (pform == PropFormat.COLOR)
             script.append("from ").append(WidgetColor.class.getPackageName()).append(" import WidgetColor\n");
         else if (pform == PropFormat.FONT)
@@ -383,8 +384,12 @@ public class RuleToScript
         else
             script.append(try_indent).append(setPropStr).append(formatPropVal(prop, -1, pform)).append(")\n");
 
-        script.append("\nexcept PVUtil.PVHasNoValueException:\n");
+        script.append("\nexcept (Exception, lang.Exception) as e:\n");
         script.append(try_indent).append(setPropStr).append(formatPropVal(prop, -1, pform)).append(")\n");
+        script.append(try_indent).append("from org.csstudio.display.builder.runtime.script import ScriptUtil\n");
+        script.append(try_indent).append("ScriptUtil.getLogger().info('Restored default value because of exception')\n");
+        script.append(try_indent).append("import traceback\n");
+        script.append(try_indent).append("ScriptUtil.getLogger().warning(traceback.format_exc())\n");
 
         return script.toString();
     }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
@@ -278,7 +278,9 @@ public class RuleToScript
             {
                 final String varname = entry.getKey();
                 /*
-                 * PVUtil.getDouble() (used for pv0, pv1, etc) does not throw an exception when the PV is disconnected
+                 * PVUtil.getDouble() (used for pv0, pv1, etc),
+                 * getSeverity() and getLegacySeverity() do not throw
+                 * an exception when the PV is disconnected:
                  * Let's make sure that we have a pvInt for every PV
                  */
                 if (expr_to_check.contains(varname) || varname.contains("pvInt"))
@@ -386,10 +388,8 @@ public class RuleToScript
 
         script.append("\nexcept (Exception, lang.Exception) as e:\n");
         script.append(try_indent).append(setPropStr).append(formatPropVal(prop, -1, pform)).append(")\n");
-        script.append(try_indent).append("from org.csstudio.display.builder.runtime.script import ScriptUtil\n");
-        script.append(try_indent).append("ScriptUtil.getLogger().info('Restored default value because of exception')\n");
-        script.append(try_indent).append("import traceback\n");
-        script.append(try_indent).append("ScriptUtil.getLogger().warning(traceback.format_exc())\n");
+        script.append(try_indent).append("if not isinstance(e, PVUtil.PVHasNoValueException):\n");
+        script.append(indent).append("raise e\n");
 
         return script.toString();
     }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/rules/RuleToScript.java
@@ -276,13 +276,14 @@ public class RuleToScript
             for (Map.Entry<String, String> entry : pvm.entrySet())
             {
                 final String varname = entry.getKey();
-                if (expr_to_check.contains(varname))
+                /*
+                 * PVUtil.getDouble() (used for pv0, pv1, etc) does not throw an exception when the PV is disconnected
+                 * Let's make sure that we have a pvInt for every PV
+                 */
+                if (expr_to_check.contains(varname) || varname.contains("pvInt"))
                     output_pvm.put(varname, entry.getValue());
             }
         }
-        // Generate code that reads the required pv* variables from PVs
-        for (Map.Entry<String, String> entry : output_pvm.entrySet())
-            script.append(entry.getKey()).append(" = ").append(entry.getValue()).append("\n");
 
         if (pform == PropFormat.COLOR)
         {   // If property is a color, create variables for all the used colors
@@ -337,8 +338,14 @@ public class RuleToScript
             }
         }
 
+        script.append("\ntry:\n");
+        final String try_indent = "    ";
+        // Generate code that reads the required pv* variables from PVs
+        for (Map.Entry<String, String> entry : output_pvm.entrySet())
+            script.append(try_indent).append(entry.getKey()).append(" = ").append(entry.getValue()).append("\n");
+
         script.append("\n## Script Body\n");
-        String indent = "    ";
+        final String indent = try_indent + "    ";
 
         final String setPropStr = "widget.setPropertyValue('" + rule.getPropID() + "', ";
         int idx = 0;
@@ -346,7 +353,7 @@ public class RuleToScript
         final Macros macros = attached_widget.getEffectiveMacros();
         for (ExpressionInfo<?> expr : rule.getExpressions())
         {
-            script.append((idx == 0) ? "if" : "elif");
+            script.append(try_indent).append((idx == 0) ? "if" : "elif");
 
             String expanded_expression;
             try
@@ -370,11 +377,14 @@ public class RuleToScript
 
         if (idx > 0)
         {
-            script.append("else:\n");
+            script.append(try_indent).append("else:\n");
             script.append(indent).append(setPropStr).append(formatPropVal(prop, -1, pform)).append(")\n");
         }
         else
-            script.append(setPropStr).append(formatPropVal(prop, -1, pform)).append(")\n");
+            script.append(try_indent).append(setPropStr).append(formatPropVal(prop, -1, pform)).append(")\n");
+
+        script.append("\nexcept PVUtil.PVHasNoValueException:\n");
+        script.append(try_indent).append(setPropStr).append(formatPropVal(prop, -1, pform)).append(")\n");
 
         return script.toString();
     }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
@@ -31,26 +31,18 @@ import org.phoebus.util.time.TimestampFormats;
 @SuppressWarnings("nls")
 public class PVUtil
 {
-    public static class PVHasNoValueException extends NullPointerException
-    {
-        public PVHasNoValueException(final String msg)
-        {
-            super(msg);
-        }
-    }
-
     /** Get valid value from PV
      *  @param pv PV
      *  @return Valid value
      *  @throws NullPointerException when PV is not connected, no valid value
      */
-    public static VType getVType(final RuntimePV pv) throws PVHasNoValueException
+    public static VType getVType(final RuntimePV pv) throws NullPointerException
     {
         final VType value = pv.read();
         if (value == null)
-            throw new PVHasNoValueException("PV " + pv.getName() + " has no value");
+            throw new NullPointerException("PV " + pv.getName() + " has no value");
         if (PV.isDisconnected(value))
-            throw new PVHasNoValueException("PV " + pv.getName() + " has no valid value");
+            throw new NullPointerException("PV " + pv.getName() + " has no valid value");
         return value;
     }
 
@@ -72,7 +64,7 @@ public class PVUtil
      *  @return Current value as int.  Boolean will turn into 0, 1.
      *  @throws NullPointerException if the PV has no value
      */
-    public static int getInt(final RuntimePV pv) throws PVHasNoValueException
+    public static int getInt(final RuntimePV pv) throws NullPointerException
     {
         return ValueUtil.getInt(getVType(pv));
     }
@@ -82,7 +74,7 @@ public class PVUtil
      *  @return Current value as long
      *  @throws NullPointerException if the PV has no value
      */
-    public static long getLong(final RuntimePV pv) throws PVHasNoValueException
+    public static long getLong(final RuntimePV pv) throws NullPointerException
     {
         return ValueUtil.getLong(getVType(pv));
     }
@@ -92,7 +84,7 @@ public class PVUtil
      *  @return Current value as string. Boolean will turn into "false"/"true"
      *  @throws NullPointerException if the PV has no value
      */
-    public static String getString(final RuntimePV pv) throws PVHasNoValueException
+    public static String getString(final RuntimePV pv) throws NullPointerException
     {
         return ValueUtil.getString(getVType(pv));
     }
@@ -106,7 +98,7 @@ public class PVUtil
      *  @return Current value as string
      *  @throws NullPointerException if the PV has no value
      */
-    public static String getString(final RuntimePV pv, final boolean byte_array_as_string) throws PVHasNoValueException
+    public static String getString(final RuntimePV pv, final boolean byte_array_as_string) throws NullPointerException
     {
         return ValueUtil.getString(getVType(pv), byte_array_as_string);
     }
@@ -116,7 +108,7 @@ public class PVUtil
      *  @return Enum labels or empty array if not enum nor table
      *  @throws NullPointerException if the PV has no value
      */
-    public static String[] getLabels(final RuntimePV pv) throws PVHasNoValueException
+    public static String[] getLabels(final RuntimePV pv) throws NullPointerException
     {
         return ValueUtil.getLabels(getVType(pv));
     }
@@ -129,7 +121,7 @@ public class PVUtil
      *          does not decode into a number.
      *  @throws NullPointerException if the PV has no value
      */
-    public static double[] getDoubleArray(final RuntimePV pv) throws PVHasNoValueException
+    public static double[] getDoubleArray(final RuntimePV pv) throws NullPointerException
     {
         return ValueUtil.getDoubleArray(getVType(pv));
     }
@@ -140,7 +132,7 @@ public class PVUtil
      *          Will return single-element array for scalar value.
      *  @throws NullPointerException if the PV has no value
      */
-    public static long[] getLongArray(final RuntimePV pv) throws PVHasNoValueException
+    public static long[] getLongArray(final RuntimePV pv) throws NullPointerException
     {
         return ValueUtil.getLongArray(getVType(pv));
     }
@@ -154,7 +146,7 @@ public class PVUtil
      *          For scalar PVs, an array with a single string is returned.
      *  @throws NullPointerException if the PV has no value
      */
-    public final static String[] getStringArray(final RuntimePV pv) throws PVHasNoValueException
+    public final static String[] getStringArray(final RuntimePV pv) throws NullPointerException
     {
         return ValueUtil.getStringArray(getVType(pv));
     }
@@ -171,7 +163,7 @@ public class PVUtil
      *  @see ValueUtil#getTimestamp(VType) to fetch time stamp for custom formatting
      *  @throws NullPointerException if the PV has no value
      */
-    public static String getTimeString(final RuntimePV pv) throws PVHasNoValueException
+    public static String getTimeString(final RuntimePV pv) throws NullPointerException
     {
         final Instant time = ValueUtil.getTimestamp(getVType(pv));
         if (time == null)
@@ -189,7 +181,7 @@ public class PVUtil
      *  @return milliseconds since 1970.
      *  @throws NullPointerException if the PV has no value
      */
-    public final static long getTimeInMilliseconds(final RuntimePV pv) throws PVHasNoValueException
+    public final static long getTimeInMilliseconds(final RuntimePV pv) throws NullPointerException
     {
         final Instant time = ValueUtil.getTimestamp(getVType(pv));
         if (time == null)
@@ -278,7 +270,7 @@ public class PVUtil
      *  @return List of rows, where each row contains either String or Number cells
      *  @throws NullPointerException if the PV has no value
      */
-    public static List<List<Object>> getTable(final RuntimePV pv) throws PVHasNoValueException
+    public static List<List<Object>> getTable(final RuntimePV pv) throws NullPointerException
     {
         return ValueUtil.getTable(getVType(pv));
     }
@@ -310,7 +302,7 @@ public class PVUtil
      *          if there is no matching sub-structure, the list is empty.
      *  @throws NullPointerException if the PV has no value
      */
-    public static List<List<Object>> getStructure(final RuntimePV pv, final String name) throws PVHasNoValueException
+    public static List<List<Object>> getStructure(final RuntimePV pv, final String name) throws NullPointerException
     {
     	return ValueUtil.getStructure(getVType(pv), name);
     }
@@ -325,7 +317,7 @@ public class PVUtil
      *  @return Either String or Number for the cell's value, null if invalid row/column
      *  @throws NullPointerException if the PV has no value
      */
-    public static Object getTableCell(final RuntimePV pv, final int row, final int column) throws PVHasNoValueException
+    public static Object getTableCell(final RuntimePV pv, final int row, final int column) throws NullPointerException
     {
         return ValueUtil.getTableCell(getVType(pv), row, column);
     }
@@ -356,7 +348,7 @@ public class PVUtil
      *          of the value.
      *  @throws NullPointerException if the PV has no value
      */
-    public static List<Object> getStructureElement(final RuntimePV pv, final String name) throws PVHasNoValueException
+    public static List<Object> getStructureElement(final RuntimePV pv, final String name) throws NullPointerException
     {
     	return ValueUtil.getStructureElement(getVType(pv), name);
     }
@@ -371,7 +363,7 @@ public class PVUtil
      *  @return Either String or Number for the cell's value, null if invalid name/index
      *  @throws NullPointerException if the PV has no value
      */
-    public static Object getStructureElement(final RuntimePV pv, final String name, final int index) throws PVHasNoValueException
+    public static Object getStructureElement(final RuntimePV pv, final String name, final int index) throws NullPointerException
     {
     	return ValueUtil.getStructureElement(getVType(pv), name, index);
     }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
@@ -31,6 +31,15 @@ import org.phoebus.util.time.TimestampFormats;
 @SuppressWarnings("nls")
 public class PVUtil
 {
+    public static class PVHasNoValueException extends NullPointerException
+    {
+        public PVHasNoValueException(final String msg)
+        {
+            super(msg);
+        }
+    }
+
+
     /** Get valid value from PV
      *  @param pv PV
      *  @return Valid value
@@ -40,9 +49,9 @@ public class PVUtil
     {
         final VType value = pv.read();
         if (value == null)
-            throw new NullPointerException("PV " + pv.getName() + " has no value");
+            throw new PVHasNoValueException("PV " + pv.getName() + " has no value");
         if (PV.isDisconnected(value))
-            throw new NullPointerException("PV " + pv.getName() + " has no valid value");
+            throw new PVHasNoValueException("PV " + pv.getName() + " has no valid value");
         return value;
     }
 

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
@@ -31,18 +31,26 @@ import org.phoebus.util.time.TimestampFormats;
 @SuppressWarnings("nls")
 public class PVUtil
 {
+    public static class PVHasNoValueException extends NullPointerException
+    {
+        public PVHasNoValueException(final String msg)
+        {
+            super(msg);
+        }
+    }
+
     /** Get valid value from PV
      *  @param pv PV
      *  @return Valid value
      *  @throws NullPointerException when PV is not connected, no valid value
      */
-    public static VType getVType(final RuntimePV pv) throws NullPointerException
+    public static VType getVType(final RuntimePV pv) throws PVHasNoValueException
     {
         final VType value = pv.read();
         if (value == null)
-            throw new NullPointerException("PV " + pv.getName() + " has no value");
+            throw new PVHasNoValueException("PV " + pv.getName() + " has no value");
         if (PV.isDisconnected(value))
-            throw new NullPointerException("PV " + pv.getName() + " has no valid value");
+            throw new PVHasNoValueException("PV " + pv.getName() + " has no valid value");
         return value;
     }
 
@@ -64,7 +72,7 @@ public class PVUtil
      *  @return Current value as int.  Boolean will turn into 0, 1.
      *  @throws NullPointerException if the PV has no value
      */
-    public static int getInt(final RuntimePV pv) throws NullPointerException
+    public static int getInt(final RuntimePV pv) throws PVHasNoValueException
     {
         return ValueUtil.getInt(getVType(pv));
     }
@@ -74,7 +82,7 @@ public class PVUtil
      *  @return Current value as long
      *  @throws NullPointerException if the PV has no value
      */
-    public static long getLong(final RuntimePV pv) throws NullPointerException
+    public static long getLong(final RuntimePV pv) throws PVHasNoValueException
     {
         return ValueUtil.getLong(getVType(pv));
     }
@@ -84,7 +92,7 @@ public class PVUtil
      *  @return Current value as string. Boolean will turn into "false"/"true"
      *  @throws NullPointerException if the PV has no value
      */
-    public static String getString(final RuntimePV pv) throws NullPointerException
+    public static String getString(final RuntimePV pv) throws PVHasNoValueException
     {
         return ValueUtil.getString(getVType(pv));
     }
@@ -98,7 +106,7 @@ public class PVUtil
      *  @return Current value as string
      *  @throws NullPointerException if the PV has no value
      */
-    public static String getString(final RuntimePV pv, final boolean byte_array_as_string) throws NullPointerException
+    public static String getString(final RuntimePV pv, final boolean byte_array_as_string) throws PVHasNoValueException
     {
         return ValueUtil.getString(getVType(pv), byte_array_as_string);
     }
@@ -108,7 +116,7 @@ public class PVUtil
      *  @return Enum labels or empty array if not enum nor table
      *  @throws NullPointerException if the PV has no value
      */
-    public static String[] getLabels(final RuntimePV pv) throws NullPointerException
+    public static String[] getLabels(final RuntimePV pv) throws PVHasNoValueException
     {
         return ValueUtil.getLabels(getVType(pv));
     }
@@ -121,7 +129,7 @@ public class PVUtil
      *          does not decode into a number.
      *  @throws NullPointerException if the PV has no value
      */
-    public static double[] getDoubleArray(final RuntimePV pv) throws NullPointerException
+    public static double[] getDoubleArray(final RuntimePV pv) throws PVHasNoValueException
     {
         return ValueUtil.getDoubleArray(getVType(pv));
     }
@@ -132,7 +140,7 @@ public class PVUtil
      *          Will return single-element array for scalar value.
      *  @throws NullPointerException if the PV has no value
      */
-    public static long[] getLongArray(final RuntimePV pv) throws NullPointerException
+    public static long[] getLongArray(final RuntimePV pv) throws PVHasNoValueException
     {
         return ValueUtil.getLongArray(getVType(pv));
     }
@@ -146,7 +154,7 @@ public class PVUtil
      *          For scalar PVs, an array with a single string is returned.
      *  @throws NullPointerException if the PV has no value
      */
-    public final static String[] getStringArray(final RuntimePV pv) throws NullPointerException
+    public final static String[] getStringArray(final RuntimePV pv) throws PVHasNoValueException
     {
         return ValueUtil.getStringArray(getVType(pv));
     }
@@ -163,7 +171,7 @@ public class PVUtil
      *  @see ValueUtil#getTimestamp(VType) to fetch time stamp for custom formatting
      *  @throws NullPointerException if the PV has no value
      */
-    public static String getTimeString(final RuntimePV pv) throws NullPointerException
+    public static String getTimeString(final RuntimePV pv) throws PVHasNoValueException
     {
         final Instant time = ValueUtil.getTimestamp(getVType(pv));
         if (time == null)
@@ -181,7 +189,7 @@ public class PVUtil
      *  @return milliseconds since 1970.
      *  @throws NullPointerException if the PV has no value
      */
-    public final static long getTimeInMilliseconds(final RuntimePV pv) throws NullPointerException
+    public final static long getTimeInMilliseconds(final RuntimePV pv) throws PVHasNoValueException
     {
         final Instant time = ValueUtil.getTimestamp(getVType(pv));
         if (time == null)
@@ -270,7 +278,7 @@ public class PVUtil
      *  @return List of rows, where each row contains either String or Number cells
      *  @throws NullPointerException if the PV has no value
      */
-    public static List<List<Object>> getTable(final RuntimePV pv) throws NullPointerException
+    public static List<List<Object>> getTable(final RuntimePV pv) throws PVHasNoValueException
     {
         return ValueUtil.getTable(getVType(pv));
     }
@@ -302,7 +310,7 @@ public class PVUtil
      *          if there is no matching sub-structure, the list is empty.
      *  @throws NullPointerException if the PV has no value
      */
-    public static List<List<Object>> getStructure(final RuntimePV pv, final String name) throws NullPointerException
+    public static List<List<Object>> getStructure(final RuntimePV pv, final String name) throws PVHasNoValueException
     {
     	return ValueUtil.getStructure(getVType(pv), name);
     }
@@ -317,7 +325,7 @@ public class PVUtil
      *  @return Either String or Number for the cell's value, null if invalid row/column
      *  @throws NullPointerException if the PV has no value
      */
-    public static Object getTableCell(final RuntimePV pv, final int row, final int column) throws NullPointerException
+    public static Object getTableCell(final RuntimePV pv, final int row, final int column) throws PVHasNoValueException
     {
         return ValueUtil.getTableCell(getVType(pv), row, column);
     }
@@ -348,7 +356,7 @@ public class PVUtil
      *          of the value.
      *  @throws NullPointerException if the PV has no value
      */
-    public static List<Object> getStructureElement(final RuntimePV pv, final String name) throws NullPointerException
+    public static List<Object> getStructureElement(final RuntimePV pv, final String name) throws PVHasNoValueException
     {
     	return ValueUtil.getStructureElement(getVType(pv), name);
     }
@@ -363,7 +371,7 @@ public class PVUtil
      *  @return Either String or Number for the cell's value, null if invalid name/index
      *  @throws NullPointerException if the PV has no value
      */
-    public static Object getStructureElement(final RuntimePV pv, final String name, final int index) throws NullPointerException
+    public static Object getStructureElement(final RuntimePV pv, final String name, final int index) throws PVHasNoValueException
     {
     	return ValueUtil.getStructureElement(getVType(pv), name, index);
     }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/RuntimeScriptHandler.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/RuntimeScriptHandler.java
@@ -45,7 +45,8 @@ public class RuntimeScriptHandler implements RuntimePVListener
     private final Widget widget;
     private final List<ScriptPV> infos;
     private final Script script;
-    private final boolean check_connections;
+    private final boolean is_rule;
+    private boolean check_connections;
 
     /** 'pvs' is aligned with 'infos', i.e. pvs[i] goes with infos.get(i) */
     private final RuntimePV[] pvs;
@@ -129,7 +130,7 @@ public class RuntimeScriptHandler implements RuntimePVListener
      */
     public RuntimeScriptHandler(final Widget widget, final ScriptInfo script_info) throws Exception
     {
-        this(widget, compileScript(widget, widget.getMacrosOrProperties(), script_info), script_info.getCheckConnections(), script_info.getPVs());
+        this(widget, compileScript(widget, widget.getMacrosOrProperties(), script_info), script_info.getCheckConnections(), false, script_info.getPVs());
     }
 
     /** @param widget Widget on which the rule is invoked
@@ -138,7 +139,7 @@ public class RuntimeScriptHandler implements RuntimePVListener
      */
     public RuntimeScriptHandler(final Widget widget, final RuleInfo rule_info) throws Exception
     {
-        this(widget, compileScript(widget, rule_info), true, rule_info.getPVs());
+        this(widget, compileScript(widget, rule_info), true, true, rule_info.getPVs());
     }
 
     /** @param widget Widget on which the script is invoked
@@ -147,11 +148,12 @@ public class RuntimeScriptHandler implements RuntimePVListener
      *  @param infos PV infos
      *  @throws Exception on error
      */
-    private RuntimeScriptHandler(final Widget widget, final Script script, final boolean check_connections, final List<ScriptPV> infos) throws Exception
+    private RuntimeScriptHandler(final Widget widget, final Script script, final boolean check_connections, final boolean is_rule, final List<ScriptPV> infos) throws Exception
     {
         this.widget = widget;
         this.infos = infos;
         this.script = script;
+        this.is_rule = is_rule;
         this.check_connections = check_connections;
         pvs = new RuntimePV[infos.size()];
         subscribed = new AtomicBoolean[infos.size()];
@@ -240,6 +242,10 @@ public class RuntimeScriptHandler implements RuntimePVListener
             if (executed_once.getAndSet(true))
                 return;
         }
+
+        // Do not check connections for rule after the first run
+        if (is_rule && check_connections)
+            check_connections = false;
 
         // Request execution of script
         script.submit(widget, pvs);

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/RuntimeScriptHandler.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/RuntimeScriptHandler.java
@@ -46,7 +46,7 @@ public class RuntimeScriptHandler implements RuntimePVListener
     private final List<ScriptPV> infos;
     private final Script script;
     private final boolean is_rule;
-    private boolean check_connections;
+    private volatile boolean check_connections;
 
     /** 'pvs' is aligned with 'infos', i.e. pvs[i] goes with infos.get(i) */
     private final RuntimePV[] pvs;


### PR DESCRIPTION
When a PV that is used in a rule disconnects (after the rule has run at least once) run the 'else' branch of the rule to restore the original state of the widget.
This is useful when a widget's visibility is controlled by a rule; when the PV disconnects the widget becomes visible again if that was the initial state