### PR TITLE
Actionbutton fixes

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/Messages.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/Messages.java
@@ -15,6 +15,7 @@ import org.phoebus.framework.nls.NLS;
 public class Messages
 {
     // Keep in alphabetical order, synchronized with messages.properties
+    public static String ActionButton_N_ActionsAsOneFmt;
     public static String ActionButton_N_ActionsFmt;
     public static String ActionButton_NoActions;
     public static String ActionsDialog_Actions;

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
@@ -118,6 +118,14 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
     /** @param event Mouse event to check for target modifier keys */
     private void checkModifiers(final MouseEvent event)
     {
+        if (! enabled)
+        {
+            // Do not let the user click a disabled button
+            event.consume();
+            base.disarm();
+            return;
+        }
+
         // 'control' ('command' on Mac OS X)
         if (event.isShortcutDown())
             target_modifier = Optional.of(OpenDisplayActionInfo.Target.TAB);
@@ -198,12 +206,11 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
 
         // Monitor keys that modify the OpenDisplayActionInfo.Target.
         // Use filter to capture event that's otherwise already handled.
-        result.addEventFilter(MouseEvent.MOUSE_PRESSED, this::checkModifiers);
+        if (! toolkit.isEditMode())
+            result.addEventFilter(MouseEvent.MOUSE_PRESSED, this::checkModifiers);
 
         // Need to attach TT to the specific button, not the common jfx_node Pane
         TooltipSupport.attach(result, model_widget.propTooltip());
-
-        result.setCursor(Cursor.HAND);
 
         return result;
     }
@@ -290,6 +297,7 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
     /** @param action Action that the user invoked */
     private void handleAction(ActionInfo action)
     {
+        // Keyboard presses are not supressed so check if the widget is enabled
         if (! enabled)
             return;
         logger.log(Level.FINE, "{0} pressed", model_widget);
@@ -454,9 +462,11 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
         }
         if (dirty_enablement.checkAndClear())
         {
-            base.setDisable(! enabled);
+            // Don't disable the widget, because that would also remove the
+            // tooltip
+            // Just apply a style that matches the disabled look.
             Styles.update(base, Styles.NOT_ENABLED, !enabled);
-            jfx_node.setCursor(enabled ? Cursor.DEFAULT : Cursors.NO_WRITE);
+            base.setCursor(enabled ? Cursor.HAND : Cursors.NO_WRITE);
         }
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
@@ -284,7 +284,12 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
             if (actions.size() < 1)
                 return Messages.ActionButton_NoActions;
             if (actions.size() > 1)
+            {
+                if (model_widget.propActions().getValue().isExecutedAsOne())
+                    return MessageFormat.format(Messages.ActionButton_N_ActionsAsOneFmt, actions.size());
+
                 return MessageFormat.format(Messages.ActionButton_N_ActionsFmt, actions.size());
+            }
             return makeActionText(actions.get(0));
         }
         else

--- a/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/messages.properties
+++ b/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/messages.properties
@@ -1,3 +1,4 @@
+ActionButton_N_ActionsAsOneFmt={0} actions
 ActionButton_N_ActionsFmt=Choose 1 of {0}
 ActionButton_NoActions=EMPTY
 ActionsDialog_Actions=Actions:


### PR DESCRIPTION
Changes:
- Do not actually disable the widget just apply the disabled style and ignore clicks
- Separate enabled and writable state of ActionButton; opening a display or running a script should be possible even if the ActionButton has a PV and that PV happens to be read-only or disconnected
- Show 'n actions' as label if there are more than one actions executed as one

Questions:
- Right now it is possible to circumvent confirmation by using the context menu and selecting the action there. Is it considered a bug?
- Is the 'Execute as one' feature a convenience or a constraint? Because right now it is possible to select any action using the context menu so it defeats the purpose of 'Execute as one' as a constraint.
- (Not specifically related to ActionButton) Shouldn't disabled widgets have their actions in the context menu also disabled?