### PR TITLE
Fix for file save deadlock

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -521,8 +521,8 @@ public class DockItem extends Tab
     /** Register check for closing the tab
      *
      *  @param ok_to_close Will be called when tab prepares to close.
-     *                     Will be invoked on the UI thread, so it may
-     *                     prompt for "Do you want to save?".
+     *                     Will be invoked on a background (non-UI) thread, so callers
+     *                     must handle UI interaction (e.g. prompt or choose file) accordingly.
      *                     May return a completed future right away,
      *                     or start a background thread to for example
      *                     save the tab's content which will complete

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -567,11 +567,8 @@ public class DockItem extends Tab
         if (close_check != null)
             for (Supplier<Future<Boolean>> check : close_check)
             {
-                // Invoke each actual ok-to-close check on UI thread,
-                // since it may open dialogs etc. before starting a "save" thread
                 final CompletableFuture<Boolean> result = new CompletableFuture<>();
-                Platform.runLater(() ->
-                {
+                JobManager.schedule("Check if OK to close", monitor -> {
                     try
                     {
                         result.complete(check.get().get());
@@ -581,7 +578,6 @@ public class DockItem extends Tab
                         result.completeExceptionally(ex);
                     }
                 });
-                // .. then await result of check started in UI thread
                 if (! result.get())
                     return false;
             }


### PR DESCRIPTION
When user attempts to close application with unsaved edits (display, data browser plot or scan file), the application will prompt user to save, cancel or ignore (yes/cancel/no). If user chooses to save (=yes), an existing file will be saved with the edited content. 

There is however a special case: if data browser plot was triggered from a context menu there is no file to save, so the user must be prompted using a file chooser dialog. Same goes for new scan: user may edit in UI, but no file is associated with the new content.

This special case will as far as I can determine cause a deadlock: the file chooser must be triggered from the JavaFX application thread (see SaveAsDialog#promptForFile), but at this point the thread is in a wait state, see DockItem#prepareToClose.

This PR attempts to fix the deadlock. Verified on display, data browser and scan.