### PR TITLE
Display Buider Editor: Drag and Drop support in Widget Tree

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -342,6 +342,7 @@ public class EditorGUI
         Label header = new Label("Widgets");
         header.setMaxWidth(Double.MAX_VALUE);
         header.getStyleClass().add("header");
+        tree.configureHeaderDnD(header);
 
         final Control tree_control = tree.create();
         VBox.setVgrow(tree_control, Priority.ALWAYS);

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
@@ -23,6 +23,7 @@ import org.csstudio.display.builder.editor.EditorUtil;
 import org.csstudio.display.builder.editor.actions.ActionDescription;
 import org.csstudio.display.builder.editor.app.CreateGroupAction;
 import org.csstudio.display.builder.editor.app.RemoveGroupAction;
+import org.csstudio.display.builder.editor.undo.UpdateWidgetOrderAction;
 import org.csstudio.display.builder.model.ArrayWidgetProperty;
 import org.csstudio.display.builder.model.ChildrenProperty;
 import org.csstudio.display.builder.model.DisplayModel;
@@ -35,6 +36,7 @@ import org.csstudio.display.builder.model.widgets.VisibleWidget;
 import org.csstudio.display.builder.model.widgets.EmbeddedDisplayWidget;
 import org.csstudio.display.builder.model.widgets.TabsWidget.TabItemProperty;
 import org.phoebus.ui.javafx.TreeHelper;
+import org.phoebus.ui.undo.CompoundReversedUndoableAction;
 
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
@@ -46,7 +48,13 @@ import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.DataFormat;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.Dragboard;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.TransferMode;
 import javafx.util.Callback;
 
 /** Tree view of widget hierarchy
@@ -134,7 +142,17 @@ public class WidgetTree
     public WidgetTree(final DisplayEditor editor)
     {
         this.editor = editor;
-        cell_factory = cell ->  new WidgetTreeCell(editor.getUndoableActionManager());
+        cell_factory = cell -> 
+        {
+            WidgetTreeCell tc = new WidgetTreeCell(editor.getUndoableActionManager());
+            tc.setOnDragDetected((MouseEvent event) -> dragDetected(event, tc));
+            tc.setOnDragOver((DragEvent event) -> dragOver(event, tc));
+            tc.setOnDragDropped((DragEvent event) -> drop(event, tc, null));
+            tc.setOnDragDone((DragEvent event) -> clearDropLocation());
+            tc.setOnDragExited((DragEvent event) -> clearDropLocation());
+            tc.setOnDragEntered((DragEvent event) -> decorateDropZone());
+            return tc;
+        };
 
         children_listener = (p, removed, added) ->
         {
@@ -553,5 +571,156 @@ public class WidgetTree
     public void collapseAllTreeItems()
     {
         TreeHelper.setExpandedEx(tree_view, false);
+    }
+
+    // DragDrop Implementation
+    private static final String TREE_ID = "text/DisplayBuiderEditor-TreeView-Id";
+    private static final DataFormat TREE_FORMAT = new DataFormat(TREE_ID);
+    private static final String DROP_HINT_STYLE = "-fx-border-color: #eea82f; -fx-border-width: 0 0 2 0; -fx-padding: 3 3 1 3";
+    private TreeItem<WidgetOrTab> draggedItem;
+    private TreeCell<WidgetOrTab> dropZone;
+
+    /**Code executed when a drag from a WidgetTreeCell is detected 
+     * 
+     * @param event - source event
+     * @param treeCell - dragged cell
+     */
+    private void dragDetected(MouseEvent event, WidgetTreeCell treeCell) {
+        draggedItem = treeCell.getTreeItem();
+
+        // root can't be dragged
+        if (draggedItem.getParent() == null) return;
+        Dragboard db = treeCell.startDragAndDrop(TransferMode.MOVE);
+
+        ClipboardContent content = new ClipboardContent();
+        content.put(TREE_FORMAT, TREE_ID);
+        db.setContent(content);
+        db.setDragView(treeCell.snapshot(null, null));
+        event.consume();
+    }
+
+    /**Code executed when a drag over a WidgetTreeCell is detected 
+     * 
+     * @param event - source event
+     * @param treeCell - possibly destination cell
+     */
+    private void dragOver(DragEvent event, WidgetTreeCell treeCell) {
+        if (!event.getDragboard().hasContent(TREE_FORMAT)) return;
+        if (!event.getDragboard().getContent(TREE_FORMAT).equals(TREE_ID)) return;
+
+        TreeItem<WidgetOrTab> thisItem = treeCell.getTreeItem();
+
+        // can't drop on itself
+        if (draggedItem == null || thisItem == null || thisItem == draggedItem) return;
+        // ignore if not common Parent and not Parent itself 
+        if (!Objects.equals(draggedItem.getParent(), thisItem.getParent()) && !Objects.equals(draggedItem.getParent(), thisItem)) {
+            clearDropLocation();
+            return;
+        }
+
+        // Not supported the case of multiple widgets selected: too much effort for edge cases
+        // (drag of discontinuous selection sets dropped inside selection etc.)
+        if (editor.getWidgetSelectionHandler().getSelection().size() > 1) {
+            clearDropLocation();
+            return;
+        }
+
+        event.acceptTransferModes(TransferMode.MOVE);
+        if (!Objects.equals(dropZone, treeCell)) {
+            clearDropLocation();
+            this.dropZone = treeCell;
+            decorateDropZone();
+        }
+    }
+
+    /**Paint a decoration under drop target cell
+     * 
+     */
+    private void decorateDropZone()
+    {
+        if (dropZone != null && editor.getWidgetSelectionHandler().getSelection().size() <= 1)
+            dropZone.setStyle(DROP_HINT_STYLE);
+    }
+
+    /**Clear a decoration under drop target cell
+     * 
+     */
+    private void clearDropLocation() {
+        if (dropZone != null) dropZone.setStyle("");
+    }
+
+    /**Code executed when a drop to a WidgetTreeCell is detected
+     * Actual implementation uses selection from editor and relies on changes in model updating the tree
+     * @param event - source event
+     * @param treeCell - possibly destination cell, if null, alternItem is used
+     * @param alternItem - alternatively to treeCell use this TreeItem
+     */
+    private void drop(DragEvent event, WidgetTreeCell treeCell, TreeItem<WidgetOrTab> alternItem) {
+        boolean success = false;
+
+        if (!event.getDragboard().hasContent(TREE_FORMAT)) return;
+        if (!event.getDragboard().getContent(TREE_FORMAT).equals(TREE_ID)) return;
+        final TreeItem<WidgetOrTab> thisItem;
+        if (treeCell == null)
+            thisItem = alternItem;
+        else
+            thisItem = treeCell.getTreeItem();
+        if (draggedItem == null || thisItem == null) return;
+
+        final TreeItem<WidgetOrTab> droppedItemParent = draggedItem.getParent();
+
+        // dropping on parent node makes it the first child
+        if (Objects.equals(droppedItemParent, thisItem)) {
+            reorder(editor, 0, droppedItemParent.getChildren().size());
+        }
+        else {
+            int frIndex = draggedItem.getParent().getChildren().indexOf(draggedItem);
+            int toIndex = thisItem.getParent().getChildren().indexOf(thisItem);
+            reorder(editor, toIndex + (frIndex > toIndex ? 1 : 0), droppedItemParent.getChildren().size());
+        }
+        // All actual tree changes will be done as a reaction to the reorder action
+        event.setDropCompleted(success);
+        event.consume();
+    }
+
+    /**Reordering widgets in model, as UndoableAction
+     * 
+     * @param editor - needed to get the getUndoableActionManager
+     * @param toIndex - target index for widgets
+     */
+    public void reorder(final DisplayEditor editor, int toIndex, int listSize)
+    {
+        List<Widget> widgets = editor.getWidgetSelectionHandler().getSelection();
+        if (widgets.isEmpty())
+            return;
+        // Not supported the case of multiple widgets selected: too much effort for edge cases
+        // (drag of discontinuous selection sets dropped inside selection etc.)
+        if (widgets.size() > 1)
+            return;
+
+        // Using compound action to be prepared for possible extension to multiple selection case
+        final CompoundReversedUndoableAction compound = new CompoundReversedUndoableAction("TreeView Reorder");
+        compound.add(new UpdateWidgetOrderAction(widgets.get(0), toIndex));
+        editor.getUndoableActionManager().execute(compound);
+    }
+
+    /**Configuring external control for drop
+     * To resolve an issue when it is not possible to drop to treeWiew root when it is not shown,
+     * enable drop to the pane header.
+     * The header control (actually a Label) must be configured for that, see EditorGUI
+     */
+    public void configureHeaderDnD(Control header)
+    {
+        header.setOnDragDropped((DragEvent event) -> drop(event, null, tree_view.getRoot()));
+        header.setOnDragOver((DragEvent event) -> 
+        {
+            if (!event.getDragboard().hasContent(TREE_FORMAT)) return;
+            if (!event.getDragboard().getContent(TREE_FORMAT).equals(TREE_ID)) return;
+
+            // ignore if Parent is not Root 
+            if (draggedItem == null || !Objects.equals(draggedItem.getParent(), tree_view.getRoot())) return;
+
+            event.acceptTransferModes(TransferMode.MOVE);
+        });
     }
 }


### PR DESCRIPTION
See #1552 discussion. Initial implementation.
Single selection and drop to the same level (root/Group/Tab) only supported atm.