### PR TITLE
PVTree: Handle formula PVs, reading their variables as inputs

### DIFF
--- a/app/pvtree/.classpath
+++ b/app/pvtree/.classpath
@@ -9,7 +9,8 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/core-types"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-ui"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-pv"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/core-vtype"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/core-formula"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/core-vtype"/>
 	<classpathentry kind="src" path="/app-email-ui"/>
 	<classpathentry kind="src" path="/app-logbook-ui"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/PVNameFilter.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/PVNameFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2013-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,9 +28,21 @@ public class PVNameFilter
             return false;
         if (pvname.startsWith("@"))
             return false;
+        // Formula is also a type of PV
+        if (isFormula(pvname))
+            return true;
         // Skip constants
         if (number.matcher(pvname).matches())
             return false;
         return true;
+    }
+
+    /** @param pvname PV Name
+     *  @return <code>true</code> if it's a formula PV
+     */
+    public static boolean isFormula(final String pvname)
+    {
+        return pvname.startsWith("=")  ||
+               pvname.startsWith("eq:");
     }
 }

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/TreeModelItem.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/TreeModelItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
+import org.csstudio.apputil.formula.Formula;
+import org.csstudio.apputil.formula.VariableNode;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.VType;
 import org.phoebus.applications.pvtree.Settings;
@@ -207,7 +209,10 @@ public class TreeModelItem
                 value_pv.set(pv);
             }
 
-            fetchType();
+            if (PVNameFilter.isFormula(record_name))
+                fetchFormulaInputs();
+            else
+                fetchType();
         }
         catch (Exception ex)
         {
@@ -233,10 +238,66 @@ public class TreeModelItem
         return links;
     }
 
+    /** `pv_name` is a formula, fetch its variables as inputs */
+    private void fetchFormulaInputs()
+    {
+        logger.log(TRACE, "Formula");
+        type = "formula";
+
+        try
+        {
+            // Remove formula PV prefix
+            final String expression;
+            if (pv_name.startsWith("="))
+                expression = pv_name.substring(1);
+            else if (pv_name.startsWith("eq://"))
+                expression = pv_name.substring(5);
+            else
+                throw new Exception("Expected '=' or 'eq://'");
+
+            // Parse formula to determine variables
+            final Formula formula = new Formula(expression, true);
+            for (VariableNode var : formula.getVariables())
+            {
+                // Use variable name as 'input'
+                try
+                {
+                    final TreeModelItem new_item = new TreeModelItem(model, this, "Variable", var.getName());
+                    links.add(new_item);
+                    model.itemLinkAdded(TreeModelItem.this, new_item);
+                }
+                catch (Exception ex)
+                {
+                    logger.log(Level.WARNING,
+                               "Cannot add tree node for formula input '" + var.getName() + "'", ex);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.log(Level.WARNING, "Cannot parse variables from formula for " + this, ex);
+        }
+    }
+
     private void fetchType()
     {
         try
         {
+            // Use knowledge of simulated and local PV types
+            if (record_name.startsWith("sim:"))
+            {
+                type = "simulated";
+                // No links to fetch
+                return;
+            }
+            else if (record_name.startsWith("loc:"))
+            {
+                type = "local";
+                // No links to fetch
+                return;
+            }
+
+            // Try to resolve record type, assuming EPICS record PV
             final PV pv = PVPool.getPV(record_name + ".RTYP");
             type_flow = pv.onValueEvent().firstOrError().subscribe(value ->
             {

--- a/app/pvtree/src/test/java/org/phoebus/applications/pvtree/FieldParserUnitTest.java
+++ b/app/pvtree/src/test/java/org/phoebus/applications/pvtree/FieldParserUnitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@ package org.phoebus.applications.pvtree;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 import java.util.Map;

--- a/app/pvtree/src/test/java/org/phoebus/applications/pvtree/TreeModelDemo.java
+++ b/app/pvtree/src/test/java/org/phoebus/applications/pvtree/TreeModelDemo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -52,7 +52,7 @@ public class TreeModelDemo
                 System.out.println("Update from " + item);
             }
         });
-        model.setRootPV("sim://sine");
+        model.setRootPV("=`sim://sine` + 100");
         model.getRoot().start();
 
         Thread.sleep(4000);


### PR DESCRIPTION
PV Tree can now parse formulas, listing their variables as inputs/links:

![Screen Shot 2021-01-14 at 4 09 14 PM](https://user-images.githubusercontent.com/1932421/104649738-2831f800-5683-11eb-89fc-0a12d19cb0be.png)

Also recognizing "sim://" and "loc://" PVs as such, no longer trying and then failing to read their ".RTYP" field.

#1727