### PR TITLE
Fall back to messages.properties on a per message level

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOver.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOver.java
@@ -51,8 +51,7 @@ public class WidgetColorPopOver extends PopOver
 	    try
         {
             final URL fxml = WidgetColorPopOver.class.getResource("WidgetColorPopOver.fxml");
-            final InputStream iStream = NLS.getMessages(WidgetColorPopOver.class);
-            final ResourceBundle bundle = new PropertyResourceBundle(iStream);
+            final ResourceBundle bundle = NLS.getMessages(WidgetColorPopOver.class);
             final FXMLLoader fxmlLoader = new FXMLLoader(fxml, bundle);
             final Node content = (Node) fxmlLoader.load();
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOver.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOver.java
@@ -44,8 +44,7 @@ public class WidgetFontPopOver extends PopOver
         try
         {
             final URL fxml = WidgetFontPopOver.class.getResource("WidgetFontPopOver.fxml");
-            final InputStream iStream = NLS.getMessages(WidgetFontPopOver.class);
-            final ResourceBundle bundle = new PropertyResourceBundle(iStream);
+            final ResourceBundle bundle = NLS.getMessages(WidgetFontPopOver.class);
             final FXMLLoader fxmlLoader = new FXMLLoader(fxml, bundle);
             final Node content = (Node) fxmlLoader.load();
 

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowser.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowser.java
@@ -46,8 +46,7 @@ public class FileBrowser implements AppInstance
         try
         {
             final URL fxml = getClass().getResource("FileBrowser.fxml");
-            final InputStream iStream = NLS.getMessages(FileBrowser.class);
-            final ResourceBundle bundle = new PropertyResourceBundle(iStream);
+            final ResourceBundle bundle = NLS.getMessages(FileBrowser.class);
             fxmlLoader = new FXMLLoader(fxml, bundle);
             content = (Node) fxmlLoader.load();
             controller = fxmlLoader.getController();

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ProbeInstance.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ProbeInstance.java
@@ -40,8 +40,7 @@ public class ProbeInstance implements AppInstance {
     public Node create() {
         try {
             final URL fxml = getClass().getResource("view/ProbeView.fxml");
-            final InputStream iStream = NLS.getMessages(ProbeInstance.class);
-            final ResourceBundle bundle = new PropertyResourceBundle(iStream);
+            final ResourceBundle bundle = NLS.getMessages(ProbeInstance.class);
             loader = new FXMLLoader(fxml, bundle);
             return loader.load();
         } catch (IOException e) {

--- a/app/save-and-restore/ui/src/main/java/org/phoebus/applications/saveandrestore/ui/BaseSaveAndRestoreController.java
+++ b/app/save-and-restore/ui/src/main/java/org/phoebus/applications/saveandrestore/ui/BaseSaveAndRestoreController.java
@@ -24,8 +24,7 @@ public abstract class BaseSaveAndRestoreController implements Initializable, Nod
     protected void openTagSearchWindow() {
         try {
             if (tagSearchWindow == null) {
-                final InputStream iStream = NLS.getMessages(SaveAndRestoreApplication.class);
-                final ResourceBundle bundle = new PropertyResourceBundle(iStream);
+                final ResourceBundle bundle = NLS.getMessages(SaveAndRestoreApplication.class);
                 SpringFxmlLoader loader = new SpringFxmlLoader();
 
                 tagSearchWindow = new Stage();

--- a/core/framework/src/main/java/org/phoebus/framework/nls/NLS.java
+++ b/core/framework/src/main/java/org/phoebus/framework/nls/NLS.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.ResourceBundle;
+import java.util.MissingResourceException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -127,6 +128,14 @@ public class NLS
      */
     public static ResourceBundle getMessages(Class<?> clazz)
     {
-        return ResourceBundle.getBundle(clazz.getPackageName() + ".messages");
+        ResourceBundle bundle;
+        try {
+            bundle = ResourceBundle.getBundle(clazz.getPackageName() + ".messages");
+        } catch (MissingResourceException e) {
+            getLogger().log(Level.SEVERE, clazz.getName() + " is missing 'messages.properties'");
+            bundle = null;
+        }
+
+        return bundle;
     }
 }

--- a/core/framework/src/main/java/org/phoebus/framework/nls/NLS.java
+++ b/core/framework/src/main/java/org/phoebus/framework/nls/NLS.java
@@ -123,7 +123,7 @@ public class NLS
      *  Tries to open "messages_{LOCALE}.properties",
      *  falling back to generic "messages.properties"
      *  @param clazz Class relative to which message resources are located
-     *  @returns ResourceBundle for messages or null
+     *  @return ResourceBundle for messages or null
      */
     public static ResourceBundle getMessages(Class<?> clazz)
     {

--- a/core/framework/src/test/java/org/phoebus/framework/nls/NLSMessagesTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/nls/NLSMessagesTest.java
@@ -25,6 +25,8 @@ public class NLSMessagesTest
     // A 'Messages' type of class needs public static String member variables
     public static String Hello;
     public static String Bye;
+    public static String HowAreYou;
+    public static String MissingMessage;
 
     private Locale original;
 
@@ -65,6 +67,37 @@ public class NLSMessagesTest
         System.out.println("Messages for '" + Locale.getDefault().getLanguage() + "': " + Hello + ", " + Bye);
         assertThat(Hello, equalTo("Moin"));
         assertThat(Bye, equalTo("Tschüss"));
+    }
+
+    /** Check if we fall back to english if a localization is missing */
+    @Test
+    public void testMissingLocalization()
+    {
+        Locale.setDefault(Locale.FRENCH);
+        NLS.initializeMessages(NLSMessagesTest.class);
+        System.out.println("Messages for the nonexistent '" + Locale.getDefault().getLanguage() + "' localization: " + Hello + ", " + Bye);
+        assertThat(Hello, equalTo("Hello"));
+        assertThat(Bye, equalTo("Bye"));
+    }
+
+    /** Check if we fall back to english if a localization is incomplete */
+    @Test
+    public void testIncompleteLocalization()
+    {
+        Locale.setDefault(Locale.GERMANY);
+        NLS.initializeMessages(NLSMessagesTest.class);
+        System.out.println("Message missing from '" + Locale.getDefault().getLanguage() + "': " + HowAreYou);
+        assertThat(HowAreYou, equalTo("How are you?"));
+    }
+
+    /** Check missing messages */
+    @Test
+    public void testMissingMessages()
+    {
+        Locale.setDefault(Locale.GERMANY);
+        NLS.initializeMessages(NLSMessagesTest.class);
+        System.out.println("Message missing from all localizations: " + MissingMessage);
+        assertThat(MissingMessage, equalTo("<MissingMessage>"));
     }
 
     @After

--- a/core/framework/src/test/resources/org/phoebus/framework/nls/messages.properties
+++ b/core/framework/src/test/resources/org/phoebus/framework/nls/messages.properties
@@ -1,2 +1,3 @@
 Hello=Hello
 Bye=Bye
+HowAreYou=How are you?


### PR DESCRIPTION
Currently we only fall back to `messages.properties` if `messages_xx.properties` doesn't exist.
If we have an incomplete `messages_xx.properties`, we fall back to the name of the field in `Messages.java`.

This provides a worse experience than having no localization at all unless localizations are completely up to date.

More information on issue #1494

With the changes in this PR, an incomplete localization will first fall back to english for the messages missing from `messages_xx.properties` and then to the field names for the messages missing from both `messages_xx.properties` and `messages.properties`.