### PR TITLE
Inform listeners of value changes

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
@@ -273,7 +273,7 @@ public class ArrayWidgetProperty<WPE extends WidgetProperty<?>> extends WidgetPr
             }
             child = child.getNextSibling();
         }
-        value = elements;
+        setValue(elements);
     }
 
     @Override

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/StructuredWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/StructuredWidgetProperty.java
@@ -160,6 +160,8 @@ public class StructuredWidgetProperty extends WidgetProperty<List<WidgetProperty
                     throw new Exception("Cannot set structure " + getName() + "." + element.getName() + " to " + new_element, ex);
                 }
             }
+            // Notify listeners of the whole array
+            firePropertyChange(this, null, this.value);
         }
         else
             throw new Exception("Elements of structure " + getName() + " cannot be assigned from " + new_value);
@@ -195,6 +197,8 @@ public class StructuredWidgetProperty extends WidgetProperty<List<WidgetProperty
                 logger.log(Level.WARNING, "Error reading " + getName() + " element " + element.getName(), ex);
             }
         }
+        // Notify listeners of the whole array
+        firePropertyChange(this, null, this.value);
     }
 
     @Override


### PR DESCRIPTION
(Possible) fix for #1468 ; it does fix the issue but I don't know if it causes side effects.
Not sure about calling `setValue()` in `ArrayWidgetProperty.readFromXML()` because `setValueFromObject()` calls `firePropertyChange()` explicitly... which one is correct?