### PR TITLE
Update of log entry display header and list view item

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryCellController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryCellController.java
@@ -64,23 +64,15 @@ public class LogEntryCellController {
         textRenderer = TextContentRenderer.builder().extensions(extensions).build();
     }
 
-    /*
     @FXML
     public void initialize() {
-        logbooks.setText("");
-        logbookIcon.setImage(null);
-        tags.setText("");
-        tagIcon.setImage(null);
+        logbookIcon.setImage(logbook);
+        tagIcon.setImage(tag);
         attachmentIcon.setImage(null);
-
-        title.setText("");
     }
-
-     */
 
     @FXML
     public void refresh() {
-        logbookIcon.setImage(logbook);
         if (logEntry != null) {
 
             time.setText(SECONDS_FORMAT.format(logEntry.getCreatedDate()));
@@ -93,12 +85,10 @@ public class LogEntryCellController {
                 logbooks.setText(logEntry.getLogbooks().stream().map(Logbook::getName).collect(Collectors.joining(",")));
             }
             if (!logEntry.getTags().isEmpty() ) {
-                tagIcon.setImage(tag);
                 tags.setText(logEntry.getTags().stream().map(Tag::getName).collect(Collectors.joining(",")));
             }
             else{
-                tagIcon.setImage(null);
-                tags.setText("");
+                tags.setText(null);
             }
             if( !logEntry.getAttachments().isEmpty()) {
                 attachmentIcon.setImage(attachment);
@@ -114,7 +104,7 @@ public class LogEntryCellController {
                 description.setText(toText(logEntry.getDescription()));
             }
             else{
-                description.setText("");
+                description.setText(null);
             }
         }
     }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryDisplayController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryDisplayController.java
@@ -6,12 +6,14 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.TitledPane;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.HBox;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.RowConstraints;
 import javafx.scene.layout.VBox;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
@@ -39,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.phoebus.util.time.TimestampFormats.MILLI_FORMAT;
+import static org.phoebus.util.time.TimestampFormats.SECONDS_FORMAT;
 
 public class LogEntryDisplayController {
 
@@ -60,13 +62,6 @@ public class LogEntryDisplayController {
     WebView logDescription;
 
     @FXML
-    HBox metaDataBox;
-    @FXML
-    ListView<String> logTags;
-    @FXML
-    ListView<String> LogLogbooks;
-
-    @FXML
     public TitledPane attachmentsPane;
     @FXML
     public AttachmentsPreviewController attachmentsPreviewController;
@@ -79,6 +74,16 @@ public class LogEntryDisplayController {
     public LogPropertiesController propertiesController;
     @FXML
     private Button downloadButton;
+    @FXML
+    private ImageView logbookIcon;
+    @FXML
+    private Label logbooks;
+    @FXML
+    private ImageView tagIcon;
+    @FXML
+    private Label tags;
+    @FXML
+    private AnchorPane attachmentsAndPropertiesPane;
 
     private LogEntry logEntry;
 
@@ -98,39 +103,6 @@ public class LogEntryDisplayController {
 
     @FXML
     public void initialize() {
-        logTime.setStyle("-fx-font-weight: bold");
-        logTitle.setStyle("-fx-font-weight: bold");
-
-        logTags.setVisible(false);
-        LogLogbooks.setVisible(false);
-
-        logTags.setCellFactory(listView -> new ListCell<String>() {
-            @Override
-            public void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty) {
-                    setText(null);
-                    setGraphic(null);
-                } else {
-                    setGraphic(new ImageView(tag));
-                    setText(item);
-                }
-            }
-        });
-
-        LogLogbooks.setCellFactory(listView -> new ListCell<>() {
-            @Override
-            public void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty) {
-                    setText(null);
-                    setGraphic(null);
-                } else {
-                    setGraphic(new ImageView(logbook));
-                    setText(item);
-                }
-            }
-        });
 
         List<Extension> extensions = Arrays.asList(TablesExtension.create(), ImageAttributesExtension.create());
         parser = Parser.builder().extensions(extensions).build();
@@ -149,10 +121,25 @@ public class LogEntryDisplayController {
                 }
             }
         });
+
+        clearLogView();
+    }
+
+    private void clearLogView(){
+        logbookIcon.setImage(null);
+        tagIcon.setImage(null);
+        logOwner.setText(null);
+        logTime.setText(null);
+        logTitle.setText(null);
+        logbooks.setText(null);
+        tags.setText(null);
     }
 
     public void refresh() {
         if (logEntry != null) {
+
+            logbookIcon.setImage(logbook);
+            tagIcon.setImage(tag);
 
             attachmentsPane.setExpanded(logEntry.getAttachments() != null && !logEntry.getAttachments().isEmpty());
             attachmentsPane.setVisible(logEntry.getAttachments() != null && !logEntry.getAttachments().isEmpty());
@@ -160,16 +147,7 @@ public class LogEntryDisplayController {
             propertiesPane.setExpanded(logEntry.getProperties() != null && !logEntry.getProperties().isEmpty());
             propertiesPane.setVisible(logEntry.getProperties() != null && !logEntry.getProperties().isEmpty());
 
-            int metaDataCount = logEntry.getLogbooks().size() >= logEntry.getTags().size() ? logEntry.getLogbooks().size() : logEntry.getTags().size();
-            metaDataBox.setPrefHeight(metaDataCount * 60);
-
-            logTags.setVisible(!logEntry.getTags().isEmpty());
-            logTags.setPrefHeight(metaDataCount * 60);
-            LogLogbooks.setVisible(!logEntry.getLogbooks().isEmpty());
-            LogLogbooks.setPrefHeight(metaDataCount * 60);
-
-            logTime.setText(MILLI_FORMAT.format(logEntry.getCreatedDate()));
-
+            logTime.setText(SECONDS_FORMAT.format(logEntry.getCreatedDate()));
             logOwner.setText(logEntry.getOwner());
 
             logTitle.setWrapText(true);
@@ -190,17 +168,27 @@ public class LogEntryDisplayController {
             }
             ObservableList<String> logbookList = FXCollections.observableArrayList();
             logbookList.addAll(logEntry.getLogbooks().stream().map(Logbook::getName).collect(Collectors.toList()));
-            LogLogbooks.setItems(logbookList);
 
             ObservableList<String> tagList = FXCollections.observableArrayList();
             tagList.addAll(logEntry.getTags().stream().map(Tag::getName).collect(Collectors.toList()));
-            logTags.setItems(tagList);
 
             attachmentsPreviewController
                     .setAttachments(FXCollections.observableArrayList(logEntry.getAttachments()));
 
             if (!logEntry.getProperties().isEmpty()) {
                 propertiesController.setProperties(logEntry.getProperties());
+            }
+
+            if ( !logEntry.getLogbooks().isEmpty() ) {
+                logbooks.setWrapText(false);
+                logbooks.setText(logEntry.getLogbooks().stream().map(Logbook::getName).collect(Collectors.joining(",")));
+            }
+
+            if (!logEntry.getTags().isEmpty() ) {
+                tags.setText(logEntry.getTags().stream().map(Tag::getName).collect(Collectors.joining(",")));
+            }
+            else{
+                tags.setText(null);
             }
         }
     }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertiesEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertiesEditorController.java
@@ -109,6 +109,7 @@ public class LogPropertiesEditorController {
                         setText(null);
                         setGraphic(textField);
                         textField.selectAll();
+                        textField.requestFocus();
                     }
 
                     @Override
@@ -142,6 +143,13 @@ public class LogPropertiesEditorController {
                                 commitEdit(textField.getText());
                             } else if (t.getCode() == KeyCode.ESCAPE) {
                                 cancelEdit();
+                            }
+                        });
+                        // Update when cell exits edit mode.
+                        // This will ensure that value is committed when focus is lost.
+                        this.editingProperty().addListener((o, n, e) -> {
+                            if(!e){
+                                updateItem(textField.getText(), false);
                             }
                         });
                     }

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/LogEntryCell.fxml
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/LogEntryCell.fxml
@@ -23,22 +23,25 @@
          <font>
             <Font size="20.0" />
          </font>
+         <GridPane.margin>
+            <Insets bottom="-3.0" top="-3.0" />
+         </GridPane.margin>
         </Label>
         <ImageView fx:id="attachmentIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="0" />
         <Label fx:id="title" text="Title" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1">
          <font>
-            <Font name="Arial Bold" size="13.0" />
+            <Font name="Arial Bold" size="14.0" />
          </font>
         </Label>
         <Label fx:id="time" text="Time" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
-        <GridPane GridPane.rowIndex="2">
+        <GridPane fx:id="logbooksAndTags" GridPane.rowIndex="2">
           <columnConstraints>
             <ColumnConstraints />
             <ColumnConstraints />
           </columnConstraints>
           <rowConstraints>
-            <RowConstraints minHeight="15.0" />
-            <RowConstraints minHeight="15.0" />
+            <RowConstraints />
+            <RowConstraints />
           </rowConstraints>
           <children>
               <ImageView fx:id="logbookIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true">
@@ -56,13 +59,13 @@
             <Insets bottom="2.0" top="2.0" />
          </padding>
         </GridPane>
-        <Label fx:id="description" text="very long description placeholder" GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.rowIndex="3" >
+        <Label fx:id="description" text="very long description placeholder" GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.rowIndex="3">
             <font>
                 <Font name="Arial" size="13.0" />
             </font>
         </Label>
     </children>
    <padding>
-      <Insets bottom="7.0" left="7.0" right="7.0" top="7.0" />
+      <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
    </padding>
 </GridPane>

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/LogEntryDisplay.fxml
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/LogEntryDisplay.fxml
@@ -2,57 +2,92 @@
 
 <?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
 <?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
 <?import javafx.scene.web.*?>
 
 <SplitPane dividerPositions="0.6" orientation="VERTICAL" prefHeight="673.0" prefWidth="845.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.phoebus.logbook.olog.ui.LogEntryDisplayController">
 <items>
   <AnchorPane minHeight="0.0" minWidth="0.0">
        <children>
-        <GridPane hgap="1.0" minHeight="140.0" vgap="1.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+        <GridPane hgap="1.0" vgap="1.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
           <columnConstraints>
-            <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" prefWidth="100.0" />
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+              <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" prefWidth="100.0" />
+              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
           </columnConstraints>
           <rowConstraints>
-            <RowConstraints maxHeight="-Infinity" minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                <RowConstraints maxHeight="-Infinity" minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+            <RowConstraints />
+                <RowConstraints />
+                <RowConstraints />
+                <RowConstraints />
+                  <RowConstraints />
           </rowConstraints>
           <children>
-            <Label fx:id="logTime" text="time" GridPane.columnSpan="2" GridPane.hgrow="NEVER" GridPane.vgrow="NEVER">
-              <padding>
-                <Insets left="5.0" />
-              </padding>
-            </Label>
-                <Label fx:id="logTitle" text="title" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1">
+            <Label fx:id="logTime" contentDisplay="RIGHT" text="1970-01-01 00:00:00" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1">
+                     <padding>
+                        <Insets right="5.0" />
+                     </padding>
+                     <font>
+                        <Font name="Arial Bold" size="14.0" />
+                     </font></Label>
+                <Label fx:id="logTitle" text="title" GridPane.rowIndex="1">
                    <padding>
                       <Insets left="5.0" />
                    </padding>
+                     <font>
+                        <Font name="Arial Bold" size="14.0" />
+                     </font>
                 </Label>
-                <Label fx:id="logOwner" text="owner" GridPane.columnIndex="1" />
-              <ScrollPane GridPane.columnSpan="2" GridPane.rowIndex="2" GridPane.rowSpan="2" GridPane.vgrow="ALWAYS">
+                <Label fx:id="logOwner" text="owner">
+                     <font>
+                        <Font size="20.0" />
+                     </font>
+                     <padding>
+                        <Insets left="5.0" />
+                     </padding>
+                     <GridPane.margin>
+                        <Insets />
+                     </GridPane.margin></Label>
+              <GridPane GridPane.rowIndex="2">
+                  <columnConstraints>
+                      <ColumnConstraints />
+                      <ColumnConstraints />
+                  </columnConstraints>
+                  <rowConstraints>
+                      <RowConstraints />
+                      <RowConstraints />
+                  </rowConstraints>
+                  <children>
+                      <ImageView fx:id="logbookIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true">
+                          <GridPane.margin>
+                              <Insets bottom="3.0" right="3.0" top="3.0" />
+                          </GridPane.margin>
+                      </ImageView>
+                      <Label fx:id="logbooks" text="Logbooks" GridPane.columnIndex="1">
+                           <GridPane.margin>
+                              <Insets />
+                           </GridPane.margin></Label>
+                      <ImageView fx:id="tagIcon" fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" GridPane.rowIndex="1">
+                          <GridPane.margin>
+                              <Insets bottom="3.0" right="3.0" top="3.0" />
+                          </GridPane.margin></ImageView>
+                      <Label fx:id="tags" text="Tags" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  </children>
+                  <padding>
+                      <Insets bottom="5.0" left="5.0" top="2.0" />
+                  </padding>
+              </GridPane>
+              <ScrollPane GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.rowIndex="3" GridPane.vgrow="ALWAYS">
                   <content>
                       <WebView fx:id="logDescription" minHeight="2048" minWidth="4096" GridPane.vgrow="ALWAYS" />
                   </content>
               </ScrollPane>
-
-                <HBox fx:id="metaDataBox" GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.rowIndex="4" GridPane.vgrow="ALWAYS">
-                   <children>
-            <ListView fx:id="LogLogbooks" HBox.hgrow="ALWAYS" />
-            <ListView fx:id="logTags" HBox.hgrow="ALWAYS" />
-                   </children>
-                </HBox>
           </children>
-          <padding>
-            <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
-          </padding>
         </GridPane>
        </children>
     </AnchorPane>
-  <AnchorPane minHeight="0.0" minWidth="0.0">
+  <AnchorPane fx:id="attachmentsAndPropertiesPane" minHeight="0.0" minWidth="0.0">
        <children>
         <Accordion AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
           <panes>
@@ -62,7 +97,7 @@
                     <children>
                         <fx:include fx:id="attachmentsPreview" source="AttachmentsPreview.fxml" GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" />
                         <Label GridPane.columnIndex="0" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" />
-                        <Button fx:id="downloadButton" onAction="#downloadSelectedAttachments"  text="%DownloadSelected" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                        <Button fx:id="downloadButton" onAction="#downloadSelectedAttachments" text="%DownloadSelected" GridPane.columnIndex="1" GridPane.rowIndex="1">
                                  <GridPane.margin>
                                     <Insets bottom="-4.0" top="5.0" />
                                  </GridPane.margin></Button>


### PR DESCRIPTION
This PR aligns the log table list view items and the log entry display header. Elements are arranged in the same manner. 

Also a change in the log properties editor to commit edit when focus is lost.