### PR TITLE
Adding text alignment properties to TextEntry

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextEntryWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextEntryWidget.java
@@ -14,8 +14,10 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFormat;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propHorizontalAlignment;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPrecision;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propShowUnits;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propVerticalAlignment;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propWrapWords;
 
 import java.util.Arrays;
@@ -39,6 +41,8 @@ import org.csstudio.display.builder.model.persist.NamedWidgetFonts;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.persist.WidgetFontService;
 import org.csstudio.display.builder.model.persist.XMLTags;
+import org.csstudio.display.builder.model.properties.HorizontalAlignment;
+import org.csstudio.display.builder.model.properties.VerticalAlignment;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.properties.WidgetFont;
 import org.phoebus.framework.persistence.XMLUtil;
@@ -206,6 +210,8 @@ public class TextEntryWidget extends WritablePVWidget
     private volatile WidgetProperty<Boolean> show_units;
     private volatile WidgetProperty<Boolean> wrap_words;
     private volatile WidgetProperty<Boolean> multi_line;
+    private volatile WidgetProperty<HorizontalAlignment> horizontal_alignment;
+    private volatile WidgetProperty<VerticalAlignment> vertical_alignment;
 
     public TextEntryWidget()
     {
@@ -234,6 +240,8 @@ public class TextEntryWidget extends WritablePVWidget
         properties.add(format = propFormat.createProperty(this, FormatOption.DEFAULT));
         properties.add(precision = propPrecision.createProperty(this, -1));
         properties.add(show_units = propShowUnits.createProperty(this, true));
+        properties.add(horizontal_alignment = propHorizontalAlignment.createProperty(this, HorizontalAlignment.LEFT));
+        properties.add(vertical_alignment = propVerticalAlignment.createProperty(this, VerticalAlignment.MIDDLE));
         properties.add(enabled = propEnabled.createProperty(this, true));
         properties.add(wrap_words = propWrapWords.createProperty(this, false));
         properties.add(multi_line = propMultiLine.createProperty(this, false));
@@ -292,5 +300,17 @@ public class TextEntryWidget extends WritablePVWidget
     public WidgetProperty<Boolean> propMultiLine()
     {
         return multi_line;
+    }
+
+    /** @return 'horizontal_alignment' property */
+    public WidgetProperty<HorizontalAlignment> propHorizontalAlignment()
+    {
+        return horizontal_alignment;
+    }
+
+    /** @return 'vertical_alignment' property */
+    public WidgetProperty<VerticalAlignment> propVerticalAlignment()
+    {
+        return vertical_alignment;
     }
 }

--- a/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/opibuilder.css
+++ b/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/opibuilder.css
@@ -292,3 +292,20 @@
     -fx-background-insets: 0;
     -fx-background-radius: 2;
 }
+
+/*
+Next are three pseudo classes that can be used to align text in a TextArea,
+see for instance TextEntryRepresentation.
+*/
+.text-area:center .text{
+ -fx-text-alignment: center;
+}
+
+.text-area:right .text{
+ -fx-text-alignment: right;
+}
+
+.text-area:left .text{
+ -fx-text-alignment: left;
+}
+


### PR DESCRIPTION
As per user request, I've added horizontal and vertical text alignment properties to the TextEntry widget. For the multi-line case however vertical alignment is ignored.