### PR TITLE
Archive Engine: Fix value display in web interface and messages

### DIFF
--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ArchiveChannel.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ArchiveChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,9 +22,9 @@ import org.csstudio.archive.ThrottledLogger;
 import org.epics.vtype.Time;
 import org.epics.vtype.VNumber;
 import org.epics.vtype.VType;
+import org.phoebus.core.vtypes.VTypeHelper;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
-import org.phoebus.core.vtypes.VTypeHelper;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.disposables.Disposable;
@@ -287,7 +287,7 @@ abstract public class ArchiveChannel
     /** @return Most recent value of the channel's PV as a string*/
     final public String getCurrentValueAsString()
     {
-        return VTypeHelper.toString(most_recent_value);
+        return ValueButcher.format(most_recent_value);
     }
 
     /** @return Count of received values */
@@ -305,7 +305,7 @@ abstract public class ArchiveChannel
     /** @return Last value written to archive as a string*/
     final public String getLastArchivedValueAsString()
     {
-        return VTypeHelper.toString(last_archived_value);
+        return ValueButcher.format(last_archived_value);
     }
 
     /** @return Sample buffer */
@@ -454,8 +454,8 @@ abstract public class ArchiveChannel
             // carries the old, original time stamp of the PV,
             // and that's back in time...
             trouble_sample_log.log(getName() + " skips back-in-time:\n" +
-                    "last: " + VTypeHelper.toString(last_value) + "\n" +
-                    "new : " + VTypeHelper.toString(value));
+                    "last: " + ValueButcher.format(last_value) + "\n" +
+                    "new : " + ValueButcher.format(value));
             return false;
         }
         // else ...

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ScannedArchiveChannel.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ScannedArchiveChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,8 +19,8 @@ import org.epics.vtype.VNumber;
 import org.epics.vtype.VNumberArray;
 import org.epics.vtype.VString;
 import org.epics.vtype.VType;
-import org.phoebus.util.time.SecondsParser;
 import org.phoebus.core.vtypes.VTypeHelper;
+import org.phoebus.util.time.SecondsParser;
 
 /** An ArchiveChannel that stores value in a periodic scan.
  *  @author Kay Kasemir
@@ -109,7 +109,7 @@ public class ScannedArchiveChannel extends ArchiveChannel implements Runnable
                 ++repeats ;
                 if (repeats < max_repeats)
                 {
-                    logger.log(Level.FINE, "{0} skips {1}: repeat {2}", new Object[] { getName(), VTypeHelper.toString(most_recent_value), repeats });
+                    logger.log(Level.FINE, "{0} skips {1}: repeat {2}", new Object[] { getName(), ValueButcher.format(most_recent_value), repeats });
                     return;
                 }
                 // No new value, but we'd like to write a sample every once in a while
@@ -121,7 +121,7 @@ public class ScannedArchiveChannel extends ArchiveChannel implements Runnable
                     return;
                 }
                 logger.log(Level.FINE, "{0} writes {1} as {2}",
-                    new Object[] { getName(), VTypeHelper.toString(most_recent_value), TimestampHelper.format(VTypeHelper.getTimestamp(value)) });
+                    new Object[] { getName(), ValueButcher.format(most_recent_value), TimestampHelper.format(VTypeHelper.getTimestamp(value)) });
             }
             else
             {   // It's a new value, so we should be able to write it

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ValueButcher.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ValueButcher.java
@@ -11,9 +11,7 @@ import org.csstudio.archive.writer.rdb.TimestampHelper;
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.AlarmStatus;
-import org.epics.vtype.Display;
 import org.epics.vtype.Time;
-import org.epics.vtype.VDouble;
 import org.epics.vtype.VString;
 import org.epics.vtype.VType;
 import org.phoebus.core.vtypes.VTypeHelper;
@@ -91,12 +89,5 @@ public class ValueButcher
                .append(alarm.getStatus())
                .append(']');
         return buf.toString();
-    }
-
-    public static void main(String[] args)
-    {
-        System.out.println(format(VDouble.of(3.15, Alarm.none(), Time.now(), Display.none())));
-        System.out.println(format(VDouble.of(3.15, Alarm.high(), Time.now(), Display.none())));
-        System.out.println(format(null));
     }
 }

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ValueButcher.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ValueButcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,16 +7,21 @@
  ******************************************************************************/
 package org.csstudio.archive.engine.model;
 
+import org.csstudio.archive.writer.rdb.TimestampHelper;
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.AlarmStatus;
+import org.epics.vtype.Display;
 import org.epics.vtype.Time;
+import org.epics.vtype.VDouble;
 import org.epics.vtype.VString;
 import org.epics.vtype.VType;
+import org.phoebus.core.vtypes.VTypeHelper;
 
 /** Helper that does various unspeakable things to values.
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class ValueButcher
 {
     // These strings match the text representation of the
@@ -24,16 +29,16 @@ public class ValueButcher
     // - if they existed in previous versions.
 
     /** Status string for 'disabled' state */
-    private static final String DISABLED = "Archive_Disabled"; //$NON-NLS-1$
+    private static final String DISABLED = "Archive_Disabled";
 
     /** Status string for 'disconnected' state */
-    private static final String DISCONNECTED = "Disconnected"; //$NON-NLS-1$
+    private static final String DISCONNECTED = "Disconnected";
 
     /** Status string for 'off' state */
-    private static final String OFF = "Archive_Off"; //$NON-NLS-1$
+    private static final String OFF = "Archive_Off";
 
     /** Status string for 'write error' state */
-    private static final String WRITE_ERROR = "Write_Error"; //$NON-NLS-1$
+    private static final String WRITE_ERROR = "Write_Error";
 
     /** @return Info value to indicate disabled state */
     public static VType createDisabled()
@@ -63,5 +68,35 @@ public class ValueButcher
     private static VType createInfoSample(final String info)
     {
         return VString.of(info, Alarm.of(AlarmSeverity.INVALID, AlarmStatus.CLIENT, info), Time.now());
+    }
+
+    /** @param value Value
+     *  @return "Time Value [Sevr/Stat]"
+     */
+    public static String format(final VType value)
+    {
+        if (value == null)
+            return "null";
+
+        final StringBuilder buf = new StringBuilder();
+        buf.append(TimestampHelper.format(VTypeHelper.getTimestamp(value)))
+           .append(' ')
+           .append(VTypeHelper.toString(value));
+
+        final Alarm alarm = Alarm.alarmOf(value);
+        if (alarm != null)
+            buf.append(" [")
+               .append(alarm.getSeverity())
+               .append('/')
+               .append(alarm.getStatus())
+               .append(']');
+        return buf.toString();
+    }
+
+    public static void main(String[] args)
+    {
+        System.out.println(format(VDouble.of(3.15, Alarm.none(), Time.now(), Display.none())));
+        System.out.println(format(VDouble.of(3.15, Alarm.high(), Time.now(), Display.none())));
+        System.out.println(format(null));
     }
 }


### PR DESCRIPTION
VTypeHelper consolidation #1160 omitted the time stamp and alarm/status,
which makes messages like "skip-in-time" which are all about the time
stamp pretty useless. This adds the time and alarm info back to the
archive engine web interface and some error messages.