### PR TITLE
Update OpenJFX to 16

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -145,52 +145,52 @@
     <classpathentry exported="true" kind="lib" path="target/lib/commonmark-ext-image-attributes-0.15.2.jar"/>
 
     <!-- On Windows, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-16-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-16-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-16-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-16-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-16-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-16-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-16-win.jar"/>
     -->
     <!-- On Linux, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-16-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-16-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-16-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-16-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-16-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-16-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-16-linux.jar"/>
     -->
     <!-- On Mac, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-15.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-15.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-16-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-16-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-16-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-16-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-16-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-16-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-16.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-16-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-16.jar"/>
     -->
 
     <classpathentry kind="output" path="target/classes"/>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <properties>
     <epics.version>7.0.7</epics.version>
     <vtype.version>1.0.4</vtype.version>
-    <openjfx.version>15</openjfx.version>
+    <openjfx.version>16</openjfx.version>
     <jackson.version>2.10.1</jackson.version>
     <batik.version>1.12</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
OpenJFX 16 was just released, and it fixes the Mac Menu bar issue #1092.
Java runtime can still be as old as JDK11, so this update doesn't force a JRE update.
Tested various displays as well as 3D viewer, all seem to work as before.
Release notes mention no breaking API changes, 
https://github.com/openjdk/jfx/blob/master/doc-files/release-notes-16.md