### PR TITLE
LED: Fix erroneous initial value

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -135,7 +135,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
         model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
         model_widget.propLineColor().addUntypedPropertyListener(styleChangedListener);
         model_widget.runtimePropValue().addPropertyListener(contentChangedListener);
-        contentChanged(null, null, null);
+        contentChanged(null, null, model_widget.runtimePropValue().getValue());
     }
 
     @Override
@@ -178,8 +178,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
     private void contentChanged(final WidgetProperty<VType> property, final VType old_value, final VType new_value)
     {
         final boolean runtime_mode = ! toolkit.isEditMode();
-        final VType value = model_widget.runtimePropValue().getValue();
-        if (value == null && runtime_mode)
+        if (new_value == null && runtime_mode)
         {
             value_color = alarm_colors[AlarmSeverity.UNDEFINED.ordinal()];
             value_label = computeLabel();


### PR DESCRIPTION
When the PV happens to connect and send a value before the LED is first
rendered, it was initialized with `null` as a `new_value`, ignoring the
`runtimePropValue` that was already correct.
The LED would be stuck in that wrong state until the PV updates again.

This was observed in displays that show a PV in 'normal' widgets as well
as widgets that are dynamically added. For the latter widgets, the PV
was already connected, and the LED started out in the wrong state.