### PR TITLE
Support 'https:' for 'xnds:' and 'pbraw:' archive data sources

### DIFF
--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceArchiveReader.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceArchiveReader.java
@@ -14,15 +14,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import org.epics.archiverappliance.retrieval.client.DataRetrieval;
+import org.epics.archiverappliance.retrieval.client.EpicsMessage;
+import org.epics.archiverappliance.retrieval.client.GenMsgIterator;
+import org.epics.archiverappliance.retrieval.client.RawDataRetrieval;
 import org.phoebus.archive.reader.ArchiveReader;
 import org.phoebus.archive.reader.UnknownChannelException;
 import org.phoebus.archive.reader.ValueIterator;
 import org.phoebus.archive.vtype.TimestampHelper;
 import org.phoebus.ui.text.RegExHelper;
-import org.epics.archiverappliance.retrieval.client.DataRetrieval;
-import org.epics.archiverappliance.retrieval.client.EpicsMessage;
-import org.epics.archiverappliance.retrieval.client.GenMsgIterator;
-import org.epics.archiverappliance.retrieval.client.RawDataRetrieval;
 
 /**
  * Appliance archive reader which reads data from EPICS archiver appliance.
@@ -70,7 +70,9 @@ public class ApplianceArchiveReader implements ArchiveReader, IteratorListener {
         this.useStatistics = useStatistics;
         this.useNewOptimizedOperator = useNewOptimizedOperator;
         this.pbrawURL = url;
-        this.httpURL = pbrawURL.replace("pbraw://", "http://");
+        this.httpURL = AppliancePreferences.useHttps
+                     ? pbrawURL.replace("pbraw://", "https://")
+                     : pbrawURL.replace("pbraw://", "http://");
     }
 
     public String getServerName() {

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/AppliancePreferences.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/AppliancePreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.phoebus.framework.preferences.Preference;
 public class AppliancePreferences {
     @Preference static boolean useStatisticsForOptimizedData;
     @Preference static boolean useNewOptimizedOperator;
+    @Preference static boolean useHttps;
 
     static {
     	AnnotatedPreferences.initialize(AppliancePreferences.class, "/appliance_preferences.properties");

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/channelarchiver/XMLRPCArchiveReader.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/channelarchiver/XMLRPCArchiveReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,8 @@ import org.epics.vtype.AlarmSeverity;
 import org.phoebus.archive.reader.ArchiveReader;
 import org.phoebus.archive.reader.UnknownChannelException;
 import org.phoebus.archive.reader.ValueIterator;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
 import org.phoebus.ui.text.RegExHelper;
 import org.w3c.dom.Element;
 
@@ -46,6 +48,13 @@ import org.w3c.dom.Element;
 @SuppressWarnings("nls")
 public class XMLRPCArchiveReader implements ArchiveReader
 {
+    @Preference static boolean use_https;
+
+    static
+    {
+        AnnotatedPreferences.initialize(XMLRPCArchiveReader.class, "/channelarchiver_preferences.properties");
+    }
+
     final URL url;
     final Integer key;
     private final Integer version;
@@ -66,7 +75,9 @@ public class XMLRPCArchiveReader implements ArchiveReader
         }
         else
             key = 1;
-        this.url = new URL("http" + url.substring(4));
+        this.url = use_https
+                 ? new URL("https" + url.substring(4))
+                 : new URL("http" + url.substring(4));
 
         final Element struct = XmlRpc.communicate(this.url, XmlRpc.command("archiver.info"));
         // XMLUtil.writeDocument(response, System.out);

--- a/app/databrowser/src/main/resources/appliance_preferences.properties
+++ b/app/databrowser/src/main/resources/appliance_preferences.properties
@@ -4,3 +4,6 @@
 
 useStatisticsForOptimizedData=true
 useNewOptimizedOperator=true
+
+# Use 'https://..' instead of plain 'http://..' ?
+useHttps=false

--- a/app/databrowser/src/main/resources/channelarchiver_preferences.properties
+++ b/app/databrowser/src/main/resources/channelarchiver_preferences.properties
@@ -1,0 +1,6 @@
+# --------------------------------------------------
+# Package org.phoebus.archive.reader.channelarchiver
+# --------------------------------------------------
+
+# Use 'https://..' instead of plain 'http://..' ?
+use_https=false


### PR DESCRIPTION
https://epics.anl.gov/tech-talk/2021/msg00123.php