### PR TITLE
Fix logging of 'superfluous' messages

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/nls/NLS.java
+++ b/core/framework/src/main/java/org/phoebus/framework/nls/NLS.java
@@ -98,7 +98,10 @@ public class NLS
                     }
                     final Field field = fields.get(name);
                     if (field == null)
-                        getLogger().log(Level.SEVERE, clazz.getName() + " contains superflous message '" + name + "'");
+                        // fxml files may reference strings in a resource file, no need for a "Messages" class.
+                        // The below should log that a message is found in the resource file, but not in
+                        // a "Messages" class.
+                        getLogger().log(Level.FINEST, clazz.getName() + " does not reference resource string '" + name + "'");
                     else
                     {
                         field.set(null, value);


### PR DESCRIPTION
The NLS class logs at Level.SEVERE if a message string is found in a resource file, but not in the class using the resource. The generated log entry phrasing is incorrect as it says the Messages class has superfluous messages, while it is actually the resource file that may contain unused strings.

Further, fxml files may reference resource strings without the need for a Messages class, so the generated log message is a bit misleading.

This PR is an attempt to address both these "issues".