### PR TITLE
On windows, don't start the CA repeater

### DIFF
--- a/phoebus-product/phoebus.bat
+++ b/phoebus-product/phoebus.bat
@@ -27,6 +27,7 @@ echo off
 FOR /F "tokens=* USEBACKQ" %%F IN (`dir /B product*.jar`) DO (SET JAR=%%F)
 echo on
 
+@REM Don't start CA repeater (#494)
 @REM To get one instance, use server mode
-@java -jar %JAR% -server 4918 %*
+@java -DCA_DISABLE_REPEATER=true -jar %JAR% -server 4918 %*
 


### PR DESCRIPTION
By default, CA client lib will start CA repeater. That process then stays up after we exit phoebus. It prevents self-update as well as blocks the next maven compile cycle, because jar files remain locked.
#494

Most users won't actually miss the CA repeater, worst side effect would be longer re-connect time when an IOC that has been down for a while is started back up.