### PR TITLE
WidgetTree: optimized moving widgets

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
@@ -10,6 +10,7 @@ package org.csstudio.display.builder.editor.tree;
 import static org.csstudio.display.builder.editor.Plugin.logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -140,6 +141,33 @@ public class WidgetTree
         {
             // Update must be on UI thread.
             // Even if already on UI thread, decouple.
+            if (removed != null && added != null && removed.size() == 1 && removed.equals(added))
+            {
+                // This was a move up/down of a widget
+                // Need to determine the index of moved item in model _now_,
+                // not in decoupled thread.
+                final Widget widget = removed.get(0);
+                final int model_index = p.getValue().indexOf(widget);
+
+                Platform.runLater(() ->
+                {
+                    active.set(true);
+                    try
+                    {
+                        moveWidget(widget, model_index);
+                    }
+                    finally
+                    {
+                        active.set(false);
+                    }
+                    // Restore tree's selection to match model
+                    // after removing/adding items may have changed it.
+                    setSelectedWidgets(editor.getWidgetSelectionHandler().getSelection());
+                });
+
+                return;
+            }
+
             if (removed != null)
                 Platform.runLater(() ->
                 {
@@ -384,6 +412,57 @@ public class WidgetTree
         else
             return ChildrenProperty.getChildren(widget_parent).getValue().indexOf(widget);
         return -1;
+    }
+
+    /** Moves a widget to match its position in the model
+     *  @param widget The widget that was moved in the model
+     *  @param model_index Index of widget in model's parent
+     */
+    private void moveWidget(final Widget widget, final int model_index)
+    {
+        final TreeItem<WidgetOrTab> item = widget2tree.get(widget);
+        final Widget widget_parent = Objects.requireNonNull(widget.getParent().get());
+        List children = null;
+        int current_index = -1;
+
+        if (widget_parent instanceof TabsWidget)
+        {
+            for (TreeItem<WidgetOrTab> cit : widget2tree.get(widget_parent).getChildren())
+            {
+                WidgetOrTab wot = cit.getValue();
+                if (wot.isWidget())
+                    continue;
+
+                if ((current_index = cit.getChildren().indexOf(item)) != -1)
+                {
+                    children = cit.getChildren();
+                    break;
+                }
+            }
+        }
+        else
+        {
+            children = widget2tree.get(widget_parent).getChildren();
+            current_index = children.indexOf(item);
+        }
+
+        if (current_index == -1)
+        {
+            logger.log(Level.SEVERE, "Couldn't find widget to move in Widget Tree: " + widget);
+            return;
+        }
+
+        final int index_diff = model_index - current_index;
+        if (index_diff == 1 || index_diff == -1)
+        {
+            // Move up/down by 1 step
+            Collections.swap(children, current_index, model_index);
+        }
+        else
+        {
+            // Move to front/back
+            Collections.rotate(children.subList(java.lang.Math.min(model_index, current_index), java.lang.Math.max(model_index, current_index) + 1), index_diff);
+        }
     }
 
     /** Add widget to existing model & tree

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/undo/UpdateWidgetOrderAction.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/undo/UpdateWidgetOrderAction.java
@@ -67,10 +67,6 @@ public class UpdateWidgetOrderAction extends UndoableAction
     {
         final ChildrenProperty children = ChildrenProperty.getParentsChildren(widget);
 
-        children.removeChild(widget);
-        if (index < 0)
-            children.addChild(widget);
-        else
-            children.addChild(index, widget);
+        children.moveChildTo(index, widget);
     }
 }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/ChildrenProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/ChildrenProperty.java
@@ -229,6 +229,37 @@ public class ChildrenProperty extends RuntimeWidgetProperty<List<Widget>>
         return index;
     }
 
+    public int moveChildTo(int index, final Widget child)
+    {
+        if (child == null)
+            throw new NullPointerException("Cannot move null in " + getWidget());
+        final List<Widget> list = value;
+        final int current_index;
+        synchronized (list)
+        {
+            current_index = list.indexOf(child);
+            if (current_index < 0)
+                throw new IllegalArgumentException("Widget hierarchy error: " + child + " is not known to " + this);
+            if (index < 0)
+                index = list.size() - 1;
+
+            final int index_diff = index - current_index;
+            if (index_diff == 1 || index_diff == -1)
+            {
+                // Move up/down by 1 step
+                Collections.swap(list, current_index, index);
+            }
+            else
+            {
+                // Move to front/back
+                Collections.rotate(list.subList(java.lang.Math.min(index, current_index), java.lang.Math.max(index, current_index) + 1), index_diff);
+            }
+        }
+        final List change = Arrays.asList(child);
+        firePropertyChange(change, change, true);
+        return index;
+    }
+
     @Override
     public void writeToXML(final ModelWriter model_writer, final XMLStreamWriter writer) throws Exception
     {

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetProperty.java
@@ -331,7 +331,25 @@ public abstract class WidgetProperty<T extends Object> extends PropertyChangeHan
      */
     protected void firePropertyChange(final T old_value, final T new_value)
     {
-        firePropertyChange(this, old_value, new_value);
+        firePropertyChange(this, old_value, new_value, false);
+    }
+
+    /** Notify listeners of property change.
+     *
+     *  <p>New value usually matches <code>property.getValue()</code>,
+     *  but in multi-threaded context value might already have changed
+     *  _again_ by the time this executes.
+     *
+     *  <p>Suppresses notifications where old_value equals new_value,
+     *  unless the values are null or forceNotify is true.
+     *
+     *  @param old_value Original value
+     *  @param new_value New value
+     *  @param forceNotify Force notification
+     */
+    protected void firePropertyChange(final T old_value, final T new_value, final boolean forceNotify)
+    {
+        firePropertyChange(this, old_value, new_value, forceNotify);
     }
 
     /** @return Debug representation */

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/PropertyChangeHandler.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/PropertyChangeHandler.java
@@ -137,13 +137,35 @@ public abstract class PropertyChangeHandler<T extends Object>
    protected void firePropertyChange(final WidgetProperty<T> property,
                                      final T old_value, final T new_value)
    {
+       firePropertyChange(property, old_value, new_value, false);
+   }
+
+    /** Notify listeners of property change.
+    *
+    *  <p>New value usually matches <code>property.getValue()</code>,
+    *  but in multi-threaded context value might already have changed
+    *  _again_ by the time this executes.
+    *
+    *  <p>Suppresses notifications where old_value equals new_value,
+    *  unless both values are null or forceNotify is true.
+    *
+    *  @param property Property that changed, or <code>null</code> for "many"
+    *  @param old_value Original value
+    *  @param new_value New value
+    *  @param forceNotify Force notification even if old_value and new_value are the same
+    */
+   @SuppressWarnings("unchecked")
+   protected void firePropertyChange(final WidgetProperty<T> property,
+                                     final T old_value, final T new_value,
+                                     final boolean forceNotify)
+   {
        // Does anybody care?
        final List<BaseWidgetPropertyListener> safe_copy = listeners;
        if (safe_copy == null)
            return;
 
        // Any change at all?
-       if (new_value != null  &&  old_value != null  &&  new_value.equals(old_value))
+       if (new_value != null  &&  old_value != null  &&  !forceNotify  &&  new_value.equals(old_value))
            return;
 
        // If a property listener changes the property,

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
@@ -79,6 +79,18 @@ abstract public class ToolkitRepresentation<TWP extends Object, TW> implements E
     /** Add/remove representations for child elements as model changes */
     private final WidgetPropertyListener<List<Widget>> container_children_listener = (children, removed, added) ->
     {
+        // Only the order of the widgets have changed
+        if (removed != null && added != null && removed.size() == 1 && removed.equals(added))
+        {
+            final Widget widget = added.get(0);
+            execute(() ->
+            {
+                final WidgetRepresentation<TWP, TW, Widget> representation = widget.getUserData(Widget.USER_DATA_REPRESENTATION);
+                representation.updateOrder();
+            });
+            return;
+        }
+
         // Move to toolkit thread.
         // May already be on toolkit, for example in drag/drop,
         // but updating the representation 'later' may reduce blocking.

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/WidgetRepresentation.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/WidgetRepresentation.java
@@ -69,6 +69,13 @@ abstract public class WidgetRepresentation<TWP, TW, MW extends Widget>
      */
     abstract public void updateChanges();
 
+    /** Update the order of widget to match model.
+     *
+     * <p>Invoked by toolkit when the widget's order changes
+     *
+     */
+    abstract public void updateOrder();
+
     /** Remove toolkit items.
      *
      *  <p>Called when model widget has been removed.

--- a/app/display/representation/src/test/java/org/csstudio/display/builder/representation/UpdateThrottleTest.java
+++ b/app/display/representation/src/test/java/org/csstudio/display/builder/representation/UpdateThrottleTest.java
@@ -70,6 +70,12 @@ public class UpdateThrottleTest
         {
             // NOP
         }
+
+        @Override
+        public void updateOrder()
+        {
+            // NOP
+        }
     }
 
     @Test


### PR DESCRIPTION
Instead of removing and re-adding the widgets simply move them in the list; removing and re-adding is expensive because all the listeners have to be removed and then re-added, the representation has to be discarded and re-created.