### PR TITLE
CSSTUDIO-1361 Make 'Level' field configurable in log client

### DIFF
--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookUiPreferences.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookUiPreferences.java
@@ -25,6 +25,7 @@ public class LogbookUiPreferences
     public static final String   logbook_factory;
     public static final boolean  is_supported;
     public static final String calendarViewItemStylesheet;
+    public static final String levelFieldName;
 
     static
     {
@@ -35,6 +36,7 @@ public class LogbookUiPreferences
         save_credentials = prefs.getBoolean("save_credentials");
         logbook_factory  = prefs.get("logbook_factory");
         calendarViewItemStylesheet = prefs.get("calendar_view_item_stylesheet");
+        levelFieldName = prefs.get("level_field_name");
 
         if (logbook_factory.isEmpty())
         {

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/Messages.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/Messages.java
@@ -24,7 +24,6 @@ public class Messages
                          CurrentDate,
                          Date,
                          High,
-                         Level,
                          Logbooks,
                          LogbookServiceUnavailableTitle,
                          LogbookServiceHasNoLogbooks,

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/FieldsViewController.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/FieldsViewController.java
@@ -167,7 +167,7 @@ public class FieldsViewController implements Initializable{
         passwordFieldLabel.setText(Messages.Password);
         dateLabel.setText(Messages.Date);
         dateField.setTooltip(new Tooltip(Messages.CurrentDate));
-        levelLabel.setText(Messages.Level);
+        levelLabel.setText(LogbookUiPreferences.levelFieldName);
         titleLabel.setText(Messages.Title);
     }
 

--- a/app/logbook/ui/src/main/resources/log_ui_preferences.properties
+++ b/app/logbook/ui/src/main/resources/log_ui_preferences.properties
@@ -14,3 +14,7 @@ save_credentials=false
 
 # Stylesheet for the items in the log calendar view
 calendar_view_item_stylesheet=Agenda.css
+
+# Text to render for the "Level" field of a log entry. Sites may wish to customize this with respect to
+# its wording and its implied purpose.
+level_field_name=Level:

--- a/app/logbook/ui/src/main/resources/org/phoebus/logbook/ui/messages.properties
+++ b/app/logbook/ui/src/main/resources/org/phoebus/logbook/ui/messages.properties
@@ -11,7 +11,6 @@ CreateLogbookEntry=Create Log Book Entry
 CurrentDate=Current Date
 Date=Date:
 High=High
-Level=Level:
 Logbooks=Logbooks:
 LogbooksTitle=Select Logbooks
 LogbooksTooltip=Add logbook to the log entry.


### PR DESCRIPTION
Sites may wish to customize the implied purpose of the "Level" field in the log entry editor. So preference `org.phoebus.logbook.ui/level_field_name` has been added, defaults to "Level:".