### PR TITLE
Expand macros in action descriptions as shown in context menu

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
@@ -235,8 +235,20 @@ class ContextMenuSupport
 
     private static MenuItem createMenuItem(final Widget widget, final ActionInfo info)
     {
+        // Expand macros in action description
+        String desc;
+        try
+        {
+            desc = MacroHandler.replace(widget.getEffectiveMacros(), info.getDescription());
+        }
+        catch (Exception ex)
+        {
+            logger.log(Level.WARNING, "Cannot expand macros in action description '" + info.getDescription() + "'", ex);
+            desc = info.getDescription();
+        }
+
         final ImageView icon = new ImageView(new Image(info.getType().getIconURL().toExternalForm()));
-        final MenuItem item = new MenuItem(info.getDescription(), icon);
+        final MenuItem item = new MenuItem(desc, icon);
         item.setOnAction(event -> ActionUtil.handleAction(widget, info));
         return item;
     }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,13 +7,17 @@
  *******************************************************************************/
 package org.csstudio.display.builder.runtime.app;
 
+import static org.csstudio.display.builder.runtime.WidgetRuntime.logger;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.macros.MacroHandler;
 import org.csstudio.display.builder.model.properties.ActionInfo;
 import org.csstudio.display.builder.model.properties.ActionInfo.ActionType;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
@@ -106,9 +110,20 @@ class ContextMenuSupport
                 {
                     if (target == Target.STANDALONE)
                         continue;
-                    final String desc = target == Target.REPLACE
-                                      ? open_info.getDescription()
-                                      : open_info.getDescription() + " (" + target + ")";
+                    // Expand macros in action description
+                    String desc;
+                    try
+                    {
+                        desc = MacroHandler.replace(widget.getEffectiveMacros(), open_info.getDescription());
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.log(Level.WARNING, "Cannot expand macros in action description '" + open_info.getDescription() + "'", ex);
+                        desc = open_info.getDescription();
+                    }
+                    // Mention non-default targets
+                    if (target != Target.REPLACE)
+                        desc += " (" + target + ")";
                     items.add(createMenuItem(widget,
                                    new OpenDisplayActionInfo(desc, open_info.getFile(),
                                                              open_info.getMacros(), target)));


### PR DESCRIPTION
Macros in action descriptions were not expanded:

<img width="223" alt="Screen Shot 2020-08-17 at 10 02 46 AM" src="https://user-images.githubusercontent.com/1932421/90410345-41089400-e078-11ea-8e70-470366260e0d.png">

Fixed:

<img width="223" alt="Screen Shot 2020-08-17 at 9 54 36 AM" src="https://user-images.githubusercontent.com/1932421/90410379-49f96580-e078-11ea-92c9-a1fae2045aea.png">

