### PR TITLE
CSSTUDIO-1213 Radio and ChoiceButton widget fixes

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ChoiceButtonWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ChoiceButtonWidget.java
@@ -79,12 +79,9 @@ public class ChoiceButtonWidget extends WritablePVWidget
 
     private static ArrayWidgetProperty.Descriptor<WidgetProperty<String>> choiceItemDescriptor =
             new ArrayWidgetProperty.Descriptor<>(WidgetPropertyCategory.BEHAVIOR, "items", "Items",
-                    (widget, index) -> {
-                        int size = ((ChoiceButtonWidget)widget).propItems().getValue().size();
-                        return CommonWidgetProperties.newStringPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR,
+                    (widget, index) -> CommonWidgetProperties.newStringPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR,
                                 "item",
-                                Messages.ComboWidget_Item).createProperty(widget, Messages.ComboWidget_Item + " " + (size + 1));
-                    });
+                                Messages.ComboWidget_Item).createProperty(widget, Messages.ComboWidget_Item + " " + (index + 1)));
 
     @Override
     protected void defineProperties(final List<WidgetProperty<?>> properties)

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ChoiceButtonWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ChoiceButtonWidget.java
@@ -18,19 +18,22 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPassword;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propSelectedColor;
 import static org.csstudio.display.builder.model.widgets.ComboWidget.propItem;
-import static org.csstudio.display.builder.model.widgets.ComboWidget.propItems;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.csstudio.display.builder.model.ArrayWidgetProperty;
+import org.csstudio.display.builder.model.Messages;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetCategory;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyCategory;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.NamedWidgetFonts;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.persist.WidgetFontService;
+import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.properties.WidgetFont;
 
@@ -61,7 +64,7 @@ public class ChoiceButtonWidget extends WritablePVWidget
     private volatile WidgetProperty<WidgetColor> foreground;
     private volatile WidgetProperty<WidgetColor> background;
     private volatile WidgetProperty<WidgetColor> selected;
-    private volatile WidgetProperty<List<WidgetProperty<String>>> items;
+    private volatile ArrayWidgetProperty<WidgetProperty<String>> items;
     private volatile WidgetProperty<Boolean> items_from_pv;
     private volatile WidgetProperty<Boolean> horizontal;
     private volatile WidgetProperty<Boolean> enabled;
@@ -74,6 +77,15 @@ public class ChoiceButtonWidget extends WritablePVWidget
         super(WIDGET_DESCRIPTOR.getType(), 100, 43);
     }
 
+    private static ArrayWidgetProperty.Descriptor<WidgetProperty<String>> choiceItemDescriptor =
+            new ArrayWidgetProperty.Descriptor<>(WidgetPropertyCategory.BEHAVIOR, "items", "Items",
+                    (widget, index) -> {
+                        int size = ((ChoiceButtonWidget)widget).propItems().getValue().size();
+                        return CommonWidgetProperties.newStringPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR,
+                                "item",
+                                Messages.ComboWidget_Item).createProperty(widget, Messages.ComboWidget_Item + " " + (size + 1));
+                    });
+
     @Override
     protected void defineProperties(final List<WidgetProperty<?>> properties)
     {
@@ -82,7 +94,10 @@ public class ChoiceButtonWidget extends WritablePVWidget
         properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(background = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BUTTON_BACKGROUND)));
         properties.add(selected = propSelectedColor.createProperty(this, new WidgetColor(200, 200, 200)));
-        properties.add(items = propItems.createProperty(this, Arrays.asList(propItem.createProperty(this, "Item 1"), propItem.createProperty(this, "Item 2"))));
+        items = choiceItemDescriptor.createProperty(this,
+                Arrays.asList(propItem.createProperty(this, Messages.ComboWidget_Item + " 1"),
+                        propItem.createProperty(this, Messages.ComboWidget_Item  + " 2")));
+        properties.add(items);
         properties.add(items_from_pv = propItemsFromPV.createProperty(this, true));
         properties.add(horizontal = propHorizontal.createProperty(this, true));
         properties.add(enabled = propEnabled.createProperty(this, true));

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/RadioWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/RadioWidget.java
@@ -16,19 +16,22 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propItemsFromPV;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPassword;
 import static org.csstudio.display.builder.model.widgets.ComboWidget.propItem;
-import static org.csstudio.display.builder.model.widgets.ComboWidget.propItems;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.csstudio.display.builder.model.ArrayWidgetProperty;
+import org.csstudio.display.builder.model.Messages;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetCategory;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyCategory;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.NamedWidgetFonts;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.persist.WidgetFontService;
+import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.properties.WidgetFont;
 
@@ -55,7 +58,7 @@ public class RadioWidget extends WritablePVWidget
 
     private volatile WidgetProperty<WidgetColor> foreground;
     private volatile WidgetProperty<WidgetFont> font;
-    private volatile WidgetProperty<List<WidgetProperty<String>>> items;
+    private volatile ArrayWidgetProperty<WidgetProperty<String>> items;
     private volatile WidgetProperty<Boolean> items_from_pv;
     private volatile WidgetProperty<Boolean> horizontal;
     private volatile WidgetProperty<Boolean> enabled;
@@ -63,9 +66,19 @@ public class RadioWidget extends WritablePVWidget
     private volatile WidgetProperty<String> confirm_message;
     private volatile WidgetProperty<String> password;
 
+    private static ArrayWidgetProperty.Descriptor<WidgetProperty<String>> radioItemDescriptor =
+            new ArrayWidgetProperty.Descriptor<>(WidgetPropertyCategory.BEHAVIOR, "items", "Items",
+                    (widget, index) -> {
+                        int size = ((RadioWidget)widget).propItems().getValue().size();
+                        return CommonWidgetProperties.newStringPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR,
+                                "item",
+                                Messages.ComboWidget_Item).createProperty(widget, Messages.ComboWidget_Item + " " + (size + 1));
+                    });
+
+
     public RadioWidget()
     {
-        super(WIDGET_DESCRIPTOR.getType(), 100, 43);
+        super(WIDGET_DESCRIPTOR.getType(), 100, 60);
     }
 
     @Override
@@ -74,7 +87,10 @@ public class RadioWidget extends WritablePVWidget
         super.defineProperties(properties);
         properties.add(font = propFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.DEFAULT)));
         properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
-        properties.add(items = propItems.createProperty(this, Arrays.asList(propItem.createProperty(this, "Item 1"), propItem.createProperty(this, "Item 2"))));
+        items = radioItemDescriptor.createProperty(this,
+                Arrays.asList(propItem.createProperty(this, Messages.ComboWidget_Item + " 1"),
+                        propItem.createProperty(this, Messages.ComboWidget_Item  + " 2")));
+        properties.add(items);
         properties.add(items_from_pv = propItemsFromPV.createProperty(this, true));
         properties.add(horizontal = propHorizontal.createProperty(this, true));
         properties.add(enabled = propEnabled.createProperty(this, true));

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/RadioWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/RadioWidget.java
@@ -68,12 +68,10 @@ public class RadioWidget extends WritablePVWidget
 
     private static ArrayWidgetProperty.Descriptor<WidgetProperty<String>> radioItemDescriptor =
             new ArrayWidgetProperty.Descriptor<>(WidgetPropertyCategory.BEHAVIOR, "items", "Items",
-                    (widget, index) -> {
-                        int size = ((RadioWidget)widget).propItems().getValue().size();
-                        return CommonWidgetProperties.newStringPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR,
+                    (widget, index) ->
+                        CommonWidgetProperties.newStringPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR,
                                 "item",
-                                Messages.ComboWidget_Item).createProperty(widget, Messages.ComboWidget_Item + " " + (size + 1));
-                    });
+                                Messages.ComboWidget_Item).createProperty(widget, Messages.ComboWidget_Item + " " + (index + 1)));
 
 
     public RadioWidget()


### PR DESCRIPTION
For Radio and ChoiceButton widgets the default item size is 2. Increasing once will add an item with the same name as an existing, i.e. "Item 2". This is a fix.

Also changed the default height of the Radio widget to avoid the tracker to be rendered over second item, see screen shot.
![Screenshot 2020-12-01 at 08 40 16](https://user-images.githubusercontent.com/35602960/100763755-e3fdd780-33f5-11eb-844b-568a00bdd46a.png)
