### PR TITLE
CSSTUDIO-1351 Make undo stack size configurable

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -332,7 +332,7 @@ public class EditorGUI
 
     private Parent createElements()
     {
-        editor = new DisplayEditor(toolkit, 50);
+        editor = new DisplayEditor(toolkit, org.csstudio.display.builder.editor.Preferences.undoStackSize);
 
         tree = new WidgetTree(editor);
 

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Preferences.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Preferences.java
@@ -9,6 +9,7 @@ package org.csstudio.display.builder.editor;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import org.phoebus.framework.preferences.PreferencesReader;
 
@@ -20,9 +21,11 @@ public class Preferences
 {
     public static final String HIDDEN_WIDGETS = "hidden_widget_types";
     public static final String NEW_DISPLAY_TEMPLATE = "new_display_template";
+    public static final String UNDO_STACK_SIZE = "undo_stack.size";
     
     public static Set<String> hidden_widget_types = new HashSet<>();
     public static String new_display_template;
+    public static int undoStackSize = 50;
 
     static
     {
@@ -36,5 +39,13 @@ public class Preferences
                 hidden_widget_types.add(type);
         }
         new_display_template = prefs.get(NEW_DISPLAY_TEMPLATE);
+
+        final String undoStack = prefs.get(UNDO_STACK_SIZE);
+        try {
+            undoStackSize = Integer.parseInt(undoStack);
+        } catch (NumberFormatException e) {
+            Logger.getLogger(Preferences.class.getName())
+                    .info(String.format("Unable to parse \"%s\" as a undo stack size, falling back to %d.", undoStack, undoStackSize));
+        }
     }
 }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Preferences.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Preferences.java
@@ -21,7 +21,7 @@ public class Preferences
 {
     public static final String HIDDEN_WIDGETS = "hidden_widget_types";
     public static final String NEW_DISPLAY_TEMPLATE = "new_display_template";
-    public static final String UNDO_STACK_SIZE = "undo_stack.size";
+    public static final String UNDO_STACK_SIZE = "undo_stack_size";
     
     public static Set<String> hidden_widget_types = new HashSet<>();
     public static String new_display_template;

--- a/app/display/editor/src/main/resources/display_editor_preferences.properties
+++ b/app/display/editor/src/main/resources/display_editor_preferences.properties
@@ -18,4 +18,4 @@ hidden_widget_types=linear-meter,knob,gauge,clock,digital_clock
 new_display_template=examples:/initial.bob
 
 # Size of undo stack. Defaults to 50 if not set.
-# undo_stack.size=
+# undo_stack_size=

--- a/app/display/editor/src/main/resources/display_editor_preferences.properties
+++ b/app/display/editor/src/main/resources/display_editor_preferences.properties
@@ -16,3 +16,6 @@ hidden_widget_types=linear-meter,knob,gauge,clock,digital_clock
 #
 # GUI Menu action Applications / Display / New Display opens the following template
 new_display_template=examples:/initial.bob
+
+# Size of undo stack. Defaults to 50 if not set.
+# undo_stack.size=

--- a/app/display/editor/src/main/resources/display_editor_preferences.properties
+++ b/app/display/editor/src/main/resources/display_editor_preferences.properties
@@ -18,4 +18,4 @@ hidden_widget_types=linear-meter,knob,gauge,clock,digital_clock
 new_display_template=examples:/initial.bob
 
 # Size of undo stack. Defaults to 50 if not set.
-# undo_stack_size=
+undo_stack_size=50

--- a/app/display/editor/src/test/java/org/csstudio/display/builder/editor/PreferencesTest.java
+++ b/app/display/editor/src/test/java/org/csstudio/display/builder/editor/PreferencesTest.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.editor;
 
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 /** JUnit test of editor preferences
  *  @author Kay Kasemir
@@ -19,5 +20,10 @@ public class PreferencesTest
     public void testPrefs()
     {
         System.out.println("Hidden widget types: " + Preferences.hidden_widget_types);
+    }
+
+    @Test
+    public void testUndoStackSize(){
+        assertEquals(50, Preferences.undoStackSize);
     }
 }


### PR DESCRIPTION
Users request ability to increase undo stack size. Still defaults to 50, but can be configured:
`org.csstudio.display.builder.editor/undo_stack.size=<new size>`