### PR TITLE
fixed windows error when trying to open embedded examples

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
@@ -133,7 +133,13 @@ public class ModelResourceUtil
         path = path.replaceAll("\\\\(?!\\\\)", "/");
 
         // Collapse "something/../" into "something/"
-        path = Paths.get(path).normalize().toString();
+        if(path.contains(":")){
+            String[] pathsplit = path.split(":");
+            String pathbefore = pathsplit[0];
+            String pathafter = pathsplit[1];
+            pathafter = Paths.get(pathafter).normalize().toString();
+            path = pathbefore + ":" + pathafter;
+        }
 
         // Pattern: '\(?!\)', i.e. backslash _not_ followed by another one.
         // Each \ is doubled as \\ to get one '\' into the string,

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
@@ -139,6 +139,8 @@ public class ModelResourceUtil
             String pathafter = pathsplit[1];
             pathafter = Paths.get(pathafter).normalize().toString();
             path = pathbefore + ":" + pathafter;
+        }else{
+            path = Paths.get(path).normalize().toString();
         }
 
         // Pattern: '\(?!\)', i.e. backslash _not_ followed by another one.


### PR DESCRIPTION
Hi,
I have a small contribution to make.
I dont know if this is considered a sloppy hack, but it works....

We noticed that on windows, phoebus generates the following error when trying to open the embedded example displays via File -> Top Resources -> Example Displays and then clicking any of the buttons. (i.e. LEDs)
phoebus would log the following:

```
Exception in thread "DisplayRuntime61" java.nio.file.InvalidPathException: Illegal char <:> at index 8: examples:/01_main.bob
        at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
        at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:229)
        at java.base/java.nio.file.Path.of(Path.java:147)
        at java.base/java.nio.file.Paths.get(Paths.java:69)
        at org.csstudio.display.builder.model.util.ModelResourceUtil.normalize(ModelResourceUtil.java:136)
        at org.csstudio.display.builder.model.util.ModelResourceUtil.combineDisplayPaths(ModelResourceUtil.java:199)
        at org.csstudio.display.builder.model.util.ModelResourceUtil.doResolveResource(ModelResourceUtil.java:289)
        at org.csstudio.display.builder.model.util.ModelResourceUtil.resolveResource(ModelResourceUtil.java:253)
        at org.csstudio.display.builder.runtime.ActionUtil.openDisplay(ActionUtil.java:172)
        at org.csstudio.display.builder.runtime.ActionUtil.lambda$handleAction$0(ActionUtil.java:48)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

this seems to be an issue with windows' path names. they apparently cannot contain ":".

- William