### PR TITLE
Add logbook client for PSI Elog

### DIFF
--- a/app/logbook/elog/.project
+++ b/app/logbook/elog/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>app-logbook-elog</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/app/logbook/elog/build.xml
+++ b/app/logbook/elog/build.xml
@@ -1,0 +1,9 @@
+<project default="app-elog">
+  <import file="../../../dependencies/ant_settings.xml"/>
+
+  <target name="app-elog" depends="compile-app">
+    <jar destfile="${build}/elog-${version}.jar">
+      <fileset dir="${classes}"/>
+    </jar>
+  </target>
+</project>

--- a/app/logbook/elog/pom.xml
+++ b/app/logbook/elog/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.phoebus</groupId>
+    <artifactId>app-logbook</artifactId>
+    <version>4.6.4-SNAPSHOT</version>
+  </parent>
+  <artifactId>app-logbook-elog</artifactId>
+  <dependencies>
+    <!-- https://mvnrepository.com/artifact/com.sun.jersey/jersey-core -->
+    <!-- https://mvnrepository.com/artifact/com.sun.jersey.contribs/jersey-multipart -->
+    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
+    <!-- https://mvnrepository.com/artifact/com.sun.xml.bind/jaxb-impl -->
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>core-logbook</artifactId>
+      <version>4.6.4-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+        <groupId>net.dongliu</groupId>
+        <artifactId>requests</artifactId>
+        <version>5.0.8</version>
+    </dependency>
+    <dependency>
+        <groupId>net.sourceforge.htmlcleaner</groupId>
+        <artifactId>htmlcleaner</artifactId>
+        <version>2.24</version>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/app/logbook/elog/src/main/java/org/phoebus/applications/logbook/ElogLogbook.java
+++ b/app/logbook/elog/src/main/java/org/phoebus/applications/logbook/ElogLogbook.java
@@ -1,0 +1,50 @@
+package org.phoebus.applications.logbook;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.phoebus.logbook.LogClient;
+import org.phoebus.logbook.LogFactory;
+import org.phoebus.elog.api.ElogClient.ElogClientBuilder;
+import org.phoebus.security.tokens.SimpleAuthenticationToken;
+
+public class ElogLogbook implements LogFactory {
+
+    public static final Logger logger = Logger.getLogger(ElogLogbook.class.getName());
+    private static String ID = "elog";
+    private LogClient eLogClient;
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public LogClient getLogClient() {
+        if (eLogClient == null) {
+            try {
+                eLogClient = ElogClientBuilder.serviceURL().create();
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "Failed to create elog client", e);
+            }
+        }
+        return eLogClient;
+    }
+
+    @Override
+    public LogClient getLogClient(Object authToken) {
+        try {
+            if (authToken instanceof SimpleAuthenticationToken) {
+                SimpleAuthenticationToken token = (SimpleAuthenticationToken) authToken;
+                return ElogClientBuilder.serviceURL().username(token.getUsername()).password(token.getPassword()).create();
+            } else if (eLogClient == null) {
+                eLogClient = ElogClientBuilder.serviceURL().create();
+
+            }
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Failed to create elog client", e);
+        }
+        return eLogClient;
+    }
+
+}

--- a/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogApi.java
+++ b/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogApi.java
@@ -348,6 +348,132 @@ public class ElogApi {
     return att;
   }
 
+  /**
+   * Get list of available types
+   *
+   * @return Collection<String>
+   */
+  public Collection<String> getTypes() throws LogbookException {
+    Map<String, Object> cookies = new HashMap<>();
+    cookies.put( "unm", this.username );
+    cookies.put( "upwd", this.password );
+
+    Response<String> resp = Requests.get( this.url + "?cmd=new" )
+                                    .cookies(cookies)
+                                    .followRedirect(false)
+                                    .verify(false)
+                                    .send()
+                                    .toTextResponse();
+    //validateResponse( resp );
+    //validateResponse does not work here, as the response body contains
+    // "form name=form1"....
+    int statuscode  = resp.statusCode();
+    if( statuscode != 200 && statuscode != 302 ) {
+      final Pattern pattern = Pattern.compile("<td.*?class=\"errormsg\".*?>(.*?)</td>");
+      Matcher m = pattern.matcher( resp.getBody() );
+      if( m.matches() ) {
+        String err = m.group();
+        throw new LogbookException("Rejected because of: " + err);
+      } else {
+        throw new LogbookException("Rejected because of unknown error.");
+      }
+    } else {
+      String location = resp.getHeader( "Location" );
+      if( location != null && !location.isEmpty() ) {
+        if( location.contains( "has moved" )) {
+          throw new LogbookException("Logbook server has moved to another location.");
+        } else if( location.contains( "fail" )) {
+          throw new LogbookException("Failed to submit log entry, invalid credentials.");
+        }
+      }
+    }
+
+    List<String> types = new ArrayList<String>();
+
+    try {
+      TagNode tagNode = new HtmlCleaner().clean( resp.getBody() );
+      org.w3c.dom.Document doc = new DomSerializer( new CleanerProperties()).createDOM(tagNode);
+      XPath xpath = XPathFactory.newInstance().newXPath();
+      NodeList typenodes = (NodeList) xpath.evaluate( "//tr/td[@class=\"attribvalue\"]/select[@name=\"Type\"]/option/@value", doc, XPathConstants.NODESET );
+      for( int i = 0; i < typenodes.getLength(); i++ ) {
+        String t = typenodes.item(i).getNodeValue();
+        if( !t.isEmpty() ) {
+          types.add( t );
+        }
+      }
+    } catch (XPathExpressionException e) {
+      throw new LogbookException( e.getMessage() );
+    } catch (ParserConfigurationException e) {
+      throw new LogbookException( e.getMessage() );
+    }
+
+    return types;
+  }
+
+  /**
+   * Get list of available categories
+   *
+   * @return Collection<String>
+   */
+  public Collection<String> getCategories() throws LogbookException {
+    Map<String, Object> cookies = new HashMap<>();
+    cookies.put( "unm", this.username );
+    cookies.put( "upwd", this.password );
+
+    Response<String> resp = Requests.get( this.url + "?cmd=new" )
+                                    .cookies(cookies)
+                                    .followRedirect(false)
+                                    .verify(false)
+                                    .send()
+                                    .toTextResponse();
+    //validateResponse( resp );
+    //validateResponse does not work here, as the response body contains
+    // "form name=form1"....
+    int statuscode  = resp.statusCode();
+    if( statuscode != 200 && statuscode != 302 ) {
+      final Pattern pattern = Pattern.compile("<td.*?class=\"errormsg\".*?>(.*?)</td>");
+      Matcher m = pattern.matcher( resp.getBody() );
+      if( m.matches() ) {
+        String err = m.group();
+        throw new LogbookException("Rejected because of: " + err);
+      } else {
+        throw new LogbookException("Rejected because of unknown error.");
+      }
+    } else {
+      String location = resp.getHeader( "Location" );
+      if( location != null && !location.isEmpty() ) {
+        if( location.contains( "has moved" )) {
+          throw new LogbookException("Logbook server has moved to another location.");
+        } else if( location.contains( "fail" )) {
+          throw new LogbookException("Failed to submit log entry, invalid credentials.");
+        }
+      }
+    }
+
+    List<String> categories = new ArrayList<String>();
+
+    try {
+      TagNode tagNode = new HtmlCleaner().clean( resp.getBody() );
+      org.w3c.dom.Document doc = new DomSerializer( new CleanerProperties()).createDOM(tagNode);
+      XPath xpath = XPathFactory.newInstance().newXPath();
+      NodeList catnodes = (NodeList) xpath.evaluate( "//tr/td[@class=\"attribvalue\"]/select[@name=\"Category\"]/option/@value", doc, XPathConstants.NODESET );
+      for( int i = 0; i < catnodes.getLength(); i++ ) {
+        String c = catnodes.item(i).getNodeValue();
+        if( !c.isEmpty() ) {
+          categories.add( c );
+        }
+      }
+    } catch (XPathExpressionException e) {
+      throw new LogbookException( e.getMessage() );
+    } catch (ParserConfigurationException e) {
+      throw new LogbookException( e.getMessage() );
+    }
+
+    return categories;
+  }
+
+
+
 
   /**
    * Try to load page for specific message.

--- a/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogApi.java
+++ b/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogApi.java
@@ -1,0 +1,416 @@
+package org.phoebus.elog.api;
+
+import java.time.Instant;
+import java.text.SimpleDateFormat;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.Date;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.nio.file.Paths;
+import java.net.URI;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import org.htmlcleaner.HtmlCleaner;
+import org.htmlcleaner.TagNode;
+import org.htmlcleaner.DomSerializer;
+import org.htmlcleaner.CleanerProperties;
+
+import net.dongliu.commons.collection.Lists;
+import net.dongliu.requests.Requests;
+import net.dongliu.requests.body.Part;
+import net.dongliu.requests.Response;
+
+import org.phoebus.logbook.LogbookException;
+
+/**
+ * PSI Elog API
+ *
+ * This class is based on the Python Library from PSI
+ * https://github.com/paulscherrerinstitute/py_elog/blob/master/elog/logbook.py
+ *
+ * @author ffeldbauer
+ */
+public class ElogApi {
+
+  private final String username;
+  private final String password;
+  private final String url;
+  private final String logbook;
+
+
+  public ElogApi( URI elogURI, String username, String password ) {
+    String tmp = elogURI.toString();
+    if( !tmp.endsWith("/") ) {
+      this.url = tmp + "/";
+    } else {
+      this.url = tmp;
+    }
+    String path[] = elogURI.getPath().split("/");
+    this.logbook  = path[ path.length-1 ];
+    this.username = username;
+    this.password = password;
+  }
+
+
+  /**
+   * Posts message to the logbook.
+   *
+   * @param attributes
+   */
+  public long post( Map<String, String> attributes ) throws LogbookException {
+    return post( attributes, Collections.emptyList(), Long.valueOf(-1) );
+  }
+
+
+  /**
+   * Posts message to the logbook.
+   *
+   * @param attributes
+   * @param attachments
+   */
+  public long post( Map<String, String> attributes, List<File> attachments ) throws LogbookException {
+    return post( attributes, attachments, Long.valueOf(-1) );
+  }
+
+
+  /**
+   * Posts message to the logbook.
+   *
+   * If msg_id is not specified new message will be created, otherwise existing
+   * message will be edited. This method returns the msg_id of the newly created message.
+   *
+   * @param attributes
+   * @param attachments
+   * @param msgId
+   * @return id of log entry
+   */
+  public long post( Map<String, String> attributes, List<File> attachments, Long msgId ) throws LogbookException {
+
+    Map<String, String> new_attributes = new HashMap<>();
+    new_attributes.putAll( attributes );
+    new_attributes.put( "Encoding", "plain" );
+
+    Map<String, String> attributes_to_edit = null;
+    if( msgId > 0 ) {
+
+      new_attributes.put( "edit_id", String.valueOf(msgId) );
+      new_attributes.put( "skiplock", "1" );
+
+      ElogEntry entry = read(msgId);
+
+      attributes_to_edit = entry.getAttributes();
+
+      int i = 0;
+      for( String attach: entry.getAttachments() ) {
+        new_attributes.put( "attachment" + String.valueOf(i), attach );
+        i++;
+      }
+
+      for( Map.Entry<String, String> attr : new_attributes.entrySet() ) {
+        if( !attr.getValue().isEmpty() ) {
+          attributes_to_edit.put( attr.getKey(), attr.getValue() );
+        }
+      }
+
+    } else {
+      new_attributes.put( "When", String.valueOf( Instant.now().toEpochMilli() ));
+    }
+
+    if( attributes_to_edit == null ) {
+      attributes_to_edit = new_attributes;
+    }
+
+    attributes_to_edit.remove("$@MID@$");
+    attributes_to_edit.remove("Date");
+    attributes_to_edit.remove("Attachment");
+
+    List<Part<?>> data = new ArrayList<Part<?>>();
+    for( Map.Entry<String, String> attr : attributes_to_edit.entrySet() ) {
+      data.add( Part.text( attr.getKey(), attr.getValue() ));
+    }
+    data.add( Part.text( "cmd", "Submit" ));
+    data.add( Part.text( "exp", this.logbook ));
+    data.add( Part.text( "unm", this.username ));
+    data.add( Part.text( "upwd", this.password ));
+    data.add( Part.text( "Author", this.username ));
+
+    int i = 0;
+    for( File att: attachments ) {
+      data.add( Part.file( "attfile" + String.valueOf(i), att ));
+      i++;
+    }
+
+    Response<String> resp = Requests.post( this.url )
+                                    .multiPartBody( data )
+                                    .followRedirect(false)
+                                    .verify(false)
+                                    .send()
+                                    .toTextResponse();
+    return validateResponse( resp );
+
+  }
+
+
+  /**
+   * Reads message from the logbook server
+   *
+   * @param msgId
+   * @return {@link ElogEntry}
+   */
+  public ElogEntry read( Long msgId ) throws LogbookException {
+    checkIfMessageOnServer( msgId );
+
+    Map<String, Object> cookies = new HashMap<>();
+    cookies.put( "unm", this.username );
+    cookies.put( "upwd", this.password );
+
+    Response<String> resp = Requests.get( this.url + String.valueOf( msgId ) + "?cmd=download" )
+                                    .cookies(cookies)
+                                    .followRedirect(false)
+                                    .verify(false)
+                                    .send()
+                                    .toTextResponse();
+    validateResponse( resp );
+
+    List<String> returned_msg = Arrays.asList( resp.getBody().split("\\r?\\n") );
+    int delimiter_idx = returned_msg.indexOf("========================================");
+
+    Map<String, String> attributes = new HashMap<>();
+    List<String> attachments = null;
+
+    for( String s : returned_msg.subList( 0, delimiter_idx ) ) {
+      String data[] = s.split( "\\s*:\\s*", 2 );
+
+      if( data[0].equals("Attachment") ) {
+        if( data[1].length() > 0 ) {
+          attachments = Arrays.asList( data[1].split( "\\s*,\\s*" ) );
+        } else {
+          attachments = Collections.emptyList();
+        }
+      } else {
+        attributes.put( data[0], data[1] );
+      }
+    }
+    attributes.put( "Text", String.join("\n", returned_msg.subList( delimiter_idx + 1, returned_msg.size() ) ) );
+
+    return new ElogEntry( attributes, attachments );
+  }
+
+
+  /**
+   * Deletes message thread (!!!message + all replies!!!) from logbook.
+   *
+   * @param msgId
+   */
+  public void delete( Long msgId ) throws LogbookException {
+    checkIfMessageOnServer( msgId );
+
+    Map<String, Object> cookies = new HashMap<>();
+    cookies.put( "unm", this.username );
+    cookies.put( "upwd", this.password );
+
+    Response<String> resp = Requests.get( this.url + String.valueOf( msgId ) + "?cmd=Delete&confirm=Yes" )
+                                    .cookies(cookies)
+                                    .followRedirect(false)
+                                    .verify(false)
+                                    .send()
+                                    .toTextResponse();
+    validateResponse( resp );
+    if( resp.statusCode() == 200 ) {
+      throw new LogbookException("Cannot process delete command (only logbooks in English supported).");
+    }
+  }
+
+
+  /**
+   * Searches the logbook and returns the message ids.
+   *
+   * @param search_term
+   * @param {@link ElogEntry}
+   */
+  public List<ElogEntry> search( Map<String, String> search_term ) throws LogbookException {
+
+    Map<String, Object> params = new HashMap<>();
+    params.put( "mode", "summary" );
+    params.put( "reverse", "1" );
+    params.put( "npp", 20 ); // number of returned results...
+    params.putAll( search_term );
+
+    Map<String, Object> cookies = new HashMap<>();
+    cookies.put( "unm", this.username );
+    cookies.put( "upwd", this.password );
+
+    Response<String> resp = Requests.get( this.url )
+                                    .cookies(cookies)
+                                    .params(params)
+                                    .followRedirect(false)
+                                    .verify(false)
+                                    .send()
+                                    .toTextResponse();
+    validateResponse( resp );
+
+    List<ElogEntry> entries = new ArrayList<ElogEntry>();
+
+    try {
+      TagNode tagNode = new HtmlCleaner().clean( resp.getBody() );
+      org.w3c.dom.Document doc = new DomSerializer( new CleanerProperties()).createDOM(tagNode);
+      XPath xpath = XPathFactory.newInstance().newXPath();
+      NodeList msgIds = (NodeList) xpath.evaluate( "(//tr/td[@class=\"list1\" or @class=\"list2\"][1])/a/@href", doc, XPathConstants.NODESET );
+      for( int i = 0; i < msgIds.getLength(); i++ ) {
+        String msgIdStr = msgIds.item(i).getNodeValue();
+        entries.add( read( Long.valueOf( msgIdStr.substring( msgIdStr.lastIndexOf('/') + 1 ) )));
+      }
+    } catch (XPathExpressionException e) {
+      throw new LogbookException( e.getMessage() );
+    } catch (ParserConfigurationException e) {
+      throw new LogbookException( e.getMessage() );
+    }
+
+    return entries;
+  }
+
+
+  /**
+   * Get a list of all messages on logbook
+   *
+   */
+  public List<ElogEntry> getMessages() throws LogbookException {
+
+    Map<String, Object> cookies = new HashMap<>();
+    cookies.put( "unm", this.username );
+    cookies.put( "upwd", this.password );
+
+    Response<String> resp = Requests.get( this.url + "page?mode=summary" )
+                                    .cookies(cookies)
+                                    .followRedirect(false)
+                                    .verify(false)
+                                    .send()
+                                    .toTextResponse();
+    validateResponse( resp );
+
+    List<ElogEntry> entries = new ArrayList<ElogEntry>();
+
+    try {
+      TagNode tagNode = new HtmlCleaner().clean( resp.getBody() );
+      org.w3c.dom.Document doc = new DomSerializer( new CleanerProperties()).createDOM(tagNode);
+      XPath xpath = XPathFactory.newInstance().newXPath();
+      NodeList msgIds = (NodeList) xpath.evaluate( "(//tr/td[@class=\"list1\" or @class=\"list2\"][1])/a/@href", doc, XPathConstants.NODESET );
+      for( int i = 0; i < msgIds.getLength(); i++ ) {
+        String msgIdStr = msgIds.item(i).getNodeValue();
+        entries.add( read( Long.valueOf( msgIdStr.substring( msgIdStr.lastIndexOf('/') + 1 ) )));
+      }
+    } catch (XPathExpressionException e) {
+      throw new LogbookException( e.getMessage() );
+    } catch (ParserConfigurationException e) {
+      throw new LogbookException( e.getMessage() );
+    }
+
+    return entries;
+  }
+
+
+  /**
+   * Get Attachment from Logbook
+   *
+   * @param filename
+   * @return File
+   */
+  public File getAttachment( String filename ) throws LogbookException {
+    Map<String, Object> cookies = new HashMap<>();
+    cookies.put( "unm", this.username );
+    cookies.put( "upwd", this.password );
+
+    File att = new File("/tmp/" + filename );
+    Requests.get( this.url + filename ).cookies( cookies ).followRedirect(false).verify(false).send().writeToFile(att);
+    return att;
+  }
+
+
+  /**
+   * Try to load page for specific message.
+   *
+   * @param logId ID of message to be checked
+   */
+  private void checkIfMessageOnServer( Long logId ) throws LogbookException {
+    Map<String, Object> cookies = new HashMap<>();
+    cookies.put( "unm", this.username );
+    cookies.put( "upwd", this.password );
+
+    Response<String> check = Requests.get( this.url + String.valueOf( logId ) )
+                                     .cookies(cookies)
+                                     .followRedirect(false)
+                                     .verify(false)
+                                     .send()
+                                     .toTextResponse();
+    validateResponse( check );
+    if( Pattern.matches( "<td.*?class=\"errormsg\".*?>.*?</td>", check.getBody() )) {
+      throw new LogbookException("Message with ID " + String.valueOf(logId) + " does not exist on logbook.");
+    }
+  }
+
+
+  /**
+   * Validate response of the request.
+   *
+   * @param resp
+   * @return id of new message
+   */
+  private long validateResponse( Response<String> resp ) throws LogbookException {
+    int statuscode  = resp.statusCode();
+    String body = resp.getBody();
+    long msgId = -1;
+    if( statuscode != 200 && statuscode != 302 ) {
+      final Pattern pattern = Pattern.compile("<td.*?class=\"errormsg\".*?>(.*?)</td>");
+      Matcher m = pattern.matcher( body );
+      if( m.matches() ) {
+        String err = m.group();
+        throw new LogbookException("Rejected because of: " + err);
+      } else {
+        throw new LogbookException("Rejected because of unknown error.");
+      }
+    } else {
+      String location = resp.getHeader( "Location" );
+      if( location != null && !location.isEmpty() ) {
+        if( location.contains( "has moved" )) {
+          throw new LogbookException("Logbook server has moved to another location.");
+        } else if( location.contains( "fail" )) {
+          throw new LogbookException("Failed to submit log entry, invalid credentials.");
+        } else {
+          URI loc = URI.create( location );
+          String path[] = loc.getPath().split("/");
+          msgId = Integer.parseInt( path[ path.length-1 ] );
+        }
+      }
+      if( body.contains("form name=form1") || body.contains("type=password") ) {
+        throw new LogbookException("Failed to submit log entry, invalid credentials.");
+      }
+    }
+    return msgId;
+  }
+
+
+}
+

--- a/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogClient.java
+++ b/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogClient.java
@@ -1,0 +1,689 @@
+package org.phoebus.elog.api;
+
+import java.time.Instant;
+import java.text.SimpleDateFormat;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.Date;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.nio.file.Paths;
+import java.net.URI;
+import java.net.FileNameMap;
+import java.net.URLConnection;
+
+import org.phoebus.logbook.Attachment;
+import org.phoebus.logbook.AttachmentImpl;
+import org.phoebus.logbook.LogClient;
+import org.phoebus.logbook.LogEntry;
+import org.phoebus.logbook.LogEntryImpl;
+import org.phoebus.logbook.LogEntryImpl.LogEntryBuilder;
+import org.phoebus.logbook.Logbook;
+import org.phoebus.logbook.LogbookImpl;
+import org.phoebus.logbook.LogbookException;
+import org.phoebus.logbook.Messages;
+import org.phoebus.logbook.Property;
+import org.phoebus.logbook.PropertyImpl;
+import org.phoebus.logbook.Tag;
+import org.phoebus.logbook.TagImpl;
+
+/**
+ * A logbook client to the Elog logbook service
+ *
+ * @author ffeldbauer
+ *
+ */
+public class ElogClient implements LogClient{
+    private final ElogApi service;
+    private Collection<Tag> categories;
+    private Collection<Logbook> types;
+
+    private static FileNameMap fileNameMap = URLConnection.getFileNameMap();
+
+    /**
+     * Builder Class to help create a elog client.
+     * 
+     * @author ffeldbauer
+     * 
+     */
+    public static class ElogClientBuilder {
+        private URI elogURI = null;
+        private String username = null;
+        private String password = null;
+        private ElogProperties properties = new ElogProperties();
+
+        private ElogClientBuilder() {
+            this.elogURI = URI.create( this.properties.getPreferenceValue("elog_url") );
+        }
+
+        /**
+         * Creates a {@link ElogClientBuilder} for a CF client to Default URL in the
+         * channelfinder.properties.
+         * 
+         * @return
+         */
+        public static ElogClientBuilder serviceURL() {
+            return new ElogClientBuilder();
+        }
+
+        /**
+         * Set the username to be used for Authentication.
+         * 
+         * @param username
+         * @return {@link ElogClientBuilder}
+         */
+        public ElogClientBuilder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        /**
+         * Set the password to be used for the Authentication.
+         * 
+         * @param password
+         * @return {@link ElogClientBuilder}
+         */
+        public ElogClientBuilder password(String password) {
+            char[] ch = new char[password.length()];
+            for (int i = 0; i < password.length(); i++) {
+                ch[i] = password.charAt(i);
+            }
+            this.password = Sha256.sha256( ch, 5000 );
+            return this;
+        }
+
+        /**
+         * Create new instance of <code>ElogClient</code>
+         * 
+         * @return {@link ElogClient}
+         */
+        public ElogClient create() throws Exception {
+            this.username = ifNullReturnPreferenceValue(this.username, "username");
+            this.password = ifNullReturnPreferenceValue(this.password, "password");
+
+            List<Logbook> types = new ArrayList<Logbook>();
+            String types_prop = this.properties.getPreferenceValue("types");
+            for( String s: types_prop.split("\\s*,\\s*") ){
+                types.add( LogbookImpl.of( s ) );
+            }
+
+            List<Tag> categories = new ArrayList<Tag>();
+            String categories_prop = this.properties.getPreferenceValue("categories");
+            for( String s: categories_prop.split("\\s*,\\s*") ){
+                categories.add( TagImpl.of( s ) );
+            }
+
+            ElogApi service = new ElogApi( this.elogURI, this.username, this.password );
+            return new ElogClient( service, categories, types );
+        }
+
+
+        private String ifNullReturnPreferenceValue(String value, String key) {
+            if (value == null) {
+                return this.properties.getPreferenceValue(key);
+            } else {
+                return value;
+            }
+        }
+    }
+
+
+    private ElogClient( ElogApi service, Collection<Tag> categories, Collection<Logbook> types ) {
+        this.service    = service;
+        this.categories = categories;
+        this.types      = types;
+    }
+
+
+    @Override
+    public LogEntry set(LogEntry log) throws LogbookException {
+        Map<String, String> attributes = new HashMap<>();
+
+        for( Logbook l: log.getLogbooks() ) {
+            if( !l.getName().isEmpty() ) {
+                attributes.put( "Type", l.getName() );
+                break;
+            }
+        }
+        if( !attributes.containsKey("Type") ) {
+            Logger.getLogger( ElogClient.class.getPackageName()).severe( "No valid type selected. Cannot submit log entry" );
+            return null;
+        }
+
+        for( Tag t: log.getTags() ) {
+            if( !t.getName().isEmpty() ) {
+                attributes.put( "Category", t.getName() );
+                break;
+            }
+        }
+
+        attributes.put( "Subject", log.getTitle() );
+        attributes.put( "Text", log.getDescription() );
+
+        List<File> files = new ArrayList<File>();
+        for( Attachment att: log.getAttachments() ) {
+          files.add( att.getFile() );
+        }
+
+        long msgId = service.post( attributes, files );
+
+        LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log( log );
+        logBuilder.id( msgId );
+        logBuilder.createdDate( Instant.now() );
+        logBuilder.modifiedDate( Instant.now() );
+        LogEntry logEntry = logBuilder.build();
+        return logEntry;
+    }
+
+
+    @Override
+    public LogEntry getLog(Long logId) {
+        ElogEntry entry = null;
+        try{
+            entry = service.read( logId );
+        } catch(LogbookException e){
+            e.printStackTrace();
+        }
+
+        LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
+        logBuilder.id( logId );
+        logBuilder.description( entry.getAttribute("Text") );
+        logBuilder.title( entry.getAttribute("Subject") );
+        try {
+            Date date = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss ZZZZ").parse( entry.getAttribute("Date") );
+            logBuilder.createdDate( date.toInstant() );
+            logBuilder.modifiedDate( date.toInstant() );
+        } catch (ParseException e) {
+            e.printStackTrace();
+            return null;
+        }
+        logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
+        logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+
+        try{
+            for( String s : entry.getAttachments() ) {
+                String mimeType = fileNameMap.getContentTypeFor(s);
+                if( mimeType == null ) {
+                    if( s.endsWith(".py") ){
+                        logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
+                    } else if( s.endsWith(".pyc") ){
+                        logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
+                    } else {
+                        logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unkown", false ));
+                    }
+                } else {
+                    logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                }
+            }
+        } catch(LogbookException e){
+            e.printStackTrace();
+        } catch(FileNotFoundException e){
+            e.printStackTrace();
+        }
+
+        LogEntry logEntry = logBuilder.build();
+        return logEntry;
+    }
+
+
+    @Override
+    public Collection<Attachment> listAttachments(Long logId) {
+        List<Attachment> attlist = new ArrayList<Attachment>();
+        try{
+            ElogEntry entry = service.read( logId );
+            for( String s : entry.getAttachments() ) {
+                String mimeType = fileNameMap.getContentTypeFor(s);
+                if( mimeType == null ) {
+                    if( s.endsWith(".py") ){
+                        attlist.add( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
+                    } else if( s.endsWith(".pyc") ){
+                        attlist.add( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
+                    } else {
+                        attlist.add( AttachmentImpl.of( service.getAttachment(s), "unkown", false ));
+                    }
+                } else {
+                    attlist.add( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                }
+            }
+        } catch(LogbookException e){
+            e.printStackTrace();
+        } catch(FileNotFoundException e){
+            e.printStackTrace();
+        }
+        return attlist;
+    }
+
+
+    @Override
+    public List<LogEntry> findLogs(Map<String, String> map) {
+        Map<String, String> query = new HashMap<>();
+        query.putAll( map );
+
+        if( query.containsKey( "start" ) ) {
+            try {
+                Date date = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").parse( map.get( "start" ) );
+                query.put("ma", String.valueOf( date.getMonth() + 1 ));
+                query.put("da", String.valueOf( date.getDate() ));
+                query.put("ya", String.valueOf( date.getYear() + 1900 ));
+                query.put("ha", String.valueOf( date.getHours() ));
+                query.put("na", String.valueOf( date.getMinutes() ));
+                query.put("ca", String.valueOf( date.getSeconds() ));
+            } catch (ParseException e) {
+                e.printStackTrace();
+                return null;
+            }
+            query.remove("start");
+        }
+        if( query.containsKey( "end" ) ) {
+            try {
+                Date date = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").parse( map.get( "end" ) );
+                query.put("mb", String.valueOf( date.getMonth() + 1 ));
+                query.put("db", String.valueOf( date.getDate() ));
+                query.put("yb", String.valueOf( date.getYear() + 1900 ));
+                query.put("hb", String.valueOf( date.getHours() ));
+                query.put("nb", String.valueOf( date.getMinutes() ));
+                query.put("cb", String.valueOf( date.getSeconds() ));
+            } catch (ParseException e) {
+                e.printStackTrace();
+                return null;
+            }
+            query.remove("end");
+        }
+        if( query.containsKey( "desc" ) ) {
+            String subtext = map.get( "desc" );
+            if( !subtext.equals("*") ) {
+                query.put("subtext", subtext );
+            }
+            query.remove("desc");
+        }
+        if( query.containsKey( "logbook" ) ) {
+            String type = map.get( "logbook" );
+            if( type.contains(",") ) {
+                query.put("Type", type.substring( 0, type.indexOf(",") ) );
+            } else {
+                query.put("Type", type );
+            }
+            query.remove("logbook");
+        }
+        if( query.containsKey( "tag" ) ) {
+            String category = map.get( "tag" );
+            if( category.contains(",") ) {
+                query.put("Category", category.substring( 0, category.indexOf(",") ) );
+            } else {
+                query.put("Category", category );
+            }
+            query.remove("tag");
+        }
+
+        List<LogEntry> entries = new ArrayList<LogEntry>();
+        try {
+            for( ElogEntry entry : service.search( query ) ) {
+                LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
+                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
+                logBuilder.description( entry.getAttribute("Text") );
+                logBuilder.title( entry.getAttribute("Subject") );
+                try {
+                    Date date = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss ZZZZ").parse( entry.getAttribute("Date") );
+                    logBuilder.createdDate( date.toInstant() );
+                    logBuilder.modifiedDate( date.toInstant() );
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                    return null;
+                }
+                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
+                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+
+                try {
+                    for( String s : entry.getAttachments() ) {
+                        String mimeType = fileNameMap.getContentTypeFor(s);
+                        if( mimeType == null ) {
+                            if( s.endsWith(".py") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
+                            } else if( s.endsWith(".pyc") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
+                            } else {
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unkown", false ));
+                            }
+                        } else {
+                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                        }
+                    }
+                } catch(FileNotFoundException e){
+                    e.printStackTrace();
+                }
+
+                entries.add( logBuilder.build() );
+            }
+        } catch(LogbookException e){
+            e.printStackTrace();
+        }
+        return entries;
+    }
+
+
+    @Override
+    public Collection<LogEntry> listLogs() {
+          List<LogEntry> entries = new ArrayList<LogEntry>();
+          try{
+            for( ElogEntry entry : service.getMessages() ) {
+                LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
+                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
+                logBuilder.description( entry.getAttribute("Text") );
+                logBuilder.title( entry.getAttribute("Subject") );
+                try {
+                    Date date = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss ZZZZ").parse( entry.getAttribute("Date") );
+                    logBuilder.createdDate( date.toInstant() );
+                    logBuilder.modifiedDate( date.toInstant() );
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                    return null;
+                }
+                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
+                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+
+                try{
+                    for( String s : entry.getAttachments() ) {
+                        String mimeType = fileNameMap.getContentTypeFor(s);
+                        if( mimeType == null ) {
+                            if( s.endsWith(".py") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
+                            } else if( s.endsWith(".pyc") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
+                            } else {
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unkown", false ));
+                            }
+                        } else {
+                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                        }
+                    }
+                } catch(FileNotFoundException e){
+                    e.printStackTrace();
+                }
+
+                entries.add( logBuilder.build() );
+            }
+        } catch(LogbookException e){
+            e.printStackTrace();
+        }
+        return entries;
+    }
+
+
+    @Override
+    public Collection<Logbook> listLogbooks() {
+        return this.types;
+    }
+
+
+    @Override
+    public Collection<Tag> listTags() {
+        return this.categories;
+    }
+
+
+    @Override
+    public InputStream getAttachment(Long logId, Attachment attachment) throws LogbookException {
+        return getAttachment( logId, attachment.getName() );
+    }
+
+
+    @Override
+    public InputStream getAttachment(Long logId, String attachmentName) throws LogbookException {
+        ElogEntry entry = service.read( logId );
+        try {
+            for( String s : entry.getAttachments() ) {
+                if( s.equals( attachmentName ) ) {
+                    return new FileInputStream( service.getAttachment(s) );
+                }
+            }
+        } catch( java.io.FileNotFoundException e ) {
+            throw new LogbookException( e.getMessage() );
+        }
+        throw new LogbookException( "Message " + logId + " has no matching attachment" );
+    }
+
+
+    @Override
+    public LogEntry update(LogEntry log) throws LogbookException {
+        Map<String, String> attributes = new HashMap<>();
+
+        for( Logbook l: log.getLogbooks() ) {
+            if( !l.getName().isEmpty() ) {
+                attributes.put( "Type", l.getName() );
+                break;
+            }
+        }
+        if( !attributes.containsKey("Type") ) {
+            Logger.getLogger( ElogClient.class.getPackageName()).severe( "No valid type selected. Cannot submit log entry" );
+            return null;
+        }
+
+        for( Tag t: log.getTags() ) {
+            if( !t.getName().isEmpty() ) {
+                attributes.put( "Category", t.getName() );
+                break;
+            }
+        }
+
+        attributes.put( "Subject", log.getTitle() );
+        attributes.put( "Text", log.getDescription() );
+
+        List<File> files = new ArrayList<File>();
+        for( Attachment att: log.getAttachments() ) {
+          files.add( att.getFile() );
+        }
+
+        long msgId = service.post( attributes, files, log.getId() );
+
+        LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log( log );
+        logBuilder.modifiedDate( Instant.now() );
+        LogEntry logEntry = logBuilder.build();
+        return logEntry;
+    }
+
+    @Override
+    public Collection<LogEntry> update(Collection<LogEntry> logs) throws LogbookException {
+        List<LogEntry> entries = new ArrayList<LogEntry>();
+        for( LogEntry entry : logs ) {
+            entries.add( this.update( entry ));
+        }
+        return entries;
+    }
+
+
+    @Override
+    public LogEntry findLogById(Long logId) throws LogbookException {
+        return getLog( logId );
+    }
+
+
+    @Override
+    public List<LogEntry> findLogsBySearch(String pattern) {
+        Map<String, String> query = new HashMap<>();
+        query.put( "subtext", pattern );
+        query.put( "sall", "1" );
+
+        List<LogEntry> entries = new ArrayList<LogEntry>();
+        try{
+            for( ElogEntry entry : service.search( query ) ) {
+                LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
+                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
+                logBuilder.description( entry.getAttribute("Text") );
+                logBuilder.title( entry.getAttribute("Subject") );
+                try {
+                    Date date = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss ZZZZ").parse( entry.getAttribute("Date") );
+                    logBuilder.createdDate( date.toInstant() );
+                    logBuilder.modifiedDate( date.toInstant() );
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                    return null;
+                }
+                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
+                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+
+                try{
+                    for( String s : entry.getAttachments() ) {
+                        String mimeType = fileNameMap.getContentTypeFor(s);
+                        if( mimeType == null ) {
+                            if( s.endsWith(".py") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
+                            } else if( s.endsWith(".pyc") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
+                            } else {
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unkown", false ));
+                            }
+                        } else {
+                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                        }
+                    }
+                } catch(FileNotFoundException e){
+                    e.printStackTrace();
+                }
+
+                entries.add( logBuilder.build() );
+            }
+        } catch(LogbookException e){
+            e.printStackTrace();
+        }
+        return entries;
+    }
+
+
+    @Override
+    public List<LogEntry> findLogsByTag(String pattern) {
+        Map<String, String> query = new HashMap<>();
+        query.put( "Category", pattern );
+
+        List<LogEntry> entries = new ArrayList<LogEntry>();
+        try{
+            for( ElogEntry entry : service.search( query ) ) {
+                LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
+                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
+                logBuilder.description( entry.getAttribute("Text") );
+                logBuilder.title( entry.getAttribute("Subject") );
+                try {
+                    Date date = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss ZZZZ").parse( entry.getAttribute("Date") );
+                    logBuilder.createdDate( date.toInstant() );
+                    logBuilder.modifiedDate( date.toInstant() );
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                    return null;
+                }
+                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
+                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+
+                try{
+                    for( String s : entry.getAttachments() ) {
+                        String mimeType = fileNameMap.getContentTypeFor(s);
+                        if( mimeType == null ) {
+                            if( s.endsWith(".py") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
+                            } else if( s.endsWith(".pyc") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
+                            } else {
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unkown", false ));
+                            }
+                        } else {
+                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                        }
+                    }
+                } catch(FileNotFoundException e){
+                    e.printStackTrace();
+                }
+
+                entries.add( logBuilder.build() );
+            }
+        } catch(LogbookException e){
+            e.printStackTrace();
+        }
+        return entries;
+    }
+
+
+    @Override
+    public List<LogEntry> findLogsByLogbook(String logbook) {
+        Map<String, String> query = new HashMap<>();
+        query.put( "Type", logbook );
+
+        List<LogEntry> entries = new ArrayList<LogEntry>();
+        try{
+            for( ElogEntry entry : service.search( query ) ) {
+                LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
+                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
+                logBuilder.description( entry.getAttribute("Text") );
+                logBuilder.title( entry.getAttribute("Subject") );
+                try {
+                    Date date = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss ZZZZ").parse( entry.getAttribute("Date") );
+                    logBuilder.createdDate( date.toInstant() );
+                    logBuilder.modifiedDate( date.toInstant() );
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                    return null;
+                }
+                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
+                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+
+                try{
+                    for( String s : entry.getAttachments() ) {
+                        String mimeType = fileNameMap.getContentTypeFor(s);
+                        if( mimeType == null ) {
+                            if( s.endsWith(".py") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
+                            } else if( s.endsWith(".pyc") ){
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
+                            } else {
+                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unkown", false ));
+                            }
+                        } else {
+                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                        }
+                    }
+                } catch(FileNotFoundException e){
+                    e.printStackTrace();
+                }
+
+                entries.add( logBuilder.build() );
+            }
+        } catch(LogbookException e){
+            e.printStackTrace();
+        }
+        return entries;
+    }
+
+
+    @Override
+    public void delete(LogEntry log) throws LogbookException {
+        service.delete( log.getId() );
+    }
+
+
+    @Override
+    public void delete(Long logId) throws LogbookException {
+        service.delete( logId );
+    }
+
+
+    @Override
+    public void delete(Collection<LogEntry> logIds) throws LogbookException {
+        for( LogEntry entry : logIds ) {
+            service.delete( entry.getId() );
+        }
+    }
+
+}
+

--- a/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogEntry.java
+++ b/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogEntry.java
@@ -1,0 +1,37 @@
+package org.phoebus.elog.api;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+ /**
+ * PSI Elog Entry
+ *
+ * @author ffeldbauer
+ */
+public class ElogEntry {
+  private final Map<String, String> attributes;
+  private final List<String> attachments;
+
+
+  public ElogEntry( Map<String, String> attributes, List<String> attachments ) {
+    this.attributes = attributes;
+    this.attachments = attachments;
+  }
+
+
+  public Map<String, String> getAttributes() {
+    return this.attributes;
+  }
+
+
+  public List<String> getAttachments() {
+    return this.attachments;
+  }
+
+
+  public String getAttribute( String key ) {
+    return this.attributes.get( key );
+  }
+}
+

--- a/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogProperties.java
+++ b/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogProperties.java
@@ -1,0 +1,22 @@
+package org.phoebus.elog.api;
+
+import org.phoebus.framework.preferences.PreferencesReader;
+
+public class ElogProperties {
+
+    final PreferencesReader prefs;
+
+    ElogProperties() {
+        prefs = new PreferencesReader(ElogProperties.class, "/elog.properties");
+    }
+
+    /**
+     * check java preferences for the requested key
+     * @param key
+     * @return
+     */
+    String getPreferenceValue(String key) {
+        return prefs.get(key);
+    }
+
+}

--- a/app/logbook/elog/src/main/java/org/phoebus/elog/api/Sha256.java
+++ b/app/logbook/elog/src/main/java/org/phoebus/elog/api/Sha256.java
@@ -1,0 +1,255 @@
+/* This file is taken from
+   https://gitlab.esss.lu.se/ics-software/jelog/-/blob/master/src/main/java/eu/ess/jelog/Sha256.java
+*/
+
+/*
+ * Copyright (C) 2018 European Spallation Source ERIC.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+/*package eu.ess.jelog;*/
+package org.phoebus.elog.api;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author Juan F. Esteban Müller <JuanF.EstebanMuller@ess.eu>
+ */
+public class Sha256 {
+
+    protected static String sha256(final char[] key, int rounds) {
+        final int keyLen = key.length;
+        final int blocksize = 32;
+
+        byte[] keyBytes = new byte[keyLen];
+        for (int i = 0; i < keyLen; i++) {
+            keyBytes[i] = (byte) key[i];
+        }
+        // Prepare for the real work.
+        StringBuilder buffer = null;
+        try {
+            // 1. start digest A
+            MessageDigest ctx = MessageDigest.getInstance("SHA-256");
+
+            // 2. the password string is added to digest A
+            ctx.update(keyBytes);
+
+            // 4. start digest B
+            MessageDigest altCtx = MessageDigest.getInstance("SHA-256");
+
+            // 5. add the password to digest B
+            altCtx.update(keyBytes);
+
+            // 7. add the password again to digest B
+            altCtx.update(keyBytes);
+
+            // 8. finish digest B
+            byte[] altResult = altCtx.digest();
+
+            // 9. For each block of 32 or 64 bytes in the password string, add digest B to digest A
+            /*
+                         * Add for any character in the key one byte of the alternate sum.
+             */
+            int cnt = keyBytes.length;
+            while (cnt > blocksize) {
+                ctx.update(altResult, 0, blocksize);
+                cnt -= blocksize;
+            }
+
+            // 10. For the remaining N bytes of the password string add the first
+            // N bytes of digest B to digest A
+            ctx.update(altResult, 0, cnt);
+
+            // 11. For each bit of the binary representation of the length of the
+            // password string up to and including the highest 1-digit, starting
+            // from to lowest bit position (numeric value 1):
+            //
+            // a) for a 1-digit add digest B to digest A
+            //
+            // b) for a 0-digit add the password string
+            /*
+                         * Take the binary representation of the length of the key and for every 1 add the alternate sum, for every 0
+                         * the key.
+             */
+            cnt = keyBytes.length;
+            while (cnt > 0) {
+                if ((cnt & 1) != 0) {
+                    ctx.update(altResult, 0, blocksize);
+                } else {
+                    ctx.update(keyBytes);
+                }
+                cnt >>= 1;
+            }
+
+            // 12. finish digest A
+            /*
+                         * Create intermediate result.
+             */
+            altResult = ctx.digest();
+
+            // 13. start digest DP
+            /*
+                         * Start computation of P byte sequence.
+             */
+            altCtx = MessageDigest.getInstance("SHA-256");
+
+            // 14. for every byte in the password (excluding the terminating NUL byte
+            // in the C representation of the string)
+            //
+            // add the password to digest DP
+            /*
+                         * For every character in the password add the entire password.
+             */
+            for (int i = 1; i <= keyLen; i++) {
+                altCtx.update(keyBytes);
+            }
+
+            // 15. finish digest DP
+            /*
+                         * Finish the digest.
+             */
+            byte[] tempResult = altCtx.digest();
+
+            // 16. produce byte sequence P of the same length as the password where
+            //
+            // a) for each block of 32 or 64 bytes of length of the password string
+            // the entire digest DP is used
+            //
+            // b) for the remaining N (up to 31 or 63) bytes use the first N
+            // bytes of digest DP
+            /*
+                         * Create byte sequence P.
+             */
+            final byte[] pBytes = new byte[keyLen];
+            int cp = 0;
+            while (cp < keyLen - blocksize) {
+                System.arraycopy(tempResult, 0, pBytes, cp, blocksize);
+                cp += blocksize;
+            }
+            System.arraycopy(tempResult, 0, pBytes, cp, keyLen - cp);
+
+            // 21. repeat a loop according to the number specified in the rounds=<N>
+            // specification in the salt (or the default value if none is
+            // present). Each round is numbered, starting with 0 and up to N-1.
+            //
+            // The loop uses a digest as input. In the first round it is the
+            // digest produced in step 12. In the latter steps it is the digest
+            // produced in step 21.h. The following text uses the notation
+            // "digest A/C" to describe this behavior.
+            /*
+                         * Repeatedly run the collected hash value through sha512 to burn CPU cycles.
+             */
+            for (int i = 0; i <= rounds - 1; i++) {
+                // a) start digest C
+                /*
+                                 * New context.
+                 */
+                ctx = MessageDigest.getInstance("SHA-256");
+
+                // b) for odd round numbers add the byte sequense P to digest C
+                // c) for even round numbers add digest A/C
+                /*
+                                 * Add key or last result.
+                 */
+                if ((i & 1) != 0) {
+                    ctx.update(pBytes, 0, keyLen);
+                } else {
+                    ctx.update(altResult, 0, blocksize);
+                }
+
+                // e) for all round numbers not divisible by 7 add the byte sequence P
+                /*
+                                 * Add key for numbers not divisible by 7.
+                 */
+                if (i % 7 != 0) {
+                    ctx.update(pBytes, 0, keyLen);
+                }
+
+                // f) for odd round numbers add digest A/C
+                // g) for even round numbers add the byte sequence P
+                /*
+                                 * Add key or last result.
+                 */
+                if ((i & 1) != 0) {
+                    ctx.update(altResult, 0, blocksize);
+                } else {
+                    ctx.update(pBytes, 0, keyLen);
+                }
+
+                // Intermediate result
+                altResult = ctx.digest();
+            }
+
+            // Constructing the output string
+            //buffer = new StringBuilder("$5$");
+            //buffer.append("$");
+            buffer = new StringBuilder();
+
+            // Encoding to Base-64
+            b64from24bit(altResult[0], altResult[10], altResult[20], 4, buffer);
+            b64from24bit(altResult[21], altResult[1], altResult[11], 4, buffer);
+            b64from24bit(altResult[12], altResult[22], altResult[2], 4, buffer);
+            b64from24bit(altResult[3], altResult[13], altResult[23], 4, buffer);
+            b64from24bit(altResult[24], altResult[4], altResult[14], 4, buffer);
+            b64from24bit(altResult[15], altResult[25], altResult[5], 4, buffer);
+            b64from24bit(altResult[6], altResult[16], altResult[26], 4, buffer);
+            b64from24bit(altResult[27], altResult[7], altResult[17], 4, buffer);
+            b64from24bit(altResult[18], altResult[28], altResult[8], 4, buffer);
+            b64from24bit(altResult[9], altResult[19], altResult[29], 4, buffer);
+            b64from24bit((byte) 0, altResult[31], altResult[30], 3, buffer);
+
+        } catch (NoSuchAlgorithmException ex) {
+            Logger.getLogger(Sha256.class.getName()).log(Level.SEVERE, null, ex);
+        }
+
+        // Clearing the password array after calculating the hash
+        for (int i = 0; i < keyLen; i++) {
+            keyBytes[i] = 0;
+            key[i] = 0;
+        }
+
+        return buffer.toString();
+    }
+
+    /**
+     * Table with characters for Base64 transformation.
+     */
+    static final String B64T = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    /**
+     * Base64 like conversion of bytes to ASCII chars.
+     *
+     * @param b2 A byte from the result.
+     * @param b1 A byte from the result.
+     * @param b0 A byte from the result.
+     * @param outLen The number of expected output chars.
+     * @param buffer Where the output chars is appended to.
+     */
+    static void b64from24bit(final byte b2, final byte b1, final byte b0, final int outLen,
+            final StringBuilder buffer) {
+        // The bit masking is necessary because the JVM byte type is signed!
+        int w = ((b2 << 16) & 0x00ffffff) | ((b1 << 8) & 0x00ffff) | (b0 & 0xff);
+        // It's effectively a "for" loop but kept to resemble the original C code.
+        int n = outLen;
+        while (n-- > 0) {
+            buffer.append(B64T.charAt(w & 0x3f));
+            w >>= 6;
+        }
+    }
+}

--- a/app/logbook/elog/src/main/resources/META-INF/services/org.phoebus.logbook.LogFactory
+++ b/app/logbook/elog/src/main/resources/META-INF/services/org.phoebus.logbook.LogFactory
@@ -1,0 +1,1 @@
+org.phoebus.applications.logbook.ElogLogbook

--- a/app/logbook/elog/src/main/resources/elog.properties
+++ b/app/logbook/elog/src/main/resources/elog.properties
@@ -6,10 +6,12 @@
 elog_url=http://localhost:8080/demo
 
 # Comma separated list of Categories
-categories=
+# If not defined, list is retrieved via HTTP request
+#categories=
 
-# Comma separated list of Type
-types=
+# Comma separated list of Types
+# If not defined, list is retrieved via HTTP request
+#types=
 
 # username for elog
 #username=

--- a/app/logbook/elog/src/main/resources/elog.properties
+++ b/app/logbook/elog/src/main/resources/elog.properties
@@ -1,0 +1,19 @@
+# --------------------------------------
+# Package org.phoebus.elog.api
+# --------------------------------------
+
+# URL of the elog server
+elog_url=http://localhost:8080/demo
+
+# Comma separated list of Categories
+categories=
+
+# Comma separated list of Type
+types=
+
+# username for elog
+#username=
+
+# hashed password for elog
+#password=
+

--- a/app/logbook/elog/src/main/resources/elog.properties
+++ b/app/logbook/elog/src/main/resources/elog.properties
@@ -6,12 +6,14 @@
 elog_url=http://localhost:8080/demo
 
 # Comma separated list of Categories
-# If not defined, list is retrieved via HTTP request
-#categories=
+# If empty, list is retrieved via HTTP request
+#categories=General, Hardware, Software, Network, Other
+categories=
 
 # Comma separated list of Types
-# If not defined, list is retrieved via HTTP request
-#types=
+# If empty, list is retrieved via HTTP request
+#types=Routine, Software Installation, Problem Fixed, Configuration, Other
+types=
 
 # username for elog
 #username=

--- a/app/logbook/pom.xml
+++ b/app/logbook/pom.xml
@@ -13,5 +13,6 @@
     <module>ui</module>
     <module>olog</module>
     <module>olog-es</module>
+    <module>elog</module>
   </modules>
 </project>

--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -44,6 +44,11 @@
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
+      <artifactId>app-logbook-elog</artifactId>
+      <version>4.6.4-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
       <artifactId>app-pvtable</artifactId>
       <version>4.6.4-SNAPSHOT</version>
     </dependency>


### PR DESCRIPTION
I developed a rather simple LogClient for the [PSI Elog](https://elog.psi.ch/elog/) based on their [python library](https://github.com/paulscherrerinstitute/py_elog).

The API supports the Attributes Author, Subject, Type, and Category.
In Phoebus Type and Category are named Logbook and Tag.

As this was my first attempt of programming with Java/Maven I oriented myself a bit on the OlogClient