### PR TITLE
Alarm Server: WARNING level for kafka library

### DIFF
--- a/services/alarm-server/src/main/resources/alarm_server_logging.properties
+++ b/services/alarm-server/src/main/resources/alarm_server_logging.properties
@@ -25,6 +25,8 @@ javax.activation.level = WARNING
 javax.mail.level = WARNING
 com.sun.mail.smtp.level = WARNING
 
+org.apache.kafka.level = WARNING
+
 org.phoebus.applications.alarm.level = INFO
 com.cosylab.epics.caj.level = WARNING
 org.phoebus.framework.rdb.level = WARNING


### PR DESCRIPTION
With #1736, the Kafka library log messages are sent to java.util.logging. This adds the corresponding level=WARNING entry to the built-in log configuration file, since otherwise we get a flurry of FINE messages.