### PR TITLE
Only print ChannelFinderException

### DIFF
--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/autocomplete/CFProposalProvider.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/autocomplete/CFProposalProvider.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.phoebus.channelfinder.ChannelFinderClient;
+import org.phoebus.channelfinder.ChannelFinderException;
 import org.phoebus.channelfinder.ChannelFinderService;
 import org.phoebus.framework.autocomplete.Proposal;
 import org.phoebus.framework.spi.PVProposalProvider;
@@ -37,6 +38,11 @@ public class CFProposalProvider implements PVProposalProvider {
                 client.getAllTags();
             } catch (Exception e) {
                 active = false;
+                Throwable cause = e.getCause();
+                while (cause != null && ! (cause instanceof ChannelFinderException))
+                    cause = cause.getCause();
+                if (cause != null)
+                    e = (Exception)cause;
                 log.log(Level.INFO, "Failed to create Channel Finder PVProposalProvider", e);
             }
         }


### PR DESCRIPTION
When there is an exception during adding ChannelFinder as a PVProposalProvider a huge stacktrace is printed because of exception chaining. This PR only prints the ChannelFinder exception significantly reducing the number of log lines