### PR TITLE
Use the previous symbol filename when adding a new symbol to the SymbolWidget

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/SymbolWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/SymbolWidget.java
@@ -80,7 +80,12 @@ public class SymbolWidget extends PVWidget {
         WidgetPropertyCategory.WIDGET,
         "symbols",
         Messages.WidgetProperties_Symbols,
-        (widget, index) -> propSymbol(index).createProperty(widget, DEFAULT_SYMBOL),
+        (widget, index) -> {
+            String symbol = DEFAULT_SYMBOL;
+            if (index > 0)
+                symbol = ((SymbolWidget)widget).propSymbols().getElement(index - 1).getValue();
+            return propSymbol(index).createProperty(widget, symbol);
+        },
         0
     );
 


### PR DESCRIPTION
Instead of using the default symbol, use the filename of the previous symbol. Makes it **a lot** easier to add symbols. For example those that only differ in their suffix (symbol_red.png, symbol_yellow.png, symbol_green.png)