### PR TITLE
CSSTDUIO-1376 Enable custom version string

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
@@ -16,6 +16,7 @@ public class Messages
     public static String AlwaysShowTabs;
     public static String Applications;
     public static String AppVersion;
+    public static String AppRevision;
     public static String AppVersionHeader;
     public static String DeleteLayouts;
     public static String DeleteLayoutsConfirmFmt;

--- a/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
+++ b/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
@@ -118,7 +118,9 @@ public class OpenAbout implements MenuEntry
         infos.add(Arrays.asList(Messages.HelpAboutInst, Locations.install().toString()));
         infos.add(Arrays.asList(Messages.HelpAboutUserDir, System.getProperty("user.dir")));
         infos.add(Arrays.asList(Messages.HelpJavaHome, System.getProperty("java.home")));
-        infos.add(Arrays.asList(Messages.AppVersionHeader, Messages.AppVersion));
+        // Check if revision is set, if not, fall back to version
+        String revision = Messages.AppRevision;
+        infos.add(Arrays.asList(Messages.AppVersionHeader, "${revision}".equals(revision) ? Messages.AppVersion : revision));
         infos.add(Arrays.asList(Messages.HelpAboutJava, System.getProperty("java.specification.vendor") + " " + System.getProperty("java.runtime.version")));
         infos.add(Arrays.asList(Messages.HelpAboutJfx, System.getProperty("javafx.runtime.version")));
         infos.add(Arrays.asList(Messages.HelpAboutPID, Long.toString(ProcessHandle.current().pid())));

--- a/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
+++ b/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
@@ -2,6 +2,7 @@ AllFiles=All Files
 AlwaysShowTabs=Always Show Tabs
 Applications=Applications
 AppVersion=${version}
+AppRevision=${revision}
 AppVersionHeader=CS Studio Version
 DeleteLayouts=Delete Layouts...
 DeleteLayoutsConfirmFmt=Delete {0} selected layouts?


### PR DESCRIPTION
Currently the "CS Studio Version" string in the About dialog is set implicitly from the artifact version tag (core-ui). Added a mechanism where the version can be specified on the maven command line, e.g.
`mvn -Drevision=x.y.z ...`

A site specific product pom may also use this to set the version for the build artifact:
`<version>${revision}</version>`

If `-Drevision=x.y.z` is not specified, the fallback is to use pom version.