### PR TITLE
Update prepareToClose/close for Ctrl-W

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -345,7 +345,13 @@ public class DockPane extends TabPane
         else if (key == KeyCode.W)
         {
             if (!isFixed())
-                item.close();
+            {
+                JobManager.schedule("Close " + item.getLabel(), monitor ->
+                {
+                    if (item.prepareToClose())
+                        Platform.runLater(item::close);
+                });
+            }
             event.consume();
         }
     }


### PR DESCRIPTION
When closing a panel with Ctrl-W (Command-W on Mac), the key handler now needs to check `prepareToClose` before calling `close`.
The original code that directly calls `close` still "works" in many cases, but will result in a logged warning and would skip proper "Do you want to save" type of dialogs.
#1546