### PR TITLE
Display import

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArcWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/ArcWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2016-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -83,8 +83,9 @@ public class ArcWidget extends MacroWidget
                        .ifPresent(fill -> arc.propTransparent().setValue(! fill));
 
                 MacroWidget.importPVName(model_reader, widget, widget_xml);
-                // Map border properties to out'line'
-                OutlineSupport.handleLegacyBorder(widget, widget_xml);
+
+                // Legacy arc supported 'border', but that was a rectangular border
+                // unrelated to the arc and not supported by this widget
             }
             return true;
         }


### PR DESCRIPTION
Noboru reported that 'arc' widgets imported from *.opi files that used to look like this:

<img width="1259" alt="cs-studio-Arc-snapshot" src="https://user-images.githubusercontent.com/1932421/108073689-531ebb80-7036-11eb-8e28-8606ef1df251.png">

.. ended up like this with no 'line':

<img width="1355" alt="CS-phoebus-Arc-snapshot" src="https://user-images.githubusercontent.com/1932421/108073735-5fa31400-7036-11eb-87b1-179ce8aa98b1.png">

Turns out to be a side effect of importing the 'border' settings for several graphics widgets, which doesn't apply to the 'arc' in the same way as for other graphics.

Now 'arc' is again imported correctly:

![Screen Shot 2021-02-16 at 9 01 44 AM](https://user-images.githubusercontent.com/1932421/108074115-d5a77b00-7036-11eb-866a-96f55397b35d.png)

While at it, also imported the display 'grid' spacing.

