### PR TITLE
Alarm border: Initial update in case value already received

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/RegionBaseRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/RegionBaseRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -179,6 +179,9 @@ abstract public class RegionBaseRepresentation<JFX extends Region, MW extends Vi
             // but some widgets may allow other data types (Table),
             // so use Object and then check for VType
             value_prop.addUntypedPropertyListener(connectionOrValueChangedListener);
+
+            // Initial update in case we have already received a value
+            connectionOrValueChangedListener.propertyChanged(value_prop, null, value_prop.getValue());
         }
 
         // Indicate 'disconnected' state


### PR DESCRIPTION
Similar to the issue observed with LED color #1845, the alarm border can fail to reflect the current alarm if an initial value has been received before the widget is first rendered.
As with the LED issue, this can happen when a PV is already shown on a display and thus connected, then a new widget is added dynamically.