### PR TITLE
Script deadlock

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JythonScriptSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JythonScriptSupport.java
@@ -262,7 +262,7 @@ class JythonScriptSupport extends BaseScriptSupport implements AutoCloseable
                 // from the set("widget"..) call, but that was before jython 2.7.2.
                 python.set("widget", widget);
                 python.set("pvs", pvs);
-                logger.log(Level.WARNING, () -> "Exec " + script + " for " + widget + " in " + python + ", locals (" + System.identityHashCode(python.getLocals())  + "): " + python.getLocals());
+                logger.log(Level.INFO, () -> "Exec " + script + " for " + widget + " in " + python + ", locals (" + System.identityHashCode(python.getLocals())  + "): " + python.getLocals());
 
                 python.exec(script.getCode());
             }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JythonScriptSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JythonScriptSupport.java
@@ -173,6 +173,12 @@ class JythonScriptSupport extends BaseScriptSupport implements AutoCloseable
             // Initialize variables that will be set when running script
             python.set("widget", null);
             python.set("pvs", null);
+
+            // This triggers 'imp.load("encodings")',
+            // which takes the import lock, traverses the path,
+            // so forcing it now avoids it being called later
+            // and potentially deadlocking
+            python.getSystemState().getCodecState();
         }
         final long end = System.currentTimeMillis();
         logger.log(Level.FINE, "Time to create jython: {0} ms", (end - start));

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JythonScriptSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JythonScriptSupport.java
@@ -188,14 +188,11 @@ class JythonScriptSupport extends BaseScriptSupport implements AutoCloseable
     private void addToPythonPath(final String path)
     {
         // Prevent concurrent modification
-        // Since PyList (path) has many synchronized methods,
-        // always lock JythonScriptSupport.class before touching path,
-        // or rely on just the PyList locks,
-        // but don't invert the lock order
-        synchronized (JythonScriptSupport.class)
+        // 'paths' is actually shared across all jython interpreters
+        final PyList paths = python.getSystemState().path;
+        synchronized (paths)
         {
             // Since using default PySystemState (see above), check if already in paths
-            final PyList paths = python.getSystemState().path;
             final int index = paths.indexOf(path);
 
             // Warn about "examples:/... path that won't really work.


### PR DESCRIPTION
#1660 describes a deadlock inside the jython library for a display with many scripts.

One thread (display runtime) compiles a script during display startup:
Compile script -> addToPythonPath -> locked JythonScriptSupport -> locked PyList 'path' -> path.indexOf calls PySystemState.getCodecState -> imp wants import lock

Another thread (script support) is concurrently executing a script that has already been compiled:
Runs script -> 'import' takes import lock -> wants to lock PyList 'path'

The deadlock is a result of one task locking 'path', then the import lock, the other taking import and then 'path' lock in opposite order.

Need to look deeper into avoiding concurrent compilation and execution, for example by pushing both onto the 'ScriptSupport' thread, but right now the deadlock as observed can be avoided by calling `PySystemState.getCodecState` during jython interpreter initialization, avoiding its `imp.load("encodings")` side effect later on.

Related to #1310 where `getCodecState()` also caused a deadlock. With jython 2.7.2, `getCodecState()` will only run the 'import' code on its first invocation, which fixed #1310, and this PR asserts that `getCodecState()` is called for sure once before we execute jython code.