### PR TITLE
Handle runtime width and height change in Poly* widgets

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolyBaseWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolyBaseWidget.java
@@ -15,8 +15,6 @@ import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.properties.Points;
 
 /** Base for widgets that display points
- *  Please not that this class does not override defineProperties() to add the points property;
- *   You have to manually add it by calling definePoints() in your defineProperties() function
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
@@ -29,8 +27,10 @@ public abstract class PolyBaseWidget extends MacroWidget
         super(type);
     }
 
-    protected void definePoints(final List<WidgetProperty<?>> properties)
+    @Override
+    protected void defineProperties(final List<WidgetProperty<?>> properties)
     {
+        super.defineProperties(properties);
         properties.add(points = propPoints.createProperty(this, new Points()));
     }
 

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolyBaseWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolyBaseWidget.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.csstudio.display.builder.model.widgets;
+
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPoints;
+
+import java.util.List;
+
+import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.properties.Points;
+
+/** Base for widgets that display points
+ *  Please not that this class does not override defineProperties() to add the points property;
+ *   You have to manually add it by calling definePoints() in your defineProperties() function
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public abstract class PolyBaseWidget extends MacroWidget
+{
+    private volatile WidgetProperty<Points> points;
+
+    public PolyBaseWidget(final String type)
+    {
+        super(type);
+    }
+
+    protected void definePoints(final List<WidgetProperty<?>> properties)
+    {
+        properties.add(points = propPoints.createProperty(this, new Points()));
+    }
+
+    /** @return 'points' property */
+    public WidgetProperty<Points> propPoints()
+    {
+        return points;
+    }
+}

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolygonWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolygonWidget.java
@@ -118,7 +118,6 @@ public class PolygonWidget extends PolyBaseWidget
         properties.add(line_width = propLineWidth.createProperty(this, 3));
         properties.add(line_color = propLineColor.createProperty(this, new WidgetColor(0, 0, 255)));
         properties.add(background_color = propBackgroundColor.createProperty(this, new WidgetColor(50, 50, 255)));
-        definePoints(properties);
     }
 
     @Override

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolygonWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolygonWidget.java
@@ -10,7 +10,6 @@ package org.csstudio.display.builder.model.widgets;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLineColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLineWidth;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPoints;
 
 import java.util.Arrays;
 import java.util.List;
@@ -23,7 +22,6 @@ import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.persist.ModelReader;
 import org.csstudio.display.builder.model.persist.XMLTags;
-import org.csstudio.display.builder.model.properties.Points;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Element;
@@ -32,7 +30,7 @@ import org.w3c.dom.Element;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class PolygonWidget extends MacroWidget
+public class PolygonWidget extends PolyBaseWidget
 {
     /** Legacy polygon used 1.0.0 */
     private static final Version version = new Version(2, 0, 0);
@@ -107,7 +105,6 @@ public class PolygonWidget extends MacroWidget
     private volatile WidgetProperty<WidgetColor> background_color;
     private volatile WidgetProperty<WidgetColor> line_color;
     private volatile WidgetProperty<Integer> line_width;
-    private volatile WidgetProperty<Points> points;
 
     public PolygonWidget()
     {
@@ -121,7 +118,7 @@ public class PolygonWidget extends MacroWidget
         properties.add(line_width = propLineWidth.createProperty(this, 3));
         properties.add(line_color = propLineColor.createProperty(this, new WidgetColor(0, 0, 255)));
         properties.add(background_color = propBackgroundColor.createProperty(this, new WidgetColor(50, 50, 255)));
-        properties.add(points = propPoints.createProperty(this, new Points()));
+        definePoints(properties);
     }
 
     @Override
@@ -156,11 +153,5 @@ public class PolygonWidget extends MacroWidget
     public WidgetProperty<Integer> propLineWidth()
     {
         return line_width;
-    }
-
-    /** @return 'points' property */
-    public WidgetProperty<Points> propPoints()
-    {
-        return points;
     }
 }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolylineWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolylineWidget.java
@@ -164,7 +164,6 @@ public class PolylineWidget extends PolyBaseWidget
         properties.add(line_style = propLineStyle.createProperty(this, LineStyle.SOLID));
         properties.add(arrows = propArrows.createProperty(this, Arrows.NONE));
         properties.add(arrow_length = propArrowLength.createProperty(this, 20));
-        definePoints(properties);
     }
 
     @Override

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolylineWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PolylineWidget.java
@@ -12,7 +12,6 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLineColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLineStyle;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLineWidth;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPoints;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +30,6 @@ import org.csstudio.display.builder.model.persist.ModelReader;
 import org.csstudio.display.builder.model.persist.XMLTags;
 import org.csstudio.display.builder.model.properties.EnumWidgetProperty;
 import org.csstudio.display.builder.model.properties.LineStyle;
-import org.csstudio.display.builder.model.properties.Points;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Document;
@@ -41,7 +39,7 @@ import org.w3c.dom.Element;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class PolylineWidget extends MacroWidget
+public class PolylineWidget extends PolyBaseWidget
 {
     /** Legacy polyline used 1.0.0 */
     private static final Version version = new Version(2, 0, 0);
@@ -143,7 +141,6 @@ public class PolylineWidget extends MacroWidget
     private volatile WidgetProperty<WidgetColor> line_color;
     private volatile WidgetProperty<Integer> line_width;
     private volatile WidgetProperty<LineStyle> line_style;
-    private volatile WidgetProperty<Points> points;
     private volatile WidgetProperty<Arrows> arrows;
     private volatile WidgetProperty<Integer> arrow_length;
 
@@ -167,7 +164,7 @@ public class PolylineWidget extends MacroWidget
         properties.add(line_style = propLineStyle.createProperty(this, LineStyle.SOLID));
         properties.add(arrows = propArrows.createProperty(this, Arrows.NONE));
         properties.add(arrow_length = propArrowLength.createProperty(this, 20));
-        properties.add(points = propPoints.createProperty(this, new Points()));
+        definePoints(properties);
     }
 
     @Override
@@ -219,11 +216,5 @@ public class PolylineWidget extends MacroWidget
     public WidgetProperty<Integer> propArrowLength()
     {
         return arrow_length;
-    }
-
-    /** @return 'points' property */
-    public WidgetProperty<Points> propPoints()
-    {
-        return points;
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PolyBaseRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PolyBaseRepresentation.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2020 European Spallation Source ERIC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.csstudio.display.builder.representation.javafx.widgets;
+
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
+import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.widgets.PolyBaseWidget;
+
+import javafx.scene.Node;
+
+/** Base class for Polygon and Polyline widget representations
+ *  @param <JFX> JFX Widget
+ *  @param <MW> Model widget
+ *  @author Krisztián Löki
+ */
+public abstract class PolyBaseRepresentation<JFX extends Node, MW extends PolyBaseWidget> extends JFXBaseRepresentation<JFX, MW>
+{
+    private final UntypedWidgetPropertyListener widthChangedListener = this::widthChanged;
+    private final UntypedWidgetPropertyListener heightChangedListener = this::heightChanged;
+    private volatile double hScale = 1.0;
+    private volatile double vScale = 1.0;
+    private volatile double width = Double.NaN;
+    private volatile double height = Double.NaN;
+
+    @Override
+    protected void registerListeners()
+    {
+        if (! toolkit.isEditMode())
+            attachTooltip();
+        // Polyline and Polygon can't use the default x/y handling from super.registerListeners();
+
+        model_widget.propWidth().addUntypedPropertyListener(widthChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(heightChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        detachTooltip();
+        model_widget.propWidth().removePropertyListener(widthChangedListener);
+        model_widget.propHeight().removePropertyListener(heightChangedListener);
+    }
+
+    abstract protected void displayChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value);
+
+    private void widthChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
+    {
+        if (Double.isNaN(width))
+            width = ((Integer)old_value).doubleValue();
+        hScale = ((Integer)new_value).doubleValue() / width;
+        displayChanged(null, null, null);
+    }
+
+    private void heightChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
+    {
+        if (Double.isNaN(height))
+            height = ((Integer)old_value).doubleValue();
+        vScale = ((Integer)new_value).doubleValue() / height;
+        displayChanged(null, null, null);
+    }
+
+    protected Double[] scalePoints()
+    {
+        // Change points x/y relative to widget location into
+        // on-screen location
+        final int x = model_widget.propX().getValue();
+        final int y = model_widget.propY().getValue();
+        final Double[] points = model_widget.propPoints().getValue().asDoubleArray();
+        for (int i = 0; i < points.length; i += 2)
+        {
+            points[i] = points[i] * hScale + x;
+            points[i + 1] = points[i + 1] * vScale + y;
+        }
+
+        return points;
+    }
+}

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PolygonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PolygonRepresentation.java
@@ -20,7 +20,7 @@ import javafx.scene.shape.StrokeLineJoin;
 /** Creates JavaFX item for model widget
  *  @author Kay Kasemir
  */
-public class PolygonRepresentation extends JFXBaseRepresentation<Polygon, PolygonWidget>
+public class PolygonRepresentation extends PolyBaseRepresentation<Polygon, PolygonWidget>
 {
     private final DirtyFlag dirty_display = new DirtyFlag();
     private final UntypedWidgetPropertyListener displayChangedListener = this::displayChanged;
@@ -37,9 +37,8 @@ public class PolygonRepresentation extends JFXBaseRepresentation<Polygon, Polygo
     @Override
     protected void registerListeners()
     {
-        if (! toolkit.isEditMode())
-            attachTooltip();
-        // Polygon can't use the default x/y handling from super.registerListeners();
+        super.registerListeners();
+
         model_widget.propVisible().addUntypedPropertyListener(displayChangedListener);
         model_widget.propX().addUntypedPropertyListener(displayChangedListener);
         model_widget.propY().addUntypedPropertyListener(displayChangedListener);
@@ -52,7 +51,8 @@ public class PolygonRepresentation extends JFXBaseRepresentation<Polygon, Polygo
     @Override
     protected void unregisterListeners()
     {
-        detachTooltip();
+        super.unregisterListeners();
+
         model_widget.propVisible().removePropertyListener(displayChangedListener);
         model_widget.propX().removePropertyListener(displayChangedListener);
         model_widget.propY().removePropertyListener(displayChangedListener);
@@ -62,7 +62,8 @@ public class PolygonRepresentation extends JFXBaseRepresentation<Polygon, Polygo
         model_widget.propPoints().removePropertyListener(displayChangedListener);
     }
 
-    private void displayChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
+    @Override
+    protected void displayChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {
         dirty_display.mark();
         toolkit.scheduleUpdate(this);
@@ -77,17 +78,7 @@ public class PolygonRepresentation extends JFXBaseRepresentation<Polygon, Polygo
             if (model_widget.propVisible().getValue())
             {
                 jfx_node.setVisible(true);
-                // Change points x/y relative to widget location into
-                // on-screen location
-                final int x = model_widget.propX().getValue();
-                final int y = model_widget.propY().getValue();
-                final Double[] points = model_widget.propPoints().getValue().asDoubleArray();
-                for (int i=0; i<points.length; i+= 2)
-                {
-                    points[i] += x;
-                    points[i+1] += y;
-                }
-                jfx_node.getPoints().setAll(points);
+                jfx_node.getPoints().setAll(scalePoints());
                 jfx_node.setFill(JFXUtil.convert(model_widget.propBackgroundColor().getValue()));
                 jfx_node.setStroke(JFXUtil.convert(model_widget.propLineColor().getValue()));
                 jfx_node.setStrokeWidth(model_widget.propLineWidth().getValue());


### PR DESCRIPTION
Polygone and Polyline widgets didn't handle width and height changes during runtime. With this PR they do.
I've decided not to override `defineProperties` in `PolyBaseWidget` but to add a separate function to keep the order of properties when saving the widgets.