### PR TITLE
Handle newline and tab in macros

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/StringWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/StringWidgetProperty.java
@@ -41,7 +41,7 @@ public class StringWidgetProperty extends MacroizedWidgetProperty<String>
     @Override
     protected String parseExpandedSpecification(final String text) throws Exception
     {
-        return text;
+        return text.replaceAll("\\\\n", "\n").replaceAll("\\\\t", "\t");
     }
 
     @Override


### PR DESCRIPTION
Replace `\n` and `\t` characters in StringWidgetProperty