### PR TITLE
Apply cursor to pane not to button

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
@@ -517,7 +517,8 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
             // tooltip
             // Just apply a style that matches the disabled look.
             Styles.update(base, Styles.NOT_ENABLED, !enabled);
-            base.setCursor(enabled ? Cursor.HAND : Cursors.NO_WRITE);
+            // Apply the cursor to the pane and not to the button
+            jfx_node.setCursor(enabled ? Cursor.HAND : Cursors.NO_WRITE);
         }
     }
 }


### PR DESCRIPTION
Rules can mess up the cursor if that is applied to the button, so apply the cursor to the pane instead.