### PR TITLE
Fix annunciator active alarm count

### DIFF
--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
@@ -440,7 +440,7 @@ class ServerModel
         int active = 0;
         for (AlarmTreeItem<?> child : item.getChildren())
             if (child.getState().severity.isActive())
-                ++active;
+                active += countAlarmPVs(child);
         return active;
     }
 


### PR DESCRIPTION
Currently, the active alarm count periodically annunciated by annunciator is not correct because the entire alarm tree is not traversed to count all active PVs. This change fixes the issue and reports correct active alarms in annunciations.