### PR TITLE
[Regression-fix] Check all the PVs, not just the one that has changed

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/RuntimeScriptHandler.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/RuntimeScriptHandler.java
@@ -222,7 +222,7 @@ public class RuntimeScriptHandler implements RuntimePVListener
         // Skip script execution unless all PVs are connected?
         if (check_connections)
             for (RuntimePV p : pvs)
-                if (PV.isDisconnected(pv.read()))
+                if (PV.isDisconnected(p.read()))
                     return;
 
         // If this is a trigger PV, execute the script.


### PR DESCRIPTION
In 634a0c7fb73cae8f3805675a9776b438c14d797d I've introduced a bug with a typo: only the PV that was changed got tested instead of all the PVs connected to the script.
