### PR TITLE
Editor: Stop auto-scroll when disposed

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/DisplayEditor.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/DisplayEditor.java
@@ -868,6 +868,7 @@ public class DisplayEditor
 
     public void dispose()
     {
+        autoScrollHandler.enable(false);
         if (model != null)
             toolkit.disposeRepresentation(model);
         model = null;

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/AutoScrollHandler.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/AutoScrollHandler.java
@@ -78,6 +78,9 @@ public class AutoScrollHandler {
     public void enable(final boolean enabled)
     {
         this.enabled = enabled;
+        // When disabled, stop any ongoing 'scroll'
+        if (! enabled)
+            canceTimeline();
     }
 
     /**


### PR DESCRIPTION
Hard to reproduce, but closing an editor with an active auto-scroll timeline resulted in never ending error messages because the UI had been removed. This stops auto-scroll when disposing a display editor.