### PR TITLE
Fix PV race condition for handling of initial value

### DIFF
--- a/app/display/model/src/main/resources/examples/structure_array.bob
+++ b/app/display/model/src/main/resources/examples/structure_array.bob
@@ -30,7 +30,7 @@ can also write to their respective array element.</text>
     <y>190</y>
     <width>250</width>
     <height>200</height>
-    <pv_name>loc://&lt;VStringArray&gt;("Monitor 1", "Monitor 2", "Monitor 3", "Monitor 4", "Monitor 5", "Monitor 6")</pv_name>
+    <pv_name>loc://textarray&lt;VStringArray&gt;("Monitor 1", "Monitor 2", "Monitor 3", "Monitor 4", "Monitor 5", "Monitor 6")</pv_name>
     <widget type="textupdate" version="2.0.0">
       <name>Text Update</name>
       <width>230</width>
@@ -121,7 +121,7 @@ all child widgets.
     <y>190</y>
     <width>250</width>
     <height>200</height>
-    <pv_name>loc://&lt;VStringArray&gt;("Monitor 1", "Monitor 2", "Monitor 3", "Monitor 4", "Monitor 5", "Monitor 6")</pv_name>
+    <pv_name>loc://textarray&lt;VStringArray&gt;("Monitor 1", "Monitor 2", "Monitor 3", "Monitor 4", "Monitor 5", "Monitor 6")</pv_name>
     <widget type="textentry" version="3.0.0">
       <name>Text Entry_1</name>
       <width>230</width>

--- a/core/pv/src/main/java/org/phoebus/pv/PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PV.java
@@ -119,6 +119,7 @@ public class PV
         catch (Exception ex)
         {
             logger.log(Level.SEVERE, "Cannot lock " + name, ex);
+            return;
         }
 
         try
@@ -297,6 +298,7 @@ public class PV
         catch (Exception ex)
         {
             logger.log(Level.SEVERE, "Cannot lock " + name, ex);
+            return;
         }
 
         try

--- a/core/pv/src/main/java/org/phoebus/pv/PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PV.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,9 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -43,6 +46,29 @@ public class PV
     public static final Logger logger = Logger.getLogger(PV.class.getPackage().getName());
 
     final private String name;
+
+    /** Lock for value notifications
+     *
+     *  A value could arrive while in addSubscription().
+     *  We don't want to miss it,
+     *  nor do we want to notify twice,
+     *  so we lock both in there and in notifyListenersOfValue().
+     *
+     *  This does raise the possibility of deadlocks
+     *  if a client adds PVs or cancels subscriptions inside
+     *  the value notification handler.
+     *
+     *  To avoid a catastrophic deadlock, use a try-lock.
+     *
+     *  An alternative to strict locking would be locking,
+     *  but only queuing notifications to be performed by
+     *  a new thread. That solves the deadlock, but
+     *  changes the behavior of "loc://" PVs which would
+     *  no longer react to write access via immediate notification
+     *  in the calling thread, which impacts unit tests and
+     *  other code that depends on this long standing behavior.
+     */
+    final private Lock value_notification_lock = new ReentrantLock();
 
     final private List<ValueEventHandler.Subscription> value_subs = new CopyOnWriteArrayList<>();
 
@@ -85,11 +111,38 @@ public class PV
      */
     void addSubscription(final ValueEventHandler.Subscription value_sub)
     {
-        // If there is a known value, perform initial update
-        final VType value = last_value;
-        if (value != null)
-            value_sub.update(value);
-        value_subs.add(value_sub);
+        try
+        {
+            if (! value_notification_lock.tryLock(1, TimeUnit.MINUTES))
+                throw new Exception("Timeout");
+        }
+        catch (Exception ex)
+        {
+            logger.log(Level.SEVERE, "Cannot lock " + name, ex);
+        }
+
+        try
+        {
+            // Register subscription so we get notified of value updates
+            value_subs.add(value_sub);
+
+            // Lock prevents notifications right now,
+            // avoiding double updates for an initial value
+
+            // If there is a known value, perform initial update
+            final VType value = last_value;
+            if (value != null)
+                value_sub.update(value);
+
+            // Lock also asserts that this initial update completes
+            // before another update happens,
+            // avoiding a possible delay of this initial update
+            // which could then be delivered _after_ what's really a new value.
+        }
+        finally
+        {
+            value_notification_lock.unlock();
+        }
     }
 
     /** @param value_sub Listener that will no longer receive value updates */
@@ -236,17 +289,34 @@ public class PV
      */
     protected void notifyListenersOfValue(final VType value)
     {
-        last_value = value;
-        for (ValueEventHandler.Subscription sub : value_subs)
+        try
         {
-            try
+            if (! value_notification_lock.tryLock(1, TimeUnit.MINUTES))
+                throw new Exception("Timeout");
+        }
+        catch (Exception ex)
+        {
+            logger.log(Level.SEVERE, "Cannot lock " + name, ex);
+        }
+
+        try
+        {
+            last_value = value;
+            for (ValueEventHandler.Subscription sub : value_subs)
             {
-                sub.update(value);
+                try
+                {
+                    sub.update(value);
+                }
+                catch (Throwable ex)
+                {
+                    logger.log(Level.WARNING, name + " value update error", ex);
+                }
             }
-            catch (Throwable ex)
-            {
-                logger.log(Level.WARNING, name + " value update error", ex);
-            }
+        }
+        finally
+        {
+            value_notification_lock.unlock();
         }
     }
 

--- a/core/pv/src/main/java/org/phoebus/pv/PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PV.java
@@ -113,7 +113,7 @@ public class PV
     {
         try
         {
-            if (! value_notification_lock.tryLock(1, TimeUnit.MINUTES))
+            if (! value_notification_lock.tryLock(20, TimeUnit.SECONDS))
                 throw new Exception("Timeout");
         }
         catch (Exception ex)
@@ -291,7 +291,7 @@ public class PV
     {
         try
         {
-            if (! value_notification_lock.tryLock(1, TimeUnit.MINUTES))
+            if (! value_notification_lock.tryLock(20, TimeUnit.SECONDS))
                 throw new Exception("Timeout");
         }
         catch (Exception ex)


### PR DESCRIPTION
As described in #1387, the initial value of a PV could be missed because PV.addSubscription used to send an already known value and then register the subscriber. When the actual first value arrived between those steps, it was lost because there was no initial value, and the subscriber was almost but not, yet, known.

Plain locking fixes this issue, but could result in deadlocks. None have been observed in initial testing, including the "PV Tree" which makes & breaks many connections inside value handlers. But when displays create PVs inside scripts, we can't control/predict what'll happen.

Trying to avoid locking, respectively moving the event notifications outside of the lock into a separate thread, would significantly change the behavior of local PVs, where the notification of value updates, both initial and in response to write access, has always been immediate, in the calling thread, and some infrastructure like the ArrayPVDispatcher depend on it.

So now fixing the issue by locking, but using a try-lock to avoid infinite hangup.