### PR TITLE
Font dialog: Add 'ok on change' option

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/WidgetFontPropertyBinding.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/WidgetFontPropertyBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,6 +49,12 @@ public class WidgetFontPropertyBinding
                 return;
             }
         }
+        // When editing just one widget,
+        // enable the 'OK' button if the font is actually changed.
+        // When editing multiple widgets, enable 'OK' after any change,
+        // even when later changed back to the original value,
+        // since the goal might be to apply that font to all widgets.
+        final boolean ok_on_any_change = !other.isEmpty();
         popover = new WidgetFontPopOver(widget_property, font ->
         {
             undo.execute(new SetWidgetPropertyAction<>(widget_property, font));
@@ -61,7 +67,7 @@ public class WidgetFontPropertyBinding
                     undo.execute(new SetWidgetPropertyAction<>(other_prop, font));
                 }
             }
-        });
+        }, ok_on_any_change);
 
         popover.show(jfx_node);
     };

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOver.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,7 @@ package org.csstudio.display.builder.representation.javafx;
 import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
-import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -38,8 +36,9 @@ public class WidgetFontPopOver extends PopOver
      *
      * @param font_prop {@link FontWidgetProperty} used to configure initial values.
      * @param fontChangeConsumer Will be called when user press OK to leave the popover.
+     * @param okOnChange Enable 'OK' on any change, or only when current value differs from original value?
     */
-    public WidgetFontPopOver ( final FontWidgetProperty font_prop, final Consumer<WidgetFont> fontChangeConsumer )
+    public WidgetFontPopOver ( final FontWidgetProperty font_prop, final Consumer<WidgetFont> fontChangeConsumer, final boolean okOnChange )
     {
         try
         {
@@ -57,7 +56,8 @@ public class WidgetFontPopOver extends PopOver
                     font_prop.getValue(),
                     font_prop.getDefaultValue(),
                     font_prop.getDescription(),
-                    fontChangeConsumer
+                    fontChangeConsumer,
+                    okOnChange
                     );
 
         }

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverDemo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,7 +29,8 @@ public class WidgetFontPopOverDemo extends ApplicationWrapper
     {
         final WidgetFontPopOver popover = new WidgetFontPopOver(
                 (FontWidgetProperty) CommonWidgetProperties.propFont.createProperty(null, WidgetFontService.get(NamedWidgetFonts.DEFAULT_BOLD)),
-                font -> System.out.println("Selected " + font)
+                font -> System.out.println("Selected " + font),
+                false
                 );
 
         final Button toggle_popup = new Button("Font");


### PR DESCRIPTION
When multiple widgets are selected, the "OK" button enables and stays enabled after modifying any font property, even if the result still matches the font in the first selected widget, since the intent might be to apply that font to all selected widgets.

#1616