### PR TITLE
CSSTUDIO-1286 Display editor save performance

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/EditorGUI.java
@@ -9,6 +9,7 @@ package org.csstudio.display.builder.editor;
 
 import static org.csstudio.display.builder.editor.Plugin.logger;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -512,8 +513,8 @@ public class EditorGUI
         logger.log(Level.FINE, "Save as {0}", file);
         try
         (
-            final FileOutputStream fwriter = new FileOutputStream(file);
-            final ModelWriter writer = new ModelWriter(fwriter);
+                final BufferedOutputStream fwriter = new BufferedOutputStream(new FileOutputStream(file));
+                final ModelWriter writer = new ModelWriter(fwriter);
         )
         {
             writer.writeModel(editor.getModel());


### PR DESCRIPTION
Wrapped the FileOutputStream used for saving a display file in a BufferedOutputStream. In some cases -  e.g. on a virtual machine where the display file is saved on the host's file system - the save operation is ~20 times faster. Write to network mounted share should probably also see a performance boost, a very basic test against a network drive mounted over SMB on a Mac shows ~4 times faster save.