### PR TITLE
Added forward compatibility

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -477,21 +477,23 @@ public class EditorGUI
             {
                 canon_path = file.getCanonicalPath();
                 model = ModelLoader.loadModel(new FileInputStream(file), canon_path);
+                this.file = file;
             }
             catch (final Exception ex)
             {
                 canon_path = null;
                 logger.log(Level.SEVERE, "Cannot load model from " + file, ex);
                 ExceptionDetailsErrorDialog.openError("Creating empty file",
-                        "Cannot load model from\n" + file + "\n\nCreating new, empty file", ex);
+                        "Cannot load model from\n" + file + "\n\nCreating new, empty model", ex);
                 model = new DisplayModel();
                 model.propName().setValue("Empty");
+                // Don't associate this editor with the file we've failed to load
+                this.file = null;
             }
 
             if (! file.canWrite())
                 model.setUserData(DisplayModel.USER_DATA_READONLY, Boolean.TRUE.toString());
             setModel(model);
-            this.file = file;
 
             try
             {

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -514,7 +514,9 @@ public class EditorGUI
             if (canon_path != null && model.isClean() == false)
             {
                 ExceptionDetailsErrorDialog.openError("Errors while loading model",
-                        "There were some errors while loading model from " + file + "\nNot all widgets are displayed correctly; saving the display in this state might lead to losing those widgets. Please check the log for details.", null);
+                        "There were some errors while loading model from " + file + "\nNot all widgets are displayed correctly; " +
+                        "saving the display in this state might lead to losing those widgets or some of their properties." +
+                        "\nPlease check the log for details.", null);
             }
 
         });

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
@@ -364,6 +364,11 @@ public class DisplayEditorInstance implements AppInstance
 
     private void handleNewModel(final DisplayModel model)
     {
+        // When the model cannot not be loaded then a new, empty one is created
+        // Let's clear dock_item's input to not overwrite whatever we tried
+        // to load as a model
+        if (editor_gui.getFile() == null)
+            dock_item.setInput(null);
         model.propName().addPropertyListener(model_name_listener);
         model_name_listener.propertyChanged(model.propName(), null, null);
     }
@@ -400,7 +405,7 @@ public class DisplayEditorInstance implements AppInstance
 
             // Check if it's a class file (*.bcf)
             File proper;
-            if(model.isClassModel())
+            if (model.isClassModel())
             {
                 proper = FileExtensionUtil.enforceFileExtension(file, WidgetClassSupport.FILE_EXTENSION);
             }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTreeCell.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTreeCell.java
@@ -17,12 +17,14 @@ import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.undo.UndoableAction;
 import org.phoebus.ui.undo.UndoableActionManager;
 
+import javafx.scene.Node;
 import javafx.scene.control.cell.TextFieldTreeCell;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Line;
+import javafx.scene.shape.Rectangle;
 import javafx.util.StringConverter;
 
 /** Tree cell that displays {@link WidgetOrTab} (name, icon, ..)
@@ -87,9 +89,25 @@ class WidgetTreeCell extends TextFieldTreeCell<WidgetOrTab>
             final Widget widget = item.getWidget();
             final String type = widget.getType();
             setText(widget.getName());
+            if (widget.isClean() == false)
+                setTextFill(Color.RED);
+
             final Image icon = WidgetIcons.getIcon(type);
+            Node graphic = null;
             if (icon != null)
             {
+                graphic = new ImageView(icon);
+                if (widget.isClean() == false)
+                {
+                    final double w = icon.getWidth();
+                    final double h = icon.getHeight();
+                    final Rectangle rect = new Rectangle(0, 0, w, h);
+                    rect.setStroke(Color.RED);
+                    rect.setStrokeWidth(2);
+                    rect.setFill(Color.rgb(255, 0, 0, 0.5));
+                    graphic = new StackPane(rect, graphic);
+                }
+
                 if (widget instanceof VisibleWidget)
                 {
                     final boolean visible = ((VisibleWidget)widget).propVisible().getValue();
@@ -103,17 +121,12 @@ class WidgetTreeCell extends TextFieldTreeCell<WidgetOrTab>
                         l2.setStroke(Color.RED);
                         l1.setStrokeWidth(2);
                         l2.setStrokeWidth(2);
-                        final StackPane pane = new StackPane(new ImageView(icon), l1, l2);
-                        setGraphic(pane);
+                        graphic = new StackPane(graphic, l1, l2);
                     }
-                    else
-                        setGraphic(new ImageView(icon));
                 }
-                else
-                    setGraphic(new ImageView(icon));
             }
-            else
-                setGraphic(null);
+
+            setGraphic(graphic);
         }
         else
         {

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/WidgetIcons.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/WidgetIcons.java
@@ -15,6 +15,7 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetFactory;
+import org.csstudio.display.builder.model.widgets.PlaceholderWidget;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javafx.scene.image.Image;
@@ -47,7 +48,9 @@ public class WidgetIcons
         }
         catch (Throwable ex)
         {
-            logger.log(Level.WARNING, "Cannot obtain widget for " + type, ex);
+            // The placeholder widget does not have an icon, we know it
+            if (! type.endsWith(PlaceholderWidget.suffix))
+                logger.log(Level.WARNING, "Cannot obtain widget for " + type, ex);
             try
             {
                 return ImageCache.getImage(WidgetIcons.class, "/icons/question_mark.png");

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/DisplayModel.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/DisplayModel.java
@@ -120,9 +120,6 @@ public class DisplayModel extends Widget
     private volatile WidgetProperty<Integer> gridStepY;
     private volatile ChildrenProperty children;
 
-    /** Loaded without errors? */
-    private volatile Boolean clean;
-
     /** Create display model */
     public DisplayModel()
     {
@@ -176,7 +173,10 @@ public class DisplayModel extends Widget
 
     public final void setReaderResult(final ModelReader modelReader)
     {
-        if (this.clean != null)
+        /*
+         * setConfiguratorResult() might have already set it to true
+         */
+        if (this.clean != null && this.clean.booleanValue() == false)
             throw new RuntimeException("Cannot change cleanliness of DisplayModel");
 
         this.clean = Boolean.valueOf(modelReader.getNumberOfWidgetErrors() == 0);
@@ -185,6 +185,7 @@ public class DisplayModel extends Widget
     /** @return <code>true</code> if this display was loaded without errors,
      *          <code>false</code> if there were widget errors
      */
+    @Override
     public final boolean isClean()
     {
         Boolean safe = clean;
@@ -198,12 +199,15 @@ public class DisplayModel extends Widget
         // Check embedded displays and navigation tabs too
         for (Widget child: getChildren())
         {
-            java.util.Optional<WidgetProperty<DisplayModel>> child_dm_prop = child.checkProperty("embedded_model");
+            java.util.Optional<WidgetProperty<DisplayModel>> child_dm_prop = child.checkProperty(EmbeddedDisplayWidget.runtimeModel.getName());
             if (child_dm_prop.isPresent())
             {
                 final DisplayModel child_dm = child_dm_prop.get().getValue();
                 if (child_dm != null && child_dm.isClean() == false)
+                {
+                    clean = Boolean.valueOf(false);
                     return false;
+                }
             }
         }
 

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetConfigurator.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetConfigurator.java
@@ -63,6 +63,17 @@ public class WidgetConfigurator
         }
     }
 
+    /** This exception is thrown when the version of the widget in the XML
+     *  config is not supported
+     */
+    public static class UnsupportedWidgetVersionException extends Exception
+    {
+        public UnsupportedWidgetVersionException(final String msg)
+        {
+            super(msg);
+        }
+    }
+
     /** Version of the XML.
      *
      *  <p>Derived class can use this to decide how to read older XML.
@@ -87,8 +98,16 @@ public class WidgetConfigurator
      *
      */
     public boolean configureFromXML(final ModelReader model_reader, final Widget widget,
-            final Element xml) throws ParseAgainException, Exception
+            final Element xml) throws ParseAgainException, UnsupportedWidgetVersionException, Exception
     {
+        if (xml_version.getMajor() > widget.getVersion().getMajor())
+        {
+            logger.log(Level.SEVERE,
+                       "Error reading widget " + widget + ": unsupported version " + xml_version);
+
+            throw new UnsupportedWidgetVersionException("Unsupported " + widget.getType() + " version: " + xml_version);
+        }
+
         // System.out.println("Reading " + widget + " from saved V" + xml_version);
         configureAllPropertiesFromMatchingXML(model_reader, widget, xml);
         return true;

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelLoader.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelLoader.java
@@ -14,6 +14,7 @@ import java.util.ServiceLoader;
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.WidgetConfigurator.UnsupportedWidgetVersionException;
 import org.csstudio.display.builder.model.WidgetClassSupport;
 import org.csstudio.display.builder.model.spi.DisplayAutoConverter;
 import org.csstudio.display.builder.model.util.ModelResourceUtil;
@@ -45,6 +46,10 @@ public class ModelLoader
         {
             final String resolved_name = ModelResourceUtil.resolveResource(parent_display, display_file);
             return loadModel(resolved_name);
+        }
+        catch (UnsupportedWidgetVersionException ex)
+        {
+            throw ex;
         }
         catch (Exception ex)
         {

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelLoader.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelLoader.java
@@ -14,7 +14,6 @@ import java.util.ServiceLoader;
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DisplayModel;
-import org.csstudio.display.builder.model.WidgetConfigurator.UnsupportedWidgetVersionException;
 import org.csstudio.display.builder.model.WidgetClassSupport;
 import org.csstudio.display.builder.model.spi.DisplayAutoConverter;
 import org.csstudio.display.builder.model.util.ModelResourceUtil;
@@ -46,10 +45,6 @@ public class ModelLoader
         {
             final String resolved_name = ModelResourceUtil.resolveResource(parent_display, display_file);
             return loadModel(resolved_name);
-        }
-        catch (UnsupportedWidgetVersionException ex)
-        {
-            throw ex;
         }
         catch (Exception ex)
         {

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
@@ -22,8 +22,8 @@ import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.Preferences;
 import org.csstudio.display.builder.model.Version;
 import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.WidgetConfigurator;
 import org.csstudio.display.builder.model.WidgetConfigurator.ParseAgainException;
-import org.csstudio.display.builder.model.WidgetConfigurator.UnsupportedWidgetVersionException;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetFactory;
 import org.csstudio.display.builder.model.WidgetFactory.WidgetTypeException;
@@ -111,6 +111,7 @@ public class ModelReader
     {
         root = XMLUtil.openXMLDocument(stream, XMLTags.DISPLAY);
         version = readVersion(root);
+        widget_errors_during_parse = 0;
         this.xml_file = xml_file;
     }
 
@@ -144,8 +145,14 @@ public class ModelReader
 
         model.setUserData(DisplayModel.USER_DATA_INPUT_VERSION, version);
 
+        widget_errors_during_parse = 0;
+
         // Read display's own properties
-        model.getConfigurator(version).configureFromXML(this, model, root);
+        final WidgetConfigurator configurator = model.getConfigurator(version);
+        configurator.configureFromXML(this, model, root);
+        if (! configurator.isClean())
+            ++widget_errors_during_parse;
+
         // Read widgets of model
         readWidgets(model.runtimeChildren(), root);
         if (widget_errors_during_parse > 0)
@@ -166,6 +173,8 @@ public class ModelReader
      */
     public void readWidgets(final ChildrenProperty children, final Element parent_xml)
     {
+        // Save the number of errors we had so far
+        int saved_widget_errors_during_parse = widget_errors_during_parse;
         // Limit the number of retries to avoid infinite loop
         for (int retries=0; retries < MAX_PARSE_AGAIN; ++retries)
         {
@@ -174,6 +183,9 @@ public class ModelReader
             {
                 for (Widget child : widgets)
                     children.addChild(child);
+
+                // Update the number of errors
+                widget_errors_during_parse += saved_widget_errors_during_parse;
                 return;
             }
         }
@@ -209,15 +221,8 @@ public class ModelReader
                 ex.printStackTrace();
                 return null;
             }
-            catch (UnsupportedWidgetVersionException ex)
-            {
-                // Already logged when thrown
-                ++widget_errors_during_parse;
-                // Continue with next widget
-            }
             catch (WidgetTypeException ex)
             {
-                ++widget_errors_during_parse;
                 // Mention missing widget only once per reader
                 if (! unknown_widget_type.contains(ex.getType()))
                 {
@@ -228,7 +233,6 @@ public class ModelReader
             }
             catch (final Throwable ex)
             {
-                ++widget_errors_during_parse;
                 logger.log(Level.SEVERE,
                            "Widget configuration file error, " + source + ":" + XMLUtil.getLineInfo(widget_xml), ex);
                 // Continue with next widget
@@ -236,6 +240,7 @@ public class ModelReader
 
             if (! added)
             {
+                ++widget_errors_during_parse;
                 Widget widget = createPlaceholderWidget(widget_xml);
                 // Check for ParseAgainException
                 if (widget == null)
@@ -300,8 +305,15 @@ public class ModelReader
         for (WidgetDescriptor desc : WidgetFactory.getInstance().getAllWidgetDescriptors(type))
         {
             final Widget widget = desc.createWidget();
-            if (widget.getConfigurator(xml_version).configureFromXML(this, widget, widget_xml))
+            final WidgetConfigurator configurator = widget.getConfigurator(xml_version);
+            if (configurator.configureFromXML(this, widget, widget_xml))
+            {
+                widget.setConfiguratorResult(configurator);
+                if (! configurator.isClean())
+                    ++widget_errors_during_parse;
+
                 return widget;
+            }
         }
         throw new WidgetTypeException(type, "No suitable widget for " + type);
     }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
@@ -23,6 +23,7 @@ import org.csstudio.display.builder.model.Preferences;
 import org.csstudio.display.builder.model.Version;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetConfigurator.ParseAgainException;
+import org.csstudio.display.builder.model.WidgetConfigurator.UnsupportedWidgetVersionException;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetFactory;
 import org.csstudio.display.builder.model.WidgetFactory.WidgetTypeException;
@@ -207,6 +208,12 @@ public class ModelReader
             {
                 ex.printStackTrace();
                 return null;
+            }
+            catch (UnsupportedWidgetVersionException ex)
+            {
+                // Already logged when thrown
+                ++widget_errors_during_parse;
+                // Continue with next widget
             }
             catch (WidgetTypeException ex)
             {

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -179,6 +179,7 @@ public class EmbeddedDisplayWidget extends MacroWidget
                     }
                     catch (NumberFormatException ex)
                     {
+                        clean_parse = false;
                         logger.log(Level.WARNING, "Cannot decode legacy resize_behavior");
                     }
                 }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PlaceholderWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PlaceholderWidget.java
@@ -30,6 +30,8 @@ import org.w3c.dom.Node;
 @SuppressWarnings("nls")
 public class PlaceholderWidget extends VisibleWidget
 {
+    public static final String suffix = "-placeholder";
+
     private static final Version VERSION = new Version(99, 0, 0);
 
     private static class CustomWidgetConfigurator extends WidgetConfigurator
@@ -63,7 +65,7 @@ public class PlaceholderWidget extends VisibleWidget
      */
     public PlaceholderWidget(final String type)
     {
-        super(type + "-placeholder");
+        super(type + suffix);
         orig_type = type;
     }
 
@@ -98,6 +100,12 @@ public class PlaceholderWidget extends VisibleWidget
     public final String getOrigType()
     {
         return orig_type;
+    }
+
+    @Override
+    public final boolean isClean()
+    {
+        return false;
     }
 
     public final void writeToXML(final ModelWriter model_writer, final XMLStreamWriter writer) throws Exception

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TabsWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TabsWidget.java
@@ -160,6 +160,7 @@ public class TabsWidget extends MacroWidget
                 {
                     if (! content_xml.getAttribute("typeId").contains("group"))
                     {
+                        clean_parse = false;
                         logger.log(Level.WARNING, "Legacy 'tab' widget misses content of tab " + i);
                         break;
                     }

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
@@ -33,6 +33,7 @@ import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.properties.ActionInfo;
 import org.csstudio.display.builder.model.util.ModelThreadPool;
+import org.csstudio.display.builder.model.widgets.PlaceholderWidget;
 import org.csstudio.display.builder.representation.spi.WidgetRepresentationsService;
 
 /** Representation for a toolkit.
@@ -300,7 +301,8 @@ abstract public class ToolkitRepresentation<TWP extends Object, TW> implements E
             WidgetRepresentationFactory<TWP, TW> factory = (WidgetRepresentationFactory<TWP, TW>) factories.get(widget.getType());
             if (factory == null)
             {
-                logger.log(Level.SEVERE, "Lacking representation for " + widget.getType());
+                if (! (widget instanceof PlaceholderWidget))
+                    logger.log(Level.SEVERE, "Lacking representation for " + widget.getType());
                 // Check for a generic "unknown" representation
                 factory = (WidgetRepresentationFactory<TWP, TW>) factories.get(WidgetRepresentationFactory.UNKNOWN);
                 if (factory == null)


### PR DESCRIPTION
Do not load displays / widgets if their major version is higher than supported.
Also, disconnect the editor from the file if the model could not be loaded instead of creating a new model with the same filename.