### PR TITLE
Archive engine: Fix 'delta' comparison after disconnects

### DIFF
--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ArchiveChannel.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ArchiveChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -220,9 +220,12 @@ abstract public class ArchiveChannel
     {
         if (PV.isDisconnected(value))
             handleDisconnected();
-        if (enablement != Enablement.Passive)
-            handleEnablement(value);
-        handleNewValue(checkReceivedValue(value));
+        else
+        {
+            if (enablement != Enablement.Passive)
+                handleEnablement(value);
+            handleNewValue(checkReceivedValue(value));
+        }
     }
 
     public void onError(final Throwable error)

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/DeltaArchiveChannel.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/DeltaArchiveChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,8 +12,8 @@ import static org.csstudio.archive.Engine.logger;
 import java.util.logging.Level;
 
 import org.epics.vtype.VType;
-import org.phoebus.util.time.SecondsParser;
 import org.phoebus.core.vtypes.VTypeHelper;
+import org.phoebus.util.time.SecondsParser;
 
 /** An ArchiveChannel that stores each incoming value that differs from
  *  the previous sample by some 'delta'.
@@ -122,6 +122,9 @@ public class DeltaArchiveChannel extends ArchiveChannel
                 return true;
             previous = VTypeHelper.toDouble(last_archived_value);
         }
+        // Can't compare against NaN and Inf, pass those on
+        if (Double.isNaN(previous)  ||  Double.isInfinite(previous))
+            return true;
         return Math.abs(previous - number) >= delta;
     }
 }

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ValueButcher.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/model/ValueButcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -78,8 +78,13 @@ public class ValueButcher
 
         final StringBuilder buf = new StringBuilder();
         buf.append(TimestampHelper.format(VTypeHelper.getTimestamp(value)))
-           .append(' ')
-           .append(VTypeHelper.toString(value));
+           .append(' ');
+
+        // Suppress 'null' for disconnected
+        if (VTypeHelper.isDisconnected(value))
+            buf.append("N/A");
+        else
+            buf.append(VTypeHelper.toString(value));
 
         final Alarm alarm = Alarm.alarmOf(value);
         if (alarm != null)


### PR DESCRIPTION
Last value after a 'disconnect' was NaN, which failed to compare against
later value updates.
Disconnect was also logged twice, as 'Disconnected' text and with the
bogis value received from CAJ.