### PR TITLE
Do not steal DEL and copy-paste keypresses

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -131,9 +131,13 @@ public class EditorGUI
         // Those keys are often used when editing text,
         // and it's easy to accidentally loose input focus
         // and then delete a widget instead of a character.
+        // Also check if property panel has focus; don't want to delete
+        // widget when its name is edited and the mouse happens to be
+        // inside the editor
         final boolean in_editor = editor.getContextMenuNode()
                                         .getLayoutBounds()
-                                        .contains(mouse_x, mouse_y);
+                                        .contains(mouse_x, mouse_y) &&
+                                  ! property_panel.hasFocus();
 
         // Use Ctrl-C .. except on Mac, where it's Command-C ..
         final boolean meta = event.isShortcutDown();

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanel.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanel.java
@@ -75,6 +75,14 @@ public class PropertyPanel extends BorderPane
         setMinHeight(0);
     }
 
+    /**
+     *  @return Whether one of the property editors has focus
+     */
+    public boolean hasFocus()
+    {
+        return section.hasFocus();
+    }
+
     /** Populate UI with properties of widgets
      *  @param widgets Widgets to configure
      */

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -110,6 +110,8 @@ public class PropertyPanelSection extends GridPane
 
     private boolean class_mode = false;
 
+    private volatile boolean has_focus = false;
+
     private final List<WidgetPropertyBinding<?,?>> bindings = new ArrayList<>();
     private int next_row = -1;
 
@@ -131,6 +133,14 @@ public class PropertyPanelSection extends GridPane
     public void setClassMode(final boolean class_mode)
     {
         this.class_mode = class_mode;
+    }
+
+    /**
+     *  @return Whether one of the property editors has focus
+     */
+    public boolean hasFocus()
+    {
+        return has_focus;
     }
 
     void fill(final UndoableActionManager undo,
@@ -651,6 +661,18 @@ public class PropertyPanelSection extends GridPane
 
         label.getStyleClass().add("property_name");
         field.getStyleClass().add("property_value");
+
+        // Update has_focus
+        final Node tmpfield;
+        if (field instanceof HBox)
+            tmpfield = ((HBox)field).getChildren().get(0);
+        else
+            tmpfield = field;
+
+        tmpfield.focusedProperty().addListener((ob, o, focused) ->
+        {
+            has_focus = focused;
+        });
 
         // Allow label to shrink (can use tooltip to see),
         // but show the value


### PR DESCRIPTION
When a property is being edited while the mouse was inside the widget editor area pressing the DEL key deleted the widget instead of the character. I'm not sure if this PR fixes all corner cases but it definitely fixes the one that has bitten me several times.