### PR TITLE
Fixes when moving widgets up/down in widgettree

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/actions/ActionDescription.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/actions/ActionDescription.java
@@ -160,9 +160,11 @@ public abstract class ActionDescription
             // -- move 'b' up -> [ b, a, c ]
             // -- move 'c' up -> [ b, c, a ]
             // Doing this in reverse original order would leave the list unchanged.
-            final List<Widget> widgets = orderWidgetsByIndex(editor.getWidgetSelectionHandler().getSelection());
+            List<Widget> widgets = editor.getWidgetSelectionHandler().getSelection();
             if (widgets.isEmpty())
                 return;
+            if (widgets.size() > 1)
+                widgets = orderWidgetsByIndex(widgets);
             final CompoundUndoableAction compound = new CompoundUndoableAction(Messages.MoveUp);
             for (Widget widget : widgets)
             {
@@ -171,7 +173,8 @@ public abstract class ActionDescription
                 if (orig > 0)
                     compound.add(new UpdateWidgetOrderAction(widget, orig, orig-1));
                 else
-                    compound.add(new UpdateWidgetOrderAction(widget, orig, -1));
+                    // This would result in moving this widget to the bottom, let's not move at all
+                    return;
             }
             editor.getUndoableActionManager().execute(compound);
         }
@@ -210,8 +213,11 @@ public abstract class ActionDescription
             List<Widget> widgets = editor.getWidgetSelectionHandler().getSelection();
             if (widgets.isEmpty())
                 return;
-            widgets = orderWidgetsByIndex(widgets);
-            Collections.reverse(widgets);
+            if (widgets.size() > 1)
+            {
+                widgets = orderWidgetsByIndex(widgets);
+                Collections.reverse(widgets);
+            }
 
             final CompoundUndoableAction compound = new CompoundUndoableAction(Messages.MoveDown);
             for (Widget widget : widgets)
@@ -221,7 +227,8 @@ public abstract class ActionDescription
                 if (orig < children.size()-1)
                     compound.add(new UpdateWidgetOrderAction(widget, orig, orig+1));
                 else
-                    compound.add(new UpdateWidgetOrderAction(widget, orig, 0));
+                    // This would result in moving this widget to the top, let's not move at all
+                    return;
             }
             editor.getUndoableActionManager().execute(compound);
         }

--- a/core/ui/src/main/java/org/phoebus/ui/undo/CompoundReversedUndoableAction.java
+++ b/core/ui/src/main/java/org/phoebus/ui/undo/CompoundReversedUndoableAction.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2017 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.ui.undo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+/** A CompoundUndoableAction that executes undo operation in the same order as the 'do' operation
+ *
+ *  <p>Used for list order manipulations
+ *
+ *  @author Krisztián Löki
+ */
+@SuppressWarnings("nls")
+public class CompoundReversedUndoableAction extends CompoundUndoableAction
+{
+    /** @param name Name used to show action in undo/redo UI */
+    public CompoundReversedUndoableAction(final String name)
+    {
+        super(name);
+    }
+    @Override
+    public void undo()
+    {
+        for (UndoableAction step : steps)
+            step.undo();
+    }
+}

--- a/core/ui/src/main/java/org/phoebus/ui/undo/CompoundUndoableAction.java
+++ b/core/ui/src/main/java/org/phoebus/ui/undo/CompoundUndoableAction.java
@@ -20,7 +20,7 @@ import java.util.logging.Level;
 @SuppressWarnings("nls")
 public class CompoundUndoableAction extends UndoableAction
 {
-    final private List<UndoableAction> steps = new ArrayList<>();
+    final protected List<UndoableAction> steps = new ArrayList<>();
 
     /** @param name Name used to show action in undo/redo UI */
     public CompoundUndoableAction(final String name)


### PR DESCRIPTION
- Do not wrap around when moving widgets up/down.
- Keep the order of widgets when moving to back/front (instead of reversing it)