### PR TITLE
Add slf4j binding for JUL and exclude log4j slf4j binding

### DIFF
--- a/app/save-and-restore/ui/pom.xml
+++ b/app/save-and-restore/ui/pom.xml
@@ -15,6 +15,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 			<version>2.1.5.RELEASE</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -491,6 +491,15 @@
       <artifactId>validation-api</artifactId>
       <version>2.0.1.Final</version>
     </dependency>
+
+    <!--JUL bindings for sfl4j-->
+    <dependency> 
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>1.7.28</version>
+    </dependency>
+
+
   </dependencies>
 
   <build>

--- a/services/alarm-config-logger/pom.xml
+++ b/services/alarm-config-logger/pom.xml
@@ -29,6 +29,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/alarm-config-logger/pom.xml
+++ b/services/alarm-config-logger/pom.xml
@@ -61,6 +61,12 @@
       <artifactId>org.eclipse.jgit</artifactId>
       <version>5.0.3.201809091024-r</version>
     </dependency>
+    <!--JUL bindings for sfl4j-->
+    <dependency> 
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>1.7.28</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/services/alarm-logger/pom.xml
+++ b/services/alarm-logger/pom.xml
@@ -29,10 +29,22 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+          </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/alarm-logger/pom.xml
+++ b/services/alarm-logger/pom.xml
@@ -91,6 +91,15 @@
       <artifactId>app-alarm-model</artifactId>
       <version>4.6.6-SNAPSHOT</version>
     </dependency>
+
+    <!--JUL bindings for sfl4j-->
+    <dependency> 
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>1.7.28</version>
+    </dependency>
+
+
   </dependencies>
   <build>
     <plugins>

--- a/services/alarm-server/pom.xml
+++ b/services/alarm-server/pom.xml
@@ -52,6 +52,12 @@
       <artifactId>app-alarm-model</artifactId>
       <version>4.6.6-SNAPSHOT</version>
     </dependency>
+    <!--JUL bindings for sfl4j-->
+    <dependency> 
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>1.7.28</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/services/save-and-restore/pom.xml
+++ b/services/save-and-restore/pom.xml
@@ -65,6 +65,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-log4j2</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j-impl</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->

--- a/services/save-and-restore/pom.xml
+++ b/services/save-and-restore/pom.xml
@@ -65,12 +65,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-log4j2</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-slf4j-impl</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->


### PR DESCRIPTION
This PR adds the slf4j binding for JUL and excludes the log4j slf4j binding, resulting in kafka logs surfaced with JUL. See: #627 

Additionally, I have a development question:

I am seeing modifications to my `dependencies/phoebus-target/.classpath` after `mvn clean install`. Why is this a tracked file and how should I be managing it during development?