### PR TITLE
Added possibility to remove log entry property

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertiesEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertiesEditorController.java
@@ -1,6 +1,8 @@
 package org.phoebus.logbook.olog.ui.write;
 
 import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -9,11 +11,15 @@ import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableColumn.CellDataFeatures;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.control.cell.TextFieldTreeTableCell;
 import javafx.scene.input.MouseEvent;
@@ -22,18 +28,20 @@ import javafx.util.Callback;
 import javafx.util.converter.DefaultStringConverter;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.logbook.LogClient;
-import org.phoebus.logbook.LogEntry;
 import org.phoebus.logbook.LogService;
 import org.phoebus.logbook.LogbookPreferences;
 import org.phoebus.logbook.Property;
 import org.phoebus.logbook.PropertyImpl;
 import org.phoebus.logbook.olog.ui.LogbookUIPreferences;
+import org.phoebus.ui.javafx.Messages;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -72,10 +80,9 @@ public class LogPropertiesEditorController {
     private List<String> hiddenPropertiesNames = Arrays.asList(LogbookUIPreferences.hidden_properties);
 
     /**
-     *
      * @param properties A collection of {@link Property}s.
      */
-    public LogPropertiesEditorController(Collection<Property> properties){
+    public LogPropertiesEditorController(Collection<Property> properties) {
         // Log entry may already contain properties, so need to handle them accordingly.
         this.hiddenProperties =
                 properties.stream().filter(p -> hiddenPropertiesNames.contains(p.getName())).collect(Collectors.toList());
@@ -93,19 +100,13 @@ public class LogPropertiesEditorController {
 
         name.setMaxWidth(1f * Integer.MAX_VALUE * 40);
         name.setCellValueFactory(
-                new Callback<TreeTableColumn.CellDataFeatures<PropertyTreeNode, String>, ObservableValue<String>>() {
-                    public ObservableValue<String> call(TreeTableColumn.CellDataFeatures<PropertyTreeNode, String> p) {
-                        return p.getValue().getValue().nameProperty();
-                    }
-                });
+                (Callback<CellDataFeatures<PropertyTreeNode, String>, ObservableValue<String>>) p -> p.getValue().getValue().nameProperty());
+
+        name.setCellFactory((Callback<TreeTableColumn<PropertyTreeNode, String>, TreeTableCell<PropertyTreeNode, String>>) param -> new PropertyNameCell());
 
         value.setMaxWidth(1f * Integer.MAX_VALUE * 60);
         value.setCellValueFactory(
-                new Callback<TreeTableColumn.CellDataFeatures<PropertyTreeNode, String>, ObservableValue<String>>() {
-                    public ObservableValue<String> call(TreeTableColumn.CellDataFeatures<PropertyTreeNode, String> p) {
-                        return p.getValue().getValue().valueProperty();
-                    }
-                });
+                (Callback<CellDataFeatures<PropertyTreeNode, String>, ObservableValue<String>>) p -> p.getValue().getValue().valueProperty());
         value.setEditable(true);
 
         value.setCellFactory((Callback<TreeTableColumn<PropertyTreeNode, String>, TreeTableCell<PropertyTreeNode, String>>) param ->
@@ -128,39 +129,33 @@ public class LogPropertiesEditorController {
         });
 
         propertyName.setCellValueFactory(
-                new Callback<TableColumn.CellDataFeatures<Property, String>, ObservableValue<String>>() {
-                    public ObservableValue<String> call(TableColumn.CellDataFeatures<Property, String> p) {
-                        return new SimpleStringProperty(p.getValue().getName());
-                    }
-                });
-        availablePropertiesView.setOnMouseClicked(new EventHandler<MouseEvent>() {
-            @Override
-            public void handle(MouseEvent event) {
-                if (event.getClickCount() > 1) {
-                    availablePropertySelection();
-                }
+                (Callback<TableColumn.CellDataFeatures<Property, String>, ObservableValue<String>>) p -> new SimpleStringProperty(p.getValue().getName()));
+        availablePropertiesView.setOnMouseClicked(event -> {
+            if (event.getClickCount() > 1) {
+                availablePropertySelection();
             }
         });
         availablePropertiesView.setEditable(false);
+        availablePropertiesView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         availablePropertiesView.setItems(availableProperties);
     }
 
     private void constructTree(Collection<Property> properties) {
-        if (properties != null && !properties.isEmpty()) {
+        if (properties != null) {
             TreeItem root = new TreeItem(new PropertyTreeNode("properties", " "));
             AtomicReference<Double> rowCount = new AtomicReference<>((double) 1);
             root.getChildren().setAll(properties.stream()
                     .map(property -> {
-                PropertyTreeNode node = new PropertyTreeNode(property.getName(), " ");
-                rowCount.set(rowCount.get() + 1);
-                TreeItem<PropertyTreeNode> treeItem = new TreeItem<>(node);
-                property.getAttributes().entrySet().stream().forEach(entry -> {
-                    rowCount.set(rowCount.get() + 1);
-                    treeItem.getChildren().add(new TreeItem<>(new PropertyTreeNode(entry.getKey(), entry.getValue())));
-                });
-                treeItem.setExpanded(true);
-                return treeItem;
-            }).collect(Collectors.toSet()));
+                        PropertyTreeNode node = new PropertyTreeNode(property.getName(), " ");
+                        rowCount.set(rowCount.get() + 1);
+                        TreeItem<PropertyTreeNode> treeItem = new TreeItem<>(node);
+                        property.getAttributes().entrySet().stream().forEach(entry -> {
+                            rowCount.set(rowCount.get() + 1);
+                            treeItem.getChildren().add(new TreeItem<>(new PropertyTreeNode(entry.getKey(), entry.getValue())));
+                        });
+                        treeItem.setExpanded(true);
+                        return treeItem;
+                    }).collect(Collectors.toSet()));
             selectedPropertiesTree.setRoot(root);
             selectedPropertiesTree.setShowRoot(false);
         }
@@ -196,6 +191,16 @@ public class LogPropertiesEditorController {
         userSelectedProperties.forEach(selectedProperties::add);
         // remove the properties from the list of available properties
         availableProperties.removeAll(userSelectedProperties);
+    }
+
+    private void removeSelectedProperty(String propertyName) {
+        Optional<Property> property =
+                selectedProperties.stream().filter(p -> p.getName().equals(propertyName)).findFirst();
+        if (property.isPresent()) {
+            selectedProperties.remove(property.get());
+            availableProperties.add(property.get());
+            availableProperties.sort(Comparator.comparing(Property::getName));
+        }
     }
 
     private static class PropertyTreeNode {
@@ -243,49 +248,94 @@ public class LogPropertiesEditorController {
      * are considered first, and then properties available from service. However, adding items to the list of properties
      * always consider equality, i.e. properties with same name are added only once. SPI implementations should therefore
      * not support properties with same name, and should not implement properties available from service.
-     *
-     * On top of that, if the user is editing a copy (reply) based on another log entry, a set of properties may
+     * <p>
+     * Further, if the user is editing a copy (reply) based on another log entry, a set of properties may
      * already be present in the new log entry. The list of available properties will not contain such properties
      * as this would be confusing.
-     *
+     * <p>
+     * When user chooses to remove a property from the list of properties, the list of available properties must
+     * also be refreshed, so this method should handle such a use case.
+     * <p>
      * Also, properties to be excluded as listed in the preferences (properties_excluded_from_view) are not
      * added to the properties tree.
      */
-    private void setupProperties(){
-        List<Property> list = new ArrayList<>();
-        // First add properties from SPI implementations
-        List<LogPropertyProvider> factories = new ArrayList<LogPropertyProvider>();
-        ServiceLoader<LogPropertyProvider> loader = ServiceLoader.load(LogPropertyProvider.class);
-        loader.stream().forEach(p -> {
-            if(p.get().getProperty() != null){
-                factories.add(p.get());
-            }
-        });
-        factories.stream()
-                .map(LogPropertyProvider::getProperty)
-                .forEach(property -> {
-                    // Do not add a property that
-                    if(!selectedProperties.contains(property)){
-                        list.add(property);
-                    }
-                });
-
+    private void setupProperties() {
         JobManager.schedule("Fetch Properties from service", monitor ->
         {
+            List<Property> list = new ArrayList<>();
+            // First add properties from SPI implementations
+            List<LogPropertyProvider> factories = new ArrayList<>();
+            ServiceLoader<LogPropertyProvider> loader = ServiceLoader.load(LogPropertyProvider.class);
+            loader.stream().forEach(p -> {
+                if (p.get().getProperty() != null) {
+                    factories.add(p.get());
+                }
+            });
+            factories.stream()
+                    .map(LogPropertyProvider::getProperty)
+                    .forEach(property -> {
+                        // Do not add a property that is already selected
+                        if (!selectedProperties.contains(property)) {
+                            list.add(property);
+                        }
+                    });
+
             LogClient logClient =
                     LogService.getInstance().getLogFactories().get(LogbookPreferences.logbook_factory).getLogClient();
             List<Property> propertyList = logClient.listProperties().stream().collect(Collectors.toList());
             Platform.runLater(() ->
             {
                 propertyList.forEach(property -> {
+                    // Do not add a property that is already selected or already added from provider
                     if (!selectedProperties.contains(property) && !list.contains(property)) {
                         list.add(property);
                     }
                 });
+                list.sort(Comparator.comparing(Property::getName));
                 availableProperties.setAll(list);
             });
         });
     }
 
+    /**
+     * Custom cell renderer supporting a context menu for property names. The context
+     * menu adds a "Remove" item to let the user remove a property from the list of
+     * selected properties.
+     * <p>
+     * Some logic is applied to make sure the context menu is shown only for the property
+     * name cell, but not for attribute name cells as this would suggest that attributes
+     * could be removed from a property.
+     */
+    private class PropertyNameCell extends TreeTableCell<PropertyTreeNode, String> {
 
+        private final ContextMenu contextMenu;
+        private final MenuItem menuItem;
+
+        public PropertyNameCell() {
+            contextMenu = new ContextMenu();
+            menuItem = new MenuItem(Messages.Remove);
+            contextMenu.getItems().add(menuItem);
+        }
+
+        @Override
+        protected void updateItem(String item, boolean empty) {
+            super.updateItem(item, empty);
+            if (empty) {
+                setText(null);
+            } else {
+                // Binding to determine if the selected cell is a leaf or not.
+                // Property name cells are not leaves.
+                BooleanBinding binding = Bindings.createBooleanBinding(() ->
+                        getTreeTableRow().getTreeItem() != null &&
+                                !getTreeTableRow().getTreeItem().leafProperty().get());
+                // Action must specify the property name subject for removal
+                menuItem.setOnAction(e -> removeSelectedProperty(item));
+                contextMenuProperty().bind(Bindings
+                        .when(binding)
+                        .then(contextMenu)
+                        .otherwise((ContextMenu) null));
+                setText(item);
+            }
+        }
+    }
 }


### PR DESCRIPTION
When editing a (Olog) log entry, user has currently no way to delete a property from the list of selected properties. This PR adds a context menu item ("Remove") to the property name cells.

Also some code changes to always sort the list of available properties (e.g. after property has been removed), and also enable multiple selection in available properties list.