### PR TITLE
PVA Server: Support EPICS_PVAS_INTF_ADDR_LIST

### DIFF
--- a/core/pva/README.md
+++ b/core/pva/README.md
@@ -65,6 +65,8 @@ Key configuration parameters:
 
 `EPICS_PVAS_BROADCAST_PORT`: PVA server UDP port (default 5076) for name searches and beacons.
 
+`EPICS_PVAS_INTF_ADDR_LIST`: Interface where server listens to name searches. When empty (default), a wildcard address is used, i.e., server listens on all local interfaces. Can be set to a specific IP address to restrict the server to one interface.
+
 `EPICS_PVA_SERVER_PORT`: First PVA TCP port used by server, defaults to 5075.
 
 See `PVASettings` source code for complete settings.

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -41,6 +41,17 @@ public class PVASettings
     /** First PVA port used by server */
     public static int EPICS_PVA_SERVER_PORT = 5075;
 
+    /** Local address to which server will bind.
+     *
+     *  <p>When empty, a wildcard address is used, i.e. the server
+     *  will listen to seach requests on all interfaces.
+     *  By setting this variable you can limit the interfaces
+     *  on which the server listens.
+     *  Note that at this time only a single address
+     *  is supported, not a list with two or more addresses.
+     */
+    public static String EPICS_PVAS_INTF_ADDR_LIST = "";
+
     /** PVA server port for name searches and beacons */
     public static int EPICS_PVAS_BROADCAST_PORT = EPICS_PVA_BROADCAST_PORT;
 
@@ -93,6 +104,14 @@ public class PVASettings
         EPICS_PVA_ADDR_LIST = get("EPICS_PVA_ADDR_LIST", EPICS_PVA_ADDR_LIST);
         EPICS_PVA_AUTO_ADDR_LIST = get("EPICS_PVA_AUTO_ADDR_LIST", EPICS_PVA_AUTO_ADDR_LIST);
         EPICS_PVA_SERVER_PORT = get("EPICS_PVA_SERVER_PORT", EPICS_PVA_SERVER_PORT);
+        EPICS_PVAS_INTF_ADDR_LIST = get("EPICS_PVAS_INTF_ADDR_LIST", EPICS_PVAS_INTF_ADDR_LIST).trim();
+        if (EPICS_PVAS_INTF_ADDR_LIST.contains(" "))
+        {   // Current implementation only handles empty (wildcard) and single address, not list with 2 or more
+            logger.log(Level.WARNING,
+                       "EPICS_PVAS_INTF_ADDR_LIST does at this time support at most one address, ignoring list '" +
+                       EPICS_PVAS_INTF_ADDR_LIST + "'");
+            EPICS_PVAS_INTF_ADDR_LIST = "";
+        }
         EPICS_PVA_BROADCAST_PORT = get("EPICS_PVA_BROADCAST_PORT", EPICS_PVA_BROADCAST_PORT);
         EPICS_PVAS_BROADCAST_PORT = get("EPICS_PVAS_BROADCAST_PORT", EPICS_PVAS_BROADCAST_PORT);
         EPICS_PVA_CONN_TMO = get("EPICS_PVA_CONN_TMO", EPICS_PVA_CONN_TMO);

--- a/core/pva/src/main/java/org/epics/pva/client/ClientUDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientUDPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -89,12 +89,12 @@ class ClientUDPHandler extends UDPHandler
         this.search_response = search_response;
 
         // Search buffer may send broadcasts and gets re-used
-        udp_search = Network.createUDP(true, 0);
+        udp_search = Network.createUDP(true, "", 0);
         local_address = (InetSocketAddress) udp_search.getLocalAddress();
         local_multicast = Network.configureMulticast(udp_search, PVASettings.EPICS_PVA_BROADCAST_PORT);
 
         // Beacon socket only receives, does not send broadcasts
-        udp_beacon = Network.createUDP(false, PVASettings.EPICS_PVA_BROADCAST_PORT);
+        udp_beacon = Network.createUDP(false, "", PVASettings.EPICS_PVA_BROADCAST_PORT);
 
         logger.log(Level.FINE, "Awaiting search replies on UDP " + local_address +
                                " and beacons on port " + PVASettings.EPICS_PVA_BROADCAST_PORT);

--- a/core/pva/src/main/java/org/epics/pva/common/Network.java
+++ b/core/pva/src/main/java/org/epics/pva/common/Network.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -125,11 +125,12 @@ public class Network
     /** Create UDP channel
      *
      *  @param broadcast Support broadcast?
+     *  @param address IP address of interface, use empty string for wildcard address
      *  @param port Port to use or 0 to auto-assign
      *  @return UDP channel
      *  @throws Exception on error
      */
-    public static DatagramChannel createUDP(boolean broadcast, int port) throws Exception
+    public static DatagramChannel createUDP(final boolean broadcast, final String address,  final int port) throws Exception
     {
         // Current use of multicast addresses works only with INET, not INET6
         final DatagramChannel udp = DatagramChannel.open(StandardProtocolFamily.INET);
@@ -137,7 +138,10 @@ public class Network
         if (broadcast)
             udp.socket().setBroadcast(true);
         udp.socket().setReuseAddress(true);
-        udp.bind(new InetSocketAddress(port));
+        if (address.isEmpty())
+            udp.bind(new InetSocketAddress(port));
+        else
+            udp.bind(new InetSocketAddress(address, port));
         return udp;
     }
 

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPListener.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -76,7 +76,11 @@ class ServerTCPListener
         socket.socket().setReuseAddress(true);
         try
         {
-            socket.bind(new InetSocketAddress(PVASettings.EPICS_PVA_SERVER_PORT));
+            if (PVASettings.EPICS_PVAS_INTF_ADDR_LIST.isEmpty())
+                socket.bind(new InetSocketAddress(PVASettings.EPICS_PVA_SERVER_PORT));
+            else
+                socket.bind(new InetSocketAddress(PVASettings.EPICS_PVAS_INTF_ADDR_LIST,
+                                                  PVASettings.EPICS_PVA_SERVER_PORT));
             return socket;
         }
         catch (BindException ex)

--- a/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,7 +54,8 @@ class ServerUDPHandler extends UDPHandler
     public ServerUDPHandler(final SearchHandler search_handler) throws Exception
     {
         this.search_handler = search_handler;
-        udp = Network.createUDP(false, PVASettings.EPICS_PVAS_BROADCAST_PORT);
+        udp = Network.createUDP(false, PVASettings.EPICS_PVAS_INTF_ADDR_LIST,
+                                       PVASettings.EPICS_PVAS_BROADCAST_PORT);
         local_multicast = Network.configureMulticast(udp, PVASettings.EPICS_PVAS_BROADCAST_PORT);
         local_address = (InetSocketAddress) udp.getLocalAddress();
         logger.log(Level.FINE, "Awaiting searches and sending beacons on UDP " + local_address);


### PR DESCRIPTION
Adds support for the EPICS_PVAS_INTF_ADDR_LIST as currently used in pvxs (https://mdavidsaver.github.io/pvxs/server.html#configuration) and recently discussed on tech-talk.