### PR TITLE
Fix IdentificationHelperTest

### DIFF
--- a/app/alarm/model/src/test/java/org/phoebus/applications/alarm/client/IdentificationHelperTest.java
+++ b/app/alarm/model/src/test/java/org/phoebus/applications/alarm/client/IdentificationHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,8 +7,7 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.client;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 
@@ -27,16 +26,19 @@ public class IdentificationHelperTest
         String user = IdentificationHelper.getUser();
         String host = IdentificationHelper.getHost();
         System.out.println("User: '" + user + "' at host: '" + host + "'");
-        assertThat(user, equalTo("???"));
-        assertThat(host, equalTo("???"));
+        if ("???".equals(user)  &&  "???".equals(host))
+        {
+            System.out.println("Initializing IdentificationHelper");
+            IdentificationHelper.initialize();
+        }
+        // else: Some other test that ran first already triggered initialization
 
-        // On successful initilization, there should soon be information
-        IdentificationHelper.initialize();
+        // On successful initialization, there should soon be information
         int wait = 0;
         while (host.equals("???"))
         {
             ++wait;
-            assertThat("Timed out waiting for information", wait < 10, equalTo(true));
+            assertTrue("Timed out waiting for information", wait < 10);
             TimeUnit.SECONDS.sleep(1);
             user = IdentificationHelper.getUser();
             host = IdentificationHelper.getHost();


### PR DESCRIPTION
Could fail if a previous test already initialized the helper, as shown in test error of #2017