### PR TITLE
Display Builder: DisplayRuntimeInstance - a little bit less flickerin…

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -41,14 +41,16 @@ import org.phoebus.ui.docking.DockStage;
 import org.phoebus.ui.javafx.ToolbarHelper;
 
 import javafx.application.Platform;
+import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.ButtonBase;
-import javafx.scene.control.TextArea;
+import javafx.scene.control.Label;
 import javafx.scene.control.ToolBar;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 
 /** PV Table Application
@@ -463,10 +465,18 @@ public class DisplayRuntimeInstance implements AppInstance
     {
         Platform.runLater(() ->
         {
-            final TextArea text = new TextArea(message);
-            text.setEditable(false);
-            text.setPrefSize(800, 600);
-            JFXRepresentation.getChildren(representation.getModelParent()).setAll(text);
+            final Label text = new Label(message);
+            final Parent parent = representation.getModelParent();
+            text.setWrapText(true);
+            text.setAlignment(Pos.TOP_LEFT);
+            if (parent instanceof Pane)
+            {
+                text.prefWidthProperty().bind(((Pane)parent).widthProperty());
+                text.prefHeightProperty().bind(((Pane)parent).heightProperty());
+            }
+            else
+                text.setPrefSize(800, 600);
+            JFXRepresentation.getChildren(parent).setAll(text);
         });
     }
 


### PR DESCRIPTION
…g on loading a display. See #896.
Using Label instead of TextArea and setting the right size to avoid scrollbars on long display names.