### PR TITLE
make olog.ui option to allow use of logbook.ui

### DIFF
--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -36,6 +36,7 @@
       <groupId>org.phoebus</groupId>
       <artifactId>app-logbook-olog-ui</artifactId>
       <version>4.6.6-SNAPSHOT</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>


### PR DESCRIPTION
@georgweiss @tanviash 
minor change but will require updating your site specific products.

I would still recommend using the olog.ui... despite its name for the time being it is generic enough to support most logbooks client implementations