### PR TITLE
PVA: EPICS_PVA_CONN_TMO was using EPICS_CA_CONN_TMO

### DIFF
--- a/core/pva/README.md
+++ b/core/pva/README.md
@@ -54,7 +54,20 @@ Similar to the C++ library, `EPICS_PVA_ADDR_LIST` can be set as an environment v
 In addition, the Java library reads a Java property of the same name.
 If both the environment variable and the Java property are defined,
 the latter is used.
-See `PVASettings` source code for additional settings.
+
+Key configuration parameters:
+
+`EPICS_PVA_ADDR_LIST`: Space-separated list of host names or IP addresses. Each may be followed by ":port", otherwise defaulting to `EPICS_PVA_BROADCAST_PORT`.  When empty, local subnet is used.
+
+`EPICS_PVA_AUTO_ADDR_LIST`: 'YES' (default) or 'NO'. 
+
+`EPICS_PVA_BROADCAST_PORT`: PVA client UDP port (default 5076) for sending name searches and receiving beacons.
+
+`EPICS_PVAS_BROADCAST_PORT`: PVA server UDP port (default 5076) for name searches and beacons.
+
+`EPICS_PVA_SERVER_PORT`: First PVA TCP port used by server, defaults to 5075.
+
+See `PVASettings` source code for complete settings.
 
 Network Details
 ---------------

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -83,7 +83,7 @@ public class PVASettings
      * <p>When approaching this time without having received a new value,
      * an 'Echo' request is sent. If still no reply, the channel is disconnected.
      */
-    public static int EPICS_CA_CONN_TMO = 30;
+    public static int EPICS_PVA_CONN_TMO = 30;
 
     /** Maximum number of array elements shown when printing data */
     public static int EPICS_PVA_MAX_ARRAY_FORMATTING = 256;
@@ -95,7 +95,7 @@ public class PVASettings
         EPICS_PVA_SERVER_PORT = get("EPICS_PVA_SERVER_PORT", EPICS_PVA_SERVER_PORT);
         EPICS_PVA_BROADCAST_PORT = get("EPICS_PVA_BROADCAST_PORT", EPICS_PVA_BROADCAST_PORT);
         EPICS_PVAS_BROADCAST_PORT = get("EPICS_PVAS_BROADCAST_PORT", EPICS_PVAS_BROADCAST_PORT);
-        EPICS_CA_CONN_TMO = get("EPICS_CA_CONN_TMO", EPICS_CA_CONN_TMO);
+        EPICS_PVA_CONN_TMO = get("EPICS_PVA_CONN_TMO", EPICS_PVA_CONN_TMO);
         EPICS_PVA_MAX_ARRAY_FORMATTING = get("EPICS_PVA_MAX_ARRAY_FORMATTING", EPICS_PVA_MAX_ARRAY_FORMATTING);
         EPICS_PVA_SEND_BUFFER_SIZE = get("EPICS_PVA_SEND_BUFFER_SIZE", EPICS_PVA_SEND_BUFFER_SIZE);
     }

--- a/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -111,7 +111,7 @@ class ClientTCPHandler extends TCPHandler
         // For default EPICS_CA_CONN_TMO: 30 sec, send echo at ~15 sec:
         // Check every ~3 seconds
         last_life_sign = last_message_sent = System.currentTimeMillis();
-        final long period = Math.max(1, PVASettings.EPICS_CA_CONN_TMO * 1000L / 30 * 3);
+        final long period = Math.max(1, PVASettings.EPICS_PVA_CONN_TMO * 1000L / 30 * 3);
         alive_check = timer.scheduleWithFixedDelay(this::checkResponsiveness, period, period, TimeUnit.MILLISECONDS);
         // Don't start the send thread, yet.
         // To prevent sending messages before the server is ready,
@@ -215,7 +215,7 @@ class ClientTCPHandler extends TCPHandler
         final long now = System.currentTimeMillis();
         // How long has server been idle, not sending anything?
         final long idle = now - last_life_sign;
-        if (idle > PVASettings.EPICS_CA_CONN_TMO * 1000)
+        if (idle > PVASettings.EPICS_PVA_CONN_TMO * 1000)
         {
             // If silent for full EPICS_CA_CONN_TMO, disconnect and start over
             logger.log(Level.FINE, () -> this + " silent for " + idle + "ms, closing");
@@ -224,7 +224,7 @@ class ClientTCPHandler extends TCPHandler
         }
 
         boolean request_echo = false;
-        if (idle >= PVASettings.EPICS_CA_CONN_TMO * 1000 / 2)
+        if (idle >= PVASettings.EPICS_PVA_CONN_TMO * 1000 / 2)
         {
             if (channels.isEmpty())
             {   // Connection is idle because no channel uses it. Close!
@@ -240,7 +240,7 @@ class ClientTCPHandler extends TCPHandler
 
         // How long have we been silent, which could case the server to close connection?
         final long silent = now - last_message_sent;
-        if (! request_echo  &&  silent >= PVASettings.EPICS_CA_CONN_TMO * 1000 / 2)
+        if (! request_echo  &&  silent >= PVASettings.EPICS_PVA_CONN_TMO * 1000 / 2)
         {
             // With default EPICS_CA_CONN_TMO of 30 seconds,
             // Echo requested every 15 seconds.


### PR DESCRIPTION
Had accidentally used the CA setting.
To be compatible with C++ implementation, should use
'EPICS_PVA_CONN_TMO'.
https://github.com/epics-base/pvAccessCPP/issues/171

Also listing key settings in README