### PR TITLE
Added opacity property to Picture widget

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
@@ -259,6 +259,7 @@ public class Messages
     public static String WidgetProperties_OnImage;
     public static String WidgetProperties_OnLabel;
     public static String WidgetProperties_OnlyExtremaVisible;
+    public static String WidgetProperties_Opacity;
     public static String WidgetProperties_Orientation;
     public static String WidgetProperties_Password;
     public static String WidgetProperties_Points;

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PictureWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PictureWidget.java
@@ -101,9 +101,17 @@ public class PictureWidget extends MacroWidget
     public static final WidgetPropertyDescriptor<Boolean> propStretch =
             newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "stretch_image", Messages.WidgetProperties_StretchToFit);
 
+    /**
+     * An opacity property. Controlling it from a rule or script works as a
+     * way to do a simple animation.
+     */
+    public static final WidgetPropertyDescriptor<Double> propOpacity =
+            newDoublePropertyDescriptor(WidgetPropertyCategory.DISPLAY, "opacity", Messages.WidgetProperties_Opacity);
+
     private volatile WidgetProperty<String> filename;
     private volatile WidgetProperty<Boolean> stretch_image;
     private volatile WidgetProperty<Double> rotation;
+    private volatile WidgetProperty<Double> opacity;
 
     public PictureWidget()
     {
@@ -117,6 +125,8 @@ public class PictureWidget extends MacroWidget
         properties.add(filename = propFile.createProperty(this, default_pic));
         properties.add(stretch_image = propStretch.createProperty(this, false));
         properties.add(rotation = propRotation.createProperty(this, 0.0));
+        properties.add(opacity = propOpacity.createProperty(this, 1.0));
+
     }
 
     /** @return 'rotation' property */
@@ -135,6 +145,12 @@ public class PictureWidget extends MacroWidget
     public WidgetProperty<Boolean> propStretch()
     {
         return stretch_image;
+    }
+
+    /** @return 'opacity' property */
+    public WidgetProperty<Double> propOpacity()
+    {
+        return opacity;
     }
 
     @Override

--- a/app/display/model/src/main/resources/examples/graphics_picture.bob
+++ b/app/display/model/src/main/resources/examples/graphics_picture.bob
@@ -1,33 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<display version="1.0.0">
+<display version="2.0.0">
   <name>Picture</name>
-  <x>-1</x>
-  <y>-1</y>
   <widget type="label" version="2.0.0">
     <name>Label</name>
+    <text>Picture Widget</text>
     <width>181</width>
     <height>31</height>
-    <text>Picture Widget</text>
     <font>
-      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      <font name="Header 1" family="Source Sans Pro" style="BOLD_ITALIC" size="36.0">
       </font>
     </font>
   </widget>
   <widget type="picture" version="2.0.0">
     <name>Grasshopper</name>
-    <x>41</x>
-    <y>61</y>
+    <file>pic/grasshopper.jpg</file>
+    <x>10</x>
+    <y>60</y>
     <width>210</width>
     <height>220</height>
-    <file>pic/grasshopper.jpg</file>
   </widget>
   <widget type="picture" version="2.0.0">
     <name>Rose</name>
-    <x>61</x>
-    <y>331</y>
+    <file>pic/Yellow-Rose.png</file>
+    <x>10</x>
+    <y>320</y>
     <width>210</width>
     <height>170</height>
     <rotation>90.0</rotation>
-    <file>pic/Yellow-Rose.png</file>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_1</name>
+    <text>Image using opacity for simple animation</text>
+    <x>320</x>
+    <y>270</y>
+    <width>320</width>
+  </widget>
+  <widget type="picture" version="2.0.0">
+    <name>Grasshopper_1</name>
+    <file>pic/grasshopper.jpg</file>
+    <x>320</x>
+    <y>60</y>
+    <width>210</width>
+    <height>220</height>
+    <rules>
+      <rule name="Simple Animation" prop_id="opacity" out_exp="true">
+        <exp bool_exp="true">
+          <expression>pv0</expression>
+        </exp>
+        <pv_name>sim://sine(0,1,1)</pv_name>
+      </rule>
+    </rules>
   </widget>
 </display>

--- a/app/display/model/src/main/resources/examples/graphics_picture.bob
+++ b/app/display/model/src/main/resources/examples/graphics_picture.bob
@@ -7,7 +7,7 @@
     <width>181</width>
     <height>31</height>
     <font>
-      <font name="Header 1" family="Source Sans Pro" style="BOLD_ITALIC" size="36.0">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
       </font>
     </font>
   </widget>

--- a/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
+++ b/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
@@ -243,6 +243,7 @@ WidgetProperties_OnColor='On' Color
 WidgetProperties_OnImage='On' Image
 WidgetProperties_OnLabel='On' Label
 WidgetProperties_OnlyExtremaVisible=Only Extrema Visible
+WidgetProperties_Opacity=Opacity
 WidgetProperties_Orientation=Orientation
 WidgetProperties_Password=Password
 WidgetProperties_Points=Points

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
@@ -69,6 +69,7 @@ public class PictureRepresentation extends JFXBaseRepresentation<ImageView, Pict
 
         model_widget.propStretch().addUntypedPropertyListener(styleChangedListener);
         model_widget.propRotation().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propOpacity().addUntypedPropertyListener(styleChangedListener);
 //      styleChanged() will be called by contentChanged()
 
         model_widget.propFile().addPropertyListener(contentChangedListener);
@@ -88,6 +89,7 @@ public class PictureRepresentation extends JFXBaseRepresentation<ImageView, Pict
         model_widget.propHeight().removePropertyListener(styleChangedListener);
         model_widget.propStretch().removePropertyListener(styleChangedListener);
         model_widget.propRotation().removePropertyListener(styleChangedListener);
+        model_widget.propOpacity().removePropertyListener(styleChangedListener);
         model_widget.propFile().removePropertyListener(contentChangedListener);
         super.unregisterListeners();
     }
@@ -219,6 +221,9 @@ public class PictureRepresentation extends JFXBaseRepresentation<ImageView, Pict
             // translate to the center of the widget
             translate.setX((widg_w - final_pic_w) / 2.0);
             translate.setY((widg_h - final_pic_h) / 2.0);
+
+            // Apply opacity
+            jfx_node.opacityProperty().setValue(model_widget.propOpacity().getValue());
         }
     }
 


### PR DESCRIPTION
As requested by users, added an opacity property to the Picture widget so that a rule or script can create a simple animation.