### PR TITLE
Spinner fixes

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
@@ -14,7 +14,6 @@ import java.util.logging.Level;
 import javafx.event.Event;
 import javafx.scene.Cursor;
 import javafx.scene.input.ContextMenuEvent;
-import javafx.scene.layout.Pane;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -48,33 +47,28 @@ import javafx.util.StringConverter;
  *  @author Amanda Carpenter
  */
 @SuppressWarnings("nls")
-public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, SpinnerWidget>
+public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<String>, SpinnerWidget>
 {
     /** Is user actively editing the content, so updates should be suppressed? */
     private volatile boolean active = false;
 
     private final DirtyFlag dirty_style = new DirtyFlag();
     private final DirtyFlag dirty_content = new DirtyFlag();
-    private final DirtyFlag dirty_enablement = new DirtyFlag();
     private final UntypedWidgetPropertyListener styleListener = this::styleChanged;
     private final UntypedWidgetPropertyListener behaviourListener = this::behaviorChanged;
     private final UntypedWidgetPropertyListener contentListener = this::contentChanged;
     private final WidgetPropertyListener<String> pvNameListener = this::pvnameChanged;
-    private final WidgetPropertyListener<Boolean> enablementChangedListener = this::enablementChanged;
 
     protected volatile String value_text = "<?>";
     protected volatile VType value = null;
     private volatile double value_max  = 100.0;
     private volatile double value_min  = 0.0;
 
-    private final Spinner<String> spinner = new Spinner<>();
-
     @Override
-    protected final Pane createJFXNode() throws Exception
+    protected final Spinner<String> createJFXNode() throws Exception
     {
+        final Spinner<String> spinner = new Spinner<>();
         spinner.setValueFactory(createSVF());
-        styleChanged(null, null, null);
-        spinner.setMinSize(Region.USE_PREF_SIZE, Region.USE_PREF_SIZE);
         spinner.focusedProperty().addListener((property, oldval, newval)->
         {
             if (!spinner.isFocused())
@@ -121,6 +115,11 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
                 e.consume();
         });
 
+        // This code manages layout,
+        // because otherwise for example border changes would trigger
+        // expensive Node.notifyParentOfBoundsChange() recursing up the scene graph
+        spinner.setManaged(false);
+
         spinner.getEditor().setOnContextMenuRequested((event) ->
         {
             event.consume();
@@ -129,9 +128,7 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
 
         spinner.getEditor().setPadding(new Insets(0, 0, 0, 0));
 
-        Pane pane = new Pane();
-        pane.getChildren().setAll(spinner);
-        return pane;
+        return spinner;
     }
 
     /** Restore representation to last known value,
@@ -140,14 +137,14 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
     private void restore()
     {
         //The old value is restored.
-        spinner.getEditor().setText(spinner.getValueFactory().getValue());
+        jfx_node.getEditor().setText(jfx_node.getValueFactory().getValue());
     }
 
     /** Submit value entered by user */
     private void submit()
     {
         //The value factory retains the old values, and will be updated as scheduled below.
-        final String text = spinner.getEditor().getText();
+        final String text = jfx_node.getEditor().getText();
         Object value =
                 FormatOptionHandler.parse(model_widget.runtimePropValue().getValue(), text, model_widget.propFormat().getValue());
         if (value instanceof Number)
@@ -355,7 +352,9 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
 
         model_widget.propForegroundColor().addUntypedPropertyListener(styleListener);
         model_widget.propBackgroundColor().addUntypedPropertyListener(styleListener);
+        model_widget.propFont().addUntypedPropertyListener(styleListener);
         model_widget.propEnabled().addUntypedPropertyListener(styleListener);
+        model_widget.runtimePropPVWritable().addUntypedPropertyListener(styleListener);
 
         model_widget.propIncrement().addUntypedPropertyListener(behaviourListener);
         model_widget.propMinimum().addUntypedPropertyListener(behaviourListener);
@@ -366,13 +365,11 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
         model_widget.propPrecision().addUntypedPropertyListener(contentListener);
         model_widget.propShowUnits().addUntypedPropertyListener(contentListener);
         model_widget.runtimePropValue().addUntypedPropertyListener(contentListener);
-        model_widget.runtimePropPVWritable().addPropertyListener(enablementChangedListener);
+
         model_widget.propPVName().addPropertyListener(pvNameListener);
-        model_widget.propFont().addUntypedPropertyListener(styleListener);
 
         behaviorChanged(null, null, null);
         contentChanged(null, null, null);
-        enablementChanged(null, null, null);
     }
 
     @Override
@@ -383,7 +380,9 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
         model_widget.propButtonsOnLeft().removePropertyListener(styleListener);
         model_widget.propForegroundColor().removePropertyListener(styleListener);
         model_widget.propBackgroundColor().removePropertyListener(styleListener);
+        model_widget.propFont().removePropertyListener(styleListener);
         model_widget.propEnabled().removePropertyListener(styleListener);
+        model_widget.runtimePropPVWritable().removePropertyListener(styleListener);
         model_widget.propIncrement().removePropertyListener(behaviourListener);
         model_widget.propMinimum().removePropertyListener(behaviourListener);
         model_widget.propMaximum().removePropertyListener(behaviourListener);
@@ -393,8 +392,6 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
         model_widget.propShowUnits().removePropertyListener(contentListener);
         model_widget.runtimePropValue().removePropertyListener(contentListener);
         model_widget.propPVName().removePropertyListener(pvNameListener);
-        model_widget.runtimePropPVWritable().removePropertyListener(enablementChangedListener);
-        model_widget.propFont().removePropertyListener(styleListener);
         super.unregisterListeners();
     }
 
@@ -413,7 +410,7 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
     private void behaviorChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {
         updateLimits();
-        final TextSpinnerValueFactory factory = (TextSpinnerValueFactory)spinner.getValueFactory();
+        final TextSpinnerValueFactory factory = (TextSpinnerValueFactory)jfx_node.getValueFactory();
         factory.setStepIncrement(model_widget.propIncrement().getValue());
         factory.setMin(value_min);
         factory.setMax(value_max);
@@ -454,39 +451,36 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
         if (dirty_style.checkAndClear())
         {
             final String color = JFXUtil.webRGB(model_widget.propForegroundColor().getValue());
-            spinner.editorProperty().getValue().setStyle("-fx-text-fill:" + color);
+            jfx_node.editorProperty().getValue().setStyle("-fx-text-fill:" + color);
             final Color background = JFXUtil.convert(model_widget.propBackgroundColor().getValue());
-            spinner.editorProperty().getValue().setBackground(new Background(new BackgroundFill(background, CornerRadii.EMPTY, Insets.EMPTY)));
-            spinner.setPrefSize(model_widget.propWidth().getValue(), model_widget.propHeight().getValue());
+            jfx_node.editorProperty().getValue().setBackground(new Background(new BackgroundFill(background, CornerRadii.EMPTY, Insets.EMPTY)));
+            jfx_node.resize(model_widget.propWidth().getValue(), model_widget.propHeight().getValue());
 
-            final boolean enabled = model_widget.propEnabled().getValue();
-            Styles.update(spinner, Styles.NOT_ENABLED, !enabled);
-            spinner.setEditable(!toolkit.isEditMode() && enabled);
+            // Enable if enabled by user and there's write access
+            final boolean enabled = model_widget.propEnabled().getValue()  &&
+                                    model_widget.runtimePropPVWritable().getValue();
+            Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
+            jfx_node.setEditable(!toolkit.isEditMode() && enabled);
+            jfx_node.getEditor().setCursor(enabled ? Cursor.DEFAULT : Cursors.NO_WRITE);
 
-            spinner.getEditor().setFont(JFXUtil.convert(model_widget.propFont().getValue()));
+            jfx_node.getEditor().setFont(JFXUtil.convert(model_widget.propFont().getValue()));
 
-            int x = spinner.getStyleClass().indexOf(Spinner.STYLE_CLASS_ARROWS_ON_LEFT_VERTICAL);
+            int x = jfx_node.getStyleClass().indexOf(Spinner.STYLE_CLASS_ARROWS_ON_LEFT_VERTICAL);
             if (model_widget.propButtonsOnLeft().getValue())
             {
                 if (x < 0)
-                    spinner.getStyleClass().add(Spinner.STYLE_CLASS_ARROWS_ON_LEFT_VERTICAL);
+                    jfx_node.getStyleClass().add(Spinner.STYLE_CLASS_ARROWS_ON_LEFT_VERTICAL);
             }
             else if (x > 0)
-                spinner.getStyleClass().remove(x);
+                jfx_node.getStyleClass().remove(x);
         }
         if (dirty_content.checkAndClear())
         {
-            ( (TextSpinnerValueFactory)spinner.getValueFactory() ).setVTypeValue(value);
-            spinner.getValueFactory().setValue(value_text);
+            ( (TextSpinnerValueFactory)jfx_node.getValueFactory() ).setVTypeValue(value);
+            jfx_node.getValueFactory().setValue(value_text);
         }
-        if (dirty_enablement.checkAndClear())
-        {
-            final boolean enabled = model_widget.propEnabled().getValue()  &&
-                    model_widget.runtimePropPVWritable().getValue();
-            spinner.getEditor().setCursor(enabled ? Cursor.DEFAULT : Cursors.NO_WRITE);
-            Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
-        }
-        spinner.layout();
+
+        jfx_node.layout();
     }
 
     /** Updates, if required, the limits */
@@ -531,18 +525,12 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
             value_max = newMax;
     }
 
-    private void enablementChanged(final WidgetProperty<Boolean> property, final Boolean old_value, final Boolean new_value)
-    {
-        dirty_enablement.mark();
-        toolkit.scheduleUpdate(this);
-    }
-
     @Override
     protected void attachTooltip()
     {
         // Use the formatted text for "$(pv_value)"
         TooltipSupport.attach(jfx_node, model_widget.propTooltip(), () -> value_text);
         // Show the tooltip for the editor part too
-        TooltipSupport.attach(spinner.getEditor(), model_widget.propTooltip(), () -> value_text);
+        TooltipSupport.attach(jfx_node.getEditor(), model_widget.propTooltip(), () -> value_text);
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
@@ -542,5 +542,7 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Pane, Spinne
     {
         // Use the formatted text for "$(pv_value)"
         TooltipSupport.attach(jfx_node, model_widget.propTooltip(), () -> value_text);
+        // Show the tooltip for the editor part too
+        TooltipSupport.attach(spinner.getEditor(), model_widget.propTooltip(), () -> value_text);
     }
 }


### PR DESCRIPTION
Shows the tooltip when the mouse is over the editor part.
Got rid of the unnecessary Pane and the double handling of the widget's enabled property (if the PV was readonly and the enabled property was changed to false then the NOT_ENABLED style was applied twice making the widget even more transparent)