### PR TITLE
Minor facelift to the log entry table cell

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryCellController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryCellController.java
@@ -4,6 +4,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.GridPane;
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.ext.image.attributes.ImageAttributesExtension;
@@ -18,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.phoebus.util.time.TimestampFormats.MILLI_FORMAT;
+import static org.phoebus.util.time.TimestampFormats.SECONDS_FORMAT;
 
 public class LogEntryCellController {
 
@@ -31,6 +32,9 @@ public class LogEntryCellController {
 
     // Model
     LogEntry logEntry;
+
+    @FXML
+    GridPane root;
 
     @FXML
     Label time;
@@ -46,8 +50,7 @@ public class LogEntryCellController {
     Label tags;
     @FXML
     ImageView tagIcon;
-    @FXML
-    Label attachments;
+
     @FXML
     ImageView attachmentIcon;
 
@@ -61,51 +64,57 @@ public class LogEntryCellController {
         textRenderer = TextContentRenderer.builder().extensions(extensions).build();
     }
 
+    /*
     @FXML
     public void initialize() {
-        time.setStyle("-fx-font-weight: bold");
-        title.setStyle("-fx-font-weight: bold");
-
         logbooks.setText("");
         logbookIcon.setImage(null);
         tags.setText("");
         tagIcon.setImage(null);
-        attachments.setText("");
         attachmentIcon.setImage(null);
 
         title.setText("");
-
-        description.setWrapText(true);
-
     }
+
+     */
 
     @FXML
     public void refresh() {
+        logbookIcon.setImage(logbook);
         if (logEntry != null) {
 
-            time.setText(MILLI_FORMAT.format(logEntry.getCreatedDate()));
+            time.setText(SECONDS_FORMAT.format(logEntry.getCreatedDate()));
             owner.setText(logEntry.getOwner());
             title.setText(logEntry.getTitle());
+            title.getStyleClass().add("title");
 
             if ( !logEntry.getLogbooks().isEmpty() ) {
-                logbookIcon.setImage(logbook);
-                logbooks.setWrapText(true);
+                logbooks.setWrapText(false);
                 logbooks.setText(logEntry.getLogbooks().stream().map(Logbook::getName).collect(Collectors.joining(",")));
             }
-            if ( !logEntry.getTags().isEmpty() ) {
+            if (!logEntry.getTags().isEmpty() ) {
                 tagIcon.setImage(tag);
-                tags.setWrapText(true);
                 tags.setText(logEntry.getTags().stream().map(Tag::getName).collect(Collectors.joining(",")));
+            }
+            else{
+                tagIcon.setImage(null);
+                tags.setText("");
             }
             if( !logEntry.getAttachments().isEmpty()) {
                 attachmentIcon.setImage(attachment);
-                attachments.setText(String.valueOf(logEntry.getAttachments().size()));
             }
+            else{
+                attachmentIcon.setImage(null);
+            }
+            description.setWrapText(false);
             if(logEntry.getSource() != null){
                 description.setText(toText(logEntry.getSource()));
             }
             else if(logEntry.getDescription() != null){
                 description.setText(toText(logEntry.getDescription()));
+            }
+            else{
+                description.setText("");
             }
         }
     }
@@ -116,12 +125,15 @@ public class LogEntryCellController {
     }
 
     /**
-     * Converts Commonmark content to Text.
+     * Converts Commonmark content to Text. At most one line of text is returned, the newline character is
+     * used to detect line break.
      * @param commonmarkString Raw Commonmark string
      * @return The Text output of the Commonmark processor.
      */
     private String toText(String commonmarkString){
         org.commonmark.node.Node document = parser.parse(commonmarkString);
-        return textRenderer.render(document);
+        String text =  textRenderer.render(document);
+        String[] lines = text.split("\r\n|\n|\r");
+        return lines[0];
     }
 }

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/LogEntryCell.fxml
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/LogEntryCell.fxml
@@ -1,61 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
 
-<AnchorPane xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.phoebus.logbook.olog.ui.LogEntryCellController">
-   <children>
-      <GridPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints />
-            <RowConstraints maxHeight="1.7976931348623157E308" minHeight="30.0" vgrow="NEVER" />
-            <RowConstraints maxHeight="40.0" minHeight="30.0" vgrow="ALWAYS" />
-            <RowConstraints />
-        </rowConstraints>
-         <children>
-            <GridPane GridPane.hgrow="ALWAYS">
-              <columnConstraints>
-                <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" prefWidth="100.0" />
-              </columnConstraints>
-              <rowConstraints>
-                <RowConstraints minHeight="10.0" />
-                <RowConstraints minHeight="10.0" />
-              </rowConstraints>
-               <children>
-                  <Label fx:id="time" text="Time" GridPane.rowIndex="0" />
-                  <Label fx:id="owner" text="Owner" GridPane.rowIndex="1" />
-               </children>
-            </GridPane>
-            <GridPane minWidth="125.0" GridPane.columnIndex="1">
-              <columnConstraints>
-                <ColumnConstraints hgrow="NEVER" minWidth="17.0" />
-                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="125.0" />
-              </columnConstraints>
-              <rowConstraints>
-                <RowConstraints minHeight="10.0" />
-                <RowConstraints minHeight="10.0" />
-                <RowConstraints minHeight="10.0" />
-              </rowConstraints>
-               <children>
-                  <ImageView fx:id="logbookIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" />
-                  <Label fx:id="logbooks" text="Logbooks" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" />
-                  <ImageView fx:id="tagIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" GridPane.rowIndex="1" />
-                  <Label fx:id="tags" text="Tags" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                  <ImageView fx:id="attachmentIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" GridPane.rowIndex="2" />
-                  <Label fx:id="attachments" text="Attachments" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-               </children>
-            </GridPane>
-            <Label fx:id="title" text="Title" GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" GridPane.vgrow="NEVER" />
-            <Label fx:id="description" text="description" GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.rowIndex="2" />
-         </children>
-      </GridPane>
-   </children>
-</AnchorPane>
+<GridPane fx:id="root" maxHeight="-Infinity" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.phoebus.logbook.olog.ui.LogEntryCellController">
+    <columnConstraints>
+      <ColumnConstraints />
+      <ColumnConstraints />
+    </columnConstraints>
+    <rowConstraints>
+      <RowConstraints />
+        <RowConstraints />
+        <RowConstraints />
+        <RowConstraints />
+        <RowConstraints />
+    </rowConstraints>
+    <children>
+        <Label fx:id="owner" text="Owner">
+         <font>
+            <Font size="20.0" />
+         </font>
+        </Label>
+        <ImageView fx:id="attachmentIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="0" />
+        <Label fx:id="title" text="Title" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1">
+         <font>
+            <Font name="Arial Bold" size="13.0" />
+         </font>
+        </Label>
+        <Label fx:id="time" text="Time" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+        <GridPane GridPane.rowIndex="2">
+          <columnConstraints>
+            <ColumnConstraints />
+            <ColumnConstraints />
+          </columnConstraints>
+          <rowConstraints>
+            <RowConstraints minHeight="15.0" />
+            <RowConstraints minHeight="15.0" />
+          </rowConstraints>
+          <children>
+              <ImageView fx:id="logbookIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true">
+               <GridPane.margin>
+                  <Insets bottom="3.0" right="3.0" top="3.0" />
+               </GridPane.margin></ImageView>
+              <Label fx:id="logbooks" text="Logbooks" GridPane.columnIndex="1" />
+              <ImageView fx:id="tagIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" GridPane.rowIndex="1">
+               <GridPane.margin>
+                  <Insets bottom="3.0" right="3.0" top="3.0" />
+               </GridPane.margin></ImageView>
+              <Label fx:id="tags" text="Tags" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+           </children>
+         <padding>
+            <Insets bottom="2.0" top="2.0" />
+         </padding>
+        </GridPane>
+        <Label fx:id="description" text="very long description placeholder" GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.rowIndex="3" >
+            <font>
+                <Font name="Arial" size="13.0" />
+            </font>
+        </Label>
+    </children>
+   <padding>
+      <Insets bottom="7.0" left="7.0" right="7.0" top="7.0" />
+   </padding>
+</GridPane>


### PR DESCRIPTION
I have done some changes to the list cells in the log entry table view (Olog), this is based on user feedback and also better aligns to the design chosen for the web client. In my view the changes improves readability of the table.

Most noticible change is the logbooks and tags lines moving to the left. Since the string generated for the list of logbooks and tags may vary, it makes more sense to "left align". Also removed the attachment count.

This PR also fixes a bug in the cell rendering: tags string was "inherited" from preceding cell when tag list is empty.

![Screenshot 2021-04-16 at 15 52 17](https://user-images.githubusercontent.com/35602960/115035973-5e268880-9ecd-11eb-8bc7-250b1950cf1e.png)
