### PR TITLE
CSSTUDIO-1295 Widget selection behavior in widget tree

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
@@ -17,6 +17,7 @@ import java.util.concurrent.RecursiveTask;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import javafx.application.Platform;
 import org.csstudio.display.builder.editor.Messages;
 import org.csstudio.display.builder.editor.WidgetSelectionHandler;
 import org.csstudio.display.builder.editor.undo.SetMacroizedWidgetPropertyAction;
@@ -633,7 +634,8 @@ public class SelectedWidgetUITracker extends Tracker
         bindToWidgets();
 
         // Get focus to allow use of arrow keys
-        tracker.requestFocus();
+        Platform.runLater(() -> tracker.requestFocus());
+
     }
 
     @Override

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
@@ -138,7 +138,7 @@ public class WidgetTree
     private final Callback<TreeView<WidgetOrTab>, TreeCell<WidgetOrTab>> cell_factory;
 
     /** Construct widget tree
-     *  @param selection Handler of selected widgets
+     *  @param editor Handler of selected widgets
      */
     public WidgetTree(final DisplayEditor editor)
     {
@@ -388,7 +388,7 @@ public class WidgetTree
     /** Called by selection handler when selected widgets have changed, or on new model
      *  @param widgets Widgets to select in tree
      */
-    public void setSelectedWidgets(final List<Widget> widgets)
+    private void setSelectedWidgets(final List<Widget> widgets)
     {
         if (! active.compareAndSet(false, true))
             return;
@@ -603,7 +603,7 @@ public class WidgetTree
     }
 
     /** Recursively remove model widget listeners
-     *  @param container Widgets to unlink
+     *  @param widget Widgets to unlink
      */
     private void removeWidgetListeners(final Widget widget)
     {


### PR DESCRIPTION
This is a fix for the following:
1) User selects a widget in widget tree.
2) User presses arrow down/up => Next widget in tree is selected.
3) User presses arrow down/up => Selected widget is moved.

After fix the widget selected in step 1) is moved on first arrow down/up.