### PR TITLE
Ignore LogPropertyProvider if Property is null

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertyFactory.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertyFactory.java
@@ -17,10 +17,13 @@ public class LogPropertyFactory {
     private static List<LogPropertyProvider> factories = new ArrayList<LogPropertyProvider>();
 
     private LogPropertyFactory() {
-        // Load available adapter factories
+        // Load available adapter factories.
+        // A LogPropertyProvider returning a null Property is ignored.
         loader = ServiceLoader.load(LogPropertyProvider.class);
         loader.stream().forEach(p -> {
-            factories.add(p.get());
+            if(p.get().getProperty() != null){
+                factories.add(p.get());
+            }
         });
     }
 


### PR DESCRIPTION
The idea is the let a LogPropertyProvider return null based on some condition (e.g. preference value). When loading providers the getProperty value is inspected to determine if it should be ignored.