### PR TITLE
Check ack auth rule while double-click action

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -447,7 +447,7 @@ public class AlarmTableUI extends BorderPane
             final TableRow<AlarmInfoRow> row = new TableRow<>();
             row.setOnMouseClicked(event ->
             {
-                if (event.getClickCount() == 2  &&  !row.isEmpty())
+                if (event.getClickCount() == 2  &&  !row.isEmpty() && AlarmUI.mayAcknowledge(client))
                     JobManager.schedule("ack", monitor ->  client.acknowledge(row.getItem().item, active));
             });
             return row;


### PR DESCRIPTION
Currently, authorization rules for alarm acks is not checked when double-click is used to ack an alarm in alarm table. This PR fixes it.