### PR TITLE
Fontpopover fixes

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/WidgetFontPropertyBinding.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/WidgetFontPropertyBinding.java
@@ -39,25 +39,31 @@ public class WidgetFontPropertyBinding
     /** Update model from user input */
     private final EventHandler<ActionEvent> action_handler = event ->
     {
-        if (popover == null)
-            popover = new WidgetFontPopOver(widget_property, font ->
+        final WidgetFontPopOver previous = popover;
+        popover = null;
+        if (previous != null)
+        {
+            if (previous.isShowing())
             {
-                undo.execute(new SetWidgetPropertyAction<>(widget_property, font));
-                if (! other.isEmpty())
+                previous.hide();
+                return;
+            }
+        }
+        popover = new WidgetFontPopOver(widget_property, font ->
+        {
+            undo.execute(new SetWidgetPropertyAction<>(widget_property, font));
+            if (! other.isEmpty())
+            {
+                final String path = widget_property.getPath();
+                for (final Widget w : other)
                 {
-                    final String path = widget_property.getPath();
-                    for (final Widget w : other)
-                    {
-                        final FontWidgetProperty other_prop = (FontWidgetProperty) w.getProperty(path);
-                        undo.execute(new SetWidgetPropertyAction<>(other_prop, font));
-                    }
+                    final FontWidgetProperty other_prop = (FontWidgetProperty) w.getProperty(path);
+                    undo.execute(new SetWidgetPropertyAction<>(other_prop, font));
                 }
-            });
+            }
+        });
 
-        if (popover.isShowing())
-            popover.hide();
-        else
-            popover.show(jfx_node);
+        popover.show(jfx_node);
     };
 
     public WidgetFontPropertyBinding(final UndoableActionManager undo,

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverController.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverController.java
@@ -173,9 +173,26 @@ public class WidgetFontPopOverController implements Initializable {
         //  Listeners to font change.
         fontProperty().addListener(( observable, oldValue, newValue ) -> {
 
-            if ( newValue instanceof NamedWidgetFont && !fontNamesUpdater.isUpdating() ) {
-                fontNames.getSelectionModel().select((NamedWidgetFont) newValue);
-                fontNames.scrollTo(fontNames.getSelectionModel().getSelectedItem());
+            if ( !fontNamesUpdater.isUpdating() ) {
+                NamedWidgetFont namedFont = null;
+                if ( newValue instanceof NamedWidgetFont)
+                    namedFont = (NamedWidgetFont) newValue;
+                else {
+                    // Try to find a named font for the currently selected family,style,size combination
+                    for (NamedWidgetFont font: namedFontsList) {
+                        if ( newValue.equals(font) ) {
+                            namedFont = font;
+                            break;
+                        }
+                    }
+                }
+
+                if ( namedFont != null ) {
+                    fontNames.getSelectionModel().select(namedFont);
+                    fontNames.scrollTo(fontNames.getSelectionModel().getSelectedItem());
+                } else
+                    // This font has no name, clear the name selection
+                    fontNames.getSelectionModel().clearSelection();
             }
 
             if ( !familiesUpdater.isUpdating() ) {
@@ -187,7 +204,9 @@ public class WidgetFontPopOverController implements Initializable {
                 styles.getSelectionModel().select(newValue.getStyle());
             }
 
-            sizes.getSelectionModel().select(newValue.getSize());
+            if ( !sizesUpdater.isUpdating()) {
+                sizes.getSelectionModel().select(newValue.getSize());
+            }
 
             preview.setFont(JFXUtil.convert(newValue));
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverController.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverController.java
@@ -94,9 +94,10 @@ public class WidgetFontPopOverController implements Initializable {
     private final CountDownLatch                  namesLoaded            = new CountDownLatch(2);
     private WidgetFont                            originalFont           = null;
     private PopOver                               popOver;
+    private AtomicBoolean                         settingFont            = new AtomicBoolean(false);
 
     private final Updater<String> familiesUpdater = new Updater<>(newValue -> {
-        if ( newValue != null ) {
+        if ( newValue != null && !settingFont.get() ) {
             setFont(new WidgetFont(
                 newValue,
                 defaultIfNull(styles.getSelectionModel().getSelectedItem(), WidgetFontStyle.REGULAR),
@@ -113,12 +114,12 @@ public class WidgetFontPopOverController implements Initializable {
         (nc1, nc2) -> String.CASE_INSENSITIVE_ORDER.compare(nc1.getName(), nc2.getName())
     ));
     private final Updater<WidgetFont> fontNamesUpdater = new Updater<>(newValue -> {
-        if ( newValue != null ) {
+        if ( newValue != null && !settingFont.get() ) {
             setFont(newValue);
         }
     });
     private final Updater<Double> sizesUpdater = new Updater<>(newValue -> {
-        if ( newValue != null ) {
+        if ( newValue != null && !settingFont.get() ) {
             setFont(new WidgetFont(
                 defaultIfNull(families.getSelectionModel().getSelectedItem(), Font.font(10.0).getFamily()),
                 defaultIfNull(styles.getSelectionModel().getSelectedItem(), WidgetFontStyle.REGULAR),
@@ -127,7 +128,7 @@ public class WidgetFontPopOverController implements Initializable {
         }
     });
     private final Updater<WidgetFontStyle> stylesUpdater = new Updater<>(newValue -> {
-        if ( newValue != null ) {
+        if ( newValue != null && !settingFont.get() ) {
             setFont(new WidgetFont(
                 defaultIfNull(families.getSelectionModel().getSelectedItem(), Font.font(10.0).getFamily()),
                 newValue,
@@ -161,7 +162,12 @@ public class WidgetFontPopOverController implements Initializable {
     }
 
     void setFont( WidgetFont font ) {
-        this.font.set(font);
+        try {
+            settingFont.set(true);
+            this.font.set(font);
+        } finally {
+            settingFont.set(false);
+        }
     }
 
     /*


### PR DESCRIPTION
- Select the matching named font when selecting family, style, or size. If there is no match, clear the named font selection
- Always reinitialize font popover so that `setInitialConditions()` is called every time
- Do not call `setFont()` from listeners if those listeners were called because of `setFont()`