### PR TITLE
Stand-alone Commonmark cheatsheet viewer

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/CommonmarkHelpViewer.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/CommonmarkHelpViewer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.logbook.olog.ui;
+
+import javafx.scene.Scene;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import org.phoebus.logbook.LogService;
+import org.phoebus.logbook.LogbookPreferences;
+
+/**
+ * Stand-alone, non-modal window used to display the Commonmark cheatsheet. Using this instead of
+ * relying on the default browser solves the problem of untrusted SSL certificates as Phoebus will
+ * accept them, while the browser might not.
+ */
+public class CommonmarkHelpViewer extends Stage {
+
+    private String helpContentUrl;
+    private WebEngine webEngine;
+
+    public CommonmarkHelpViewer() {
+        initModality(Modality.WINDOW_MODAL);
+        String url = LogService.getInstance().getLogFactories().get(LogbookPreferences.logbook_factory).getLogClient().getServiceUrl();
+        if (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+        // Need to get rid of Olog path element under which all REST endpoints are published.
+        // The help file however is published directly on the context root.
+        int idx = url.indexOf("/Olog");
+        this.helpContentUrl = url.substring(0, idx) + "/" + LogbookUIPreferences.markup_help;
+
+        WebView webView = new WebView();
+        this.webEngine = webView.getEngine();
+
+        setOnShown(windowEvent -> webEngine.load(helpContentUrl));
+        setTitle("Olog Markup Quick Reference");
+        setWidth(1000);
+        setHeight(1000);
+
+        Scene scene = new Scene(webView);
+        setScene(scene);
+    }
+}

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/FieldsViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/FieldsViewController.java
@@ -51,6 +51,7 @@ import org.phoebus.logbook.LogService;
 import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.LogbookPreferences;
 import org.phoebus.logbook.Tag;
+import org.phoebus.logbook.olog.ui.CommonmarkHelpViewer;
 import org.phoebus.logbook.olog.ui.LogbookUIPreferences;
 import org.phoebus.logbook.olog.ui.Messages;
 import org.phoebus.olog.es.api.OlogProperties;
@@ -293,15 +294,7 @@ public class FieldsViewController implements Initializable {
 
     @FXML
     public void showHelp() {
-        String url =  LogService.getInstance().getLogFactories().get(LogbookPreferences.logbook_factory).getLogClient().getServiceUrl();
-        if(url.endsWith("/")){
-            url = url.substring(0, url.length() - 1);
-        }
-        // Need to get rid of Olog path element under which all REST endpoints are published.
-        // The help file however is published directly on the context root.
-        int idx = url.indexOf("/Olog");
-        String helpUrl = url.substring(0, idx) + "/" + LogbookUIPreferences.markup_help;
-        Platform.runLater(() -> PhoebusApplication.INSTANCE.getHostServices().showDocument(helpUrl));
+        new CommonmarkHelpViewer().show();
     }
 
     public TextArea getTextArea() {


### PR DESCRIPTION
Changing from showing the cheatsheet in default browser to stand-alone window in Phoebus. Reason is that if the Olog service is served over SSL using untrusted certificate, Phoebus will handle the REST API, but a browser might not accept the certificate. With this change the cheatsheet will be rendered as long as the REST API also works from the client.