### PR TITLE
Resolve relative file names with spaces for http://.. parent

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
@@ -503,7 +503,12 @@ public class ModelResourceUtil
      */
     public static InputStream openURL(final String resource_name, final int timeout_ms) throws Exception
     {
-        return ResourceParser.getContent(new URL(resource_name).toURI(), timeout_ms);
+        // Received name may be the result of resolving "some file.png"
+        // relative to "http://server/displays/main.bob" as a string,
+        // i.e. "http://server/displays/some file.png"
+        // This would be acceptable for a file path, but URL() expects spaces to be escaped
+        final String escaped = resource_name.replace(" ", "%20");
+        return ResourceParser.getContent(new URL(escaped).toURI(), timeout_ms);
     }
 
     /** Write a resource.


### PR DESCRIPTION

Scenario was a 'symbol' widget that used `some file.png`.
Works fine when opened locally via `/some/path/to/display.bob`, but failed when opened remotely via `http://server.org/displays/display.bob`.
In the latter case, the image resolves to `http://server.org/displays/some file.png`.
The `URL` class refuses to handle the space in the path, must escape as `%20`.