### PR TITLE
Launcher: Add '-layout /path/to/Example.memento' option

### DIFF
--- a/core/launcher/src/main/java/org/phoebus/product/Launcher.java
+++ b/core/launcher/src/main/java/org/phoebus/product/Launcher.java
@@ -201,6 +201,7 @@ public class Launcher
         System.out.println("-server port                            -  Create instance server on given TCP port");
         System.out.println("-app probe                              -  Launch an application with input arguments");
         System.out.println("-resource  /tmp/example.plt             -  Open an application configuration file with the default application");
+        System.out.println("-layout /path/to/Example.memento        -  Start with the specified saved layout instead of the default 'memento'");
         System.out.println("-main org.package.Main                  -  Run alternate application Main");
         System.out.println();
         System.out.println("In 'server' mode, first instance opens UI.");

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -226,7 +226,7 @@ public class PhoebusApplication extends Application {
 
         // Load saved state (slow file access) off UI thread, allocating 30% to that
         monitor.beginTask(Messages.MonitorTaskSave);
-        final MementoTree memento = loadDefaultMemento(new SubJobMonitor(monitor, 30));
+        final MementoTree memento = loadDefaultMemento(getParameters().getRaw(), new SubJobMonitor(monitor, 30));
 
         // Trigger initialization of authentication service
         AuthorizationService.init();
@@ -964,15 +964,24 @@ public class PhoebusApplication extends Application {
         });
     }
 
-    /** @param monitor {@link JobMonitor}
+    /** @param parameters Command line parameters that may contain '-layout /path/to/Example.memento'
+     *  @param monitor {@link JobMonitor}
      *  @return Memento for previously persisted state or <code>null</code> if none found
      */
-    private MementoTree loadDefaultMemento(final JobMonitor monitor)
+    private MementoTree loadDefaultMemento(final List<String> parameters, final JobMonitor monitor)
     {
         monitor.beginTask(Messages.MonitorTaskPers, 1);
-        final File memfile = XMLMementoTree.getDefaultFile();
+        File memfile = XMLMementoTree.getDefaultFile();
         try
         {
+            for (int i=0;  i<parameters.size();  ++i)
+                if ("-layout".equals(parameters.get(i)))
+                {
+                    if (i >= parameters.size() - 1)
+                        throw new Exception("Missing /path/to/Example.memento for -layout option");
+                    memfile = new File(parameters.get(i+1));
+                    break;
+                }
             if (memfile.canRead())
             {
                 logger.log(Level.INFO, "Loading state from " + memfile);


### PR DESCRIPTION
While it is possible to start with a defined layout by copying the desired layout into the phoebus.user 'memento' file, this command line option simplifies the task and makes it much more obvious because the '-help' option will describe it.