### PR TITLE
Change auto update task description while download is in progress

### DIFF
--- a/app/update/src/main/java/org/phoebus/applications/update/Update.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/Update.java
@@ -110,8 +110,9 @@ public class Update
                 while (! done.await(1, TimeUnit.SECONDS))
                 {
                     final long size = file.length();
-                    monitor.updateTaskName(String.format("Downloaded " + distribution_url + ": %.3f MB", size/1.0e6));
+                    monitor.updateTaskName(String.format("Downloading " + distribution_url + ": %.3f MB", size/1.0e6));
                 }
+                monitor.updateTaskName(String.format("Download Finished"));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Our users like the auto update feature a lot, but some have become confused because the current text is "Downloaded https://..."

If the user does not make the box bigger, they might think the download has finish when it has not. This commit just updates the text. I will create an issue about some other issues they had that I didn't address in this.