### PR TITLE
Data browser archive fetch delay

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -112,7 +112,7 @@ public class DataBrowserInstance implements AppInstance
         {   setDirty(true);   }
 
         @Override
-        public void changedItemDataConfig(PVItem item)
+        public void changedItemDataConfig(final PVItem item, final boolean archive_invalid)
         {   setDirty(true);   }
 
         @Override

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/archive/ArchiveFetchJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/archive/ArchiveFetchJob.java
@@ -202,7 +202,6 @@ public class ArchiveFetchJob implements JobRunnable
         this.start = start;
         this.end = end;
         this.listener = listener;
-        new Exception("NEW " + this).printStackTrace();
         this.job = JobManager.schedule(toString(), this);
     }
 
@@ -236,19 +235,14 @@ public class ArchiveFetchJob implements JobRunnable
 
         // Cancelled before even started the worker?
         if (monitor.isCanceled())
-        {
-            System.out.println("Quit before even starting " + this);
             return;
-        }
+
         concurrent_requests.acquire();
         try
         {
             monitor.beginTask(Messages.ArchiveFetchStart);
 
             final WorkerThread worker = new WorkerThread();
-
-            System.out.println("ACTUALLY RUNNING " + this);
-
             final Future<?> done = Activator.thread_pool.submit(worker);
             // Poll worker and progress monitor
             long start = System.currentTimeMillis();
@@ -287,7 +281,6 @@ public class ArchiveFetchJob implements JobRunnable
      */
     public void cancel()
     {
-        new Exception("CANCEL " + this).printStackTrace();
         job.cancel();
     }
 

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/archive/ArchiveFetchJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/archive/ArchiveFetchJob.java
@@ -231,7 +231,9 @@ public class ArchiveFetchJob implements JobRunnable
         // Wait a little to then check if we're already cancelled,
         // instead of starting the request right away only to then
         // have a hard time cancelling the ongoing query.
-        TimeUnit.MILLISECONDS.sleep(700);
+        // (For zoom/pan, this delay is actually used twice:
+        //  before starting the fetch job, then right here)
+        TimeUnit.MILLISECONDS.sleep(Preferences.archive_fetch_delay);
 
         // Cancelled before even started the worker?
         if (monitor.isCanceled())

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
@@ -932,13 +932,14 @@ public class Model
             listener.changedItemUnits(item);
     }
 
-    /** Notify listeners of changed item configuration
-     *  @param item Item that changed
-     */
-    void fireItemDataConfigChanged(final PVItem item)
+    /** Notify listeners of changed item data source configuration
+     *  @param item Item with changed data sources
+     *  @param archive_invalid Was a data source added, do we need to get new archived data?
+     *                         Or does the change not affect archived data?     */
+    void fireItemDataConfigChanged(final PVItem item, final boolean archive_invalid)
     {
         for (ModelListener listener : listeners)
-            listener.changedItemDataConfig(item);
+            listener.changedItemDataConfig(item, archive_invalid);
     }
 
     void fireItemRefreshRequested(final PVItem item)

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
@@ -935,7 +935,8 @@ public class Model
     /** Notify listeners of changed item data source configuration
      *  @param item Item with changed data sources
      *  @param archive_invalid Was a data source added, do we need to get new archived data?
-     *                         Or does the change not affect archived data?     */
+     *                         Or does the change not affect archived data?
+     */
     void fireItemDataConfigChanged(final PVItem item, final boolean archive_invalid)
     {
         for (ModelListener listener : listeners)

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/Model.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/ModelListener.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/ModelListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/ModelListener.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/ModelListener.java
@@ -15,66 +15,68 @@ import java.util.Optional;
 public interface ModelListener
 {
     /** @param save_changes Should UI ask to save changes to the model? */
-    default void changedSaveChangesBehavior(final boolean save_changes) {};
+    default void changedSaveChangesBehavior(final boolean save_changes) {}
 
     /** Title changed */
-    default void changedTitle() {};
+    default void changedTitle() {}
 
     /** The visbility for the toolbar and/or legend has changed */
-    default void changedLayout() {};
+    default void changedLayout() {}
 
     /** The update period or scroll step changed */
-    default void changedTiming() {};
+    default void changedTiming() {}
 
     /** The archive-rescale configuration has changed */
-    default void changedArchiveRescale() {};
+    default void changedArchiveRescale() {}
 
     /** One of the colors (background, ...) or overall fonts changed */
-    default void changedColorsOrFonts() {};
+    default void changedColorsOrFonts() {}
 
     /** The time range (start/end time or span) was changed */
-    default void changedTimerange() {};
+    default void changedTimerange() {}
 
     /** Time axis grid, .. changed */
-    default void changedTimeAxisConfig() {};
+    default void changedTimeAxisConfig() {}
 
     /** @param axis Axis that changed its color, range, ....
      *              If <code>null</code>, an axis was added or removed
      */
-    default void changedAxis(Optional<AxisConfig> axis) {};
+    default void changedAxis(Optional<AxisConfig> axis) {}
 
     /** @param item Item that was added to the model */
-    default void itemAdded(ModelItem item) {};
+    default void itemAdded(ModelItem item) {}
 
     /** @param item Item that was removed from the model */
-    default void itemRemoved(ModelItem item) {};
+    default void itemRemoved(ModelItem item) {}
 
     /** @param item Item that turned visible/invisible */
-    default void changedItemVisibility(ModelItem item) {};
+    default void changedItemVisibility(ModelItem item) {}
 
     /** @param item Item that changed its visible attributes:
      *              color, line width, display name, ...
      */
-    default void changedItemLook(ModelItem item) {};
+    default void changedItemLook(ModelItem item) {}
 
     /** @param item Item that changed its units */
-    default void changedItemUnits(ModelItem item) {};
+    default void changedItemUnits(ModelItem item) {}
 
     /** @param item Item that changed its data configuration:
      *              Archives, request method.
+     *  @param archive_invalid Was a data source added, do we need to get new archived data?
+     *                         Or does the change not affect archived data?
      */
-    default void changedItemDataConfig(PVItem item) {};
+    default void changedItemDataConfig(PVItem item, boolean archive_invalid) {}
 
     /** The annotation list changed */
-    default void changedAnnotations() {};
+    default void changedAnnotations() {}
 
     /**
      * The item requested to refresh its history.
      *
      * @param item the item to refresh the history data for
      */
-    default void itemRefreshRequested(PVItem item) {};
+    default void itemRefreshRequested(PVItem item) {}
 
     /** ModelItems have new selected sample */
-    default void selectedSamplesChanged() {};
+    default void selectedSamplesChanged() {}
 }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -110,7 +110,7 @@ public class PVItem extends ModelItem
         if (index < 0)
             index = 0;
         if (waveform_index.getAndSet(index) != index)
-            fireItemDataConfigChanged();
+            fireItemDataConfigChanged(false);
     }
 
     /** Set new item name, which changes the underlying PV name
@@ -155,7 +155,7 @@ public class PVItem extends ModelItem
         this.period = period;
         if (running)
             start();
-        fireItemDataConfigChanged();
+        fireItemDataConfigChanged(false);
     }
 
     /** {@inheritDoc} */
@@ -184,7 +184,7 @@ public class PVItem extends ModelItem
     public void setLiveCapacity(final int new_capacity) throws Exception
     {
         samples.setLiveCapacity(new_capacity);
-        fireItemDataConfigChanged();
+        fireItemDataConfigChanged(false);
     }
 
     /** @return Archive data sources for this item */
@@ -199,7 +199,7 @@ public class PVItem extends ModelItem
         archives.clear();
         for (ArchiveDataSource arch : Preferences.archives)
             archives.add(arch);
-        fireItemDataConfigChanged();
+        fireItemDataConfigChanged(true);
     }
 
     /** @param archive Archive data source
@@ -221,7 +221,7 @@ public class PVItem extends ModelItem
         if (hasArchiveDataSource(archive))
             throw new Error("Duplicate archive " + archive);
         archives.add(archive);
-        fireItemDataConfigChanged();
+        fireItemDataConfigChanged(true);
     }
 
     /**
@@ -237,14 +237,15 @@ public class PVItem extends ModelItem
                 archives.add(archive);
             }
         if (change)
-            fireItemDataConfigChanged();
+            fireItemDataConfigChanged(true);
     }
 
     /** @param archive Archive to remove as a source from this item. */
     public void removeArchiveDataSource(final ArchiveDataSource archive)
     {
+        // Archive removed -> (Probably) no need to get new data
         if (archives.remove(archive))
-            fireItemDataConfigChanged();
+            fireItemDataConfigChanged(false);
     }
 
     /** @param archs Archives to remove as a source from this item. Ignored when not used. */
@@ -255,7 +256,7 @@ public class PVItem extends ModelItem
             if (archives.remove(archive))
                 change = true;
         if (change)
-            fireItemDataConfigChanged();
+            fireItemDataConfigChanged(false);
     }
 
     /** Replace existing archive data sources with given archives
@@ -280,7 +281,7 @@ public class PVItem extends ModelItem
         archives.clear();
         for (ArchiveDataSource arch : archs)
             archives.add(arch);
-        fireItemDataConfigChanged();
+        fireItemDataConfigChanged(true);
     }
 
     /** @return Archive data request type */
@@ -295,14 +296,17 @@ public class PVItem extends ModelItem
         if (this.request_type == request_type)
             return;
         this.request_type = request_type;
-        fireItemDataConfigChanged();
+        fireItemDataConfigChanged(true);
     }
 
-    /** Notify listeners */
-    private void fireItemDataConfigChanged()
+    /** Notify listeners
+     *  @param archive_invalid Was a data source added, do we need to get new archived data?
+     *                         Or does the change not affect archived data?
+     */
+    private void fireItemDataConfigChanged(final boolean archive_invalid)
     {
         if (model.isPresent())
-            model.get().fireItemDataConfigChanged(this);
+            model.get().fireItemDataConfigChanged(this, archive_invalid);
     }
 
     /** Connect control system PV, start scanning, ...

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
@@ -466,9 +466,10 @@ public class Controller
             }
 
             @Override
-            public void changedItemDataConfig(final PVItem item)
+            public void changedItemDataConfig(final PVItem item, final boolean archive_invalid)
             {
-                getArchivedData(item);
+                if (archive_invalid)
+                    getArchivedData(item);
             }
 
             @Override

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/TracesTab.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/TracesTab.java
@@ -222,7 +222,7 @@ public class TracesTab extends Tab
         }
 
         @Override
-        public void changedItemDataConfig(final PVItem item)
+        public void changedItemDataConfig(final PVItem item, final boolean archive_invalid)
         {
             trace_table.refresh();
         }


### PR DESCRIPTION
Skip superfluous archive fetch jobs.
Opening a saved file can result in multiple archive fetch jobs being added then soon cancelled and replaced with new jobs.
Cancelling, however, can take some time if an RDB or web operation has been started.
By delaying the actual work a little, jobs that are soon cancelled will just end before they ever did anything, allowing the later jobs to then run, which is overall faster.
