### PR TITLE
Display: When closing because of initialization error ...

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -330,12 +330,15 @@ public class DisplayRuntimeInstance implements AppInstance
                         "Cannot load model from\n" + info.getPath() + exception_message, ex);
 
                 display_info = Optional.empty();
-                Platform.runLater(() ->
-                {
-                    final Parent parent = representation.getModelParent();
-                    JFXRepresentation.getChildren(parent).clear();
-                    close();
-                });
+                
+                if (dock_item.prepareToClose())
+	                Platform.runLater(() ->
+	                {
+	                    final Parent parent = representation.getModelParent();
+	                    JFXRepresentation.getChildren(parent).clear();
+	                    
+	                    close();
+	                });
                 return;
             }
         });


### PR DESCRIPTION
... do that via prepareToClose, then close, to avoid additional warnings
about breaking that convention

#1546