### PR TITLE
Startup: Load saved layouts even if there is no default 'memento'

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -287,6 +287,9 @@ public class PhoebusApplication extends Application {
             new Welcome().create();
         monitor.worked(1);
 
+        // Launch background job to list saved layouts
+        createLoadLayoutsMenu();
+
         // Check command line parameters
         monitor.updateTaskName(Messages.MonitorTaskCmdl);
         handleParameters(getParameters().getRaw());
@@ -1020,8 +1023,6 @@ public class PhoebusApplication extends Application {
                 DockStage.dump(buf, stage);
             logger.log(Level.WARNING, buf.toString());
         }
-
-        createLoadLayoutsMenu();
 
         try
         {


### PR DESCRIPTION
Original code used to load default `memento`, i.e. the state saved at last shutdown, and then populated the saved-layouts-menu.
If there was no default `memento` file, however, the saved-layouts-menu was erroneously left empty.
Now it's filled regardless of finding a default layout or not. 