### PR TITLE
Close/Save handling: Use `Future<Boolean>` in ok-to-close test

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/annunciator/AnnunciatorTableInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/annunciator/AnnunciatorTableInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@ package org.phoebus.applications.alarm.ui.annunciator;
 import static org.phoebus.applications.alarm.AlarmSystem.logger;
 
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import org.phoebus.applications.alarm.AlarmSystem;
@@ -46,7 +47,7 @@ public class AnnunciatorTableInstance implements AppInstance
         tab.addCloseCheck(() ->
         {
             dispose();
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
         DockPane.getActiveDockPane().addTab(tab);
     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/area/AlarmAreaInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/area/AlarmAreaInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@ package org.phoebus.applications.alarm.ui.area;
 import static org.phoebus.applications.alarm.AlarmSystem.logger;
 
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import org.phoebus.applications.alarm.AlarmSystem;
@@ -47,7 +48,7 @@ public class AlarmAreaInstance implements AppInstance
         tab.addCloseCheck(() ->
         {
             dispose();
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
         DockPane.getActiveDockPane().addTab(tab);
     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@ package org.phoebus.applications.alarm.ui.table;
 import static org.phoebus.applications.alarm.AlarmSystem.logger;
 
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import org.phoebus.applications.alarm.AlarmSystem;
@@ -48,7 +49,7 @@ class AlarmTableInstance implements AppInstance
         tab.addCloseCheck(() ->
         {
             dispose();
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
         DockPane.getActiveDockPane().addTab(tab);
     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@ package org.phoebus.applications.alarm.ui.tree;
 import static org.phoebus.applications.alarm.AlarmSystem.logger;
 
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import org.phoebus.applications.alarm.AlarmSystem;
@@ -46,7 +47,7 @@ class AlarmTreeInstance implements AppInstance
         tab.addCloseCheck(() ->
         {
             dispose();
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
         DockPane.getActiveDockPane().addTab(tab);
     }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -15,7 +15,6 @@ import java.io.FileOutputStream;
 import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import org.csstudio.trends.databrowser3.model.AxisConfig;
@@ -146,11 +145,7 @@ public class DataBrowserInstance implements AppInstance
         dock_item = new DockItemWithInput(this, perspective, null, file_extensions, this::doSave);
         DockPane.getActiveDockPane().addTab(dock_item);
 
-        dock_item.addCloseCheck(() ->
-        {
-            dispose();
-            return CompletableFuture.completedFuture(true);
-        });
+        dock_item.addClosedNotification(this::dispose);
 
         perspective.getModel().addListener(model_listener);
     }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -15,6 +15,7 @@ import java.io.FileOutputStream;
 import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import org.csstudio.trends.databrowser3.model.AxisConfig;
@@ -148,7 +149,7 @@ public class DataBrowserInstance implements AppInstance
         dock_item.addCloseCheck(() ->
         {
             dispose();
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
 
         perspective.getModel().addListener(model_listener);

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import org.csstudio.display.builder.editor.DisplayEditor;
 import org.csstudio.display.builder.editor.EditorGUI;
@@ -29,7 +30,6 @@ import org.csstudio.display.builder.model.WidgetClassSupport;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.persist.WidgetClassesService;
-import org.csstudio.display.builder.model.util.ModelResourceUtil;
 import org.csstudio.display.builder.model.util.ModelThreadPool;
 import org.csstudio.display.builder.model.widgets.GroupWidget;
 import org.csstudio.display.builder.representation.javafx.FilenameSupport;
@@ -46,6 +46,7 @@ import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.javafx.ToolbarHelper;
+import org.phoebus.util.FileExtensionUtil;
 
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
@@ -59,7 +60,6 @@ import javafx.scene.control.Control;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.input.ContextMenuEvent;
-import org.phoebus.util.FileExtensionUtil;
 
 /** Display Editor Instance
  *  @author Kay Kasemir
@@ -457,7 +457,7 @@ public class DisplayEditorInstance implements AppInstance
         }
     }
 
-    private boolean okToClose()
+    private Future<Boolean> okToClose()
     {
         if (save_job != null)
         {
@@ -467,10 +467,10 @@ public class DisplayEditorInstance implements AppInstance
             prompt.setHeaderText(Messages.AbortSave);
             DialogHelper.positionDialog(prompt, dock_item.getTabPane(), -200, -200);
             if (prompt.showAndWait().orElse(ButtonType.CANCEL) != ButtonType.OK)
-                return false;
+                return CompletableFuture.completedFuture(false);
         }
 
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     private void dispose()

--- a/app/errlog/src/main/java/org/phoebus/applications/errlog/ErrLogInstance.java
+++ b/app/errlog/src/main/java/org/phoebus/applications/errlog/ErrLogInstance.java
@@ -1,11 +1,13 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
 package org.phoebus.applications.errlog;
+
+import java.util.concurrent.CompletableFuture;
 
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
@@ -46,7 +48,7 @@ class ErrLogInstance implements AppInstance
         {
             errlog.close();
             INSTANCE = null;
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
         DockPane.getActiveDockPane().addTab(tab);
     }

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/dataplot/ScanDataPlotInstance.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/dataplot/ScanDataPlotInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@ package org.csstudio.scan.ui.dataplot;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import org.csstudio.scan.ui.ScanURI;
 import org.phoebus.framework.persistence.Memento;
@@ -42,7 +43,7 @@ public class ScanDataPlotInstance implements AppInstance
         tab.addCloseCheck(() ->
         {
             data_plot.stop();
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
         DockPane.getActiveDockPane().addTab(tab);
     }

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/datatable/ScanDataTableInstance.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/datatable/ScanDataTableInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,6 +8,7 @@
 package org.csstudio.scan.ui.datatable;
 
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 
 import org.csstudio.scan.client.Preferences;
 import org.csstudio.scan.client.ScanClient;
@@ -39,7 +40,7 @@ public class ScanDataTableInstance implements AppInstance
         tab.addCloseCheck(() ->
         {
             data_table.dispose();
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
         DockPane.getActiveDockPane().addTab(tab);
     }

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScanMonitor.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScanMonitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@ import static org.csstudio.scan.ScanSystem.logger;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import org.csstudio.scan.client.ScanClient;
@@ -84,7 +85,7 @@ public class ScanMonitor implements AppInstance
         tab.addCloseCheck(() ->
         {
             dispose();
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
         tab.addClosedNotification(() -> INSTANCE = null);
         DockPane.getActiveDockPane().addTab(tab);

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -560,7 +560,8 @@ public class DockItem extends Tab
     public boolean prepareToClose() throws Exception
     {
         if (Platform.isFxApplicationThread())
-            throw new IllegalStateException("Must not be called on UI thread because it can block/deadlock");
+            logger.log(Level.SEVERE, "'prepareToClose' must not be called on UI thread because it can block/deadlock", new Exception("Stack Trace"));
+
         if (close_check != null)
             for (Supplier<Future<Boolean>> check : close_check)
             {

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,10 +15,13 @@ import java.awt.PointerInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 
+import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.security.authorization.AuthorizationService;
@@ -76,6 +79,9 @@ import javafx.stage.Window;
  *  {@link Tab#setOnClosed(EventHandler)}
  *  are used internally and should not be called.
  *
+ *  <p>Instead of `setOnCloseRequest`, use {@link DockItem#addCloseCheck}.
+ *  <p>Instead of `setOnClosed`, use {@link DockItem#addClosedNotification}.
+ *
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
@@ -117,7 +123,7 @@ public class DockItem extends Tab
     protected final Label name_tab;
 
     /** Called to check if OK to close the tab */
-    private List<BooleanSupplier> close_check = null;
+    private List<Supplier<Future<Boolean>>> close_check = new ArrayList<>();
 
     /** Called after tab was closed */
     private List<Runnable> closed_callback = null;
@@ -191,18 +197,20 @@ public class DockItem extends Tab
         split_vert.setOnAction(event -> split(false));
 
         final MenuItem close = new MenuItem(Messages.DockClose, new ImageView(DockPane.close_icon));
-        close.setOnAction(event -> close());
+        close.setOnAction(event -> close(List.of(this)));
 
         final MenuItem close_other = new MenuItem(Messages.DockCloseOthers, new ImageView(close_many_icon));
         close_other.setOnAction(event ->
         {
             // Close all other tabs in non-fixed panes of this window
             final Stage stage = (Stage) getDockPane().getScene().getWindow();
+            final List<DockItem> tabs = new ArrayList<>();
             for (DockPane pane : DockStage.getDockPanes(stage))
                 if (! pane.isFixed())
                     for (Tab tab : new ArrayList<>(pane.getTabs()))
                         if ((tab instanceof DockItem)  &&  tab != DockItem.this)
-                            ((DockItem)tab).close();
+                            tabs.add((DockItem)tab);
+            close(tabs);
         });
 
         final MenuItem close_all = new MenuItem(Messages.DockCloseAll, new ImageView(close_many_icon));
@@ -210,13 +218,14 @@ public class DockItem extends Tab
         {
             // Close all tabs in non-fixed panes of this window
             final Stage stage = (Stage) getDockPane().getScene().getWindow();
+            final List<DockItem> tabs = new ArrayList<>();
             for (DockPane pane : DockStage.getDockPanes(stage))
                 if (! pane.isFixed())
                     for (Tab tab : new ArrayList<>(pane.getTabs()))
                         if ((tab instanceof DockItem))
-                            ((DockItem)tab).close();
+                            tabs.add((DockItem)tab);
+            close(tabs);
         });
-
 
         final ContextMenu menu = new ContextMenu(info);
 
@@ -250,6 +259,23 @@ public class DockItem extends Tab
         });
 
         name_tab.setContextMenu(menu);
+    }
+
+    /** @param tabs Tabs to prepare and then close */
+    private void close(final List<DockItem> tabs)
+    {
+        JobManager.schedule("Close", monitor ->
+        {
+            for (DockItem tab : tabs)
+                if (! tab.prepareToClose())
+                    return;
+
+            Platform.runLater(() ->
+            {
+                for (DockItem tab : tabs)
+                    tab.close();
+            });
+        });
     }
 
     /** @return Unique ID of this dock item */
@@ -492,29 +518,73 @@ public class DockItem extends Tab
 
     /** Register check for closing the tab
      *
-     *  @param ok_to_close Will be called when tab is about to close.
-     *                     Should return <code>true</code> if OK to close,
+     *  @param ok_to_close Will be called when tab prepares to close.
+     *                     Will be invoked on the UI thread, so it may
+     *                     prompt for "Do you want to save?".
+     *                     May return a completed future right away,
+     *                     or start a background thread to for example
+     *                     save the tab's content which will complete
+     *                     the future when done.
+     *                     Future must be <code>true</code> if OK to close,
      *                     <code>false</code> to leave the tab open.
      */
-    public void addCloseCheck(final BooleanSupplier ok_to_close)
+    public void addCloseCheck(final Supplier<Future<Boolean>> ok_to_close)
     {
-        if (close_check == null)
-        {
-            close_check = new ArrayList<>();
+        if (getOnCloseRequest() == null)
             setOnCloseRequest(event ->
             {
-                for (BooleanSupplier check : close_check)
-                    if (! check.getAsBoolean())
-                    {
-                        event.consume();
-                        return;
-                    }
-                // Clear entries, but don't reset to null
-                // since onCloseRequest handler still registered
-                close_check.clear();
+                // For now, prevent closing
+                event.consume();
+
+                // Invoke all the ok-to-close checks in background threads
+                // since those that save files might take time.
+                JobManager.schedule("Close " + getLabel(), monitor ->
+                {
+                    if (prepareToClose())
+                        Platform.runLater(() -> close());
+                });
             });
-        }
+
         close_check.add(ok_to_close);
+    }
+
+    /** Prepare dock item to close
+     *
+     *  Invokes all ok-to-close checks,
+     *  which may start "save" threads and take some time
+     *  before returning result.
+     *
+     *  @return <code>true</code> when OK to close
+     *  @throws Exception on error
+     */
+    public boolean prepareToClose() throws Exception
+    {
+        if (Platform.isFxApplicationThread())
+            throw new IllegalStateException("Must not be called on UI thread because it can block/deadlock");
+        if (close_check != null)
+            for (Supplier<Future<Boolean>> check : close_check)
+            {
+                // Invoke each actual ok-to-close check on UI thread,
+                // since it may open dialogs etc. before starting a "save" thread
+                final CompletableFuture<Boolean> result = new CompletableFuture<>();
+                Platform.runLater(() ->
+                {
+                    try
+                    {
+                        result.complete(check.get().get());
+                    }
+                    catch (Exception ex)
+                    {
+                        result.completeExceptionally(ex);
+                    }
+                });
+                // .. then await result of check started in UI thread
+                if (! result.get())
+                    return false;
+            }
+
+        close_check.clear();
+        return true;
     }
 
     /** Register for notification when tab was closed
@@ -548,27 +618,19 @@ public class DockItem extends Tab
 
     /** Programmatically close this tab
      *
-     *  <p>Will invoke on-close-request handler that can abort the action,
-     *  otherwise invoke the on-closed handler and remove the tab
+     *  <p>Should be called after {@link #prepareToClose) has been used
+     *  to allow "save".
      *
      *  @return <code>true</code> if tab closed, <code>false</code> if it remained open
      */
-    public boolean close()
+    public void close()
     {
-        EventHandler<Event> handler = getOnCloseRequest();
-        if (handler != null)
-        {
-            final Event event = new Event(Tab.TAB_CLOSE_REQUEST_EVENT);
-            handler.handle(event);
-            if (event.isConsumed())
-                return false;
-        }
+        if (! close_check.isEmpty())
+            logger.log(Level.SEVERE, "Failed to call prepareToClose", new Exception("Stack Trace"));
 
         handleClosed(null);
 
         getDockPane().getTabs().remove(this);
-
-        return true;
     }
 
     @Override

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -202,15 +203,12 @@ public class DockItemWithInput extends DockItem
     }
 
     /** Called when user tries to close the tab
-     *
-     *  <p>Derived class may override.
-     *
      *  @return Should the tab close? Otherwise it stays open.
      */
-    protected boolean okToClose()
+    private Future<Boolean> okToClose()
     {
         if (! isDirty())
-            return true;
+            return CompletableFuture.completedFuture(true);
 
         final String text = MessageFormat.format(Messages.DockAlertMsg, getLabel());
         final Alert prompt = new Alert(AlertType.NONE,
@@ -224,16 +222,21 @@ public class DockItemWithInput extends DockItem
 
         // Cancel the close request
         if (result == ButtonType.CANCEL)
-            return false;
+            return CompletableFuture.completedFuture(false);
 
         // Close without saving?
         if (result == ButtonType.NO)
-            return true;
+            return CompletableFuture.completedFuture(true);
 
         // Save in background job ...
-        JobManager.schedule(Messages.Save, monitor -> save(monitor));
-        // .. and leave the tab open, so user can then try to close again
-        return false;
+        final CompletableFuture<Boolean> done = new CompletableFuture<>();
+        JobManager.schedule(Messages.Save, monitor ->
+        {
+            save(monitor);
+            // Indicate if we may close, or need to stay open because of error
+            done.complete(! isDirty());
+        });
+        return done;
     }
 
     /** Save the content of the item to its current 'input'

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
@@ -31,7 +31,6 @@ import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.dialog.SaveAsDialog;
 
 import javafx.application.Platform;
-import javafx.event.Event;
 import javafx.scene.Node;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
@@ -431,11 +430,13 @@ public class DockItemWithInput extends DockItem
      * {@inheritDoc}
      * */
     @Override
-    protected void handleClosed(final Event event)
+    final protected void handleClosed()
     {
-        // Do the same as in the parent class, DockItem.handleClosed, but clean up save_handler.
-        super.handleClosed(event);
+        // Do the same as in the parent class, DockItem.handleClosed...
+        super.handleClosed();
 
+        // Remove save_handler to avoid memory leaks.
+        // Side benefit is detecting erroneous 'save' after item has been closed.
         save_handler = null;
     }
 

--- a/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
@@ -346,6 +346,9 @@ public class MementoHelper
     }
 
     /** Close a DockPane or SplitDock and all tabs held within.
+     * 
+     *  <p>Dock items must have been prepared to close.
+     *  
      *  @param node Node, either a dock item or split pane, that will be closed.
      *  @return boolean <code>true</code> if all the tabs close successfully.
      */
@@ -357,11 +360,7 @@ public class MementoHelper
             final DockPane pane = (DockPane) node;
             final List<DockItem> items = pane.getDockItems();
             for (final DockItem item : items)
-            {
-                // If it refuses to close, return false.
-                if (! item.close())
-                    return false;
-            }
+                item.close();
         }
         else if (node instanceof SplitDock)
         {

--- a/core/ui/src/main/java/org/phoebus/ui/jobs/JobViewer.java
+++ b/core/ui/src/main/java/org/phoebus/ui/jobs/JobViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,6 +8,7 @@
 package org.phoebus.ui.jobs;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -65,7 +66,7 @@ class JobViewer implements AppInstance
         tab.addCloseCheck(() ->
         {
             stopUpdates();
-            return true;
+            return CompletableFuture.completedFuture(true);
         });
         tab.addClosedNotification(() -> INSTANCE = null);
         DockPane.getActiveDockPane().addTab(tab);


### PR DESCRIPTION
... to allow "save" tasks to run, check if all was successful, and then close/exit as mentioned in #1545

Splits the overall "close" process into

1) Background thread that calls all the ok-to-close checks, awaiting their `Future<Boolean>` to check if we can close, or end right there.
2) Then, back on UI thread, close the items.

Does require updates to code that called `DockItem.addCloseCheck`.
Before, that used a `BooleanSupplier`, now a `Supplier<Future<Boolean>>`.
Use has been limited, though, so changes outside of core.ui are small.

Before, with`DockItem.addCloseCheck` using a `BooleanSupplier`, a 'dirty' editor could only return `false` to keep the tab open, schedule the file to be saved, and then the display remained open.

Tested various scenarios, like two stages, all multiple tabs, one dirty, then

 * close one in secondary window via tab 'x'.
 * close one in secondary window via context menu.
 * close 'others' in secondary window via tab context menu.
 * close 'all' in secondary window via tab context menu.
 * close secondary window.
 * close primary window.
 * File/Exit

Also tested various "Window/Load Layout" changes with dirty editors.

Still, there might be cases that have not been considered or apps that will need tweaks related to calling `DockItem.addCloseCheck` and `DockItem.addClosedNotification`.