### PR TITLE
Preferences: Support annotations

### DIFF
--- a/app/3d-viewer/src/main/java/org/phoebus/applications/viewer3d/Preferences.java
+++ b/app/3d-viewer/src/main/java/org/phoebus/applications/viewer3d/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.phoebus.applications.viewer3d;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preferences class for the org.phoebus.app.viewer3d package.
  *  @author Evan Smith
@@ -15,20 +16,12 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Preferences
 {
-    public static String READ_TIMEOUT = "read_timeout";
-    public static String DEFAULT_DIR = "default_dir";
-    public static String CONE_FACES = "cone_faces";
-
-    public final static int read_timeout;
-    public final static String default_dir;
-    public final static int cone_faces;
+    @Preference public static int read_timeout;
+    @Preference public static String default_dir;
+    @Preference public static int cone_faces;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Preferences.class, "/3d_viewer_preferences.properties");
-
-        read_timeout = prefs.getInt(READ_TIMEOUT);
-        default_dir = prefs.get(DEFAULT_DIR);
-        cone_faces = prefs.getInt(CONE_FACES);
+    	AnnotatedPreferences.initialize(Preferences.class, "/3d_viewer_preferences.properties");
     }
 }

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
@@ -8,11 +8,12 @@
 package org.phoebus.applications.alarm;
 
 import java.io.File;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.phoebus.applications.alarm.client.IdentificationHelper;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.preferences.PreferencesReader;
 import org.phoebus.util.time.SecondsParser;
 
@@ -54,7 +55,7 @@ public class AlarmSystem
     public static final String LONG_TERM_TOPIC_SUFFIX = "LongTerm";
 
     /** Kafka Server host:port */
-    public static final String server;
+    @Preference public static String server;
 
     /** Name of alarm tree root
      *
@@ -62,40 +63,40 @@ public class AlarmSystem
      *  UI instances may select different one at runtime,
      *  but this remains unchanged.
      */
-    public static final String config_name;
+    @Preference public static String config_name;
 
     /** Names of selectable alarm configurations */
-    public static final List<String> config_names;
+    @Preference public static String[] config_names;
 
     /** Timeout in seconds for initial PV connection */
-    public static final int connection_timeout;
+    @Preference public static int connection_timeout;
 
     /** Item level of alarm area. A level of 2 would show all the root levels children. */
-    public static final int alarm_area_level;
+    @Preference public static int alarm_area_level;
 
     /** Number of columns in the alarm area */
-    public static final int alarm_area_column_count;
+    @Preference public static int alarm_area_column_count;
 
     /** Gap between alarm area panel items */
-    public static final int alarm_area_gap;
+    @Preference public static int alarm_area_gap;
 
     /** Font size for the alarm area view */
-    public static final int alarm_area_font_size;
+    @Preference public static int alarm_area_font_size;
 
     /** Limit for the number of context menu items */
-    public static final int alarm_menu_max_items;
+    @Preference public static int alarm_menu_max_items;
 
     /** Alarm table row limit */
-    public static final int alarm_table_max_rows;
+    @Preference public static int alarm_table_max_rows;
 
     /** Directory used for executing commands */
-    public static final File command_directory;
+    @Preference public static File command_directory;
 
     /** Annunciator threshold */
-    public static final int annunciator_threshold;
+    @Preference public static int annunciator_threshold;
 
     /** Annunciator message retention count */
-    public static final int annunciator_retention_count;
+    @Preference public static int annunciator_retention_count;
 
     /** Timeout in milliseconds at which server sends idle state updates
      *  for the 'root' element if there's no real traffic
@@ -103,13 +104,13 @@ public class AlarmSystem
     public static final long idle_timeout_ms;
 
     /** Name of the sender, the 'from' field of automated email actions */
-    public static final String automated_email_sender;
+    @Preference  public static String automated_email_sender;
 
     /** Automated actions that request follow-up when alarm no longer active */
-    public static final List<String> automated_action_followup;
+    @Preference public static String[] automated_action_followup;
 
     /** Optional heartbeat PV */
-    public static final String heartbeat_pv;
+    @Preference public static String heartbeat_pv;
 
     /** Heartbeat PV period in milliseconds */
     public static final long heartbeat_ms;
@@ -118,30 +119,13 @@ public class AlarmSystem
     public static final long nag_period_ms;
 
     /** Disable notify feature */
-    public static final boolean disable_notify_visible;
+    @Preference public static boolean disable_notify_visible;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(AlarmSystem.class, "/alarm_preferences.properties");
-        server = prefs.get("server");
-        config_name = prefs.get("config_name");
-        config_names = getItems(prefs.get("config_names"));
-        connection_timeout = prefs.getInt("connection_timeout");
-        alarm_area_level = prefs.getInt("alarm_area_level");
-        alarm_area_column_count = prefs.getInt("alarm_area_column_count");
-        alarm_area_gap = prefs.getInt("alarm_area_gap");
-        alarm_area_font_size = prefs.getInt("alarm_area_font_size");
-        alarm_menu_max_items = prefs.getInt("alarm_menu_max_items");
-        alarm_table_max_rows = prefs.getInt("alarm_table_max_rows");
-        command_directory = new File(prefs.get("command_directory"));
-        annunciator_threshold = prefs.getInt("annunciator_threshold");
-        annunciator_retention_count = prefs.getInt("annunciator_retention_count");
-        idle_timeout_ms = prefs.getInt("idle_timeout") * 1000L;
-        automated_email_sender = prefs.get("automated_email_sender");
-        automated_action_followup = getItems(prefs.get("automated_action_followup"));
-        heartbeat_pv = prefs.get("heartbeat_pv");
+    	final PreferencesReader prefs = AnnotatedPreferences.initialize(AlarmSystem.class, "/alarm_preferences.properties");
+        idle_timeout_ms = prefs.getInt("idle_timeout") * 1000L;        
         heartbeat_ms = prefs.getInt("heartbeat_secs") * 1000L;
-        disable_notify_visible = prefs.getBoolean("disable_notify_visible");
 
         double secs = 0.0;
         try
@@ -155,14 +139,5 @@ public class AlarmSystem
         nag_period_ms = Math.round(Math.max(0, secs) * 1000.0);
 
         IdentificationHelper.initialize();
-    }
-
-    private static List<String> getItems(final String comma_options)
-    {
-        final String[] split = comma_options.split("\\s*,\\s*");
-        if (split.length == 1  &&  split[0].isEmpty())
-            return List.of();
-        else
-            return List.of(split);
     }
 }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/annunciator/AnnunciatorTableInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/annunciator/AnnunciatorTableInstance.java
@@ -76,7 +76,7 @@ public class AnnunciatorTableInstance implements AppInstance
             annunciatorTable = new AnnunciatorTable(client);
             client.start();
 
-            if (AlarmSystem.config_names.size() > 0)
+            if (AlarmSystem.config_names.length > 0)
             {
                 final AlarmConfigSelector configs = new AlarmConfigSelector(config_name, this::changeConfig);
                 annunciatorTable.getToolbar().getItems().add(0, configs);

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/area/AlarmAreaInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/area/AlarmAreaInstance.java
@@ -71,7 +71,7 @@ public class AlarmAreaInstance implements AppInstance
             final AlarmAreaView area_view = new AlarmAreaView(client);
             client.start();
 
-            if (AlarmSystem.config_names.size() > 0)
+            if (AlarmSystem.config_names.length > 0)
             {
                 final AlarmConfigSelector select = new AlarmConfigSelector(config_name, new_config_name ->
                 {

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableInstance.java
@@ -80,7 +80,7 @@ class AlarmTableInstance implements AppInstance
             client.addListener(mediator);
             client.start();
 
-            if (AlarmSystem.config_names.size() > 0)
+            if (AlarmSystem.config_names.length > 0)
             {
                 final AlarmConfigSelector configs = new AlarmConfigSelector(config_name, this::changeConfig);
                 // Place after "Active Alarms: 12" and strut

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeInstance.java
@@ -76,7 +76,7 @@ class AlarmTreeInstance implements AppInstance
             final AlarmTreeView tree_view = new AlarmTreeView(client);
             client.start();
 
-            if (AlarmSystem.config_names.size() > 0)
+            if (AlarmSystem.config_names.length > 0)
             {
                 final AlarmConfigSelector configs = new AlarmConfigSelector(config_name, this::changeConfig);
                 tree_view.getToolbar().getItems().add(0, configs);

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
@@ -19,7 +19,8 @@ import org.phoebus.channelfinder.utility.RemovePropertyChannelsJob;
 import org.phoebus.channelfinder.utility.RemoveTagChannelsJob;
 import org.phoebus.framework.adapter.AdapterService;
 import org.phoebus.framework.jobs.Job;
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.ui.application.ContextMenuService;
 import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
@@ -74,12 +75,11 @@ public class ChannelTableController extends ChannelFinderController {
     private Collection<String> properties;
     private Collection<String> tags;
     private boolean isCBSelected = true;
-    public static final boolean showActiveCb;
+    @Preference(name="show_active_cb") public static boolean showActiveCb;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(ChannelTableController.class, "/cv_preferences.properties");
-        showActiveCb = prefs.getBoolean("show_active_cb");
+    	AnnotatedPreferences.initialize(ChannelTableController.class, "/cv_preferences.properties");
     }
 
     @SuppressWarnings("unchecked")

--- a/app/console/src/main/java/org/phoebus/applications/console/Console.java
+++ b/app/console/src/main/java/org/phoebus/applications/console/Console.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,8 @@ import java.io.File;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.util.RingBuffer;
 
 import javafx.application.Platform;
@@ -42,28 +43,20 @@ public class Console
     /** Logger for all Terminal code */
     public static final Logger logger = Logger.getLogger(Console.class.getPackageName());
 
-    private static final int output_line_limit;
-    private static final int history_size;
-    private static final String font_name;
-    private static final int font_size;
-    private static final String prompt;
-    private static final String prompt_info;
-    static final String shell;
-    static final File directory;
+    @Preference private static int output_line_limit;
+    @Preference private static int history_size;
+    @Preference private static String font_name;
+    @Preference private static int font_size;
+    @Preference private static String prompt;
+    @Preference private static String prompt_info;
+    @Preference static String shell;
+    @Preference static File directory;
 
     /** Preferences */
     static
     {
-        PreferencesReader prefs = new PreferencesReader(Console.class, "/console_preferences.properties");
-        output_line_limit = prefs.getInt("output_line_limit");
-        history_size = prefs.getInt("history_size");
-        font_name = prefs.get("font_name");
-        font_size = prefs.getInt("font_size");
-        prompt = prefs.get("prompt");
-        prompt_info = prefs.get("prompt_info");
-        shell = prefs.get("shell");
-        directory = new File(prefs.get("directory"));
-    }
+    	AnnotatedPreferences.initialize(Console.class, "/console_preferences.properties");
+   }
 
     public enum LineType
     {

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/LiveSamples.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/LiveSamples.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public class LiveSamples extends PlotSamples
     // No locking in here, all access is via PVSamples
 
     private RingBuffer<PlotSample> samples =
-        new RingBuffer<PlotSample>(Preferences.buffer_size);
+        new RingBuffer<PlotSample>(Preferences.live_buffer_size);
 
     /** Waveform index */
     final private AtomicInteger waveform_index;

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -499,7 +499,7 @@ public class PVItem extends ModelItem
         final double period = XMLUtil.getChildDouble(node, XMLPersistence.TAG_SCAN_PERIOD).orElse(0.0);
 
         final PVItem item = new PVItem(name, period);
-        final int buffer_size = XMLUtil.getChildInteger(node, XMLPersistence.TAG_LIVE_SAMPLE_BUFFER_SIZE).orElse(Preferences.buffer_size);
+        final int buffer_size = XMLUtil.getChildInteger(node, XMLPersistence.TAG_LIVE_SAMPLE_BUFFER_SIZE).orElse(Preferences.live_buffer_size);
         item.setLiveCapacity(buffer_size);
 
         final String req_txt = XMLUtil.getChildString(node, XMLPersistence.TAG_REQUEST).orElse(RequestType.OPTIMIZED.name());

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
@@ -16,6 +16,8 @@ import org.csstudio.javafx.rtplot.TraceType;
 import org.csstudio.trends.databrowser3.Activator;
 import org.csstudio.trends.databrowser3.model.ArchiveDataSource;
 import org.csstudio.trends.databrowser3.model.ArchiveRescale;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.preferences.PreferencesReader;
 import org.phoebus.util.time.TimeParser;
 import org.phoebus.util.time.TimeRelativeInterval;
@@ -30,29 +32,9 @@ public class Preferences
     /** Preference tags.
      *  For explanation of the settings see preferences.ini
      */
-    final public static String
-        ARCHIVE_FETCH_DELAY = "archive_fetch_delay",
-        CONCURRENT_REQUESTS = "concurrent_requests",
-        ARCHIVE_RESCALE = "archive_rescale",
-        ARCHIVES = "archives",
-        URLS = "urls",
-        AUTOMATIC_HISTORY_REFRESH = "automatic_history_refresh",
-        BUFFER_SIZE = "live_buffer_size",
-        LINE_WIDTH = "line_width",
-        OPACITY = "opacity",
-        PLOT_BINS = "plot_bins",
-        SCAN_PERIOD = "scan_period",
-        SCROLL_STEP = "scroll_step",
-        TIME_SPAN = "time_span",
-        TRACE_TYPE = "trace_type",
-        UPDATE_PERIOD = "update_period",
-        USE_AUTO_SCALE = "use_auto_scale",
-        USE_DEFAULT_ARCHIVES = "use_default_archives",
-        DROP_FAILED_ARCHIVES = "drop_failed_archives",
-        USE_TRACE_NAMES = "use_trace_names",
+    final private static String
         PROMPT_FOR_RAW_DATA = "prompt_for_raw_data_request",
-        PROMPT_FOR_VISIBILITY = "prompt_for_visibility",
-        TIME_SPAN_SHORTCUTS = "time_span_shortcuts";
+	    PROMPT_FOR_VISIBILITY = "prompt_for_visibility";
 
     public static class TimePreset
     {
@@ -66,82 +48,45 @@ public class Preferences
         }
     }
 
-    public static int archive_fetch_delay;
-    public static int concurrent_requests;
-    public static ArchiveRescale archive_rescale = ArchiveRescale.STAGGER;
+    @Preference public static int archive_fetch_delay;
+    @Preference public static int concurrent_requests;
+    @Preference public static ArchiveRescale archive_rescale;
     public static List<ArchiveDataSource> archive_urls;
     public static List<ArchiveDataSource> archives;
-    public static boolean automatic_history_refresh;
-    public static int buffer_size;
-    public static int line_width;
-    public static int opacity;
-    public static int plot_bins;
-    public static double scan_period;
+    @Preference public static boolean automatic_history_refresh;
+    @Preference public static int live_buffer_size;
+    @Preference public static int line_width;
+    @Preference public static int opacity;
+    @Preference public static int plot_bins;
+    @Preference public static double scan_period;
     public static Duration scroll_step;
     public static Duration time_span;
-    public static TraceType trace_type = TraceType.AREA;
-    public static double update_period;
-    public static boolean use_auto_scale;
-    public static boolean use_default_archives;
-    public static boolean drop_failed_archives;
-    public static boolean use_trace_names;
-    public static boolean prompt_for_raw_data_request;
-    public static boolean prompt_for_visibility;
-    public static List<TimePreset> time_presets;
+    @Preference public static TraceType trace_type;
+    @Preference public static double update_period;
+    @Preference public static boolean use_auto_scale;
+    @Preference public static boolean use_default_archives;
+    @Preference public static boolean drop_failed_archives;
+    @Preference public static boolean use_trace_names;
+    @Preference public static boolean prompt_for_raw_data_request;
+    @Preference public static boolean prompt_for_visibility;
+    @Preference public static List<TimePreset> time_presets;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Activator.class, "/databrowser_preferences.properties");
-
-        archive_fetch_delay = prefs.getInt(ARCHIVE_FETCH_DELAY);
+        final PreferencesReader prefs = AnnotatedPreferences.initialize(Activator.class, "/databrowser_preferences.properties");
 
         // Allow at least one at a time
-        concurrent_requests = Math.max(1, prefs.getInt(CONCURRENT_REQUESTS));
+        if (concurrent_requests < 1)
+        	concurrent_requests = 1;
+        
+        archive_urls = parseArchives(prefs.get("urls"));
+        archives = parseArchives(prefs.get("archives"));
 
-        String enum_name = prefs.get(ARCHIVE_RESCALE);
-        try
-        {
-            archive_rescale = ArchiveRescale.valueOf(enum_name);
-        }
-        catch (Exception ex)
-        {
-            Activator.logger.log(Level.WARNING, "Undefined rescale option '" + enum_name + "'", ex);
-        }
-
-        archive_urls = parseArchives(prefs.get(URLS));
-        archives = parseArchives(prefs.get(ARCHIVES));
-
-        automatic_history_refresh = prefs.getBoolean(AUTOMATIC_HISTORY_REFRESH);
-        buffer_size = prefs.getInt(BUFFER_SIZE);
-        line_width = prefs.getInt(LINE_WIDTH);
-        opacity = prefs.getInt(OPACITY);
-        plot_bins = prefs.getInt(PLOT_BINS);
-        scan_period = prefs.getDouble(SCAN_PERIOD);
-        scroll_step = Duration.ofSeconds( Math.max(1, prefs.getInt(SCROLL_STEP)) );
-        time_span = Duration.ofSeconds( Math.round( Math.max(prefs.getDouble(TIME_SPAN), 1.0) ) );
-
-        enum_name = prefs.get(TRACE_TYPE);
-        try
-        {
-            trace_type = TraceType.valueOf(enum_name);
-        }
-        catch (Exception ex)
-        {
-            Activator.logger.log(Level.WARNING, "Undefined trace type option '" + enum_name + "'", ex);
-        }
-
-        update_period = prefs.getDouble(UPDATE_PERIOD);
-        use_auto_scale = prefs.getBoolean(USE_AUTO_SCALE);
-        use_default_archives = prefs.getBoolean(USE_DEFAULT_ARCHIVES);
-        drop_failed_archives = prefs.getBoolean(DROP_FAILED_ARCHIVES);
-        use_trace_names = prefs.getBoolean(USE_TRACE_NAMES);
-
-        prompt_for_raw_data_request = prefs.getBoolean(PROMPT_FOR_RAW_DATA);
-        prompt_for_visibility = prefs.getBoolean(PROMPT_FOR_VISIBILITY);
-
+        scroll_step = Duration.ofSeconds( Math.max(1, prefs.getInt("scroll_step")) );
+        time_span = Duration.ofSeconds( Math.round( Math.max(prefs.getDouble("time_span"), 1.0) ) );
 
         time_presets = new ArrayList<>();
-        for (String preset : prefs.get(TIME_SPAN_SHORTCUTS).split("\\|"))
+        for (String preset : prefs.get("time_span_shortcuts").split("\\|"))
         {
             final String[] label_span = preset.split(",");
             time_presets.add(new TimePreset(label_span[0], TimeRelativeInterval.startsAt(TimeParser.parseTemporalAmount(label_span[1]))));

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
@@ -69,11 +69,11 @@ public class Preferences
     @Preference public static boolean use_trace_names;
     @Preference public static boolean prompt_for_raw_data_request;
     @Preference public static boolean prompt_for_visibility;
-    @Preference public static List<TimePreset> time_presets;
+    public static final List<TimePreset> time_presets = new ArrayList<>();
 
     static
     {
-        final PreferencesReader prefs = AnnotatedPreferences.initialize(Activator.class, "/databrowser_preferences.properties");
+        final PreferencesReader prefs = AnnotatedPreferences.initialize(Preferences.class, "/databrowser_preferences.properties");
 
         // Allow at least one at a time
         if (concurrent_requests < 1)
@@ -85,7 +85,6 @@ public class Preferences
         scroll_step = Duration.ofSeconds( Math.max(1, prefs.getInt("scroll_step")) );
         time_span = Duration.ofSeconds( Math.round( Math.max(prefs.getDouble("time_span"), 1.0) ) );
 
-        time_presets = new ArrayList<>();
         for (String preset : prefs.get("time_span_shortcuts").split("\\|"))
         {
             final String[] label_span = preset.split(",");

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/EditMultipleItemsAction.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/EditMultipleItemsAction.java
@@ -56,7 +56,7 @@ public class EditMultipleItemsAction extends MenuItem
         private final TextField period = new TextField("0.0");
 
         private final CheckBox set_buffer = new CheckBox(Messages.LiveSampleBufferSize);
-        private final TextField buffer = new TextField(Integer.toString(Preferences.buffer_size));
+        private final TextField buffer = new TextField(Integer.toString(Preferences.live_buffer_size));
 
         private final CheckBox set_axis = new CheckBox(Messages.Axis);
         private final ComboBox<String> axis = new ComboBox<>();

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/AppliancePreferences.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/AppliancePreferences.java
@@ -7,7 +7,8 @@
  ******************************************************************************/
 package org.phoebus.archive.reader.appliance;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /**
  * Settings for Appliance archive reader
@@ -16,15 +17,10 @@ import org.phoebus.framework.preferences.PreferencesReader;
  */
 @SuppressWarnings("nls")
 public class AppliancePreferences {
-    static final String USESTATS = "useStatisticsForOptimizedData";
-    static final String USEOPTIMIZED = "useNewOptimizedOperator";
-
-    static boolean useStatisticsForOptimizedData;
-    static boolean useNewOptimizedOperator;
+    @Preference static boolean useStatisticsForOptimizedData;
+    @Preference static boolean useNewOptimizedOperator;
 
     static {
-        final PreferencesReader prefs = new PreferencesReader(AppliancePreferences.class, "/appliance_preferences.properties");
-        useStatisticsForOptimizedData = prefs.getBoolean(USESTATS);
-        useNewOptimizedOperator = prefs.getBoolean(USEOPTIMIZED);
+    	AnnotatedPreferences.initialize(AppliancePreferences.class, "/appliance_preferences.properties");
     }
 }

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RDBArchiveReader.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RDBArchiveReader.java
@@ -116,8 +116,8 @@ public class RDBArchiveReader implements ArchiveReader
             addForCancellation(statement);
             try
             {
-                if (RDBPreferences.timeout > 0)
-                    statement.setQueryTimeout(RDBPreferences.timeout);
+                if (RDBPreferences.timeout_secs > 0)
+                    statement.setQueryTimeout(RDBPreferences.timeout_secs);
                 statement.setFetchSize(100);
                 final ResultSet result = statement.executeQuery(sql.sel_stati);
                 while (result.next())
@@ -150,8 +150,8 @@ public class RDBArchiveReader implements ArchiveReader
             addForCancellation(statement);
             try
             {
-                if (RDBPreferences.timeout > 0)
-                    statement.setQueryTimeout(RDBPreferences.timeout);
+                if (RDBPreferences.timeout_secs > 0)
+                    statement.setQueryTimeout(RDBPreferences.timeout_secs);
                 statement.setFetchSize(100);
                 final ResultSet result = statement.executeQuery(sql.sel_severities);
                 while (result.next())
@@ -330,8 +330,8 @@ public class RDBArchiveReader implements ArchiveReader
             addForCancellation(statement);
             try
             {
-                if (RDBPreferences.timeout > 0)
-                    statement.setQueryTimeout(RDBPreferences.timeout);
+                if (RDBPreferences.timeout_secs > 0)
+                    statement.setQueryTimeout(RDBPreferences.timeout_secs);
                 statement.setString(1, name);
                 final ResultSet result = statement.executeQuery();
                 if (!result.next())

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RDBPreferences.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RDBPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  ******************************************************************************/
 package org.phoebus.archive.reader.rdb;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Settings for RDB archive reader
  *  @author Kay Kasemir
@@ -15,31 +16,14 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class RDBPreferences
 {
-    static final String USER = "user";
-    static final String PASSWORD = "password";
-    static final String PREFIX = "prefix";
-    static final String TIMEOUT_SECS = "timeout_secs";
-    static final String USE_ARRAY_BLOB = "use_array_blob";
-    static final String STORED_PROCEDURE = "stored_procedure";
-    static final String STARTTIME_FUNCTION = "starttime_function";
-    static final String FETCH_SIZE = "fetch_size";
-
-    static String user, password, prefix;
-    static int timeout;
-    static boolean use_array_blob;
-    static String stored_procedure, starttime_function;
-    static int fetch_size;
+    @Preference static String user, password, prefix;
+    @Preference static int timeout_secs;
+    @Preference static boolean use_array_blob;
+    @Preference static String stored_procedure, starttime_function;
+    @Preference static int fetch_size;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(RDBPreferences.class, "/archive_reader_rdb_preferences.properties");
-        user               = prefs.get(USER);
-        password           = prefs.get(PASSWORD);
-        prefix             = prefs.get(PREFIX);
-        timeout            = prefs.getInt(TIMEOUT_SECS);
-        use_array_blob     = prefs.getBoolean(USE_ARRAY_BLOB);
-        stored_procedure   = prefs.get(STORED_PROCEDURE);
-        starttime_function = prefs.get(STARTTIME_FUNCTION);
-        fetch_size         = prefs.getInt(FETCH_SIZE);
+    	AnnotatedPreferences.initialize(RDBPreferences.class, "/archive_reader_rdb_preferences.properties");
     }
 }

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RDBPreferences.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RDBPreferences.java
@@ -19,7 +19,8 @@ public class RDBPreferences
     @Preference static String user, password, prefix;
     @Preference static int timeout_secs;
     @Preference static boolean use_array_blob;
-    @Preference static String stored_procedure, starttime_function;
+    @Preference static String stored_procedure;
+    @Preference static String starttime_function;
     @Preference static int fetch_size;
 
     static

--- a/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/model/PVItemUnitTest.java
+++ b/app/databrowser/src/test/java/org/csstudio/trends/databrowser3/model/PVItemUnitTest.java
@@ -57,7 +57,9 @@ public class PVItemUnitTest
         System.out.println(samples);
         assertThat(samples.hasNewSamples(), equalTo(true));
 
+        samples.getLock().lock();
         final int count = samples.size();
+        samples.getLock().unlock();
         final int perc_diff = Math.abs(count - expected) * 100 / expected;
         System.out.println("Got " + count + " samples, expected " + expected + ", difference of " + perc_diff + "%");
         assertThat(perc_diff < 50, equalTo(true));

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@ import java.util.prefs.Preferences;
 import java.util.regex.Pattern;
 
 import org.csstudio.display.builder.model.util.ModelResourceUtil;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.preferences.PreferencesReader;
 
 /** Phoebus application for EDM converter
@@ -27,7 +29,8 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class ConverterPreferences
 {
-    public static String colors_list;
+    @Preference public static String colors_list;
+    @Preference private static String edm_paths_config;
 
     public static final List<String> paths = new ArrayList<>();
 
@@ -48,8 +51,7 @@ public class ConverterPreferences
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(ConverterPreferences.class, "/edm_converter_preferences.properties");
-        colors_list = prefs.get("colors_list");
+        final PreferencesReader prefs = AnnotatedPreferences.initialize(ConverterPreferences.class, "/edm_converter_preferences.properties");
 
         try
         {
@@ -60,7 +62,6 @@ public class ConverterPreferences
             logger.log(Level.WARNING, "Cannot parse font_mappings", ex);
         }
 
-        final String edm_paths_config = prefs.get("edm_paths_config").trim();
         if (! edm_paths_config.isEmpty())
             try
             {

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -332,7 +332,7 @@ public class EditorGUI
 
     private Parent createElements()
     {
-        editor = new DisplayEditor(toolkit, org.csstudio.display.builder.editor.Preferences.undoStackSize);
+        editor = new DisplayEditor(toolkit, org.csstudio.display.builder.editor.Preferences.undo_stack_size);
 
         tree = new WidgetTree(editor);
 

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Preferences.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,9 +9,9 @@ package org.csstudio.display.builder.editor;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Editor preferences
  *  @author Kay Kasemir
@@ -19,33 +19,16 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Preferences
 {
-    public static final String HIDDEN_WIDGETS = "hidden_widget_types";
-    public static final String NEW_DISPLAY_TEMPLATE = "new_display_template";
-    public static final String UNDO_STACK_SIZE = "undo_stack_size";
-    
+	@Preference(name="hidden_widget_types") private static String[] hidden_widget_spec;
     public static Set<String> hidden_widget_types = new HashSet<>();
-    public static String new_display_template;
-    public static int undoStackSize = 50;
+    @Preference public static String new_display_template;
+    @Preference public static int undo_stack_size;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Preferences.class, "/display_editor_preferences.properties");
+    	AnnotatedPreferences.initialize(Preferences.class, "/display_editor_preferences.properties");
 
-        final String list = prefs.get(HIDDEN_WIDGETS);
-        for (String item : list.split(" *, *"))
-        {
-            final String type = item.trim();
-            if (! type.isEmpty())
-                hidden_widget_types.add(type);
-        }
-        new_display_template = prefs.get(NEW_DISPLAY_TEMPLATE);
-
-        final String undoStack = prefs.get(UNDO_STACK_SIZE);
-        try {
-            undoStackSize = Integer.parseInt(undoStack);
-        } catch (NumberFormatException e) {
-            Logger.getLogger(Preferences.class.getName())
-                    .info(String.format("Unable to parse \"%s\" as a undo stack size, falling back to %d.", undoStack, undoStackSize));
-        }
+        for (String item : hidden_widget_spec)
+            hidden_widget_types.add(item);
     }
 }

--- a/app/display/editor/src/test/java/org/csstudio/display/builder/editor/PreferencesTest.java
+++ b/app/display/editor/src/test/java/org/csstudio/display/builder/editor/PreferencesTest.java
@@ -23,7 +23,8 @@ public class PreferencesTest
     }
 
     @Test
-    public void testUndoStackSize(){
-        assertEquals(50, Preferences.undoStackSize);
+    public void testUndoStackSize()
+    {
+        assertEquals(50, Preferences.undo_stack_size);
     }
 }

--- a/app/display/model/.classpath
+++ b/app/display/model/.classpath
@@ -8,7 +8,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/core-util"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="lib" path="/dependencies/phoebus-target/target/lib/epics-util-1.0.4.jar"/>
-	<classpathentry kind="lib" path="/dependencies/phoebus-target/target/lib/vtype-1.0.4.jar"/>
+	<classpathentry kind="lib" path="/phoebus-target/target/lib/epics-util-1.0.4.jar"/>
+	<classpathentry kind="lib" path="/phoebus-target/target/lib/vtype-1.0.4.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/Preferences.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,8 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.macros.MacroXMLUtil;
 import org.phoebus.framework.macros.Macros;
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preference settings
  *
@@ -22,52 +23,26 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Preferences
 {
-    public static final String CACHE_TIMEOUT = "cache_timeout";
-    public static final String CLASS_FILES = "class_files";
-    public static final String COLOR_FILES = "color_files";
-    public static final String FONT_FILES = "font_files";
-    public static final String READ_TIMEOUT = "read_timeout";
-    public static final String LEGACY_FONT_CALIBRATION = "legacy_font_calibration";
-    public static final String MACROS = "macros";
-    public static final String MAX_REPARSE_ITERATIONS = "max_reparse_iterations";
-    public static final String SKIP_DEFAULTS = "skip_defaults";
-
-    public static String[] class_files, color_files, font_files;
-    public static int read_timeout, cache_timeout, max_reparse;
-    public static double legacy_font_calibration;
-    public static boolean skip_defaults;
+	@Preference public static String[] class_files, color_files, font_files;
+	@Preference public static int read_timeout, cache_timeout, max_reparse_iterations;
+	@Preference public static double legacy_font_calibration;
+	@Preference public static boolean skip_defaults;
+    @Preference(name="macros") private static String macro_spec;
     private static Macros macros;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Preferences.class, "/display_model_preferences.properties");
+    	AnnotatedPreferences.initialize(Preferences.class, "/display_model_preferences.properties");
 
-        class_files = getFiles(prefs, CLASS_FILES);
-        color_files = getFiles(prefs, COLOR_FILES);
-        font_files = getFiles(prefs, FONT_FILES);
-        read_timeout = prefs.getInt(READ_TIMEOUT);
-        cache_timeout = prefs.getInt(CACHE_TIMEOUT);
-        max_reparse = prefs.getInt(MAX_REPARSE_ITERATIONS);
-        legacy_font_calibration = prefs.getDouble(LEGACY_FONT_CALIBRATION);
-        skip_defaults = prefs.getBoolean(SKIP_DEFAULTS);
         try
         {
-            macros = MacroXMLUtil.readMacros(prefs.get(MACROS));
+            macros = MacroXMLUtil.readMacros(macro_spec);
         }
         catch (Exception ex)
         {
             logger.log(Level.WARNING, "Error in macro preference", ex);
             macros = new Macros();
         }
-    }
-
-    private static String[] getFiles(final PreferencesReader prefs, final String key)
-    {
-        final String[] setting = prefs.get(key).split(" *; *");
-        // split() will turn "" into { "" }, which we change into empty array
-        if (setting.length == 0  ||  (setting.length == 1 && setting[0].isEmpty()))
-            return new String[0];
-        return setting;
     }
 
     public static Macros getMacros()

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
@@ -75,7 +75,6 @@ import org.w3c.dom.Element;
 @SuppressWarnings("nls")
 public class ModelReader
 {
-    private final static int MAX_PARSE_AGAIN = Preferences.max_reparse;
     private final Element root;
     private final Version version;
     private final String xml_file;
@@ -176,7 +175,7 @@ public class ModelReader
         // Save the number of errors we had so far
         int saved_widget_errors_during_parse = widget_errors_during_parse;
         // Limit the number of retries to avoid infinite loop
-        for (int retries=0; retries < MAX_PARSE_AGAIN; ++retries)
+        for (int retries=0; retries < Preferences.max_reparse_iterations; ++retries)
         {
             final List<Widget> widgets = readWidgetsAllowingRetry(parent_xml);
             if (widgets != null)
@@ -190,7 +189,7 @@ public class ModelReader
             }
         }
 
-        throw new IllegalStateException("Too many requests to parse again, limited to " + MAX_PARSE_AGAIN + " requests");
+        throw new IllegalStateException("Too many requests to parse again, limited to " + Preferences.max_reparse_iterations + " requests");
     }
 
     /** Read all '&lt;widget>..' child entries

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXPreferences.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preference settings
  *  @author Kay Kasemir
@@ -15,11 +16,10 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class JFXPreferences
 {
-    public static boolean inc_dec_slider;
+    @Preference public static boolean inc_dec_slider;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(JFXPreferences.class, "/jfx_repr_preferences.properties");
-        inc_dec_slider = prefs.getBoolean("inc_dec_slider");
+    	AnnotatedPreferences.initialize(JFXPreferences.class, "/jfx_repr_preferences.properties");
     }
 }

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/Preferences.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,11 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation;
 
-import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
-
-import java.util.logging.Level;
-
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preference settings
  *
@@ -20,27 +17,12 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Preferences
 {
-    public static int performance_log_period_secs, performance_log_threshold_ms,
+    @Preference public static int performance_log_period_secs, performance_log_threshold_ms,
                       update_accumulation_time, update_delay, plot_update_delay, image_update_delay,
                       tooltip_length, embedded_timeout;
 
     static
     {
-        try
-        {
-            PreferencesReader prefs = new PreferencesReader(Preferences.class, "/display_representation_preferences.properties");
-            performance_log_period_secs = prefs.getInt("performance_log_period_secs");
-            performance_log_threshold_ms = prefs.getInt("performance_log_threshold_ms");
-            update_accumulation_time = prefs.getInt("update_accumulation_time");
-            update_delay = prefs.getInt("update_delay");
-            plot_update_delay = prefs.getInt("plot_update_delay");
-            image_update_delay = prefs.getInt("image_update_delay");
-            tooltip_length = prefs.getInt("tooltip_length");
-            embedded_timeout = prefs.getInt("embedded_timeout");
-        }
-        catch (Exception ex)
-        {
-            logger.log(Level.WARNING, "Display representation preference error", ex);
-        }
+    	AnnotatedPreferences.initialize(Preferences.class, "/display_representation_preferences.properties");
     }
 }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/Preferences.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/Preferences.java
@@ -16,6 +16,7 @@ import java.util.regex.PatternSyntaxException;
 
 import org.phoebus.framework.preferences.AnnotatedPreferences;
 import org.phoebus.framework.preferences.Preference;
+import org.phoebus.framework.preferences.PreferencesReader;
 
 /** Preference settings
  *
@@ -27,16 +28,17 @@ public class Preferences
     @Preference public static String python_path;
     @Preference(name="update_throttle") public static int update_throttle_ms;
     @Preference public static String probe_display;
-    @Preference(name="pv_name_patches") private static String patch_spec;
-    public static List<TextPatch> pv_name_patches = new ArrayList<>();
+    public static final List<TextPatch> pv_name_patches = new ArrayList<>();
 
     static
     {
-    	AnnotatedPreferences.initialize(Preferences.class, "/display_runtime_preferences.properties");
-        if (! patch_spec.isEmpty())
+    	final PreferencesReader prefs = AnnotatedPreferences.initialize(Preferences.class, "/display_runtime_preferences.properties");
+        
+    	final String setting = prefs.get("pv_name_patches");
+    	if (! setting.isEmpty())
         {
             // Split on '@', except if preceded by '[' to skip '[@]'
-            final String[] config = patch_spec.split("(?<!\\[)@");
+            final String[] config = setting.split("(?<!\\[)@");
             if (config.length % 2 == 0)
             {
                 for (int i=0; i<config.length; i+=2)

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/Preferences.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.regex.PatternSyntaxException;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preference settings
  *
@@ -23,22 +24,19 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Preferences
 {
-    public static String python_path;
-    public static List<TextPatch> pv_name_patches;
-    public static int update_throttle_ms;
-    public static String probe_display;
+    @Preference public static String python_path;
+    @Preference(name="update_throttle") public static int update_throttle_ms;
+    @Preference public static String probe_display;
+    @Preference(name="pv_name_patches") private static String patch_spec;
+    public static List<TextPatch> pv_name_patches = new ArrayList<>();
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Preferences.class, "/display_runtime_preferences.properties");
-        python_path = prefs.get("python_path");
-
-        pv_name_patches = new ArrayList<>();
-        final String setting = prefs.get("pv_name_patches");
-        if (! setting.isEmpty())
+    	AnnotatedPreferences.initialize(Preferences.class, "/display_runtime_preferences.properties");
+        if (! patch_spec.isEmpty())
         {
             // Split on '@', except if preceded by '[' to skip '[@]'
-            final String[] config = setting.split("(?<!\\[)@");
+            final String[] config = patch_spec.split("(?<!\\[)@");
             if (config.length % 2 == 0)
             {
                 for (int i=0; i<config.length; i+=2)
@@ -61,8 +59,5 @@ public class Preferences
                 logger.log(Level.SEVERE, "Invalid setting for pv_name_patches," +
                                          "need even number of items (pairs of pattern@replacement)");
         }
-
-        update_throttle_ms = prefs.getInt("update_throttle");
-        probe_display = prefs.get("probe_display");
     }
 }

--- a/app/errlog/src/main/java/org/phoebus/applications/errlog/Preferences.java
+++ b/app/errlog/src/main/java/org/phoebus/applications/errlog/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  ******************************************************************************/
 package org.phoebus.applications.errlog;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** LineLog preference settings
  *  @author Kay Kasemir
@@ -15,11 +16,10 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Preferences
 {
-    public static int max_lines;
+    @Preference public static int max_lines;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Preferences.class, "/errlog_preferences.properties");
-        max_lines = prefs.getInt("max_lines");
+    	AnnotatedPreferences.initialize(Preferences.class, "/errlog_preferences.properties");
     }
 }

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserApp.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserApp.java
@@ -3,6 +3,8 @@ package org.phoebus.applications.filebrowser;
 import java.io.File;
 import java.net.URI;
 
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.preferences.PreferencesReader;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.framework.spi.AppResourceDescriptor;
@@ -15,16 +17,14 @@ public class FileBrowserApp implements AppResourceDescriptor {
     public static final String DisplayName = Messages.DisplayName;
 
     /** Initial root directory for newly opened file browser */
-    public static final File default_root;
+    @Preference public static File default_root;
 
     /** Show hidden files (File.isHidden)? */
-    public static final boolean show_hidden;
+    @Preference public static boolean show_hidden;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(FileBrowserApp.class, "/filebrowser_preferences.properties");
-        default_root = new File(prefs.get("default_root"));
-        show_hidden = prefs.getBoolean("show_hidden");
+    	AnnotatedPreferences.initialize(FileBrowserApp.class, "/filebrowser_preferences.properties");
     }
 
     @Override

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderViewController.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalenderViewController.java
@@ -170,7 +170,7 @@ public class LogEntryCalenderViewController extends LogbookSearchController {
         // find the css file
 
         try {
-            String styleSheetResource = LogbookUiPreferences.calendarViewItemStylesheet;
+            String styleSheetResource = LogbookUiPreferences.calendar_view_item_stylesheet;
             agenda.getStylesheets().add(this.getClass().getResource(styleSheetResource).toString());
         } catch (Exception e) {
             logger.log(Level.WARNING, "Failed to set css style", e);

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookUiPreferences.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookUiPreferences.java
@@ -11,6 +11,8 @@ import static org.phoebus.ui.application.PhoebusApplication.logger;
 
 import java.util.logging.Level;
 
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.preferences.PreferencesReader;
 import org.phoebus.logbook.LogService;
 
@@ -20,23 +22,16 @@ import org.phoebus.logbook.LogService;
 @SuppressWarnings("nls")
 public class LogbookUiPreferences
 {
-    public static final String[] default_logbooks;
-    public static final boolean  save_credentials;
-    public static final String   logbook_factory;
-    public static final boolean  is_supported;
-    public static final String calendarViewItemStylesheet;
-    public static final String levelFieldName;
+    @Preference public static String[] default_logbooks;
+    @Preference public static boolean  save_credentials;
+    @Preference public static String   logbook_factory;
+    @Preference public static boolean  is_supported;
+    @Preference public static String calendar_view_item_stylesheet;
+    @Preference public static String level_field_name;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(LogbookUiPreferences.class, "/log_ui_preferences.properties");
-
-        // Split the comma separated list.
-        default_logbooks = prefs.get("default_logbooks").split("(\\s)*,(\\s)*");
-        save_credentials = prefs.getBoolean("save_credentials");
-        logbook_factory  = prefs.get("logbook_factory");
-        calendarViewItemStylesheet = prefs.get("calendar_view_item_stylesheet");
-        levelFieldName = prefs.get("level_field_name");
+        final PreferencesReader prefs = AnnotatedPreferences.initialize(LogbookUiPreferences.class, "/log_ui_preferences.properties");
 
         if (logbook_factory.isEmpty())
         {

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/FieldsViewController.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/FieldsViewController.java
@@ -167,7 +167,7 @@ public class FieldsViewController implements Initializable{
         passwordFieldLabel.setText(Messages.Password);
         dateLabel.setText(Messages.Date);
         dateField.setTooltip(new Tooltip(Messages.CurrentDate));
-        levelLabel.setText(LogbookUiPreferences.levelFieldName);
+        levelLabel.setText(LogbookUiPreferences.level_field_name);
         titleLabel.setText(Messages.Title);
     }
 

--- a/app/pvtable/src/main/java/org/phoebus/applications/pvtable/Settings.java
+++ b/app/pvtable/src/main/java/org/phoebus/applications/pvtable/Settings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.phoebus.applications.pvtable;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preference settings
  *  @author Kay Kasemir
@@ -15,26 +16,15 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Settings
 {
-    private static final String TREAT_BYTE_ARRAY_AS_STRING = "treat_byte_array_as_string";
-    private static final String SHOW_UNITS = "show_units";
-    private static final String SHOW_DESCRIPTION = "show_description";
-    private static final String TOLERANCE = "tolerance";
-    private static final String MAX_UPDATE_PERIOD = "max_update_period";
-
-    public static boolean treat_byte_array_as_string;
-    public static boolean show_units;
-    public static boolean show_description;
-    public static double tolerance;
+    @Preference public static boolean treat_byte_array_as_string;
+    @Preference public static boolean show_units;
+    @Preference public static boolean show_description;
+    @Preference public static double tolerance;
     public static int update_item_threshold = 50;
-    public static long max_update_period_ms = 500;
+    @Preference(name="max_update_period") public static long max_update_period_ms;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Settings.class, "/pv_table_preferences.properties");
-        treat_byte_array_as_string = prefs.getBoolean(TREAT_BYTE_ARRAY_AS_STRING);
-        show_units = prefs.getBoolean(SHOW_UNITS);
-        show_description = prefs.getBoolean(SHOW_DESCRIPTION);
-        tolerance = prefs.getDouble(TOLERANCE);
-        max_update_period_ms = prefs.getInt(MAX_UPDATE_PERIOD);
+    	AnnotatedPreferences.initialize(Settings.class, "/pv_table_preferences.properties");
     }
 }

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/Settings.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/Settings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,27 +14,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.preferences.PreferencesReader;
+
 /** Preference settings
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
 public class Settings
 {
-    private static final String UPDATE_PERIOD = "update_period";
-    private static final String FIELDS = "fields";
-    private static final String READ_LONG_FIELDS = "read_long_fields";
-
-    public static final boolean read_long_fields;
+    @Preference public static boolean read_long_fields;
+    @Preference(name="update_period") public static double max_update_period;
     public static Map<String, List<String>> field_info;
-    public static final double max_update_period;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Settings.class, "/pv_tree_preferences.properties");
-        read_long_fields = prefs.getBoolean(READ_LONG_FIELDS);
+        final PreferencesReader prefs = AnnotatedPreferences.initialize(Settings.class, "/pv_tree_preferences.properties");
 
-        final String spec = prefs.get(FIELDS);
+        final String spec = prefs.get("fields");
         try
         {
             field_info = FieldParser.parse(spec);
@@ -44,7 +42,5 @@ public class Settings
             logger.log(Level.SEVERE, "Cannot parse fields from '" + spec + "'", ex);
             field_info = Collections.emptyMap();
         }
-
-        max_update_period = prefs.getDouble(UPDATE_PERIOD);
     }
 }

--- a/app/rtplot/.classpath
+++ b/app/rtplot/.classpath
@@ -8,7 +8,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-util"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>
-	<classpathentry kind="lib" path="/dependencies/phoebus-target/target/lib/epics-util-1.0.4.jar"/>
-	<classpathentry kind="lib" path="/dependencies/phoebus-target/target/lib/vtype-1.0.4.jar"/>
+	<classpathentry kind="lib" path="/phoebus-target/target/lib/epics-util-1.0.4.jar"/>
+	<classpathentry kind="lib" path="/phoebus-target/target/lib/vtype-1.0.4.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/Activator.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Logger;
 
 import org.phoebus.framework.jobs.NamedThreadFactory;
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javafx.scene.image.Image;
@@ -26,6 +27,7 @@ public class Activator
 {
     final public static Logger logger = Logger.getLogger(Activator.class.getPackageName());
 
+    @Preference(name="shady_future") private static int[] rgba;
     public static final Color shady_future;
 
     /** Thread pool for scrolling, throttling updates
@@ -37,9 +39,8 @@ public class Activator
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Activator.class, "/rt_plot_preferences.properties");
-        final String[] rgba = prefs.get("shady_future").split("\\s*,\\s*");
-        shady_future = new Color(Integer.parseInt(rgba[0]),Integer.parseInt(rgba[1]), Integer.parseInt(rgba[2]), Integer.parseInt(rgba[3]));
+    	AnnotatedPreferences.initialize(Activator.class, "/rt_plot_preferences.properties");
+        shady_future = new Color(rgba[0], rgba[1], rgba[2], rgba[3]);
     }
 
     public static Image getIcon(final String base_name)

--- a/app/scan/client/src/main/java/org/csstudio/scan/client/Preferences.java
+++ b/app/scan/client/src/main/java/org/csstudio/scan/client/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.csstudio.scan.client;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preference settings
  *  @author Kay Kasemir
@@ -15,15 +16,12 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Preferences
 {
-    public static String host;
-    public static int port;
-    public static int poll_period;
+    @Preference public static String host;
+    @Preference public static int port;
+    @Preference public static int poll_period;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Preferences.class, "/scan_client_preferences.properties");
-        host = prefs.get("host");
-        port = prefs.getInt("port");
-        poll_period = prefs.getInt("poll_period");
+    	AnnotatedPreferences.initialize(Preferences.class, "/scan_client_preferences.properties");
     }
 }

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/ScanUIPreferences.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/ScanUIPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,8 @@ package org.csstudio.scan.ui;
 
 import java.util.prefs.Preferences;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preference settings
  *  @author Kay Kasemir
@@ -18,12 +19,11 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class ScanUIPreferences
 {
-    public static boolean monitor_status;
+    @Preference public static boolean monitor_status;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(ScanUIPreferences.class, "/scan_ui_preferences.properties");
-        monitor_status = prefs.getBoolean("monitor_status");
+    	AnnotatedPreferences.initialize(ScanUIPreferences.class, "/scan_ui_preferences.properties");
     }
 
     /** @param show New 'monitor_status' preference value to write */

--- a/app/update/src/main/java/org/phoebus/applications/update/Update.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/Update.java
@@ -26,6 +26,8 @@ import java.util.zip.ZipFile;
 
 import org.phoebus.framework.jobs.JobMonitor;
 import org.phoebus.framework.jobs.SubJobMonitor;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.preferences.PreferencesReader;
 import org.phoebus.framework.workbench.FileHelper;
 import org.phoebus.framework.workbench.Locations;
@@ -51,32 +53,28 @@ public class Update
     public static final Logger logger = Logger.getLogger(Update.class.getPackageName());
 
     /** Initial delay to allow other apps to start */
-    public static final int delay;
+    @Preference public static int delay;
 
     /** Current version, or <code>null</code> if not set */
     public static final Instant current_version;
 
     /** Update URL, or empty if not set */
-    public static final String update_url;
+    @Preference public static String update_url;
 
     /** Path removals */
     public static final PathWrangler wrangler;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Update.class, "/update_preferences.properties");
+        final PreferencesReader prefs = AnnotatedPreferences.initialize(Update.class, "/update_preferences.properties");
         current_version = TimestampFormats.parse(prefs.get("current_version"));
 
-        delay = prefs.getInt("delay");
-
-        String url = prefs.get("update_url");
         if (PlatformInfo.is_linux)
-            url = url.replace("$(arch)", "linux");
+        	update_url = update_url.replace("$(arch)", "linux");
         else if (PlatformInfo.is_mac_os_x)
-            url = url.replace("$(arch)", "mac");
+        	update_url = update_url.replace("$(arch)", "mac");
         else
-            url = url.replace("$(arch)", "win");
-        update_url = url;
+        	update_url = update_url.replace("$(arch)", "win");
 
         wrangler = new PathWrangler(prefs.get("removals"));
     }

--- a/core/email/src/main/java/org/phoebus/email/EmailPreferences.java
+++ b/core/email/src/main/java/org/phoebus/email/EmailPreferences.java
@@ -7,7 +7,8 @@
  ******************************************************************************/
 package org.phoebus.email;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preference settings for email
  *  @author Kunal Shroff
@@ -16,11 +17,11 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class EmailPreferences
 {
-    public static final String mailhost;
-    public static final int mailport;
-    public static final String username;
-    public static final String password;
-    public static final String from;
+    @Preference public static String mailhost;
+    @Preference public static int mailport;
+    @Preference public static String username;
+    @Preference public static String password;
+    @Preference public static String from;
 
     /** @return Is email supported? */
     public static final boolean isEmailSupported()
@@ -31,11 +32,6 @@ public class EmailPreferences
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(EmailPreferences.class, "/email_preferences.properties");
-        mailhost = prefs.get("mailhost");
-        mailport = prefs.getInt("mailport");
-        username = prefs.get("username");
-        password = prefs.get("password");
-        from = prefs.get("from");
+    	AnnotatedPreferences.initialize(EmailPreferences.class, "/email_preferences.properties");
     }
 }

--- a/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
@@ -26,8 +26,10 @@ public class AnnotatedPreferences
 	 *  
 	 *  @param clazz Class to be initialized, also sets the package name for preference keys
 	 *  @param preferences_properties_filename Preference properties file, loaded as resource of the `clazz`
+	 *  
+	 *  @return {@link PreferencesReader} in case caller wants to directly read some items for special handling
 	 */
-	public static void initialize(final Class<?> clazz, final String preferences_properties_filename)
+	public static PreferencesReader initialize(final Class<?> clazz, final String preferences_properties_filename)
 	{
 		final PreferencesReader prefs = new PreferencesReader(clazz, preferences_properties_filename);
 
@@ -55,6 +57,8 @@ public class AnnotatedPreferences
 				{
 					if (field.getType() == int.class)
 						field.setInt(clazz, prefs.getInt(pref_name));
+					else if (field.getType() == long.class)
+						field.setLong(clazz, prefs.getLong(pref_name));
 					else if (field.getType() == String.class)
 						field.set(clazz, prefs.get(pref_name));
 					else if (field.getType() == double.class)
@@ -100,6 +104,8 @@ public class AnnotatedPreferences
 				    	   ex);
 			}
 		}
+		
+		return prefs;
 	}
 
 }

--- a/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
@@ -47,8 +47,8 @@ public class AnnotatedPreferences
 						               ? field.getName()
 						               : anno.name();
 
-			    // Does 'private' field need to be made accessible?
-			    final boolean make_accessible = (field.getModifiers() & Modifier.PRIVATE) != 0;
+			    // Does non-public field need to be made accessible?
+			    final boolean make_accessible = (field.getModifiers() & Modifier.PUBLIC) == 0;
 			    if (make_accessible)
 		        	field.setAccessible(true);
 			    
@@ -87,8 +87,20 @@ public class AnnotatedPreferences
 					}
 					else if (field.getType() == File.class)
 						field.set(clazz, new File(prefs.get(pref_name)));
+					else if (field.getType().isEnum())
+					{
+						// Find matching enum option
+						final String value = prefs.get(pref_name);
+						for (Object option : field.getType().getEnumConstants())
+							if (option.toString().equals(value))
+							{
+								field.set(clazz, option);
+								return prefs;
+							}
+						throw new Exception("Cannot determine enum option for value '" + value + "'");
+					}
 					else
-						throw new Exception("Cannot handle annotated preference of type " + field.getType());
+						throw new Exception("Cannot handle fields of type " + field.getType());
 				}
 				finally
 				{

--- a/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
@@ -91,16 +91,19 @@ public class AnnotatedPreferences
 					{
 						// Find matching enum option
 						final String value = prefs.get(pref_name);
+						boolean found = false;
 						for (Object option : field.getType().getEnumConstants())
 						{
 							final String name = ((Enum<?>) option).name();
 							if (name.equals(value))
 							{
 								field.set(clazz, option);
-								return prefs;
+								found = true;
+								break;
 							}
 						}
-						throw new Exception("Cannot determine enum option for value '" + value + "'");
+						if (! found)
+							throw new Exception("Cannot determine enum option for value '" + value + "'");
 					}
 					else
 						throw new Exception("Cannot handle fields of type " + field.getType());

--- a/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.framework.preferences;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Helper for setting fields of an annotated 'preference' class
+ *  
+ *  @author Kay Kasemir
+ */
+public class AnnotatedPreferences
+{
+	/** Initialize static fields of a class from preferences.
+	 * 
+	 *  <p>Fields to be set from preferences need to be marked
+	 *  as @{@link Preference}
+	 *  
+	 *  @param clazz Class to be initialized, also sets the package name for preference keys
+	 *  @param preferences_properties_filename Preference properties file, loaded as resource of the `clazz`
+	 */
+	public static void initialize(final Class<?> clazz, final String preferences_properties_filename)
+	{
+		final PreferencesReader prefs = new PreferencesReader(clazz, preferences_properties_filename);
+
+		for (Field field : clazz.getDeclaredFields())
+		{
+			try
+			{
+				// Look for fields annotated as @Preference
+				final Preference anno = field.getAnnotation(Preference.class);
+				if (anno == null)
+					continue;
+				
+				// Non-default preference name? Otherwise default to field name
+				final String pref_name = anno.name().isBlank()
+						               ? field.getName()
+						               : anno.name();
+
+			    // Does 'private' field need to be made accessible?
+			    final boolean make_accessible = (field.getModifiers() & Modifier.PRIVATE) != 0;
+			    if (make_accessible)
+		        	field.setAccessible(true);
+			    
+			    // Assign preference to the various field types
+				try
+				{
+					if (field.getType() == int.class)
+						field.setInt(clazz, prefs.getInt(pref_name));
+					else if (field.getType() == String.class)
+						field.set(clazz, prefs.get(pref_name));
+					else if (field.getType() == double.class)
+						field.setDouble(clazz, prefs.getDouble(pref_name));
+					else if (field.getType() == boolean.class)
+						field.setBoolean(clazz, prefs.getBoolean(pref_name));
+					else if (field.getType() == int[].class)
+					{
+						final String[] items = prefs.get(pref_name).split("\\s*,\\s*");
+				        if (items.length == 0  ||  (items.length == 1 && items[0].isEmpty()))
+				        	throw new Exception("Expect at least one integer");
+						final int nums[] = new int[items.length];
+						for (int i=0; i<nums.length; ++i)
+							nums[i] = Integer.parseInt(items[i]);
+						field.set(clazz, nums);
+
+					}
+					else if (field.getType() == String[].class)
+					{
+						String[] items = prefs.get(pref_name).split("\\s*,\\s*");
+				        // split() will turn "" into { "" }, which we change into empty array
+				        if (items.length == 0  ||  (items.length == 1 && items[0].isEmpty()))
+				        	items = new String[0];
+
+						field.set(clazz, items);
+					}
+					else if (field.getType() == File.class)
+						field.set(clazz, new File(prefs.get(pref_name)));
+					else
+						throw new Exception("Cannot handle annotated preference of type " + field.getType());
+				}
+				finally
+				{
+					if (make_accessible)
+			        	field.setAccessible(false);
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.getLogger(AnnotatedPreferences.class.getPackageName())
+				      .log(Level.WARNING,
+				    	   "Failed to assign value to annotated preference " + clazz.getName() + " field " + field.getName(),
+				    	   ex);
+			}
+		}
+	}
+
+}

--- a/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/AnnotatedPreferences.java
@@ -92,11 +92,14 @@ public class AnnotatedPreferences
 						// Find matching enum option
 						final String value = prefs.get(pref_name);
 						for (Object option : field.getType().getEnumConstants())
-							if (option.toString().equals(value))
+						{
+							final String name = ((Enum<?>) option).name();
+							if (name.equals(value))
 							{
 								field.set(clazz, option);
 								return prefs;
 							}
+						}
 						throw new Exception("Cannot determine enum option for value '" + value + "'");
 					}
 					else

--- a/core/framework/src/main/java/org/phoebus/framework/preferences/Preference.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/Preference.java
@@ -29,8 +29,9 @@ import java.lang.annotation.Target;
  *  <li>boolean
  *  <li>String
  *  <li>File
- *  <li>int[]  - Parses comma-separated int values from preference string
- *  <li>String[]  - Parses comma-separated text values from preference string
+ *  <li>enum     - Preference string must match one of the enum labels/names
+ *  <li>int[]    - Parses comma-separated int values from preference string
+ *  <li>String[] - Parses comma-separated text values from preference string
  *  </ul>
  *  
  *  <p>Fields set from preferences may be 'public' as well as 'private'.

--- a/core/framework/src/main/java/org/phoebus/framework/preferences/Preference.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/Preference.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.framework.preferences;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Annotation that marks a member variable as a preference
+ * 
+ *  <p>Used with {@link AnnotatedPreferences}.
+ *  
+ *  <p>Static fields of a class with this annotation
+ *  will be set from preference keys.
+ *  The package name of the class is used as the preference path.
+ *  The name of the field is used as the preference key,
+ *  unless a different 'name' parameter is set on the annotation.
+ *  
+ *  <p>Supported types:
+ *  <ul>
+ *  <li>int
+ *  <li>double
+ *  <li>boolean
+ *  <li>String
+ *  <li>File
+ *  <li>int[]  - Parses comma-separated int values from preference string
+ *  <li>String[]  - Parses comma-separated text values from preference string
+ *  </ul>
+ *  
+ *  <p>Fields set from preferences may be 'public' as well as 'private'.
+ *  
+ *  @author Kay Kasemir
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Preference
+{
+    String name() default "";
+}

--- a/core/framework/src/main/java/org/phoebus/framework/preferences/PreferencesReader.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/PreferencesReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -160,6 +160,17 @@ public class PreferencesReader
         if (value.isBlank())
             return 0;
         return Integer.parseInt(value);
+    }
+
+    /** @param key Key for preference setting
+     *  @return Long value from preferences, defaulting to value from property file
+     */
+    public long getLong(final String key)
+    {
+        final String value = get(key);
+        if (value.isBlank())
+            return 0;
+        return Long.parseLong(value);
     }
 
     /** @param key Key for preference setting

--- a/core/framework/src/main/java/org/phoebus/framework/workbench/WorkbenchPreferences.java
+++ b/core/framework/src/main/java/org/phoebus/framework/workbench/WorkbenchPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,8 @@ import java.util.Collection;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.preferences.PreferencesReader;
 
 /** Workbench Preferences
@@ -23,14 +25,12 @@ public class WorkbenchPreferences
     /** Logger for the 'workbench' package */
     public static final Logger logger = Logger.getLogger(WorkbenchPreferences.class.getPackageName());
 
-
+    @Preference public static File external_apps_directory;
     public static final Collection<String> external_apps;
-    public static final File external_apps_directory;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(WorkbenchPreferences.class, "/workbench_preferences.properties");
-        external_apps_directory = new File(prefs.get("external_apps_directory"));
+        final PreferencesReader prefs = AnnotatedPreferences.initialize(WorkbenchPreferences.class, "/workbench_preferences.properties");
         external_apps = prefs.getKeys("external_app_.*").stream().map(prefs::get).collect(Collectors.toList());
     }
 }

--- a/core/framework/src/test/java/org/phoebus/framework/preferences/AnnotatedPreferencesTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/preferences/AnnotatedPreferencesTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.framework.preferences;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.junit.Test;
+
+/** JUnit test of {@link AnnotatedPreferences}
+ *  @author Kay Kasemir
+ */
+public class AnnotatedPreferencesTest
+{
+	// Basic examples for reading int, String, double, File, ...,
+	// using same name for the variable and the preference tag.
+	
+	// Will be set from 'example_int=42' in preference file
+	@Preference
+	public static int example_int;
+	
+	@Preference
+	public static String example_string;
+
+	@Preference
+	public static double example_double;
+
+	@Preference
+	public static boolean example_bool;
+	
+	@Preference
+	public static int[] example_rgb;
+
+	@Preference
+	public static String[] example_strings;
+
+	@Preference
+	public static File example_file;
+
+	// Name in preference file that differs from the field name used in here
+	@Preference(name="example_named_bar")
+	public static String example_foo;
+
+	// Not annotated, not set from preferences
+	public static int not_set_from_preferences = -1;
+
+	
+	// Example for more complex preference that's first read as a string
+	// (or other basic supported type) and then parsed.
+	// Keeping the 'raw' value private
+	
+	@Preference(name="example_first_last")
+	private static String first_last_spec;
+	
+	public static String[] example_first_last;
+		
+	static
+	{
+		AnnotatedPreferences.initialize(AnnotatedPreferencesTest.class, "/anno_prefs_test.properties");
+	}
+	
+	
+	@Test
+	public void testAnnotatedPreference()
+	{
+		assertEquals(42, example_int);
+		assertEquals("Fred Flintstone", example_string);
+		assertEquals(3.14, example_double, 0.1);
+		assertEquals(true, example_bool);
+		assertArrayEquals(new int[] { 128, 50, 255}, example_rgb);
+		assertArrayEquals(new String[] { "One", "Two", "Three" }, example_strings);
+		assertEquals(new File("/tmp/example.dat"), example_file);
+		assertEquals("Value of foo", example_foo);
+		
+		// Not reading 13 from preference file
+		assertEquals(-1, not_set_from_preferences);
+	
+		// Reading 'raw' value
+		assertEquals("Fred Jason, Miller", first_last_spec);
+		example_first_last = first_last_spec.split("\\s*,\\s*");
+		assertEquals("Fred Jason", example_first_last[0]);
+		assertEquals("Miller", example_first_last[1]);
+	}
+}

--- a/core/framework/src/test/java/org/phoebus/framework/preferences/AnnotatedPreferencesTest.java
+++ b/core/framework/src/test/java/org/phoebus/framework/preferences/AnnotatedPreferencesTest.java
@@ -60,6 +60,12 @@ public class AnnotatedPreferencesTest
 	private static String first_last_spec;
 	
 	public static String[] example_first_last;
+	
+	
+	static enum ExampleEnum { RED, GREEN, BLUE };
+	
+	@Preference
+	public static ExampleEnum example_enum;
 		
 	static
 	{
@@ -87,5 +93,7 @@ public class AnnotatedPreferencesTest
 		example_first_last = first_last_spec.split("\\s*,\\s*");
 		assertEquals("Fred Jason", example_first_last[0]);
 		assertEquals("Miller", example_first_last[1]);
+
+		assertEquals(ExampleEnum.BLUE, example_enum);
 	}
 }

--- a/core/framework/src/test/resources/anno_prefs_test.properties
+++ b/core/framework/src/test/resources/anno_prefs_test.properties
@@ -1,0 +1,30 @@
+# For testing AnnotatedPreferences
+
+# 'int'
+example_int=42
+
+# 'String'
+example_string=Fred Flintstone
+
+# 'double'
+example_double=3.14
+
+# 'boolean'
+example_bool=true
+
+# 'int[]' with 3 elements
+example_rgb=128, 50, 255
+
+# 'String[]' with 3 elements
+example_strings=One, Two, Three
+
+# 'java.io.File'
+example_file=/tmp/example.dat
+
+# 'String', but preference field will use different name
+example_named_bar=Value of foo
+
+not_set_from_preferences=13
+
+# Comma-separated first name, last name
+example_first_last=Fred Jason, Miller

--- a/core/framework/src/test/resources/anno_prefs_test.properties
+++ b/core/framework/src/test/resources/anno_prefs_test.properties
@@ -28,3 +28,6 @@ not_set_from_preferences=13
 
 # Comma-separated first name, last name
 example_first_last=Fred Jason, Miller
+
+# Enumerated type
+example_enum=BLUE

--- a/core/pv/src/main/java/org/phoebus/pv/PVPool.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PVPool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,8 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.pv.RefCountMap.ReferencedEntry;
 import org.phoebus.pv.formula.FormulaPVFactory;
 
@@ -62,7 +63,7 @@ public class PVPool
     final private static Map<String, PVFactory> factories = new HashMap<>();
 
     /** Default PV name type prefix */
-    private static String default_type = "ca";
+    @Preference(name="default") private static String default_type;
 
     static
     {
@@ -76,8 +77,7 @@ public class PVPool
                 factories.put(type, factory);
             }
 
-            final PreferencesReader prefs = new PreferencesReader(PVPool.class, "/pv_preferences.properties");
-            default_type = prefs.get(DEFAULT);
+            AnnotatedPreferences.initialize(PVPool.class, "/pv_preferences.properties");
 
             logger.log(Level.INFO, "Default PV type " + default_type + "://");
         }

--- a/core/pv/src/main/java/org/phoebus/pv/formula/FormulaPVPreferences.java
+++ b/core/pv/src/main/java/org/phoebus/pv/formula/FormulaPVPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  ******************************************************************************/
 package org.phoebus.pv.formula;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preferences for {@link FormulaPV}s
  *  @author Kay Kasemir
@@ -15,11 +16,10 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 class FormulaPVPreferences
 {
-    public static final int throttle_ms;
+    @Preference public static int throttle_ms;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(FormulaPVFactory.class, "/pv_formula_preferences.properties");
-        throttle_ms = prefs.getInt("throttle_ms");
+    	AnnotatedPreferences.initialize(FormulaPVFactory.class, "/pv_formula_preferences.properties");
     }
 }

--- a/core/pv/src/main/java/org/phoebus/pv/mqtt/MQTT_PVConn.java
+++ b/core/pv/src/main/java/org/phoebus/pv/mqtt/MQTT_PVConn.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,7 +42,7 @@ public class MQTT_PVConn implements MqttCallback
     /** Mapping from topic to PVs */
     final ConcurrentHashMap<String, CopyOnWriteArrayList<MQTT_PV>> subscribers = new ConcurrentHashMap<>();
 
-    volatile private String brokerURL = MQTT_Preferences.brokerURL;
+    volatile private String brokerURL = MQTT_Preferences.mqtt_broker;
     volatile private String clientID;
 
     //Random integer in case

--- a/core/pv/src/main/java/org/phoebus/pv/mqtt/MQTT_Preferences.java
+++ b/core/pv/src/main/java/org/phoebus/pv/mqtt/MQTT_Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.phoebus.pv.mqtt;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /**
  * Singleton preferences class for MQTT PVs
@@ -16,11 +17,10 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class MQTT_Preferences
 {
-    public static final String brokerURL;
+    @Preference public static String mqtt_broker;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(MQTT_PVConn.class, "/pv_mqtt_preferences.properties");
-        brokerURL = prefs.get("mqtt_broker");
+    	AnnotatedPreferences.initialize(MQTT_Preferences.class, "/pv_mqtt_preferences.properties");
     }
 }

--- a/core/security/src/main/java/org/phoebus/security/PhoebusSecurity.java
+++ b/core/security/src/main/java/org/phoebus/security/PhoebusSecurity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,8 @@ package org.phoebus.security;
 
 import java.util.logging.Logger;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Phoebus security logger & Preference settings
  *  @author Kay Kasemir
@@ -19,11 +20,10 @@ public class PhoebusSecurity
 {
     public static final Logger logger = Logger.getLogger(PhoebusSecurity.class.getPackageName());
 
-    public static final String authorization_file;
+    @Preference public static String authorization_file;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(PhoebusSecurity.class, "/phoebus_security_preferences.properties");
-        authorization_file = prefs.get("authorization_file");
+        AnnotatedPreferences.initialize(PhoebusSecurity.class, "/phoebus_security_preferences.properties");
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.phoebus.ui;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Preference settings
  *
@@ -16,36 +17,23 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Preferences
 {
-    public static final String DEFAULT_APPS = "default_apps";
-    public static final String HOME_DISPLAY = "home_display";
-    public static final String TOP_RESOURCES = "top_resources";
     public static final String SPLASH = "splash";
 
-    public static final String[] default_apps;
-    public static final String home_display;
-    public static final String top_resources;
-    public static final boolean splash;
-    public static final String welcome;
-    public static final int max_array_formatting;
-    public static final int ui_monitor_period;
-    public static final String[] hide_spi_menu;
-    public static final boolean status_show_user;
-    public static final String default_save_path;
+    @Preference public static String[] default_apps;
+    @Preference public static String home_display;
+    @Preference public static String top_resources;
+    @Preference public static boolean splash;
+    @Preference public static String welcome;
+    @Preference public static int max_array_formatting;
+    @Preference public static int ui_monitor_period;
+    @Preference public static String[] hide_spi_menu;
+    @Preference public static boolean status_show_user;
+    @Preference public static String default_save_path;
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Preferences.class, "/phoebus_ui_preferences.properties");
-        default_apps = prefs.get(DEFAULT_APPS).split("\\s*,\\s*");
-        home_display = prefs.get(HOME_DISPLAY);
-        top_resources = prefs.get(TOP_RESOURCES);
-        splash = prefs.getBoolean(SPLASH);
-        welcome = prefs.get("welcome");
-        max_array_formatting = prefs.getInt("max_array_formatting");
-        ui_monitor_period = prefs.getInt("ui_monitor_period");
-        hide_spi_menu = prefs.get("hide_spi_menu").split("\\s*,\\s*");
-        status_show_user = prefs.getBoolean("status_show_user");
-        default_save_path = prefs.get("default_save_path");
-
+    	AnnotatedPreferences.initialize(Preferences.class, "/phoebus_ui_preferences.properties");
+ 
         // In case PVA library is included, sync its array formatting
         // (PVASettings cannot use Preferences.max_array_formatting
         //  since the PVA library may be used standalone)

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -2,4 +2,4 @@ Developer Information
 =====================
 
 To get started with developing for phoebus,
-refer to the instructions on https://github.com/shroffk/phoebus .
+refer to the instructions on https://github.com/ControlSystemStudio/phoebus .

--- a/docs/source/preferences.rst
+++ b/docs/source/preferences.rst
@@ -4,7 +4,7 @@ Preference Settings
 When you run Phoebus, you may find that it cannot connect to your control system
 because for example the EPICS Channel Access address list is not configured.
 
-To locate available preferences, refer to the complete list of
+To locate available preferences, refer to the complete 
 :ref:`preference_settings`
 or check the source code for files named ``*preferences.properties``,
 for example in the ``core-pv`` sources::
@@ -118,7 +118,35 @@ In that file, list the available settings, with explanatory comments::
    # Enable some feature, allowed values are true or false
    my_other_setting=true
 
-Load that as the default, then read the ``java.util.prefs.Preferences`` like this::
+In your application code, you can most conveniently access them like this::
+
+    package org.phoebus.applications.my_app
+
+    import org.phoebus.framework.preferences.AnnotatedPreferences;
+    import org.phoebus.framework.preferences.Preference;
+
+    class MyAppSettings
+    {
+        @Preference public static String my_setting;
+        @Preference public static boolean my_other_setting;
+
+        static
+        {
+            AnnotatedPreferences.initialize(MyAppSettings.class, "/my_app_preferences.properties");
+        }
+    }
+
+
+The ``AnnotatedPreferences`` helper will read your ``*preferences.properties``,
+apply updates from ``java.util.prefs.Preferences``, and then set the values
+of all static fields annotated with ``@Preference``.
+It handles basic types like ``int``, ``long``, ``double``, ``boolean``, ``String``,
+``File``. It can also parse comma-separated items into ``int[]`` or ``String[]``.
+
+By default, it uses the name of the field as the name of the preference setting,
+which can be overridden via ``@Preference(name="name_of_settings")``.
+If more elaborate settings need to be handled, ``AnnotatedPreferences.initialize``
+returns a ``PreferencesReader``, or you could directly use that lower level API like this::
 
     package org.phoebus.applications.my_app
     
@@ -129,7 +157,9 @@ Load that as the default, then read the ``java.util.prefs.Preferences`` like thi
     
     String pref1 = prefs.get("my_setting");
     Boolean pref2 = prefs.getBoolean("my_other_setting");
-    // .. use getInt, getDouble as needed
+    // .. use getInt, getDouble as needed.
+    // For more complex settings, use `get()` to fetch the string
+    // and parse as desired.
 
 The ``PreferencesReader`` loads defaults from the property file,
 then allows overrides via the ``java.util.prefs.Preferences`` API.

--- a/services/alarm-server/src/test/java/org/phoebus/applications/alarm/server/AutomatedActionTest.java
+++ b/services/alarm-server/src/test/java/org/phoebus/applications/alarm/server/AutomatedActionTest.java
@@ -237,7 +237,7 @@ public class AutomatedActionTest
     {
         System.out.println("testAutomatedEmailFollowup");
 
-        if (! AlarmSystem.automated_action_followup.contains("mailto:"))
+        if (! List.of(AlarmSystem.automated_action_followup).contains("mailto:"))
         {
             System.out.println("Skipping test of automated email follow up");
             return;

--- a/services/archive-engine/src/main/java/org/csstudio/archive/Preferences.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,8 @@
  ******************************************************************************/
 package org.csstudio.archive;
 
-import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 
 /** Archive preferences
  *  @author Kay Kasemir
@@ -15,42 +16,26 @@ import org.phoebus.framework.preferences.PreferencesReader;
 @SuppressWarnings("nls")
 public class Preferences
 {
-    public static final String url;
-    public static final String user;
-    public static final String password;
-    public static final String schema;
-    public static final int timeout_secs;
-    public static final boolean use_array_blob;
-    public static final String write_sample_table;
-    public static final int max_text_sample_length;
-    public static final boolean use_postgres_copy;
-    public static final int log_trouble_samples;
-    public static final int log_overrun;
-    public static final int write_period;
-    public static final int max_repeats;
-    public static final int batch_size;
-    public static final double buffer_reserve;
-    public static final int ignored_future;
+    @Preference public static String url;
+    @Preference public static String user;
+    @Preference public static String password;
+    @Preference public static String schema;
+    @Preference public static int timeout_secs;
+    @Preference public static boolean use_array_blob;
+    @Preference public static String write_sample_table;
+    @Preference public static int max_text_sample_length;
+    @Preference public static boolean use_postgres_copy;
+    @Preference public static int log_trouble_samples;
+    @Preference public static int log_overrun;
+    @Preference public static int write_period;
+    @Preference public static int max_repeats;
+    @Preference public static int batch_size;
+    @Preference public static double buffer_reserve;
+    @Preference public static int ignored_future;
 
 
     static
     {
-        final PreferencesReader prefs = new PreferencesReader(Preferences.class, "/archive_preferences.properties");
-        url = prefs.get("url");
-        user = prefs.get("user");
-        password = prefs.get("password");
-        schema = prefs.get("schema");
-        timeout_secs = prefs.getInt("timeout_secs");
-        use_array_blob = prefs.getBoolean("use_array_blob");
-        write_sample_table = prefs.get("write_sample_table");
-        max_text_sample_length = prefs.getInt("max_text_sample_length");
-        use_postgres_copy = prefs.getBoolean("use_postgres_copy");
-        log_trouble_samples = prefs.getInt("log_trouble_samples");
-        log_overrun = prefs.getInt("log_overrun");
-        write_period = prefs.getInt("write_period");
-        max_repeats = prefs.getInt("max_repeats");
-        batch_size = prefs.getInt("batch_size");
-        buffer_reserve = prefs.getDouble("buffer_reserve");
-        ignored_future = prefs.getInt("ignored_future");
+    	AnnotatedPreferences.initialize(Preferences.class, "/archive_preferences.properties");
     }
 }


### PR DESCRIPTION
Almost every core and app module uses preferences, often based on this pattern:
```
public class MyPreferences
{
    // Constant for the 'tag' name used in preferences
    public static String SOME_SETTING = "some_setting";

    // Variable that'll receive the current value of the preference
    public static int some_setting;		

    static
    {
        // Parse property file with default settings, apply Java preferences that might override
        final PreferencesReader prefs = new PreferencesReader(MyPreferences.class, "/my_app_preferences.properties");		    	
   
        // .. and then fetch every value
        some_setting = prefs.getInt(SOME_SETTING);
    }
```

That's a lot of boilerplate. The fact that the 'tag' name used in the preferences and the variable name used in the Java code can be different offers some flexibility, but can also add confusion.
While still allowing the above scenario, this adds a `@Preference` annotation and a helper class that maps preferences to the static variables:
```
public class MyPreferences
{
    // Variable that'll receive the current value of the preference with same name
    @Preference public static int some_setting;		

    static
    {
        // Parse property file with default settings, apply Java preferences that might override,
        // set all fields annotated with @Preference
        AnnotatedPreferences.initialize(MyPreferences.class, "/my_app_preferences.properties");		    	
    }
```

In many cases, this significantly simplifies the preference code, handling basic settings of type `int`, `long`, `double`, `String`, `int[]`, `String[]`, `File`, `enum`.
If you need to parse/construct more complex settings from some preference text, the `AnnotatedPreferences.initialize()` method returns the `PreferencesReader` to use it as before.

If for some reason the name of the variable must differ from the tag name of the preference, the `@Preference(name="name_of_tag")` variant can do that.


There's a new unit test to check the new functionality, but I'll use some time to do more testing because so many classes have been updated to use the new API.