### PR TITLE
CSSTUDIO-1337 Thermometer widget renders beyond boundary

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ThermometerRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ThermometerRepresentation.java
@@ -247,11 +247,10 @@ public class ThermometerRepresentation extends RegionBaseRepresentation<Region, 
             max_val = 100.0;
         }
 
-        // Determine percentage of value within the min..max range
         final double value = VTypeUtil.getValueNumber(vtype).doubleValue();
         min = min_val;
         max = max_val;
-        val = value;
+        val = Math.min(max, value); // Avoid rendering value beyond maximum
         dirty_value.mark();
         toolkit.scheduleUpdate(this);
     }


### PR DESCRIPTION
Thermometer widget does not honor upper limit, regardless if set as widget property or in PV. If value exceeds upper limit, the widget renders erroneously, see screen shot. This is a fix.
![Screenshot 2020-09-27 at 09 02 22](https://user-images.githubusercontent.com/35602960/94422193-fe61cd80-0186-11eb-82fd-c21d7c449083.png)
