### PR TITLE
Update to Open JavaFX 15

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -142,52 +142,52 @@
     <classpathentry exported="true" kind="lib" path="target/lib/commons-math3-3.6.1.jar"/>
 
     <!-- On Windows, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15-win.jar"/>
     -->
     <!-- On Linux, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15-linux.jar"/>
     -->
     <!-- On Mac, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-14.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15.jar"/>
     -->
 
     <classpathentry kind="output" path="target/classes"/>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <epics.version>7.0.6</epics.version>
     <vtype.version>1.0.3</vtype.version>
-    <openjfx.version>14</openjfx.version>
+    <openjfx.version>15</openjfx.version>
     <jackson.version>2.10.1</jackson.version>
     <batik.version>1.12</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
Updates to the current version of Open JavaFX.

Release notes, https://github.com/openjdk/jfx/blob/jfx15/doc-files/release-notes-15.md, don't seem to include anything desperately needed for phoebus or to address known problems, but probably best to stay up-to-date.

Tried on Mac with Open JDK 15.
On Linux with Open JDK 14, and both `-Djdk.gtk.version=2` as well as `3`.