### PR TITLE
Changes to support Commonmark in Olog ES UI

### DIFF
--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogClient.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogClient.java
@@ -255,6 +255,7 @@ public class OlogClient implements LogClient {
 
         try {
             clientResponse = service.path("logs")
+                    .queryParam("markup", "commonmark")
                     .type(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_XML)
                     .accept(MediaType.APPLICATION_JSON)

--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogLog.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogLog.java
@@ -134,6 +134,7 @@ public class OlogLog implements LogEntry {
      * @return owner
      */
     @XmlAttribute
+    @Override
     public String getOwner() {
         return owner;
     }
@@ -153,6 +154,7 @@ public class OlogLog implements LogEntry {
      * @return level
      */
     @XmlAttribute
+    @Override
     public String getLevel() {
         return level;
     }
@@ -199,6 +201,7 @@ public class OlogLog implements LogEntry {
      * @return modifiedDate
      */
     @XmlElement
+    @Override
     public Instant getModifiedDate() {
         return modifiedDate;
     }
@@ -218,6 +221,7 @@ public class OlogLog implements LogEntry {
      * @return source IP
      */
     @XmlAttribute
+    @Override
     public String getSource() {
         return source;
     }
@@ -237,6 +241,7 @@ public class OlogLog implements LogEntry {
      * @return description
      */
     @XmlElement(name = "description")
+    @Override
     public String getDescription() {
         return description;
     }
@@ -294,6 +299,7 @@ public class OlogLog implements LogEntry {
      */
     @XmlElementWrapper(name = "tags")
     @XmlElement(type = OlogTag.class, name = "tag")
+    @Override
     public Collection<Tag> getTags() {
         return tags == null ? new ArrayList<Tag>() : tags;
     }

--- a/app/logbook/olog/ui/pom.xml
+++ b/app/logbook/olog/ui/pom.xml
@@ -57,6 +57,24 @@
             <artifactId>jfxtras-common</artifactId>
             <version>9.0-r1</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.atlassian.commonmark/commonmark -->
+        <dependency>
+            <groupId>com.atlassian.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>0.15.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.commonmark</groupId>
+            <artifactId>commonmark-ext-gfm-tables</artifactId>
+            <version>0.15.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.commonmark</groupId>
+            <artifactId>commonmark-ext-image-attributes</artifactId>
+            <version>0.15.2</version>
+        </dependency>
+
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-core</artifactId>

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTable.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTable.java
@@ -20,12 +20,13 @@ public class LogEntryTable implements AppInstance {
     private final LogEntryTableApp app;
     private LogEntryTableViewController controller;
 
-    LogEntryTable(final LogEntryTableApp app)
+    public LogEntryTable(final LogEntryTableApp app)
     {
         this.app = app;
         try {
             FXMLLoader loader = new FXMLLoader();
             loader.setLocation(this.getClass().getResource("LogEntryTableView.fxml"));
+
             loader.setControllerFactory(clazz -> {
                 try {
                     if(clazz.isAssignableFrom(LogEntryTableViewController.class))

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -4,8 +4,6 @@ import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
@@ -46,7 +44,6 @@ import org.phoebus.logbook.olog.ui.write.AttachmentsViewController;
 import org.phoebus.logbook.olog.ui.write.LogEntryModel;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.util.time.TimeParser;
-import org.w3c.dom.Document;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -289,12 +289,20 @@ public class LogEntryTableViewController extends LogbookSearchController {
         });
     }
 
+    /**
+     * Converts Commonmark content to HTML.
+     * @param commonmarkString Raw Commonmark string
+     * @return The HTML output of the Commonmark processor.
+     */
     private String toHtml(String commonmarkString){
         org.commonmark.node.Node document = parser.parse(commonmarkString);
-        String html = htmlRenderer.render(document);
-        return html;
+        return htmlRenderer.render(document);
     }
 
+    /**
+     * An {@link AttributeProvider} used to style elements of a log entry. Other types of
+     * attribute processing is of course possible.
+     */
     static class OlogAttributeProvider implements AttributeProvider {
         @Override
         public void setAttributes(org.commonmark.node.Node node, String s, Map<String, String> map) {

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -182,7 +182,9 @@ public class LogEntryTableViewController extends LogbookSearchController {
             WebView webView = new WebView();
 
             // Hard coding WebView height as dynamic calculation turned out to not work...
-            webView.setPrefHeight(200);
+            // 150 is a bit conservative, but should be sufficient to at least get a clue of what the
+            // log entry is about.
+            webView.setPrefHeight(150);
             WebEngine webEngine = webView.getEngine();
             webEngine.setUserStyleSheetLocation(getClass()
                     .getResource("/webview.css").toExternalForm());
@@ -296,9 +298,6 @@ public class LogEntryTableViewController extends LogbookSearchController {
     static class OlogAttributeProvider implements AttributeProvider {
         @Override
         public void setAttributes(org.commonmark.node.Node node, String s, Map<String, String> map) {
-            if (node instanceof org.commonmark.node.Image) {
-                map.put("class", "md-image");
-            }
             if (node instanceof TableBlock) {
                 map.put("class", "olog-table");
             }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryModel.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryModel.java
@@ -487,8 +487,6 @@ public class LogEntryModel {
         LogEntryBuilder logEntryBuilder = new LogEntryBuilder();
         logEntryBuilder.title(title)
                 .description(text)
-//                .createdDate(date)
-//                .modifiedDate(date)
                 .level(level);
 
         for (String selectedLogbook : selectedLogbooks)

--- a/app/logbook/olog/ui/src/main/resources/webview.css
+++ b/app/logbook/olog/ui/src/main/resources/webview.css
@@ -24,6 +24,12 @@ body{
     font-family: sans-serif;
 }
 
+blockquote{
+    padding: 10px 20px;
+    margin: 0 0 20px;
+    border-left: 5px solid #eee;
+}
+
 .olog-table {
   font-family: Arial, Helvetica, sans-serif;
   border-collapse: collapse;

--- a/app/logbook/olog/ui/src/main/resources/webview.css
+++ b/app/logbook/olog/ui/src/main/resources/webview.css
@@ -1,3 +1,29 @@
+/**
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+/**
+ * Styles for the log entry WebView.
+ */
+
+body{
+    font-family: sans-serif;
+}
+
 .olog-table {
   font-family: Arial, Helvetica, sans-serif;
   border-collapse: collapse;

--- a/app/logbook/olog/ui/src/main/resources/webview.css
+++ b/app/logbook/olog/ui/src/main/resources/webview.css
@@ -1,0 +1,23 @@
+.olog-table {
+  font-family: Arial, Helvetica, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.olog-table  td, .olog-table  th {
+  border: 1px solid #ddd;
+  padding: 8px;
+  display: table-cell;
+}
+
+.olog-table  tr:nth-child(even){background-color: #f2f2f2;}
+
+.olog-table  tr:hover {background-color: #ddd;}
+
+.olog-table  th {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  text-align: left;
+  background-color: #4CAF50;
+  color: white;
+}

--- a/core/logbook/src/main/java/org/phoebus/logbook/LogEntry.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/LogEntry.java
@@ -13,6 +13,10 @@ public interface LogEntry {
 
     public String getDescription();
 
+    public default String getSource(){
+        return null;
+    }
+
     public String getLevel();
 
     public Instant getCreatedDate();

--- a/core/logbook/src/main/java/org/phoebus/logbook/LogEntry.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/LogEntry.java
@@ -13,6 +13,13 @@ public interface LogEntry {
 
     public String getDescription();
 
+    /**
+     * This (optional) field holds the user specified log entry description in some markup format.
+     * The actual markup scheme is not mandated to anything specific, but is rather an
+     * implementation detail with the logbook clients. If the client does not use any markup,
+     * this field should be identical to the <code>description</code> field.
+     * @return
+     */
     public default String getSource(){
         return null;
     }

--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -140,6 +140,9 @@
     <classpathentry exported="true" kind="lib" path="target/lib/xml-apis-ext-1.3.04.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/xmlgraphics-commons-2.4.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commons-math3-3.6.1.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/commonmark-0.15.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/commonmark-ext-gfm-tables-0.15.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/commonmark-ext-image-attributes-0.15.2.jar"/>
 
     <!-- On Windows, need to add this:
     <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15.jar"/>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -337,6 +337,23 @@
       <version>0.15.2</version>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/com.atlassian.commonmark/commonmark -->
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
+      <version>0.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark-ext-gfm-tables</artifactId>
+      <version>0.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark-ext-image-attributes</artifactId>
+      <version>0.15.2</version>
+    </dependency>
+
     <!-- Display Builder -->
     <dependency>
       <groupId>org.controlsfx</groupId>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -320,6 +320,23 @@
       <version>9.0-r1</version>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/com.atlassian.commonmark/commonmark -->
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
+      <version>0.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark-ext-gfm-tables</artifactId>
+      <version>0.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark-ext-image-attributes</artifactId>
+      <version>0.15.2</version>
+    </dependency>
+
     <!-- Display Builder -->
     <dependency>
       <groupId>org.controlsfx</groupId>


### PR DESCRIPTION
In short, user may use markup as defined by the Commonmark in the log entry text field. In the log table view the text is processed to HTML and rendered in a WebView.

For this to work, the Olog ES service must be of commit 9c1f2da7ff01f1dd41e07651eb25d3c7208e17a7 or later.