### PR TITLE
Show symbol value of TextSymbol in tooltip

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
@@ -296,6 +296,7 @@ public class Messages
     public static String WidgetProperties_StretchToFit;
     public static String WidgetProperties_Symbol;
     public static String WidgetProperties_Symbols;
+    public static String WidgetProperties_SymbolValue;
     public static String WidgetProperties_SyncedKnob;
     public static String WidgetProperties_TagColor;
     public static String WidgetProperties_TagVisible;

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextSymbolWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextSymbolWidget.java
@@ -73,6 +73,8 @@ public class TextSymbolWidget extends PVWidget {
         (widget, index) -> propSymbol.createProperty(widget, "\u263A")
     );
 
+    private static final WidgetPropertyDescriptor<String>                       runtimePropSymbolValue = newStringPropertyDescriptor(WidgetPropertyCategory.RUNTIME, "symbol_value", Messages.WidgetProperties_SymbolValue);
+
     private volatile WidgetProperty<Integer>                     array_index;
     private volatile WidgetProperty<WidgetColor>                 background;
     private volatile WidgetProperty<Boolean>                     enabled;
@@ -84,6 +86,7 @@ public class TextSymbolWidget extends PVWidget {
     private volatile WidgetProperty<Boolean>                     transparent;
     private volatile WidgetProperty<VerticalAlignment>           vertical_alignment;
     private volatile WidgetProperty<Boolean>                     wrap_words;
+    private volatile WidgetProperty<String>                      symbol_value;
 
     public TextSymbolWidget ( ) {
         super(WIDGET_DESCRIPTOR.getType(), 32, 32);
@@ -133,6 +136,10 @@ public class TextSymbolWidget extends PVWidget {
         return wrap_words;
     }
 
+    public WidgetProperty<String> runtimePropSymbolValue ( ) {
+        return symbol_value;
+    }
+
     @Override
     protected void defineProperties ( final List<WidgetProperty<?>> properties ) {
 
@@ -152,6 +159,14 @@ public class TextSymbolWidget extends PVWidget {
         properties.add(array_index          = propArrayIndex.createProperty(this, 0));
         properties.add(enabled              = propEnabled.createProperty(this, true));
 
+        properties.add(symbol_value         = runtimePropSymbolValue.createProperty(this, ""));
+
     }
 
+    @Override
+    protected String getInitialTooltip()
+    {
+        // Show the symbol value too
+        return super.getInitialTooltip() + "\n$(symbol_value)";
+    }
 }

--- a/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
+++ b/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
@@ -280,6 +280,7 @@ WidgetProperties_StartFromZero=Start From Zero
 WidgetProperties_StretchToFit=Stretch to Fit
 WidgetProperties_Symbol=Symbol
 WidgetProperties_Symbols=Symbols
+WidgetProperties_SymbolValue=Text Symbol value
 WidgetProperties_SyncedKnob=Synced Knob
 WidgetProperties_TagColor=Tag Color
 WidgetProperties_TagVisible=Tag Visible

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextSymbolRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextSymbolRepresentation.java
@@ -102,7 +102,9 @@ public class TextSymbolRepresentation extends RegionBaseRepresentation<Label, Te
 
             symbolIndex = Math.min(Math.max(symbolIndex, 0), model_widget.propSymbols().size() - 1);
 
-            jfx_node.setText(( symbolIndex >= 0 ) ? model_widget.propSymbols().getElement(symbolIndex).getValue() : "\u263A");
+            final String symbol_value = ( symbolIndex >= 0 ) ? model_widget.propSymbols().getElement(symbolIndex).getValue() : "\u263A";
+            model_widget.runtimePropSymbolValue().setValue(symbol_value);
+            jfx_node.setText(symbol_value);
 
         }
 
@@ -201,7 +203,9 @@ public class TextSymbolRepresentation extends RegionBaseRepresentation<Label, Te
 
             symbolIndex = Math.min(Math.max(symbolIndex, 0), model_widget.propSymbols().size() - 1);
 
-            jfx_node.setText(( symbolIndex >= 0 ) ? model_widget.propSymbols().getElement(symbolIndex).getValue() : "\u263A");
+            final String symbol_value = ( symbolIndex >= 0 ) ? model_widget.propSymbols().getElement(symbolIndex).getValue() : "\u263A";
+            model_widget.runtimePropSymbolValue().setValue(symbol_value);
+            jfx_node.setText(symbol_value);
 
         }
 


### PR DESCRIPTION
Useful if the widget is not wide enough to display the whole symbol value