### PR TITLE
Update rxjava from 2(.1.14) to 3(.0.9)

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,8 +34,8 @@ import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 import org.w3c.dom.Element;
 
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** Data Browser Model Item for 'live' PV.
  *  <p>

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/pv/ArrayPVDispatcher.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/pv/ArrayPVDispatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ import org.epics.vtype.VType;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** Dispatches elements of an array PV to per-element local PVs
  *

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/pv/RuntimePV.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/pv/RuntimePV.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ import org.epics.vtype.VType;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** Process Variable, API for accessing life control system data.
  *

--- a/app/pace/src/main/java/org/csstudio/display/pace/model/Cell.java
+++ b/app/pace/src/main/java/org/csstudio/display/pace/model/Cell.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,13 +14,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.csstudio.display.pace.Messages;
 import org.epics.vtype.VType;
+import org.phoebus.core.vtypes.VTypeHelper;
 import org.phoebus.framework.macros.MacroHandler;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 import org.phoebus.util.time.TimestampFormats;
-import org.phoebus.core.vtypes.VTypeHelper;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ObservableValue;
 

--- a/app/pace/src/test/java/org/csstudio/display/pace/ModelUnitTest.java
+++ b/app/pace/src/test/java/org/csstudio/display/pace/ModelUnitTest.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
 package org.csstudio.display.pace;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertFalse;
@@ -22,12 +23,12 @@ import java.util.function.Consumer;
 
 import org.csstudio.display.pace.model.Cell;
 import org.csstudio.display.pace.model.Model;
-import org.phoebus.core.vtypes.VTypeHelper;
 import org.junit.Test;
+import org.phoebus.core.vtypes.VTypeHelper;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** JUnit test of Model
  *

--- a/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
@@ -26,7 +26,7 @@ import org.phoebus.ui.vtype.FormatOption;
 import org.phoebus.ui.vtype.FormatOptionHandler;
 import org.phoebus.util.time.TimestampFormats;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;

--- a/app/pvtable/src/main/java/org/phoebus/applications/pvtable/model/PVTableItem.java
+++ b/app/pvtable/src/main/java/org/phoebus/applications/pvtable/model/PVTableItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,12 +27,11 @@ import org.epics.vtype.VNumberArray;
 import org.epics.vtype.VString;
 import org.epics.vtype.VType;
 import org.phoebus.applications.pvtable.Settings;
+import org.phoebus.core.vtypes.VTypeHelper;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
-import org.phoebus.core.vtypes.VTypeHelper;
-
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** One item (row) in the PV table.
  *

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/TreeModelItem.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/model/TreeModelItem.java
@@ -24,8 +24,8 @@ import org.phoebus.applications.pvtree.Settings;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
-import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.functions.Consumer;
 
 /** One 'item' in the PV Tree
  *

--- a/core/pv/pom.xml
+++ b/core/pv/pom.xml
@@ -20,9 +20,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.reactivex.rxjava2</groupId>
+      <groupId>io.reactivex.rxjava3</groupId>
       <artifactId>rxjava</artifactId>
-      <version>2.1.14</version>
+      <version>3.0.9</version>
     </dependency>
 
     <dependency>

--- a/core/pv/src/main/java/org/phoebus/pv/AccessRightsEventHandler.java
+++ b/core/pv/src/main/java/org/phoebus/pv/AccessRightsEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,10 +7,10 @@
  ******************************************************************************/
 package org.phoebus.pv;
 
-import io.reactivex.Flowable;
-import io.reactivex.FlowableEmitter;
-import io.reactivex.FlowableOnSubscribe;
-import io.reactivex.functions.Cancellable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableEmitter;
+import io.reactivex.rxjava3.core.FlowableOnSubscribe;
+import io.reactivex.rxjava3.functions.Cancellable;
 
 /** Support for {@link Flowable} that sends <code>true</code> for write access
  *  @author Eric Berryman

--- a/core/pv/src/main/java/org/phoebus/pv/PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PV.java
@@ -25,8 +25,8 @@ import org.epics.vtype.VDouble;
 import org.epics.vtype.VTable;
 import org.epics.vtype.VType;
 
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.core.Flowable;
 
 /** Process Variable, API for accessing life control system data.
  *

--- a/core/pv/src/main/java/org/phoebus/pv/ValueEventHandler.java
+++ b/core/pv/src/main/java/org/phoebus/pv/ValueEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,10 +9,10 @@ package org.phoebus.pv;
 
 import org.epics.vtype.VType;
 
-import io.reactivex.Flowable;
-import io.reactivex.FlowableEmitter;
-import io.reactivex.FlowableOnSubscribe;
-import io.reactivex.functions.Cancellable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableEmitter;
+import io.reactivex.rxjava3.core.FlowableOnSubscribe;
+import io.reactivex.rxjava3.functions.Cancellable;
 
 /** Support for {@link Flowable} that sends PV value updates
  *  @author Eric Berryman

--- a/core/pv/src/main/java/org/phoebus/pv/formula/FormulaInput.java
+++ b/core/pv/src/main/java/org/phoebus/pv/formula/FormulaInput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.epics.vtype.VType;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** Input to a formula
  *

--- a/core/pv/src/test/java/org/phoebus/pv/FormulaTest.java
+++ b/core/pv/src/test/java/org/phoebus/pv/FormulaTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2020-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.phoebus.core.vtypes.VTypeHelper;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** @author Kay Kasemir */
 @SuppressWarnings("nls")

--- a/core/pv/src/test/java/org/phoebus/pv/LocalPVTest.java
+++ b/core/pv/src/test/java/org/phoebus/pv/LocalPVTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.phoebus.pv.loc.LocalPVFactory;
 import org.phoebus.pv.loc.ValueHelper;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** @author Kay Kasemir */
 @SuppressWarnings("nls")

--- a/core/pv/src/test/java/org/phoebus/pv/ReactivePVTest.java
+++ b/core/pv/src/test/java/org/phoebus/pv/ReactivePVTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,8 +22,8 @@ import org.epics.vtype.VNumber;
 import org.epics.vtype.VType;
 import org.junit.Test;
 
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** Demos of the {@link PV}'s "Reactive" API
  *

--- a/core/pv/src/test/java/org/phoebus/pv/SimPVTest.java
+++ b/core/pv/src/test/java/org/phoebus/pv/SimPVTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,9 @@ import static org.junit.Assert.assertEquals;
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.Test;
-
-import io.reactivex.disposables.Disposable;
 import org.phoebus.core.vtypes.VTypeHelper;
+
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** @author Kay Kasemir */
 @SuppressWarnings("nls")

--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -112,9 +112,9 @@
     <classpathentry exported="true" kind="lib" path="target/lib/protobuf-java-2.4.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/py4j-0.10.2.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/rank-eval-client-6.4.2.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/reactive-streams-1.0.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/reactive-streams-1.0.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/rhino-1.7.12.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/rxjava-2.1.14.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/rxjava-3.0.9.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/slf4j-api-1.7.25.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/spring-aop-5.1.7.RELEASE.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/spring-beans-5.1.7.RELEASE.jar"/>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -280,9 +280,9 @@
 
     <!-- Reactive ('Flow') API used by PV -->
     <dependency>
-      <groupId>io.reactivex.rxjava2</groupId>
+      <groupId>io.reactivex.rxjava3</groupId>
       <artifactId>rxjava</artifactId>
-      <version>2.1.14</version>
+      <version>3.0.9</version>
     </dependency>
 
     <!-- freeTTS text to speech library used by annunciator -->

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerPV.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerPV.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,8 +36,8 @@ import org.phoebus.core.vtypes.VTypeHelper;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** Alarm tree leaf
  *

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/Filter.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/Filter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -19,13 +19,12 @@ import java.util.logging.Level;
 import org.csstudio.apputil.formula.Formula;
 import org.csstudio.apputil.formula.VariableNode;
 import org.epics.vtype.VType;
+import org.phoebus.core.vtypes.VTypeHelper;
 import org.phoebus.framework.jobs.NamedThreadFactory;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
-import org.phoebus.core.vtypes.VTypeHelper;
-
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** Filter that computes alarm enablement from expression.
  *  <p>
@@ -70,7 +69,7 @@ public class Filter
     /** Is a call to evaluate() pending? */
     private final AtomicBoolean evaluation_pending = new AtomicBoolean();
 
-    private class FilterPVhandler implements io.reactivex.functions.Consumer<VType>
+    private class FilterPVhandler implements io.reactivex.rxjava3.functions.Consumer<VType>
     {
         private final int index;
 

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ArchiveChannel.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ArchiveChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,8 +26,8 @@ import org.phoebus.core.vtypes.VTypeHelper;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /** Base for archived channels.
  *

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/device/PVDevice.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/device/PVDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 import org.phoebus.util.time.TimeDuration;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 
 /** {@link Device} that is connected to a Process Variable,


### PR DESCRIPTION
The PV layer uses RxJava for flow control, caching, queuing etc.
This commit updates it from version 2 to 3, because 2 won't be developed after end of February.

RxJava3 support some Java 8 additions like Streams, but in this commit the usage within Phoebus remains unchanged.
The RxJava maintainers have decided to use different package names for RxJava 2 and 3 to potentially allow using both, which required updating all 'import' statements, but otherwise existing code still runs.

Long term, RxJava intends to use the java.util.concurrent.Flow API introduced in Java 9, but that will have to wait until Android supports Java 9.
For more, see https://github.com/ReactiveX/RxJava/wiki/What's-different-in-3.0

So bottom line this just updates to the latest RxJava, and basic tests suggest that all still "works", so we're ready for the next update.