### PR TITLE
CSSTUDIO-1346 Add save&restore server API to enable use of file paths

### DIFF
--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/NodeDAO.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/NodeDAO.java
@@ -144,4 +144,26 @@ public interface NodeDAO {
 	public List<Tag> getAllTags();
 
 	public List<Tag> getTags(String uniqueSnapshotId);
+
+	/**
+	 * Given a file path like /node1/node2/nodeX, find matching node(s). Since a folder node may
+	 * contain a folder node and a save set node with the same name, the returned list may
+	 * contain one or two {@link Node} objects, or will be <code>null</code> if the path does not correspond
+	 * to an existing node.
+	 * @param path A non-null "file path" that must start with a forward slash, otherwise an empty list
+	 *            is returned. Search will start at the
+	 *             tree root, i.e. the top level folder named "Save &amp; Restore Root".
+	 * @return A {@link List	} one or two elements, or <code>null</code>.
+	 */
+	public List<Node> getFromPath(String path);
+
+	/**
+	 * Given an unique node id, find the full path of the node matching the node id. The
+	 * returned string will start with a forward slash and omit the name of the top level root
+	 * node named "Save &amp; Restore Root". If the specified node id does not exist, <code>null</code>
+	 * is returned.
+	 * @param uniqueNodeId Unique id of a {@link Node}.
+	 * @return Full path of the {@link Node} if found, otherwise <code>null</code>.
+	 */
+	public String getFullPath(String uniqueNodeId);
 }

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/services/IServices.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/services/IServices.java
@@ -60,4 +60,19 @@ public interface IServices {
 	public List<Tag> getTags(String uniqueSnapshotId);
 
 	public List<Tag> getAllTags();
+
+	/**
+	 * See {@link org.phoebus.service.saveandrestore.persistence.dao.NodeDAO#getFromPath(String)}
+	 * @param path A full path like /topLevelFolder/folderNode/node
+	 * @return A list of {@link Node} objects if the full path is valid, otherwise <code>null</code>.
+	 */
+	public List<Node> getFromPath(String path);
+
+	/**
+	 * See {@link org.phoebus.service.saveandrestore.persistence.dao.NodeDAO#getFullPath(String)}
+	 * @param uniqueNodeId Non-null unique node id.
+	 * @return A full path like /topLevelFolder/folderNode/node corresponding to the specified unique
+	 * node id, or <code>null</code> if the full path is invalid.
+	 */
+	public String getFullPath(String uniqueNodeId);
 }

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/services/impl/Services.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/services/impl/Services.java
@@ -166,4 +166,14 @@ public class Services implements IServices {
 
 		return nodeDAO.getAllTags();
 	}
+
+	@Override
+	public List<Node> getFromPath(String path){
+		return nodeDAO.getFromPath(path);
+	}
+
+	@Override
+	public String getFullPath(String uniqueNodeId){
+		return nodeDAO.getFullPath(uniqueNodeId);
+	}
 }

--- a/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/services/impl/ServicesTest.java
+++ b/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/services/impl/ServicesTest.java
@@ -299,9 +299,20 @@ public class ServicesTest {
 	
 	@Test
 	public void testSaveSnapshot() {
-		
 		when(nodeDAO.saveSnapshot("a", Collections.emptyList(), "b", "c", "d")).thenReturn(Node.builder().nodeType(NodeType.SNAPSHOT).build());
-		
 		assertNotNull(services.saveSnapshot("a", Collections.emptyList(), "b", "d", "c"));
+	}
+
+	@Test
+	public void testGetFromPath(){
+		Node node = Node.builder().name("SomeFolder").build();
+		when(nodeDAO.getFromPath("path")).thenReturn(Arrays.asList(node));
+		assertEquals("SomeFolder", services.getFromPath("path").get(0).getName());
+	}
+
+	@Test
+	public void testGetFullPath(){
+		when(nodeDAO.getFullPath("nodeId")).thenReturn("/a/b/c");
+		assertEquals("/a/b/c", nodeDAO.getFullPath("nodeId"));
 	}
 }


### PR DESCRIPTION
From the Javadoc in ConfigurationController:
/**
	 * Retrieves the "full path" of the specified node, e.g. /topLevelFolder/folder/nodeName,
	 * where nodeName is the name of the node uniquely identified by <code>unqiueNodeId</code>,
	 * and any preceding path elements are the names of parent folders all the way up to the root.
	 * The root folder corresponds to a single "/".
	 * @param uniqueNodeId Non-null unique node id of the node for which the client wishes to get the
	 *                     full path.
	 * @return A string like /topLevelFolder/folder/nodeName if the node exists, otherwise HTTP 404
	 * is returned.
	 *
	 */
	@GetMapping("/path/{uniqueNodeId}")
public String getFullPath(@PathVariable String uniqueNodeId){

/**
	 * Retrieves the node(s) corresponding to the specified "full path". Since a folder node may
	 * contain a folder node and a save set (configuration) node with the same name, this end point will - as long
	 * as the specified path is valid - return a list with one or two node objects.
	 * @param path Non-null path that must start with a forward slash and not end in a forward slash.
	 * @return A {@link List} containing one or two {@link Node}s. If the specified path is invalid or
	 * cannot be resolved to an existing node, HTTP 404 is returned.
	 */
	@GetMapping("/path")
	public List<Node> getFromPath(@RequestParam(value = "path") String path){