### PR TITLE
Archive Engine (RDB): Warn when importing 'duplicate' PVs but continue

### DIFF
--- a/services/archive-engine/src/main/java/org/csstudio/archive/Engine.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/Engine.java
@@ -257,7 +257,6 @@ public class Engine
                     duplicates = DuplicateMode.ABORT;
                     iter.remove();
                 }
-
                 else if (cmd.equals("-steal_channels"))
                 {
                     duplicates = DuplicateMode.STEAL;

--- a/services/archive-engine/src/main/java/org/csstudio/archive/Engine.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/Engine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import org.csstudio.archive.engine.config.RDBConfig;
+import org.csstudio.archive.engine.config.RDBConfig.DuplicateMode;
 import org.csstudio.archive.engine.config.XMLConfig;
 import org.csstudio.archive.engine.model.ArchiveChannel;
 import org.csstudio.archive.engine.model.ArchiveGroup;
@@ -65,6 +66,7 @@ public class Engine
         System.out.println("-import engine_config.xml     Import configuration from XML");
         System.out.println("-description \"Some Info\"      Import: Description for the engine");
         System.out.println("-replace_engine               Import: Replace existing engine config, or stop?");
+        System.out.println("-abort_on_duplicate_channel   Import: Abort if channel is already listed with other engine (default: skip with warning)?");
         System.out.println("-steal_channels               Import: Reassign channels that belong to other engine?");
         System.out.println("-settings settings.ini        Import preferences (PV connectivity, archive URL, ...) from property format file");
         System.out.println("-noshell                      Disable the command shell for running without a terminal");
@@ -123,6 +125,7 @@ public class Engine
         return true;
     }
 
+
     public static void main(final String[] original_args) throws Exception
     {
         LogManager.getLogManager().readConfiguration(Engine.class.getResourceAsStream("/engine_logging.properties"));
@@ -133,7 +136,8 @@ public class Engine
 
         int port = 4812;
         boolean skip_last = false;
-        boolean list = false, delete = false, replace_engine = false, steal_channels = false, use_shell = true;
+        boolean list = false, delete = false, replace_engine = false, use_shell = true;
+        RDBConfig.DuplicateMode duplicates = DuplicateMode.SKIP;
         File import_file = null, export_file = null;
 
         // Handle arguments
@@ -248,9 +252,15 @@ public class Engine
                     replace_engine = true;
                     iter.remove();
                 }
+                else if (cmd.equals("-abort_on_duplicate_channel"))
+                {
+                    duplicates = DuplicateMode.ABORT;
+                    iter.remove();
+                }
+
                 else if (cmd.equals("-steal_channels"))
                 {
-                    steal_channels = true;
+                    duplicates = DuplicateMode.STEAL;
                     iter.remove();
                 }
                 else
@@ -305,7 +315,7 @@ public class Engine
             logger.log(Level.INFO, "Description         : " + description);
             logger.log(Level.INFO, "URL                 : " + url);
             logger.log(Level.INFO, "Replace engine      : " + replace_engine);
-            logger.log(Level.INFO, "Steal channels      : " + steal_channels);
+            logger.log(Level.INFO, "Duplicate channels  : " + duplicates);
 
             try
             (
@@ -313,7 +323,7 @@ public class Engine
             )
             {
                 final int engine_id = config.createEngine(config_name, description, replace_engine, url);
-                new XMLConfig().read(import_file, config, engine_id, steal_channels);
+                new XMLConfig().read(import_file, config, engine_id, duplicates);
             }
             return;
         }

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
@@ -245,6 +245,7 @@ public class RDBConfig implements AutoCloseable
                             return;
                         case STEAL:
                         default:
+                            logger.log(Level.WARNING, "Channel '" + name + "' will be 'stolen' from group '" + result.getString(2) + "' (" + result.getInt(1) + ") and moved to this engine.");
                             // Continue with moving channel to this engine's group
                         }
                     }

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,17 @@ import org.phoebus.framework.rdb.RDBInfo;
 @SuppressWarnings("nls")
 public class RDBConfig implements AutoCloseable
 {
+    /** How to handle a channel that's already under another engine's configuration */
+    public static enum DuplicateMode
+    {
+        /** Abort import */
+        ABORT,
+        /** Log warning and skip the channel */
+        SKIP,
+        /** Remove channel from original engine and move into this engine */
+        STEAL
+    }
+
     private final RDBInfo rdb;
     private final SQL sql;
     private final Connection connection;
@@ -97,12 +108,13 @@ public class RDBConfig implements AutoCloseable
         )
         {
             statement.setString(1, config_name);
-            ResultSet result = statement.executeQuery();
-            if (result.next())
-                engine_id = result.getInt(1);
-            else
-                engine_id = -1;
-            result.close();
+            try (ResultSet result = statement.executeQuery())
+            {
+                if (result.next())
+                    engine_id = result.getInt(1);
+                else
+                    engine_id = -1;
+            }
         }
 
         if (engine_id >= 0)
@@ -120,14 +132,13 @@ public class RDBConfig implements AutoCloseable
             try
             (
                 PreparedStatement statement = connection.prepareStatement(sql.smpl_eng_next_id);
+                ResultSet result = statement.executeQuery();
             )
             {
-                ResultSet result = statement.executeQuery();
                 if (result.next())
                     engine_id = result.getInt(1) + 1;
                 else
                     engine_id = 1;
-                result.close();
             }
 
             logger.log(Level.INFO, "Creating new engine '" + config_name + "' (" + engine_id + ")");
@@ -158,14 +169,13 @@ public class RDBConfig implements AutoCloseable
         try
         (
             PreparedStatement statement = connection.prepareStatement(sql.chan_grp_next_id);
+            ResultSet result = statement.executeQuery();
         )
         {
-            ResultSet result = statement.executeQuery();
             if (result.next())
                 group_id = result.getInt(1) + 1;
             else
                 group_id = 1;
-            result.close();
         }
 
         logger.log(Level.INFO, "Creating new group '" + group_name + "' (" + group_id + ")");
@@ -184,7 +194,7 @@ public class RDBConfig implements AutoCloseable
     }
 
     /** @param group_id Group where to add channel
-     *  @param steal_channels Steal from other group, if channel already attached?
+     *  @param duplicates How to handle duplicate channels
      *  @param name Name of channel
      *  @param monitor
      *  @param period
@@ -192,7 +202,7 @@ public class RDBConfig implements AutoCloseable
      *  @param enable
      *  @throws Exception on error, including existing channel
      */
-    public void addChannel(final int group_id, final boolean steal_channels, final String name,
+    public void addChannel(final int group_id, final DuplicateMode duplicate_mode, final String name,
                            final boolean monitor, final double period, final double delta,
                            final boolean enable) throws Exception
     {
@@ -203,30 +213,43 @@ public class RDBConfig implements AutoCloseable
         )
         {
             statement.setString(1, name);
-            ResultSet result = statement.executeQuery();
-            if (result.next())
-                channel_id = result.getInt(1);
-            result.close();
+            try (ResultSet result = statement.executeQuery())
+            {
+                if (result.next())
+                    channel_id = result.getInt(1);
+            }
         }
 
         if (channel_id >= 0)
         {
             // Check if existing channel is simply an old one with data,
             // or currently listed in another engine's group
-            Exception existing = null;
             try
             (
                 PreparedStatement statement = connection.prepareStatement(sql.chan_grp_sel_by_channel);
             )
             {
                 statement.setString(1, name);
-                ResultSet result = statement.executeQuery();
-                if (result.next())
-                    existing = new Exception("Channel '" + name + "' is already in group '" + result.getString(2) + "' (" + result.getInt(1) + "). Use option -steal_channels to move to this engine.");
-                result.close();
+                try (ResultSet result = statement.executeQuery())
+                {
+                    if (result.next())
+                    {
+                        // Channel is already used by another archive engine
+                        switch (duplicate_mode)
+                        {
+                        case ABORT:
+                            throw new Exception("Channel '" + name + "' is already in group '" + result.getString(2) + "' (" + result.getInt(1) + ").");
+                        case SKIP:
+                            logger.log(Level.WARNING, "Channel '" + name + "' is already in group '" + result.getString(2) + "' (" + result.getInt(1) + ") and not moved to this engine.");
+                            // Leave channel "as is" with other engine
+                            return;
+                        case STEAL:
+                        default:
+                            // Continue with moving channel to this engine's group
+                        }
+                    }
+                }
             }
-            if (existing != null  &&  !steal_channels)
-                throw existing;
 
             // Update channel to be in new group
             logger.log(Level.INFO, "Updating channel '" + name + "' (" + channel_id + ")");
@@ -249,14 +272,13 @@ public class RDBConfig implements AutoCloseable
             try
             (
                 PreparedStatement statement = connection.prepareStatement(sql.channel_next_id);
+                ResultSet result = statement.executeQuery();
             )
             {
-                ResultSet result = statement.executeQuery();
                 if (result.next())
                     channel_id = result.getInt(1) + 1;
                 else
                     channel_id = 1;
-                result.close();
             }
 
             logger.log(Level.INFO, "Adding new channel '" + name + "' (" + channel_id + ")");
@@ -290,12 +312,13 @@ public class RDBConfig implements AutoCloseable
         )
         {
             statement.setString(1, config_name);
-            ResultSet result = statement.executeQuery();
-            if (result.next())
-                engine_id = result.getInt(1);
-            else
-                engine_id = -1;
-            result.close();
+            try (ResultSet result = statement.executeQuery())
+            {
+                if (result.next())
+                    engine_id = result.getInt(1);
+                else
+                    engine_id = -1;
+            }
         }
 
         if (engine_id < 0)
@@ -371,20 +394,20 @@ public class RDBConfig implements AutoCloseable
         )
         {
             stmt.setString(1, config_name);
-            final ResultSet result = stmt.executeQuery();
-            if (! result.next())
-                throw new Exception("Unknown archive engine '" + config_name + "'");
+            try (final ResultSet result = stmt.executeQuery())
+            {
+                if (! result.next())
+                    throw new Exception("Unknown archive engine '" + config_name + "'");
 
-            id = result.getInt(1);
-            final URI url = new URI(result.getString(3));
-            logger.info("ID: " + id);
-            logger.info("Description: " + result.getString(2));
-            logger.info("Web Server : " + url);
-            result.close();
-
-            if (url.getPort() != port)
-                throw new Exception("Engine running on port " + port +
-                        " while configuration requires " + url);
+                id = result.getInt(1);
+                final URI url = new URI(result.getString(3));
+                logger.info("ID: " + id);
+                logger.info("Description: " + result.getString(2));
+                logger.info("Web Server : " + url);
+                if (url.getPort() != port)
+                    throw new Exception("Engine running on port " + port +
+                                        " while configuration requires " + url);
+            }
         }
 
         readGroups(model, id, skip_last);
@@ -405,50 +428,53 @@ public class RDBConfig implements AutoCloseable
         )
         {
             sel_groups.setInt(1, engine_id);
-            final ResultSet grp_result = sel_groups.executeQuery();
-            while (grp_result.next())
+
+            try (ResultSet grp_result = sel_groups.executeQuery())
             {
-                final int grp_id = grp_result.getInt(1);
-                final String grp_name = grp_result.getString(2);
-                final int enabling_chan_id = grp_result.getInt(3);
-                logger.log(Level.INFO, "Group '" + grp_name + "' (" + grp_id + ")");
-
-                // Add channels to group
-                final ArchiveGroup group = model.addGroup(grp_name);
-
-                sel_chann.setInt(1, grp_id);
-                final ResultSet chann_result = sel_chann.executeQuery();
-                while (chann_result.next())
+                while (grp_result.next())
                 {
-                    final int channel_id = chann_result.getInt(1);
-                    final String name = chann_result.getString(2);
-                    final int smpl_mode_id = Math.max(1, chann_result.getInt(3));
-                    final double smpl_val = chann_result.getDouble(4);
-                    final double smpl_per = chann_result.getDouble(5);
+                    final int grp_id = grp_result.getInt(1);
+                    final String grp_name = grp_result.getString(2);
+                    final int enabling_chan_id = grp_result.getInt(3);
+                    logger.log(Level.INFO, "Group '" + grp_name + "' (" + grp_id + ")");
 
-                    Instant last_sample_time = null;
-                    if (! skip_last)
+                    // Add channels to group
+                    final ArchiveGroup group = model.addGroup(grp_name);
+
+                    sel_chann.setInt(1, grp_id);
+                    try (ResultSet chann_result = sel_chann.executeQuery())
                     {
-                        sel_last_sample_time.setInt(1, channel_id);
-                        final ResultSet result = sel_last_sample_time.executeQuery();
-                        if (result.next())
-                            last_sample_time = TimestampHelper.fromSQLTimestamp(result.getTimestamp(1));
-                        result.close();
+                        while (chann_result.next())
+                        {
+                            final int channel_id = chann_result.getInt(1);
+                            final String name = chann_result.getString(2);
+                            final int smpl_mode_id = Math.max(1, chann_result.getInt(3));
+                            final double smpl_val = chann_result.getDouble(4);
+                            final double smpl_per = chann_result.getDouble(5);
+
+                            Instant last_sample_time = null;
+                            if (! skip_last)
+                            {
+                                sel_last_sample_time.setInt(1, channel_id);
+                                try (ResultSet result = sel_last_sample_time.executeQuery())
+                                {
+                                    if (result.next())
+                                        last_sample_time = TimestampHelper.fromSQLTimestamp(result.getTimestamp(1));
+                                }
+                            }
+
+                            Enablement enablement = Enablement.Passive;
+                            if (channel_id == enabling_chan_id)
+                                enablement = Enablement.Enabling;
+                            final SampleMode sample_mode = new SampleMode(smpl_mode_id == monitor_mode_id, smpl_val,  smpl_per);
+
+                            logger.log(Level.INFO, "Channel '" + name + "' (" + channel_id + "), " + sample_mode +
+                                                   (last_sample_time != null ? ", last written " + last_sample_time : ""));
+                            model.addChannel(name, group, enablement, sample_mode, last_sample_time);
+                        }
                     }
-
-                    Enablement enablement = Enablement.Passive;
-                    if (channel_id == enabling_chan_id)
-                        enablement = Enablement.Enabling;
-                    final SampleMode sample_mode = new SampleMode(smpl_mode_id == monitor_mode_id, smpl_val,  smpl_per);
-
-                    logger.log(Level.INFO, "Channel '" + name + "' (" + channel_id + "), " + sample_mode +
-                                           (last_sample_time != null ? ", last written " + last_sample_time : ""));
-                    model.addChannel(name, group, enablement, sample_mode, last_sample_time);
                 }
-                chann_result.close();
-
             }
-            grp_result.close();
         }
     }
 

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/XMLConfig.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/XMLConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -124,10 +124,10 @@ public class XMLConfig
 
     /** @param import_file XML file to read
      *  @param config RDB to update with configuration from XML file
-     *  @param steal_channels
+     *  @param duplicates How to handle duplicate channels
      *  @throws Exception on error
      */
-    public void read(final File import_file, final RDBConfig config, final int engine_id, final boolean steal_channels) throws FileNotFoundException, Exception
+    public void read(final File import_file, final RDBConfig config, final int engine_id, final RDBConfig.DuplicateMode duplicates) throws FileNotFoundException, Exception
     {
         // TODO RDB: Load sample modes?
 
@@ -148,7 +148,7 @@ public class XMLConfig
                 final double delta = XMLUtil.getChildDouble(ce, DELTA).orElse(-1.0);
                 final boolean enable = XMLUtil.getChildBoolean(ce, ENABLE).orElse(false);
 
-                config.addChannel(group_id, steal_channels, name, monitor, period, delta, enable);
+                config.addChannel(group_id, duplicates, name, monitor, period, delta, enable);
             }
         }
     }


### PR DESCRIPTION
Default used to be 'abort', with option to 'steal'.
Adding option (and making it the default) to 'warn' and skip duplicate channel.

#1728