### PR TITLE
Archive engine: Fix import of '<channel><enable/>'

### DIFF
--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
@@ -297,6 +297,20 @@ public class RDBConfig implements AutoCloseable
                 statement.executeUpdate();
             }
         }
+
+        if (enable)
+        {
+            // Register this channel as an 'enabling' channel for the group
+            try
+            (
+                PreparedStatement statement = connection.prepareStatement(sql.chan_grp_set_enable_channel);
+            )
+            {
+                statement.setInt(1, channel_id);
+                statement.setInt(2, group_id);
+                statement.executeUpdate();
+            }
+        }
     }
 
     /** @param config_name Name of engine config to delete

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/XMLConfig.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/XMLConfig.java
@@ -146,7 +146,7 @@ public class XMLConfig
                 final boolean monitor = XMLUtil.getChildElement(ce, MONITOR) != null;
                 final double period = SecondsParser.parseSeconds(XMLUtil.getChildString(ce, PERIOD).orElse("60.0"));
                 final double delta = XMLUtil.getChildDouble(ce, DELTA).orElse(-1.0);
-                final boolean enable = XMLUtil.getChildBoolean(ce, ENABLE).orElse(false);
+                final boolean enable = XMLUtil.getChildElement(ce, ENABLE) != null;
 
                 config.addChannel(group_id, duplicates, name, monitor, period, delta, enable);
             }


### PR DESCRIPTION
Kudleep reported on EPICS tech-talk that the import of an archive config with a channel marked to "<enable/>" the group seemed to be ignored.
This fixes the issue.