### PR TITLE
app-update: Avoid NPE in final 'restart' dialog

### DIFF
--- a/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
@@ -109,6 +109,7 @@ public class UpdateApplication implements AppDescriptor
         // to prevent starting another update.
         // When declined, don't bother until restart of phoebus.
         // In any case, button can only be removed after dialog ran because of DialogHelper.positionDialog
+        final Node parent = node.getParent();
         StatusBar.getInstance().removeItem(start_update);
         start_update = null;
 
@@ -122,7 +123,7 @@ public class UpdateApplication implements AppDescriptor
                 Update.downloadAndUpdate(monitor, stage_area);
                 Update.adjustCurrentVersion();
                 if (! monitor.isCanceled())
-                    Platform.runLater(() -> restart(node));
+                    Platform.runLater(() -> restart(parent));
             });
         }
     }


### PR DESCRIPTION
After recent changes to remove the 'update' button as soon as pressed, there was an NPE in the final 'Restart..' dialog since it used that button to anchor its position.
