### PR TITLE
#1734 adding enum formulas

### DIFF
--- a/core/formula/src/main/java/org/csstudio/apputil/formula/enums/EnumOfFunction.java
+++ b/core/formula/src/main/java/org/csstudio/apputil/formula/enums/EnumOfFunction.java
@@ -1,0 +1,60 @@
+package org.csstudio.apputil.formula.enums;
+
+import org.csstudio.apputil.formula.spi.FormulaFunction;
+import org.epics.vtype.Alarm;
+import org.epics.vtype.EnumDisplay;
+import org.epics.vtype.Time;
+import org.epics.vtype.VEnum;
+import org.epics.vtype.VNumber;
+import org.epics.vtype.VNumberArray;
+import org.epics.vtype.VStringArray;
+import org.epics.vtype.VType;
+
+import java.util.List;
+
+/**
+ * A Formula function to create an enum type
+ * @author Kunal Shroff
+ */
+public class EnumOfFunction implements FormulaFunction {
+    @Override
+    public String getCategory()
+    {
+        return "enum";
+    }
+
+    @Override
+    public String getName()
+    {
+        return "enumOf";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Creates a VEnum based a value and a set of intervals.";
+    }
+
+    @Override
+    public List<String> getArguments()
+    {
+        return List.of("value", "intervals", "labels");
+    }
+
+    @Override
+    public VType compute(VType... args) throws Exception
+    {
+        VNumber value = (VNumber) args[0];
+        VNumberArray intervals = (VNumberArray) args[1];
+        VStringArray labels = (VStringArray) args[2];
+        int index = 0;
+        while (index < intervals.getData().size() && value.getValue().doubleValue() >= intervals.getData().getDouble(index)) {
+            index++;
+        }
+        return VEnum.of(value.getValue().intValue(),
+                        EnumDisplay.of(labels.getData()),
+                        Alarm.none(),
+                        Time.now());
+    }
+
+}

--- a/core/formula/src/main/java/org/csstudio/apputil/formula/enums/IndexOfFunction.java
+++ b/core/formula/src/main/java/org/csstudio/apputil/formula/enums/IndexOfFunction.java
@@ -1,0 +1,60 @@
+package org.csstudio.apputil.formula.enums;
+
+import org.csstudio.apputil.formula.spi.FormulaFunction;
+import org.epics.vtype.Display;
+import org.epics.vtype.Time;
+import org.epics.vtype.VEnum;
+import org.epics.vtype.VInt;
+import org.epics.vtype.VType;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A Formula function to retrieve the index of an enum.
+ * This function is equivalent to a caget -n *pv_name*
+ * @author Kunal Shroff
+ */
+public class IndexOfFunction implements FormulaFunction {
+    @Override
+    public String getCategory()
+    {
+        return "enum";
+    }
+
+    @Override
+    public String getName()
+    {
+        return "indexOf";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Return the index of the enum value.";
+    }
+
+    @Override
+    public List<String> getArguments()
+    {
+        return List.of("Enum");
+    }
+
+    @Override
+    public VType compute(VType... args) throws Exception
+    {
+        if(args[0] instanceof VEnum)
+        {
+            final VEnum value = (VEnum)args[0];
+            return VInt.of(value.getIndex(),
+                    value.getAlarm(),
+                    Time.now(),
+                    Display.none());
+        } else
+        {
+            throw new Exception("Function " + getName() + " requires an enum argument " + Arrays.toString(args));
+        }
+
+    }
+
+}

--- a/core/formula/src/main/resources/META-INF/services/org.csstudio.apputil.formula.spi.FormulaFunction
+++ b/core/formula/src/main/resources/META-INF/services/org.csstudio.apputil.formula.spi.FormulaFunction
@@ -51,3 +51,8 @@ org.csstudio.apputil.formula.array.ArrayMinFunction
 org.csstudio.apputil.formula.alarm.HighestSeverityFunction
 org.csstudio.apputil.formula.alarm.MajorAlarmFunction
 org.csstudio.apputil.formula.alarm.MinorAlarmFunction
+
+# Enum
+org.csstudio.apputil.formula.enums.IndexOfFunction
+org.csstudio.apputil.formula.enums.EnumOfFunction
+


### PR DESCRIPTION
While the second formula `enumOf(..)` should be deprecated since the functionality is broady available in `loc://pv<VEnum>` I would like to include it for a short period as I transition the old boy screens to bob.

Since we don't have a clear deprecation policy in Phoebus as yet, I would say that the `enumOf` could be removed in 90 days
 
