### PR TITLE
PVA client: Allow UTF strings as PV names

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/data/PVAString.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAString.java
@@ -24,9 +24,8 @@ public class PVAString extends PVAData
      */
     public static int getEncodedSize(final String string)
     {
-        // null string will be encoded as one byte with value -1 for size
         if (string == null)
-            return 1;
+            return PVASize.size(-1);
 
         final int len = string.getBytes().length;
         return PVASize.size(len) + len;

--- a/core/pva/src/main/java/org/epics/pva/data/PVAString.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAString.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,11 @@ public class PVAString extends PVAData
      */
     public static int getEncodedSize(final String string)
     {
-        final int len = string.length();
+        // null string will be encoded as one byte with value -1 for size
+        if (string == null)
+            return 1;
+
+        final int len = string.getBytes().length;
         return PVASize.size(len) + len;
     }
 
@@ -37,8 +41,9 @@ public class PVAString extends PVAData
             PVASize.encodeSize(-1, buffer);
         else
         {
-            PVASize.encodeSize(string.length(), buffer);
-            buffer.put(string.getBytes());
+            final byte[] bytes = string.getBytes();
+            PVASize.encodeSize(bytes.length, buffer);
+            buffer.put(bytes);
         }
     }
 
@@ -167,6 +172,6 @@ public class PVAString extends PVAData
         if (! (obj instanceof PVAString))
             return false;
         final PVAString other = (PVAString) obj;
-        return other.value.equals(value);
+        return Objects.equals(other.value, value);
     }
 }


### PR DESCRIPTION
Need to encode/decode byte count instead of string length.

Similar to JCA issue https://github.com/epics-base/jca/pull/55, this allows access to PVs and enum labels where the UTF-8 byte representation is longer than the `String#length()` because of for example Umlaut characters.