### PR TITLE
Fix for issues related to transparent color

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/WidgetColorPropertyField.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/WidgetColorPropertyField.java
@@ -57,7 +57,10 @@ public class WidgetColorPropertyField extends HBox
     public void setColor(final WidgetColor color)
     {
         final GraphicsContext gc = blob.getGraphicsContext2D();
-
+        // If user selects transparent color, clearing the rectangle
+        // is required. Without previous color will be visible through
+        // the transparent rectangle.
+        gc.clearRect(0, 0, 16, 16);
         gc.setFill(JFXUtil.convert(color));
         gc.fillRect(0, 0, 16, 16);
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOverController.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOverController.java
@@ -460,12 +460,10 @@ public class WidgetColorPopOverController implements Initializable {
                 setGraphic(blob);
 
                 final GraphicsContext gc = blob.getGraphicsContext2D();
-
+                gc.clearRect(0, 0, SIZE, SIZE);
                 gc.setFill(JFXUtil.convert(color));
                 gc.fillRect(0, 0, SIZE, SIZE);
-
             }
-
         }
     };
 

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTMeter.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTMeter.java
@@ -118,6 +118,8 @@ public class RTMeter extends ImageView
 
     private WritableImage awt_jfx_convert_buffer = null;
 
+    private static final Color NO_COLOR = new Color(0, 0, 0, 0);
+
     /** Redraw on UI thread by adding needle to 'meter_background' */
     private final Runnable redraw_runnable = () ->
     {
@@ -322,6 +324,10 @@ public class RTMeter extends ImageView
 
         computeLayout(gc, area_copy);
 
+        // To correctly handle transparent background in edit mode, the widget
+        // rectangle must be cleared using a transparent background color.
+        gc.setBackground(NO_COLOR);
+        gc.clearRect(0, 0, area_copy.width, area_copy.height);
         gc.setColor(background);
         gc.fillRect(0, 0, area_copy.width, area_copy.height);
 


### PR DESCRIPTION
This PR fixes the following issues related to using transparent color:

1) In the palette the small box shows whatever color was selected before user select transparent color:
<img width="350" alt="Screenshot 2021-05-04 at 13 57 43" src="https://user-images.githubusercontent.com/35602960/117000295-27c87600-ace1-11eb-9ee8-0f7a96527481.png">

2) In the color picker the box for the transparent color may have incorrect appearance:
<img width="299" alt="Screenshot 2021-05-04 at 13 57 26" src="https://user-images.githubusercontent.com/35602960/117000415-55152400-ace1-11eb-91a9-cb8bc2073b3d.png">

3) For the Meter widget, selecting transparent colors may result in incorrect colors on the widget. This is an edit mode only issue.
<img width="845" alt="Screenshot 2021-05-04 at 13 58 46" src="https://user-images.githubusercontent.com/35602960/117000537-8261d200-ace1-11eb-9620-bc46a6ad3cea.png">
