### PR TITLE
CSSTUDIO 1210 Enable CTRL/CMD+A in editor's widget pane to select all

### DIFF
--- a/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/opieditor.css
+++ b/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/opieditor.css
@@ -172,16 +172,8 @@
 
 .widget_pane_unfocused{
     -fx-border-color: #F4F4F4;
-    -fx-border-style: solid;
-    -fx-border-width: 1px;
 }
 
 .widget_pane_focused{
     -fx-border-color: #00A0D8;
-    -fx-border-style: solid;
-    -fx-border-width: 1px;
-}
-
-.no-border{
-    -fx-border-width: 0px;
 }

--- a/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/opieditor.css
+++ b/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/opieditor.css
@@ -169,3 +169,19 @@
 	-fx-content-display: graphic-only;
 	-fx-snap-to-pixel: false
 }
+
+.widget_pane_unfocused{
+    -fx-border-color: #F4F4F4;
+    -fx-border-style: solid;
+    -fx-border-width: 1px;
+}
+
+.widget_pane_focused{
+    -fx-border-color: #00A0D8;
+    -fx-border-style: solid;
+    -fx-border-width: 1px;
+}
+
+.no-border{
+    -fx-border-width: 0px;
+}


### PR DESCRIPTION
As per user request.
Also added a "focused border" to highlight that widget pane in editor has focus.