### PR TITLE
Support months and years in log search query

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookQueryUtil.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookQueryUtil.java
@@ -4,11 +4,16 @@ import com.google.common.base.Strings;
 import org.phoebus.util.time.TimeParser;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -135,8 +140,14 @@ public class LogbookQueryUtil {
                     Object time = TimeParser.parseInstantOrTemporalAmount(value);
                     if (time instanceof Instant) {
                         return MILLI_FORMAT.format((Instant)time);
-                    } else if (time instanceof TemporalAmount) {
-                        return MILLI_FORMAT.format(Instant.now().minus((TemporalAmount)time));
+                    } else if(time instanceof Period){ // If month or year, or both, are specified.
+                        Period period = (Period)time;
+                        // One year is on average 365.25 days when considering leap years
+                        // One month is on average 30.4375 days when considering leap years
+                        Duration duration = Duration.ofDays(Math.round(30.4375 * period.getMonths() + 365.25 * period.getYears()) + period.getDays());
+                        return MILLI_FORMAT.format(Instant.now().minus(duration));
+                    } else if (time instanceof TemporalAmount) { // If neither month or year is specified
+                        return MILLI_FORMAT.format(Instant.now().minus((TemporalAmount) time));
                     }
                 }
                 return value;

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/QueryParserTest.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/QueryParserTest.java
@@ -63,4 +63,15 @@ public class QueryParserTest {
         URI uri = URI.create("logbook://?desc=*Fault*Motor*&tag=operation&tag=loto");
         Map<String, String> queryParameters = LogbookQueryUtil.parseQueryURI(uri);
     }
+
+    @Test
+    public void testParseYearsMonthsDays(){
+        long now = System.currentTimeMillis();
+        URI uri = URI.create("logbook://?start=2%20years%208%20months%203days&end=now");
+        Map<String, String> queryParameters = LogbookQueryUtil.parseQueryURI(uri);
+        assertEquals(now, Instant.from(MILLI_FORMAT.parse(queryParameters.get(Keys.ENDTIME.getName()))).toEpochMilli(), 60000);
+        assertEquals((now-(Math.round((2*365.25 + 8*30.4375 + 3) * 24* 60 * 60 * 1000))),
+                Instant.from(MILLI_FORMAT.parse(queryParameters.get(Keys.STARTTIME.getName()))).toEpochMilli(), 60000);
+
+    }
 }


### PR DESCRIPTION
Using specifiers "months" and "years" in the log search query will trigger exceptions in java.time.Instant.

This is an attempt to provide basic support for these date/time specifiers. Note that the added implementation makes a few assumptions and simplifications in order to calculate the time based on "days":
1) One year is on average 365.25 days when leap years are considered.
2) One month is on average 30.4375 days when leap years are considered.
3) A search string like "2 years 8 months 4 days 12 hours" will consider years, months and days, but ignore hours.
