### PR TITLE
Fix logbook preference warning

### DIFF
--- a/core/logbook/src/main/java/org/phoebus/logbook/LogbookPreferences.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/LogbookPreferences.java
@@ -12,7 +12,10 @@ public class LogbookPreferences {
 
     @Preference
     public static String logbook_factory;
-    @Preference
+
+    /** Is there support for a logbook?
+     *  Is the 'logbook_factory' configured and available?
+     */
     public static boolean is_supported;
 
     static


### PR DESCRIPTION
`LogbookPreferences` has two settings: `logbook_factory`, which is read from the preferences, and `is_supported` which is automatically set based on the availability of the selected logbook factory.

`logbook_factory` is correctly annotated as `@Preference`, since it's initialized from preferences.

`is_supported` was erroneously annotated as `@Preference`, resulting in this error on startup because there is no such setting in the preference files, and there's not supposed to be one since the variable is automatically set:
```
SEVERE [org.phoebus.framework.preferences] No default setting for preference org.phoebus.logbook/is_supported
```