### PR TITLE
CSSTUDIO-1350 File not dirty when undo stack is empty

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
@@ -112,7 +112,7 @@ public class DisplayEditorInstance implements AppInstance
         // Mark 'dirty' whenever there's a change, i.e. something to un-do
         editor_gui.getDisplayEditor()
                   .getUndoableActionManager()
-                  .addListener((to_undo, to_redo) -> dock_item.setDirty(to_undo != null));
+                  .addListener((to_undo, to_redo, changeCount) -> dock_item.setDirty(to_undo != null || changeCount > 0));
 
         final ContextMenu menu = new ContextMenu();
         final Control menu_node = editor_gui.getDisplayEditor().getContextMenuNode();

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/editor/ScanEditorInstance.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/editor/ScanEditorInstance.java
@@ -59,7 +59,7 @@ public class ScanEditorInstance  implements AppInstance
 
         DockPane.getActiveDockPane().addTab(tab);
 
-        editor.getUndo().addListener((undo, redo) ->  tab.setDirty(undo != null));
+        editor.getUndo().addListener((undo, redo, changeCount) ->  tab.setDirty(undo != null || changeCount > 0));
     }
 
     @Override

--- a/core/ui/src/main/java/org/phoebus/ui/undo/UndoButtons.java
+++ b/core/ui/src/main/java/org/phoebus/ui/undo/UndoButtons.java
@@ -38,7 +38,7 @@ public class UndoButtons
         redo_btn.setOnAction(event -> undo_manager.redoLast());
 
         // Automatically enable/disable based on what's possible
-        undo_manager.addListener((to_undo, to_redo) ->
+        undo_manager.addListener((to_undo, to_redo, changeCount) ->
             Platform.runLater(()->
             {
                 undo_btn.setDisable(to_undo == null);

--- a/core/ui/src/main/java/org/phoebus/ui/undo/UndoRedoListener.java
+++ b/core/ui/src/main/java/org/phoebus/ui/undo/UndoRedoListener.java
@@ -16,6 +16,9 @@ public interface UndoRedoListener
 {
     /** @param to_undo Description of action to undo or <code>null</code>
      *  @param to_redo of action to re-do or <code>null</code>
+     *  @param changeCount Counter indicating the number of changes made when through the {@link UndoableActionManager}.
+     *                     If this is non-zero the underlying resource should be treated as "dirty".
+     *
      */
     public void operationsHistoryChanged(final String to_undo, final String to_redo, int changeCount);
 }

--- a/core/ui/src/main/java/org/phoebus/ui/undo/UndoRedoListener.java
+++ b/core/ui/src/main/java/org/phoebus/ui/undo/UndoRedoListener.java
@@ -15,7 +15,7 @@ package org.phoebus.ui.undo;
 public interface UndoRedoListener
 {
     /** @param to_undo Description of action to undo or <code>null</code>
-     *  @param to_redoDescription of action to re-do or <code>null</code>
+     *  @param to_redo of action to re-do or <code>null</code>
      */
-    public void operationsHistoryChanged(final String to_undo, final String to_redo);
+    public void operationsHistoryChanged(final String to_undo, final String to_redo, int changeCount);
 }

--- a/core/ui/src/main/java/org/phoebus/ui/undo/UndoableActionManager.java
+++ b/core/ui/src/main/java/org/phoebus/ui/undo/UndoableActionManager.java
@@ -24,6 +24,12 @@ public class UndoableActionManager
     private final SizeLimitedStack<UndoableAction> undoStack;
     private final SizeLimitedStack<UndoableAction> redoStack;
     private final List<UndoRedoListener> listeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Keeps track of changes when actions are put on the undo stack and redo stack.
+     * This can be used to determine if a resource has changes even if the
+     * undo stack is empty.
+     */
     private int changeCount;
 
     /** @param stack_size Number of undo/redo entries */

--- a/core/ui/src/main/java/org/phoebus/ui/undo/UndoableActionManager.java
+++ b/core/ui/src/main/java/org/phoebus/ui/undo/UndoableActionManager.java
@@ -24,6 +24,7 @@ public class UndoableActionManager
     private final SizeLimitedStack<UndoableAction> undoStack;
     private final SizeLimitedStack<UndoableAction> redoStack;
     private final List<UndoRedoListener> listeners = new CopyOnWriteArrayList<>();
+    private int changeCount;
 
     /** @param stack_size Number of undo/redo entries */
     public UndoableActionManager(final int stack_size)
@@ -74,6 +75,7 @@ public class UndoableActionManager
     /** @param action Action that has already been performed, which can be un-done */
     public void add(final UndoableAction action)
     {
+        changeCount++;
         undoStack.push(action);
         redoStack.clear();
         fireOperationsHistoryChanged();
@@ -89,6 +91,7 @@ public class UndoableActionManager
         final UndoableAction action = undoStack.pop();
         try
         {
+            changeCount--;
             logger.log(Level.FINE, "Undo {0}", action);
             action.undo();
         }
@@ -109,6 +112,7 @@ public class UndoableActionManager
     {
         if (redoStack.isEmpty())
             return null;
+        changeCount++;
         final UndoableAction action = redoStack.pop();
         logger.log(Level.FINE, "Redo {0}", action);
         action.run();
@@ -122,6 +126,7 @@ public class UndoableActionManager
     {
         undoStack.clear();
         redoStack.clear();
+        changeCount = 0;
         fireOperationsHistoryChanged();
     }
 
@@ -130,7 +135,7 @@ public class UndoableActionManager
         final String to_undo = undoStack.isEmpty() ? null : undoStack.peek().toString();
         final String to_redo = redoStack.isEmpty() ? null : redoStack.peek().toString();
         for (final UndoRedoListener listener : listeners)
-            listener.operationsHistoryChanged(to_undo, to_redo);
+            listener.operationsHistoryChanged(to_undo, to_redo, changeCount);
     }
 
     /**


### PR DESCRIPTION
This is a fix for a corner case: when user has used up all undo operations (defined by the undo_stack_size limit) the file is not treated as dirty, even if there are additional changes. User may close file without being prompted to save -> changes lost.
The fix affects display editor as well as scan editor.