### PR TITLE
DataBrowserInstance: use null instead of empty strings for unused par…

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -199,8 +199,8 @@ public class DataBrowserInstance implements AppInstance
                         new URI(input.getScheme(),
                                 input.getAuthority(),
                                 input.getPath(),
-                                "",
-                                "")));
+                                null,
+                                null)));
 
                 Platform.runLater(() ->
                 {


### PR DESCRIPTION
…ameters for filename URI. See #1437 