### PR TITLE
Replace Travis and AppVeyor badges with GitHub Actions badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# phoebus 
-[![Travis Status](https://travis-ci.org/ControlSystemStudio/phoebus.svg?branch=master)](https://travis-ci.org/ControlSystemStudio/phoebus)
-[![Appveyor Status](https://ci.appveyor.com/api/projects/status/kwktt0vf955aged1/branch/master?svg=true)](https://ci.appveyor.com/project/mattclarke/phoebus-o58ne/branch/master)
+# phoebus
+![GitHub Actions Status](https://github.com/ControlSystemStudio/phoebus/actions/workflows/build.yml/badge.svg)
 
 Phoebus is a framework and a collections of tools to monitor and operate large scale control systems, such as the ones in the accelerator community. Phoebus is an update of the Control System Studio toolset that removes dependencies on Eclipse RCP and SWT.
 


### PR DESCRIPTION
Replaces the Travis and AppVeyor badges with a GitHub Actions one. 

I also think we should remove the Travis configuration as it will stop working soon anyway.