### PR TITLE
Alarms: Create "tombstone" Kafka "state:" message for deleted PV

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
@@ -292,9 +292,15 @@ public class AlarmClient
             else if (type.equals(AlarmSystem.STATE_PREFIX))
             {   // State update
                 if (json == null)
-                    logger.log(Level.WARNING, "Got state update with null content: " + record.key() + " " + node_config);
+                {   // State update for deleted node, ignore
+                    logger.log(Level.FINE, () -> "Got state update for deleted node: " + record.key() + " " + node_config);
+                    return;
+                }
                 else if (! JsonModelReader.isStateUpdate(json))
+                {
                     logger.log(Level.WARNING, "Got state update with config content: " + record.key() + " " + node_config);
+                    return;
+                }
                 else if (deleted_paths.contains(path))
                 {
                     // It it _deleted_??

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
@@ -170,7 +170,8 @@ class ServerModel
                     {   // No config -> Delete node
                         final AlarmTreeItem<?> node = deleteNode(path);
                         if (node != null)
-                            stopPVs(node);
+                            stopDeletedPVs(node);
+                        // else: Deletion message for node we never created
                     }
                     else
                     {
@@ -360,14 +361,18 @@ class ServerModel
     /** Stop PVs in a subtree of the alarm hierarchy
      *  @param node Node where to start
      */
-    private void stopPVs(final AlarmTreeItem<?> node)
+    private void stopDeletedPVs(final AlarmTreeItem<?> node)
     {
-        // If this was a known PV, notify listener
         if (node instanceof AlarmServerPV)
+        {
+            // Stop the PV, i.e. no longer react to value updates
             ((AlarmServerPV) node).stop();
+            // Send a null "tombstone" status update
+            sendStateUpdate(node.getPathName(), null);
+        }
         else
             for (AlarmTreeItem<?> child : node.getChildren())
-                stopPVs(child);
+                stopDeletedPVs(child);
     }
 
     /** Send alarm update to 'state' topic


### PR DESCRIPTION
While the "config:" topic contains a "delete" info message followed by a
tombstone which deletes the PV, the last "state:" message remains in the
Kafka stream. The combination of non-null "state:" followed by null
"config:" will briefly create and then delete the PV in GUI clients.
Adding the null "state:" message optimizes this.

#1921