### PR TITLE
Controlsfx: Update, but keep openjfx15

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -20,7 +20,7 @@
     <classpathentry exported="true" kind="lib" path="target/lib/commonj.sdo-2.1.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commons-codec-1.10.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commons-logging-1.1.3.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/controlsfx-9.0.0.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/controlsfx-11.0.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/derby-10.14.1.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/eclipselink-2.7.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-6.4.2.jar"/>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -325,6 +325,20 @@
       <groupId>org.controlsfx</groupId>
       <artifactId>controlsfx</artifactId>
       <version>11.0.3</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.openjfx</groupId>
+          <artifactId>javafx-base</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.openjfx</groupId>
+          <artifactId>javafx-graphics</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.openjfx</groupId>
+          <artifactId>javafx-media</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Apache Batik (for SVG) -->


### PR DESCRIPTION

#1722 updated the version of controlsfx.
In one pom, it had exclusions to keep openjfx15, preventing a downgrade to openjfx11.
In the 'dependencies' pom, there were no such exclusions, resulting in a mix of openjfx jars for version 11 and 15.