### PR TITLE
Add button to embed screen shot to log entry

### DIFF
--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogAttachment.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogAttachment.java
@@ -118,6 +118,11 @@ public class OlogAttachment implements Attachment {
         return file;
     }
 
+    @Override
+    public void setId(String id){
+        this.id = id;
+    }
+
     public void setFile(File file) {
         this.file = file;
     }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/EmbedImageDialog.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/EmbedImageDialog.java
@@ -25,6 +25,7 @@ import javafx.scene.control.DialogPane;
 import org.phoebus.framework.nls.NLS;
 import org.phoebus.logbook.olog.ui.Messages;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
@@ -36,6 +37,8 @@ import java.util.logging.Logger;
  */
 public class EmbedImageDialog extends Dialog<EmbedImageDescriptor> {
 
+    private EmbedImageDialogController controller;
+
     public EmbedImageDialog(){
         super();
         ResourceBundle resourceBundle =  NLS.getMessages(Messages.class);
@@ -43,7 +46,36 @@ public class EmbedImageDialog extends Dialog<EmbedImageDescriptor> {
                 new FXMLLoader(getClass().getResource("EmbedImageDialog.fxml"), resourceBundle);
         try {
             DialogPane dialogPane = loader.load();
-            EmbedImageDialogController controller = loader.getController();
+            controller = loader.getController();
+            setTitle(Messages.EmbedImageDialogTitle);
+            setDialogPane(dialogPane);
+            setResultConverter(buttonType -> {
+                if(buttonType.getButtonData() == ButtonData.OK_DONE){
+                    return controller.getEmbedImageDescriptor();
+                }
+                else{
+                    return null;
+                }
+            });
+        } catch (IOException e) {
+            Logger.getLogger(EmbedImageDialog.class.getName())
+                    .log(Level.SEVERE, "Unable to launch dialog to embedded image.", e);
+        }
+    }
+
+    public void setFile(File file){
+        controller.setFile(file);
+    }
+
+    public EmbedImageDialog(File file){
+        super();
+        ResourceBundle resourceBundle =  NLS.getMessages(Messages.class);
+        FXMLLoader loader =
+                new FXMLLoader(getClass().getResource("EmbedImageDialog.fxml"), resourceBundle);
+        try {
+            DialogPane dialogPane = loader.load();
+            controller = loader.getController();
+            controller.setFile(file);
             setTitle(Messages.EmbedImageDialogTitle);
             setDialogPane(dialogPane);
             setResultConverter(buttonType -> {

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/EmbedImageDialogController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/EmbedImageDialogController.java
@@ -161,6 +161,20 @@ public class EmbedImageDialogController implements Initializable{
         filenameProperty.set(id);
     }
 
+    public void setFile(File file){
+        filenameProperty.set(file.getName());
+        try {
+            BufferedImage bufferedImage = ImageIO.read(file);
+            image = SwingFXUtils.toFXImage(bufferedImage, null);
+            widthProperty.set((int)Math.round(image.getWidth()));
+            heightProperty.set((int)Math.round(image.getHeight()));
+            id = UUID.randomUUID().toString();
+        } catch (IOException ex) {
+            Logger.getLogger(EmbedImageDialogController.class.getName())
+                    .log(Level.SEVERE, "Unable to load image file " + file.getAbsolutePath(), ex);
+        }
+    }
+
     /**
      * @return A {@link EmbedImageDescriptor} that will carry the data
      * required to create an image attachment for the log entry.

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryModel.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryModel.java
@@ -164,6 +164,7 @@ public class LogEntryModel {
             addSelectedTag(tag.getName());
         });
 
+
         attachmentList.addAll(template.getAttachments());
     }
 

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/write/AttachmentsView.fxml
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/write/AttachmentsView.fxml
@@ -23,7 +23,8 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<VBox fx:id="root" maxHeight="1.7976931348623157E308" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.phoebus.logbook.olog.ui.write.AttachmentsViewController">
+<VBox fx:id="root" maxHeight="1.7976931348623157E308" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1"
+      fx:controller="org.phoebus.logbook.olog.ui.write.AttachmentsViewController">
     <children>
         <fx:include fx:id="attachmentsPreview" source="../AttachmentsPreview.fxml" />
         <HBox fx:id="buttonBar" spacing="5.0" GridPane.rowIndex="2" VBox.vgrow="NEVER">
@@ -37,6 +38,11 @@
             <Button maxWidth="1.7976931348623157E308" onAction="#embedImage" text="%EmbedImage" HBox.hgrow="ALWAYS">
                 <tooltip>
                     <Tooltip text="%EmbedImageTooltip"/>
+                </tooltip>
+            </Button>
+            <Button fx:id="embedSelectedButton" maxWidth="1.7976931348623157E308" onAction="#embedSelected" text="%EmbedSelected" HBox.hgrow="ALWAYS">
+                <tooltip>
+                    <Tooltip text="%EmbedSelectedTooltip"/>
                 </tooltip>
             </Button>
             <Button fx:id="removeButton" maxWidth="1.7976931348623157E308" onAction="#removeFiles" text="%Remove" HBox.hgrow="ALWAYS" />

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/write/AttachmentsViewControllerTest.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/write/AttachmentsViewControllerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.logbook.olog.ui.write;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class AttachmentsViewControllerTest {
+
+    @Test
+    public void testRemoveImageMarkup(){
+        AttachmentsViewController attachmentsViewController =
+                new AttachmentsViewController(null, false);
+
+        String markup = "![](attachment/123456789){width=100 height=100}";
+        String result = attachmentsViewController.removeImageMarkup(markup, "123456789");
+        assertTrue(result.isEmpty());
+
+        markup = "ABC ![](attachment/123456789){width=100 height=100} DEF";
+        result = attachmentsViewController.removeImageMarkup(markup, "123456789");
+        assertEquals("ABC  DEF", result);
+
+        markup = "![](attachment/ABCDE){width=100 height=100}\n![](attachment/123456789){width=100 height=100}\n![](attachment/abcde){width=100 height=100}";
+        result = attachmentsViewController.removeImageMarkup(markup, "123456789");
+        assertEquals("![](attachment/ABCDE){width=100 height=100}\n\n![](attachment/abcde){width=100 height=100}", result);
+
+        markup = "![](attachment/123456789){width=100 height=100}";
+        result = attachmentsViewController.removeImageMarkup(markup, "abcde");
+        assertEquals("![](attachment/123456789){width=100 height=100}", result);
+
+        markup = "whatever";
+        result = attachmentsViewController.removeImageMarkup(markup, "123456789");
+        assertEquals("whatever", result);
+    }
+}

--- a/core/logbook/src/main/java/org/phoebus/logbook/Attachment.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/Attachment.java
@@ -15,6 +15,12 @@ public interface Attachment {
     default String getId(){
         return null;
     }
+
+    /**
+     * In some cases the client must be able to set the (unique) id.
+     * @param id
+     */
+    default void setId(String id){}
     
     public String getName();
 

--- a/core/logbook/src/main/java/org/phoebus/logbook/AttachmentImpl.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/AttachmentImpl.java
@@ -51,7 +51,8 @@ public class AttachmentImpl implements Attachment {
         return id;
     }
 
-    private void setId(String id){
+    @Override
+    public void setId(String id){
         this.id = id;
     }
 


### PR DESCRIPTION
As per user request: added button in Olog log entry editor to embed image file attachment added through other actions, e.g. when added as screenshot from OPI.

Also added code to remove image markup if attachment is removed from attachment list.