### PR TITLE
CSSTUDIO-1230 Support settings.ini in user home directory

### DIFF
--- a/core/launcher/src/main/java/org/phoebus/product/Launcher.java
+++ b/core/launcher/src/main/java/org/phoebus/product/Launcher.java
@@ -42,6 +42,13 @@ public class Launcher
             logger.log(Level.CONFIG, "Loading settings from " + site_settings);
             PropertyPreferenceLoader.load(new FileInputStream(site_settings));
         }
+        else {
+            File userHomeSettings = new File(System.getProperty("user.home"), "settings.ini");
+            if(userHomeSettings.canRead()){
+                logger.log(Level.CONFIG, "Loading settings from " + userHomeSettings);
+                PropertyPreferenceLoader.load(new FileInputStream(userHomeSettings));
+            }
+        }
 
         // Handle arguments, potentially not even starting the UI
         final List<String> args = new ArrayList<>(List.of(original_args));


### PR DESCRIPTION
After struggling a bit with jpackage I fail to understand how to build an application package such that settings can be read from user's home directory. As $HOME is evaluated at jpackage build time it is not usable for the generic case.
Using the user's home directory for setting is desirable to avoid issues when new installers are run to update the application.
A solution is to let the application find a settings file in user's home dir.

This PR implements a mechanism where a file settings.ini in user's home directory is read if not found in phoebus.install. The -settings option still takes precedence.