### PR TITLE
Plot annotations: Hide when the associated trace is not visible  …

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -444,13 +444,8 @@ public class Controller
 
             @Override
             public void changedItemVisibility(final ModelItem item)
-            {   // Add/remove from plot, but don't need to get archived data
-                // When made visible, note that item could be in 'middle'
-                // of existing traces, so need to re-create all
-                if (item.isVisible())
-                    createPlotTraces();
-                else // To hide, simply remove
-                    plot.removeTrace(item);
+            {
+                plot.updateTrace(item);
             }
 
             @Override
@@ -630,8 +625,7 @@ public class Controller
             for (AxisConfig axis : model.getAxes())
                 plot.updateAxis(i++, axis);
             for (ModelItem item : model.getItems())
-                if (item.isVisible())
-                    plot.addTrace(item);
+                plot.addTrace(item);
         }
         finally
         {

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/plot/ModelBasedPlot.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/plot/ModelBasedPlot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -322,6 +322,7 @@ public class ModelBasedPlot
                 item.getLineStyle(),
                 item.getPointType(), item.getPointSize(),
                 item.getAxisIndex());
+        trace.setVisible(item.isVisible());
         items_by_trace.put(trace, item);
     }
 
@@ -336,11 +337,8 @@ public class ModelBasedPlot
             trace = findTrace(item);
         }
         catch (IllegalArgumentException ex)
-        {   // Could be called with a trace that was not visible,
-            // so it was never in the plot,
-            // and now gets removed.
-            // --> No error, because trace to be removed is already
-            //     absent from plot
+        {   // Trace to be removed is already
+            // absent from plot
             return;
         }
         plot.removeTrace(trace);
@@ -352,15 +350,13 @@ public class ModelBasedPlot
      */
     public void updateTrace(final ModelItem item)
     {
-        // Invisible items have no trace, nothing to update,
-        // and findTrace() would throw an exception
-        if (! item.isVisible())
-            return;
         final Trace<Instant> trace = findTrace(item);
+
         // Update Trace with item's configuration
         final String name = item.getResolvedDisplayName();
         if (!trace.getName().equals(name))
             trace.setName(name);
+        trace.setVisible(item.isVisible());
         trace.setUnits(item.getUnits());
         // These happen to not cause an immediate redraw, so
         // set even if no change

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AnnotationImpl.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AnnotationImpl.java
@@ -118,6 +118,11 @@ public class AnnotationImpl<XTYPE extends Comparable<XTYPE>> extends Annotation<
      */
     boolean isSelected(final Point2D point)
     {
+        // When trace is not visible, this annotation is not shown,
+        // so it should ignore the mouse
+        if (! trace.isVisible())
+            return false;
+
         // In case the handle is above the rect,
         // select that first
         if (areWithinDistance(screen_pos, point))

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AnnotationImpl.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AnnotationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -693,6 +693,9 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends PlotCanvasBase
         // Annotations use label font
         for (AnnotationImpl<XTYPE> annotation : annotations)
         {
+            // Hide annotation when the associated trace is not visible
+            if (! annotation.getTrace().isVisible())
+                continue;
             try
             {
                 annotation.updateValue(annotation.getPosition());


### PR DESCRIPTION
Equivalent to https://github.com/ControlSystemStudio/cs-studio/pull/2683 for Eclipse version.

When traces are hidden, their annotations are hidden as well.

Before this change, hidden traces were removed from the plot, but that complicates associating traces in the model with traces in the plot, and locating the trace for an annotation based on its "index".
Now all traces are always in the plot, the drawing is simply skipped for hidden traces (and annotations).