### PR TITLE
Annunciator: Only count enabled alarms

### DIFF
--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
@@ -454,8 +454,9 @@ class ServerModel
      */
     private int countAlarmPVs(final AlarmTreeItem<?> item)
     {
+        // Only count enabled items
         if (item instanceof AlarmServerPV)
-            return item.getState().severity.isActive() ? 1 : 0;
+            return ((AlarmServerPV) item).isEnabled() &&  item.getState().severity.isActive() ? 1 : 0;
         int active = 0;
         for (AlarmTreeItem<?> child : item.getChildren())
             if (child.getState().severity.isActive())


### PR DESCRIPTION
Currently, annunciator reports both enabled and disabled PVs in its 'active alarm count' which can be confusing at times since alarm table reports only enabled PVs as active alarms. This PR updates annunciator to count only enabled alarms as active.