### PR TITLE
Data browser export macro handling

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/ExportJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/ExportJob.java
@@ -182,7 +182,7 @@ abstract public class ExportJob implements JobRunnable
      */
     protected void printItemInfo(final PrintStream out, final ModelItem item)
     {
-        out.println(comment + "Channel: " + item.getName());
+        out.println(comment + "Channel: " + item.getResolvedName());
         // If display name differs from PV, show the _resolved_ version
         if (! item.getName().equals(item.getDisplayName()))
             out.println(comment + "Name   : " + item.getResolvedDisplayName());
@@ -224,10 +224,10 @@ abstract public class ExportJob implements JobRunnable
             {
                 ValueIterator iter;
                 if (source == Source.OPTIMIZED_ARCHIVE  &&  optimize_parameter > 1)
-                    iter = reader.getOptimizedValues(item.getName(), start, end, (int)optimize_parameter);
+                    iter = reader.getOptimizedValues(item.getResolvedName(), start, end, (int)optimize_parameter);
                 else
                 {
-                    iter = reader.getRawValues(item.getName(), start, end);
+                    iter = reader.getRawValues(item.getResolvedName(), start, end);
                     if (source == Source.LINEAR_INTERPOLATION && optimize_parameter >= 1)
                         iter = new LinearValueIterator(iter, TimeDuration.ofSeconds(optimize_parameter));
                 }
@@ -236,7 +236,7 @@ abstract public class ExportJob implements JobRunnable
             }
             catch (Exception ex)
             {
-                Logger.getLogger(getClass().getName()).log(Level.FINE, "Export error for " + item.getName(), ex);
+                Logger.getLogger(getClass().getName()).log(Level.FINE, "Export error for " + item.getResolvedName(), ex);
                 if (error == null)
                     error = ex;
             }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/MatlabScriptExportJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/MatlabScriptExportJob.java
@@ -66,7 +66,7 @@ public class MatlabScriptExportJob extends ExportJob
                 out.println();
             printItemInfo(out, item);
             // Get data
-            monitor.beginTask(MessageFormat.format("Fetching data for {0}", item.getName()));
+            monitor.beginTask(MessageFormat.format("Fetching data for {0}", item.getResolvedName()));
             final ValueIterator values = createValueIterator(item);
             // Dump all values
             MatlabQualityHelper qualities = new MatlabQualityHelper();
@@ -79,9 +79,10 @@ public class MatlabScriptExportJob extends ExportJob
                 final VType value = values.next();
                 ++line_count;
                 // t(1)='2010/03/15 13:30:10.123';
+                Instant timeInstant = org.phoebus.core.vtypes.VTypeHelper.getTimestamp(value);
                 out.println(unixTimeStamp ?
-                        "t{" + line_count + "}=" + org.phoebus.core.vtypes.VTypeHelper.getTimestamp(value).toEpochMilli() + ";" :
-                        "t{" + line_count + "}='" + date_format.format(Date.from(org.phoebus.core.vtypes.VTypeHelper.getTimestamp(value)) + "';"));
+                        "t{" + line_count + "}=" + timeInstant.toEpochMilli() + ";" :
+                        "t{" + line_count + "}='" + date_format.format(Date.from(timeInstant)) + "';");
                 // v(1)=4.125;
                 final double num = VTypeHelper.toDouble(value);
                 if (Double.isNaN(num) || Double.isInfinite(num))
@@ -91,7 +92,7 @@ public class MatlabScriptExportJob extends ExportJob
                 // q(1)=0;
                 out.println("q(" + line_count + ")=" + qualities.getQualityCode(org.phoebus.core.vtypes.VTypeHelper.getSeverity(value), VTypeHelper.getMessage(value)) +";");
                 if (line_count % PROGRESS_UPDATE_LINES == 0)
-                    monitor.beginTask(MessageFormat.format("{0}: Wrote {1} samples", item.getName(), line_count));
+                    monitor.beginTask(MessageFormat.format("{0}: Wrote {1} samples", item.getResolvedName(), line_count));
             }
 
             out.println(comment + "Convert time stamps into 'date numbers'");

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/PlainExportJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/PlainExportJob.java
@@ -65,7 +65,7 @@ public class PlainExportJob extends ExportJob
                 out.println();
             printItemInfo(out, item);
             // Get data
-            monitor.beginTask(MessageFormat.format("Fetching data for {0}", item.getName()));
+            monitor.beginTask(MessageFormat.format("Fetching data for {0}", item.getResolvedName()));
             final ValueIterator values = createValueIterator(item);
             // Dump all values
             out.println(comment + Messages.TimeColumn + Messages.Export_Delimiter + formatter.getHeader());
@@ -79,7 +79,7 @@ public class PlainExportJob extends ExportJob
                 out.println(time + Messages.Export_Delimiter + formatter.format(value));
                 ++line_count;
                 if (++line_count % PROGRESS_UPDATE_LINES == 0)
-                    monitor.beginTask(MessageFormat.format("{0}: Wrote {1} samples", item.getName(), line_count));
+                    monitor.beginTask(MessageFormat.format("{0}: Wrote {1} samples", item.getResolvedName(), line_count));
             }
             ++count;
         }

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/SpreadsheetExportJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/SpreadsheetExportJob.java
@@ -45,13 +45,15 @@ public class SpreadsheetExportJob extends PlainExportJob
                                  final PrintStream out) throws Exception
     {
         // Item header
-        for (ModelItem item : model.getItems())
+        for (ModelItem item : model.getItems()){
             printItemInfo(out, item);
+        }
+
         out.println();
         // Spreadsheet Header
         out.print("# " + Messages.TimeColumn);
         for (ModelItem item : model.getItems())
-            out.print(Messages.Export_Delimiter + item.getName() + " " + formatter.getHeader());
+            out.print(Messages.Export_Delimiter + item.getResolvedName() + " " + formatter.getHeader());
         out.println();
 
         // Create speadsheet interpolation


### PR DESCRIPTION
This PR fixes an issue for the following use case:

- User prepares a plt file where a PV name is specified using a macro.
- OPI contains a Databrowser widget referencing the plt file. As OPI sets macro value, the Databrowser widget is able to resolve the PV name.
- User launches Databrowser app from context menu. PV name resolution still OK.
- User launches data export tool to save the plot. At this point macros are not resolved => export fails.

The PR also contains a bug fix introduced in commit 9ee12d71c554d15df249296321a48179f2d1f8e9.