### PR TITLE
Navigation Tabs color handling fix

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
@@ -272,6 +272,7 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
     private void tabLookChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {
         dirty_tab_look.mark();
+        dirty_active_tab.mark();
         toolkit.scheduleUpdate(this);
     }
 

--- a/core/ui/src/main/java/org/phoebus/ui/javafx/JFXUtil.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/JFXUtil.java
@@ -35,7 +35,8 @@ public class JFXUtil
             final int r = (int)Math.round(col.getRed() * 255.0);
             final int g = (int)Math.round(col.getGreen() * 255.0);
             final int b = (int)Math.round(col.getBlue() * 255.0);
-            return String.format((Locale) null, "#%02X%02X%02X", r, g, b);
+            final int alfa = (int)Math.round(col.getOpacity() * 255.0);
+            return String.format((Locale) null, "#%02X%02X%02X%02X", r, g, b, alfa);
         });
     }
 }

--- a/core/ui/src/test/java/org/phoebus/ui/javafx/JFXUtilTest.java
+++ b/core/ui/src/test/java/org/phoebus/ui/javafx/JFXUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.ui.javafx;
+
+import javafx.scene.paint.Color;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JFXUtilTest {
+
+    @Test
+    public void testWebRGB(){
+        Color color = new Color(1.0, 1.0, 1.0, 1.0);
+        String webRGB = JFXUtil.webRGB(color);
+        assertEquals("#FFFFFFFF", webRGB);
+
+        color = new Color(1.0, 1.0, 1.0, 0.0);
+        webRGB = JFXUtil.webRGB(color);
+        assertEquals("#FFFFFF00", webRGB);
+
+        color = Color.color(1.0, 1.0, 1.0);
+        webRGB = JFXUtil.webRGB(color);
+        assertEquals("#FFFFFFFF", webRGB);
+    }
+}


### PR DESCRIPTION
Changed JFXUtils.webRGB to honor alpha value when converting. This is needed for instance when selecting the selected or deselected color in the Navigation Tabs widget.

Also fixed issue with toggle button color not changing for selected tab when selecting new (non-default) color:

![Screenshot 2021-05-05 at 13 25 52](https://user-images.githubusercontent.com/35602960/117134500-f49bea80-ada5-11eb-856b-1307a091d52e.png)
