### PR TITLE
Show LED label when disconnected if 'requested'

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -116,6 +116,11 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
      */
     abstract protected String computeLabel(final int color_index);
 
+    /** Compute the label when PV is disconnected
+     *  @return String to show in label
+     */
+    abstract protected String computeLabel();
+
     @Override
     protected void registerListeners()
     {
@@ -174,7 +179,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
         if (value == null && runtime_mode)
         {
             value_color = alarm_colors[AlarmSeverity.UNDEFINED.ordinal()];
-            value_label = "";
+            value_label = computeLabel();
         }
         else
         {

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LEDRepresentation.java
@@ -83,4 +83,13 @@ public class LEDRepresentation extends BaseLEDRepresentation<LEDWidget>
             return model_widget.propOnLabel().getValue();
         return model_widget.propOffLabel().getValue();
     }
+
+    @Override
+    protected String computeLabel()
+    {
+        if (model_widget.propOnLabel().getValue().contentEquals(model_widget.propOffLabel().getValue()))
+            return model_widget.propOnLabel().getValue();
+
+        return "";
+    }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/MultiStateLEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/MultiStateLEDRepresentation.java
@@ -97,4 +97,10 @@ public class MultiStateLEDRepresentation extends BaseLEDRepresentation<MultiStat
             return states.get(color_index).label().getValue();
         return model_widget.propFallbackLabel().getValue();
     }
+
+    @Override
+    protected String computeLabel()
+    {
+        return model_widget.propFallbackLabel().getValue();
+    }
 }


### PR DESCRIPTION
When the labels of a two state LED are the same then do not "hide" the label when the PV is disconnected.
For MultistateLEDs show the fallback label.