### PR TITLE
Allow nested XML file inclusions

### DIFF
--- a/app/alarm/examples/alarm_configuration.xsd
+++ b/app/alarm/examples/alarm_configuration.xsd
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xi="http://www.w3.org/2001/XInclude" elementFormDefault="qualified">
+<xs:import namespace="http://www.w3.org/2001/XInclude" schemaLocation="http://www.w3.org/2001/xinclude.xsd"/>
+    <xs:element name="config">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element maxOccurs="unbounded" ref="component" />
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="xi:include"/>
+            </xs:choice>
+            <xs:attribute name="name" use="required" type="xs:NCName" />
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="component">
+        <xs:complexType>
+            <xs:choice>
+                <xs:choice>
+                    <xs:element maxOccurs="unbounded" ref="guidance" />
+                    <xs:element maxOccurs="unbounded" ref="display" />
+                    <xs:element maxOccurs="unbounded" ref="command" />
+                    <xs:element maxOccurs="unbounded" ref="automated_action" />
+                </xs:choice>
+                <xs:choice minOccurs="1" maxOccurs="unbounded">
+                    <xs:element ref="component" />
+                    <xs:element ref="pv" />
+                    <xs:element ref="xi:include"/>
+                </xs:choice>
+            </xs:choice>
+            <xs:attribute name="name" use="required" type="xs:NCName" />
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="pv">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element maxOccurs="1" ref="enabled" />
+                <xs:element maxOccurs="1" ref="latching" />
+                <xs:element minOccurs="0" maxOccurs="1" ref="description" />
+                <xs:element minOccurs="0" maxOccurs="1" ref="delay" />
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element ref="command" />
+                    <xs:element ref="display" />
+                    <xs:element ref="guidance" />
+                    <xs:element ref="count" />
+                    <xs:element ref="filter" />
+                    <xs:element ref="automated_action"/>
+                </xs:choice>
+            </xs:choice>
+            <xs:attribute name="name" use="required" type="xs:NCName" />
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="enabled" type="xs:boolean" />
+    <xs:element name="latching" type="xs:boolean" />
+    <xs:element name="description" type="xs:string" />
+    <xs:element name="count" type="xs:integer" />
+    <xs:element name="filter" type="xs:string" />
+    <xs:element name="guidance">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="title" />
+                <xs:element ref="detail" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="display">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="title" />
+                <xs:element ref="detail" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="command">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="title" />
+                <xs:element ref="detail" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="automated_action">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="title" />
+                <xs:element ref="detail" />
+                <xs:element ref="delay" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="delay" type="xs:integer" />
+    <xs:element name="title" type="xs:string" />
+    <xs:element name="detail" type="xs:string" />
+</xs:schema>

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelReader.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelReader.java
@@ -17,6 +17,7 @@ import java.util.logging.Level;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.phoebus.applications.alarm.client.AlarmClientLeaf;
 import org.phoebus.applications.alarm.client.AlarmClientNode;
@@ -74,9 +75,22 @@ public class XmlModelReader
     // Parse the xml stream and load the stream into a document.
     public void load(final InputStream stream) throws Exception
     {
-        final DocumentBuilder docBuilder =
-                DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        final DocumentBuilderFactory docBuilderFactory =DocumentBuilderFactory.newInstance();
+
+        // Enable xinclude parsing
+        docBuilderFactory.setNamespaceAware(true);
+
+        try {
+            docBuilderFactory.setFeature("http://apache.org/xml/features/xinclude", 
+                            true);
+        } 
+        catch (ParserConfigurationException e) {
+            System.err.println("could not set parser feature");
+        }
+
+        final DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
         final Document doc = docBuilder.parse(stream);
+
 
         buildModel(doc);
         // Clear map used to check for duplicates

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelReader.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelReader.java
@@ -75,7 +75,7 @@ public class XmlModelReader
     // Parse the xml stream and load the stream into a document.
     public void load(final InputStream stream) throws Exception
     {
-        final DocumentBuilderFactory docBuilderFactory =DocumentBuilderFactory.newInstance();
+        final DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
 
         // Enable xinclude parsing
         docBuilderFactory.setNamespaceAware(true);

--- a/app/alarm/ui/doc/index.rst
+++ b/app/alarm/ui/doc/index.rst
@@ -217,7 +217,7 @@ without adding filtering that might not be obvious when later inspecting an alar
 
 Note again that the alarm system only reacts to the severity of alarm trigger PVs.
 For EPICS records, this is for example configured via the HIGH, HSV and HYST fields of analog records,
-o the ZSV and OSV fields of binary records.
+or the ZSV and OSV fields of binary records.
 Why, when and for how long an alarm trigger PV enters an alarm state is configured on the data source,
 and is not immediately obvious from the received alarm severity.
 

--- a/app/alarm/ui/doc/index.rst
+++ b/app/alarm/ui/doc/index.rst
@@ -134,6 +134,8 @@ They can also be opened from the cmd line as follows::
 Alarm Configuration Options
 ---------------------------
 
+Alarm configurations are imported into the Alarm Server in an XML 
+format, the schema for which may be found `here <https://github.com/ControlSystemStudio/phoebus/app/alarm/examples/alarm_configuration.xsd>`_.
 The options for an entry in the hierarchical alarm configuration
 always include guidance, display links etc. as described further below.
 In addition, alarm PV entries have the following settings.
@@ -215,7 +217,7 @@ without adding filtering that might not be obvious when later inspecting an alar
 
 Note again that the alarm system only reacts to the severity of alarm trigger PVs.
 For EPICS records, this is for example configured via the HIGH, HSV and HYST fields of analog records,
-or the ZSV and OSV fields of binary records.
+o the ZSV and OSV fields of binary records.
 Why, when and for how long an alarm trigger PV enters an alarm state is configured on the data source,
 and is not immediately obvious from the received alarm severity.
 
@@ -355,4 +357,57 @@ Suggested PV template::
         field(PINI, "YES")
     }
  
- 
+Inclusions
+^^^^^^^^^^
+The Phoebus alarm server supports Xinclude, allowing for the breakup of hierarchies into multiple files.
+
+.. code-block:: xml
+
+  <?xml version='1.0' encoding='utf8'?>
+  <config name="HeartOfGold">
+      <pv name="NUTRIMATIC">
+          <enabled>true</enabled>
+          <latching>false</latching>
+          <annunciating>false</annunciating>
+          <description>Does not make tea</description>
+          <delay>10</delay>
+          <count>30</count>
+      </pv>
+      <pv name="INFINITE:IMPROBABILITY:DRIVE">
+          <enabled>true</enabled>
+          <latching>false</latching>
+          <annunciating>false</annunciating>
+          <filter> Marvin + Eddie == 0</filter>
+      </pv>
+      <xi:include href="/path/to/inclusion/file/includion_file.xml" xpointer="include-component" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  </config>
+
+Where the include component is identified in the inclusion file with a DID declared id component:
+
+.. code-block:: xml
+
+  <?xml version='1.0' encoding='utf8'?>
+  <!DOCTYPE config [
+    <!ATTLIST component id ID #IMPLIED>
+  ]>
+  <config name="GPP">
+      <component name="GPP" id ="component">
+          <pv name="EDDIE">
+              <enabled>true</enabled>
+              <latching>false</latching>
+              <annunciating>false</annunciating>
+              <description>Eddie the Computer</description>
+          </pv>
+          <pv name="MARVIN">
+              <enabled>true</enabled>
+              <latching>true</latching>
+              <annunciating>false</annunciating>
+              <description>Paranoid android</description>
+              <delay>100</delay>
+              <count>1000</count>
+          </pv>
+      </component>
+  </config>
+
+
+


### PR DESCRIPTION
This PR enables the Xinclude feature on the document builder, allowing for the use of nested configuration files when assembling a single configuration. Additionally, docs have been updated to mention the inclusions as well as point to a schema document for XML assembly, which was not included in the docs previously. 

The XML scheme requires a DTD declaration of this id component for parsing. For the sake of formality, all XML components would then require a declaration, but this is unnecessary for function.

An example is given below:
```xml
<?xml version='1.0' encoding='utf8'?>
<config name="HeartOfGold">
    <pv name="NUTRIMATIC">
        <enabled>true</enabled>
        <latching>false</latching>
        <annunciating>false</annunciating>
        <description>Does not make tea</description>
        <delay>10</delay>
        <count>30</count>
    </pv>
    <pv name="INFINITE:IMPROBABILITY:DRIVE">
        <enabled>true</enabled>
        <latching>false</latching>
        <annunciating>false</annunciating>
        <filter> Marvin + Eddie == 0</filter>
    </pv>
    <xi:include href="/path/to/inclusion/inclusion_file.xml" xpointer="component" xmlns:xi="http://www.w3.org/2001/XInclude"/>
</config>
```

The inclusion file declares the id component:

```xml
<?xml version='1.0' encoding='utf8'?>
<!DOCTYPE config [
  <!ATTLIST component id ID #IMPLIED>
]>
<config name="GPP">
    <component name="GPP" id ="component">
        <pv name="EDDIE">
            <enabled>true</enabled>
            <latching>false</latching>
            <annunciating>false</annunciating>
            <description>Eddie the Computer</description>
        </pv>
        <pv name="MARVIN">
            <enabled>true</enabled>
            <latching>true</latching>
            <annunciating>false</annunciating>
            <description>Paranoid android</description>
            <delay>100</delay>
            <count>1000</count>
        </pv>
    </component>
</config>
```
 