### PR TITLE
Auto select first attachment in log entry viewer

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
@@ -149,6 +149,7 @@ public class AttachmentsPreviewController {
                 splitPane.getScene().setCursor(Cursor.MOVE);
             }
         });
+
         imagePreview.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
             if(selectedAttachment.get() != null && selectedAttachment.get().getContentType().startsWith("image")){
                 launchImageViewer();
@@ -187,6 +188,10 @@ public class AttachmentsPreviewController {
                 }
             }
         });
+        // Automatically select first attachment.
+        if(attachments != null && attachments.size() > 0){
+            attachmentListView.getSelectionModel().select(attachments.get(0));
+        }
     }
 
     private class AttachmentRow extends ListCell<Attachment> {


### PR DESCRIPTION
When user selects a log entry with attachments, the attachment preview should automatically select first item and render it.