### PR TITLE
StripTool file support

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserApp.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserApp.java
@@ -26,8 +26,13 @@ import org.phoebus.ui.docking.DockStage;
 @SuppressWarnings("nls")
 public class DataBrowserApp implements AppResourceDescriptor
 {
+    /** Primary file extension for data browser config files */
     public static final String FILE_EXTENSION = "plt";
+
+    /** Handle extensions include strip tool files */
     private static final List<String> FILE_EXTENSIONS = List.of(FILE_EXTENSION, "stp");
+
+    /** Application name */
     public static final String NAME = "databrowser";
 
     @Override

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserApp.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserApp.java
@@ -26,7 +26,8 @@ import org.phoebus.ui.docking.DockStage;
 @SuppressWarnings("nls")
 public class DataBrowserApp implements AppResourceDescriptor
 {
-    private static final List<String> FILE_EXTENSIONS = List.of("plt", "stp");
+    public static final String FILE_EXTENSION = "plt";
+    private static final List<String> FILE_EXTENSIONS = List.of(FILE_EXTENSION, "stp");
     public static final String NAME = "databrowser";
 
     @Override

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserApp.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserApp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ import org.phoebus.ui.docking.DockStage;
 @SuppressWarnings("nls")
 public class DataBrowserApp implements AppResourceDescriptor
 {
-    private static final List<String> FILE_EXTENSIONS = List.of("plt");
+    private static final List<String> FILE_EXTENSIONS = List.of("plt", "stp");
     public static final String NAME = "databrowser";
 
     @Override

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -35,6 +35,7 @@ import org.phoebus.framework.util.ResourceParser;
 import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
+import org.phoebus.util.FileExtensionUtil;
 
 import javafx.application.Platform;
 import javafx.stage.FileChooser.ExtensionFilter;
@@ -199,7 +200,20 @@ public class DataBrowserInstance implements AppInstance
                                 null,
                                 null));
                 if (input.getPath().endsWith(".stp"))
+                {
+                    final File file = ResourceParser.getFile(input);
+                    if (file != null)
+                    {
+                        // If input is *.stp, enforce *.plt which will later be used to save changes
+                        final File proper = FileExtensionUtil.enforceFileExtension(file, DataBrowserApp.FILE_EXTENSION);
+                        if (! file.equals(proper))
+                        {
+                            logger.log(Level.WARNING, "Changing strip tool file " + input + " into " + proper);
+                            dock_item.setInput(proper.toURI());
+                        }
+                    }
                     StripToolParser.load(input, new_model, stream);
+                }
                 else
                     XMLPersistence.load(new_model, stream);
 
@@ -247,8 +261,6 @@ public class DataBrowserInstance implements AppInstance
     {
         perspective.save(memento);
     }
-
-    // TODO: If input is *.stp, enforce *.plt on save
 
     private void doSave(final JobMonitor monitor) throws Exception
     {

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -35,7 +35,6 @@ import org.phoebus.framework.util.ResourceParser;
 import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
-import org.phoebus.util.FileExtensionUtil;
 
 import javafx.application.Platform;
 import javafx.stage.FileChooser.ExtensionFilter;
@@ -201,18 +200,10 @@ public class DataBrowserInstance implements AppInstance
                                 null));
                 if (input.getPath().endsWith(".stp"))
                 {
-                    final File file = ResourceParser.getFile(input);
-                    if (file != null)
-                    {
-                        // If input is *.stp, enforce *.plt which will later be used to save changes
-                        final File proper = FileExtensionUtil.enforceFileExtension(file, DataBrowserApp.FILE_EXTENSION);
-                        if (! file.equals(proper))
-                        {
-                            logger.log(Level.WARNING, "Changing strip tool file " + input + " into " + proper);
-                            dock_item.setInput(proper.toURI());
-                        }
-                    }
                     StripToolParser.load(input, new_model, stream);
+                    // Tread *.plt as 'read-only', not supporting 'save'.
+                    // 'save-as' is supported, and will enforce *.plt extension.
+                    new_model.setSaveChanges(false);
                 }
                 else
                     XMLPersistence.load(new_model, stream);

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ import static org.csstudio.trends.databrowser3.Activator.logger;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
@@ -191,12 +192,16 @@ public class DataBrowserInstance implements AppInstance
 
                 // Load model from file in background
                 // (strip 'query' from input)
-                XMLPersistence.load(new_model, ResourceParser.getContent(
+                final InputStream stream = ResourceParser.getContent(
                         new URI(input.getScheme(),
                                 input.getAuthority(),
                                 input.getPath(),
                                 null,
-                                null)));
+                                null));
+                if (input.getPath().endsWith(".stp"))
+                    StripToolParser.load(input, new_model, stream);
+                else
+                    XMLPersistence.load(new_model, stream);
 
                 Platform.runLater(() ->
                 {
@@ -242,6 +247,8 @@ public class DataBrowserInstance implements AppInstance
     {
         perspective.save(memento);
     }
+
+    // TODO: If input is *.stp, enforce *.plt on save
 
     private void doSave(final JobMonitor monitor) throws Exception
     {

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/StripToolParser.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/StripToolParser.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.trends.databrowser3;
+
+import static org.csstudio.trends.databrowser3.Activator.logger;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.csstudio.trends.databrowser3.model.ArchiveRescale;
+import org.csstudio.trends.databrowser3.model.AxisConfig;
+import org.csstudio.trends.databrowser3.model.Model;
+import org.csstudio.trends.databrowser3.model.ModelItem;
+import org.csstudio.trends.databrowser3.model.PVItem;
+import org.phoebus.util.time.TimeRelativeInterval;
+
+import javafx.scene.paint.Color;
+
+/** Read EPICS 'Strip Tool' configuration file
+ *
+ *  <p>Strip tool and data browser are quite different:
+ *  Strip tool shows only one axis at a time,
+ *  and takes samples at fixed times (no 'monitor' mode).
+ *  This parser imports the essential PV name, color, range
+ *  information.
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class StripToolParser
+{
+    /** Load Strip Tool configuration
+     *
+     *  @param input Input name, used for logging
+     *  @param model Model to configure, should start out empty
+     *  @param stream Stream for Strip Tool configuration
+     *  @throws Exception on error
+     */
+    public static void load(final URI input, final Model model, final InputStream stream) throws Exception
+    {
+        final Pattern color_pattern = Pattern.compile("Strip.Color.Color([0-9]+)[ \t]+([0-9]+)[ \t]+([0-9]+)[ \t]+([0-9]+)[ \t]*");
+        final Pattern span_pattern = Pattern.compile("Strip.Time.Timespan[ \t]+([0-9]+)");
+        final Pattern grid_pattern = Pattern.compile("Strip.Option.GridXon[ \t]+([0-9]+)");
+        final Pattern name_pattern = Pattern.compile("Strip.Curve.([0-9]+).Name[ \t]+(.+)");
+        final Pattern min_pattern = Pattern.compile("Strip.Curve.([0-9]+).Min[ \t]+(.+)");
+        final Pattern max_pattern = Pattern.compile("Strip.Curve.([0-9]+).Max[ \t]+(.+)");
+        final Pattern scale_pattern = Pattern.compile("Strip.Curve.([0-9]+).Scale[ \t]+(.+)");
+
+        // Trace index to color
+        final Map<Integer, Color> colors = new HashMap<>();
+
+        try
+        (
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(stream))
+        )
+        {
+            String version = null;
+
+            for (String line = reader.readLine();
+                 line != null;
+                 line = reader.readLine())
+            {
+                // System.out.println(line);
+
+                // First, check version
+                if (version == null)
+                {
+                    final Matcher version_check = Pattern.compile("StripConfig[ \t]+([.1-9]+)").matcher(line);
+                    if (! version_check.matches())
+                        throw new Exception("Missing 'StripConfig' at start of *.stp file");
+                    version = version_check.group(1);
+                    if ("1.2".compareTo(version) > 0)
+                        logger.log(Level.WARNING, "Expect StripConfig version 1.2, got " + version + " in " + input);
+                    continue;
+                }
+
+                // Time span (scrolling mode)
+                Matcher check = span_pattern.matcher(line);
+                if (check.matches())
+                {
+                    final int seconds = Integer.parseInt(check.group(1));
+                    model.setTimerange(TimeRelativeInterval.of(Duration.ofSeconds(seconds), Duration.ZERO));
+                    continue;
+                }
+
+                // X Grid?
+                check = grid_pattern.matcher(line);
+                if (check.matches())
+                {
+                    final int mode = Integer.parseInt(check.group(1));
+                    if (mode == 1)
+                        model.setGridVisible(true);
+                    continue;
+                }
+
+                 // Cache trace colors, PVs that use them follow later in the file
+                check = color_pattern.matcher(line);
+                if (check.matches())
+                {
+                    // Colors counted from 1, not 0
+                    final int index = checkIndex(check.group(1)) - 1;
+                    final int r = Integer.parseInt(check.group(2));
+                    final int g = Integer.parseInt(check.group(3));
+                    final int b = Integer.parseInt(check.group(4));
+                    colors.put(index, Color.rgb(r >> 8, g >> 8, b >> 8));
+                    continue;
+                }
+
+                // PV name creates the trace on individual axis
+                check = name_pattern.matcher(line);
+                if (check.matches())
+                {
+                    final int index = checkIndex(check.group(1));
+                    final String name = check.group(2);
+
+                    // Create model items up to that index
+                    while (model.getItems().size() <= index)
+                        model.addItem(new PVItem("PV" + model.getItems().size(), 0.0));
+
+                    // Create Axes
+                    while (model.getAxisCount() <= index)
+                        model.addAxis();
+
+                    final ModelItem item = model.getItems().get(index);
+                    item.setName(name);
+                    item.setDisplayName(name);
+                    item.setAxis(model.getAxis(index));
+                    if (colors.get(index) != null)
+                        item.setColor(colors.get(index));
+                    continue;
+                }
+
+                // Adjust axis min ..
+                check = min_pattern.matcher(line);
+                if (check.matches())
+                {
+                    final int index = checkIndex(check.group(1));
+                    final double min = Double.parseDouble(check.group(2));
+
+                    final AxisConfig axis = model.getAxis(index);
+                    axis.setRange(min, axis.getMax());
+                    continue;
+                }
+
+                // .. max ..
+                check = max_pattern.matcher(line);
+                if (check.matches())
+                {
+                    final int index = checkIndex(check.group(1));
+                    final double max = Double.parseDouble(check.group(2));
+
+                    final AxisConfig axis = model.getAxis(index);
+                    axis.setRange(axis.getMin(), max);
+                    continue;
+                }
+
+                // .. log scale setting
+                check = scale_pattern.matcher(line);
+                if (check.matches())
+                {
+                    final int index = checkIndex(check.group(1));
+                    final int scale = Integer.parseInt(check.group(2));
+
+                    model.getAxis(index).setLogScale(scale == 1);
+                    continue;
+                }
+            }
+
+            // Use axis limits from striptool config, don't re-scale
+            model.setArchiveRescale(ArchiveRescale.NONE);
+
+            // Use default archives (since stript tool config won't provide any)
+            for (ModelItem item : model.getItems())
+                if (item instanceof PVItem)
+                    ((PVItem) item).useDefaultArchiveDataSources();
+
+        }
+    }
+
+    /** @param text Trace index
+     *  @return index
+     *  @throws Exception for invalid index (outside 0..10)
+     */
+    private static int checkIndex(final String text) throws Exception
+    {
+        final int index = Integer.parseInt(text);
+        // 'Curve' entries use index 0..9,
+        // 'Color' entries use index 1..10.
+        // In here we're not trying to fix a broken Strip Tool config,
+        // but mostly prevent a 'huge' index like 50000 that would
+        // result in creating that many model items and axes.
+        if (index < 0  ||  index > 10)
+            throw new Exception("Invalid curve index " + index);
+        return index;
+
+    }
+}

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,8 @@ public class ConverterPreferences
 {
     @Preference public static String colors_list;
     @Preference private static String edm_paths_config;
+    @Preference public static String stp_path_patch_pattern;
+    @Preference public static String stp_path_patch_replacement;
 
     public static final List<String> paths = new ArrayList<>();
 

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_shellCmdClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_shellCmdClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,8 +7,11 @@
  *******************************************************************************/
 package org.csstudio.display.converter.edm.widgets;
 
+import static org.csstudio.display.converter.edm.Converter.logger;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
@@ -17,6 +20,7 @@ import org.csstudio.display.builder.model.properties.ActionInfos;
 import org.csstudio.display.builder.model.properties.ExecuteCommandActionInfo;
 import org.csstudio.display.builder.model.properties.OpenFileActionInfo;
 import org.csstudio.display.builder.model.widgets.ActionButtonWidget;
+import org.csstudio.display.converter.edm.ConverterPreferences;
 import org.csstudio.display.converter.edm.EdmConverter;
 import org.csstudio.opibuilder.converter.model.EdmString;
 import org.csstudio.opibuilder.converter.model.EdmWidget;
@@ -63,8 +67,14 @@ public class Convert_shellCmdClass extends ConverterBase<ActionButtonWidget>
                     file = command;
                 else
                     file = command.substring(start + 1);
+
+                // Apply configurable patch
+                final String patched = file.replaceAll(ConverterPreferences.stp_path_patch_pattern,
+                                                       ConverterPreferences.stp_path_patch_replacement);
+
                 // Open as 'file', which will use the data browser since it handles *.stp
-                actions.add(new OpenFileActionInfo(description, file));
+                logger.log(Level.INFO, "Converting 'shell' button into 'action' button for {0}", patched);
+                actions.add(new OpenFileActionInfo(description, patched));
             }
             else
                 actions.add(new ExecuteCommandActionInfo(description, command));

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_shellCmdClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_shellCmdClass.java
@@ -15,14 +15,12 @@ import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.properties.ActionInfo;
 import org.csstudio.display.builder.model.properties.ActionInfos;
 import org.csstudio.display.builder.model.properties.ExecuteCommandActionInfo;
-import org.csstudio.display.builder.model.properties.OpenDisplayActionInfo;
-import org.csstudio.display.builder.model.properties.OpenDisplayActionInfo.Target;
+import org.csstudio.display.builder.model.properties.OpenFileActionInfo;
 import org.csstudio.display.builder.model.widgets.ActionButtonWidget;
 import org.csstudio.display.converter.edm.EdmConverter;
 import org.csstudio.opibuilder.converter.model.EdmString;
 import org.csstudio.opibuilder.converter.model.EdmWidget;
 import org.csstudio.opibuilder.converter.model.Edm_shellCmdClass;
-import org.phoebus.framework.macros.Macros;
 
 /** Convert an EDM widget into Display Builder counterpart
  *  @author Kay Kasemir
@@ -56,16 +54,17 @@ public class Convert_shellCmdClass extends ConverterBase<ActionButtonWidget>
             if (command.endsWith("&"))
                 command = command.substring(0, command.length()-1).trim();
 
-            // Command that looks like opening a StripTool file?
             if (command.endsWith(".stp"))
             {
+                // Command that looks like opening a StripTool file?
                 final String file;
                 int start = command.lastIndexOf(" ");
                 if (start < 0)
                     file = command;
                 else
                     file = command.substring(start + 1);
-                actions.add(new OpenDisplayActionInfo(description, file, new Macros(), Target.TAB));
+                // Open as 'file', which will use the data browser since it handles *.stp
+                actions.add(new OpenFileActionInfo(description, file));
             }
             else
                 actions.add(new ExecuteCommandActionInfo(description, command));

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_shellCmdClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_shellCmdClass.java
@@ -15,11 +15,14 @@ import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.properties.ActionInfo;
 import org.csstudio.display.builder.model.properties.ActionInfos;
 import org.csstudio.display.builder.model.properties.ExecuteCommandActionInfo;
+import org.csstudio.display.builder.model.properties.OpenDisplayActionInfo;
+import org.csstudio.display.builder.model.properties.OpenDisplayActionInfo.Target;
 import org.csstudio.display.builder.model.widgets.ActionButtonWidget;
 import org.csstudio.display.converter.edm.EdmConverter;
 import org.csstudio.opibuilder.converter.model.EdmString;
 import org.csstudio.opibuilder.converter.model.EdmWidget;
 import org.csstudio.opibuilder.converter.model.Edm_shellCmdClass;
+import org.phoebus.framework.macros.Macros;
 
 /** Convert an EDM widget into Display Builder counterpart
  *  @author Kay Kasemir
@@ -49,11 +52,23 @@ public class Convert_shellCmdClass extends ConverterBase<ActionButtonWidget>
             final EdmString menuLabel = t.getCommandLabel().getEdmAttributesMap().get(is);
             final String description = menuLabel != null ? menuLabel.get() : "";
 
-            String command = t.getCommand().getEdmAttributesMap().get(is).get();
+            String command = t.getCommand().getEdmAttributesMap().get(is).get().trim();
             if (command.endsWith("&"))
                 command = command.substring(0, command.length()-1).trim();
 
-            actions.add(new ExecuteCommandActionInfo(description, command));
+            // Command that looks like opening a StripTool file?
+            if (command.endsWith(".stp"))
+            {
+                final String file;
+                int start = command.lastIndexOf(" ");
+                if (start < 0)
+                    file = command;
+                else
+                    file = command.substring(start + 1);
+                actions.add(new OpenDisplayActionInfo(description, file, new Macros(), Target.TAB));
+            }
+            else
+                actions.add(new ExecuteCommandActionInfo(description, command));
         }
         widget.propActions().setValue(new ActionInfos(actions));
 

--- a/app/display/convert-edm/src/main/resources/edm_converter_preferences.properties
+++ b/app/display/convert-edm/src/main/resources/edm_converter_preferences.properties
@@ -38,3 +38,26 @@ font_mappings=helvetica=Liberation Sans,courier=Liberation Mono,times=Liberation
 # When the edm_paths_config is left empty,
 # the converter won't find files.
 edm_paths_config=
+
+# Pattern and replacement for patching paths to *.stp (StripTool) files
+#
+# 'Shell Command' buttons in EDM that invoke a command of the form
+#
+#     StripTool /some/path/to/plot.stp
+#
+# are converted into ActionButtons which open the `/some/path/to/plot.stp` file.
+# Data Browser will then open the file when the action is invoked.
+#
+# The following regular expression pattern and replacement can be used
+# to patch `/some/path/to/plot.stp`.
+# By default, both are empty, so the path remains unchanged.
+#
+# Example for transforming all absolute paths into a web location:
+#
+# stp_path_patch_pattern=^(/)
+# stp_path_patch_replacement=https://my_web_server/stripcharts$1
+#
+# Note how the pattern may include group markers (..)
+# and the replacement can reference them via $1, $2, ...
+stp_path_patch_pattern=
+stp_path_patch_replacement=


### PR DESCRIPTION
Extends Data Browser to open Strip Tool `*.stp` files.
While the tools are of course different, it will import the PV names, trace colors, axis ranges and time span.

Extends the EDM converter to turn shell command buttons which run `StripToolOrWhatever /path/to/plot.stp` into an action button which will open the file `/path/to/plot.stp`, with simple reg-ex based option to patch the path name.