### PR TITLE
Adding support for auto properties for log entries

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookUIPreferences.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookUIPreferences.java
@@ -31,6 +31,7 @@ public class LogbookUIPreferences
     @Preference public static String web_client_root_URL;
     @Preference public static boolean log_entry_groups_support;
     @Preference public static String[] hidden_properties;
+    @Preference public static String[] auto_properties;
 
     static
     {

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertiesEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertiesEditorController.java
@@ -78,6 +78,7 @@ public class LogPropertiesEditorController {
     TableColumn propertyName;
 
     private List<String> hiddenPropertiesNames = Arrays.asList(LogbookUIPreferences.hidden_properties);
+    private List<String> autoPropertiesNames = Arrays.asList(LogbookUIPreferences.auto_properties);
 
     /**
      * @param properties A collection of {@link Property}s.
@@ -137,7 +138,6 @@ public class LogPropertiesEditorController {
         });
         availablePropertiesView.setEditable(false);
         availablePropertiesView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
-        availablePropertiesView.setItems(availableProperties);
     }
 
     private void constructTree(Collection<Property> properties) {
@@ -293,6 +293,15 @@ public class LogPropertiesEditorController {
                 });
                 list.sort(Comparator.comparing(Property::getName));
                 availableProperties.setAll(list);
+                availablePropertiesView.setItems(availableProperties);
+                List<Property> autoSelected = new ArrayList<>();
+                availableProperties.stream().forEach(p -> {
+                    if(autoPropertiesNames.contains(p.getName())){
+                        selectedProperties.add(p);
+                        autoSelected.add(p);
+                    }
+                });
+                availableProperties.removeAll(autoSelected);
             });
         });
     }

--- a/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
+++ b/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
@@ -33,3 +33,7 @@ log_entry_groups_support=false
 # Comma separated list of "hidden" properties. For instance, properties that serve internal
 # business logic, but should not be rendered in the properties view.
 hidden_properties=Log Entry Group
+
+# Comma separated list of properties automatically added to new log entries.
+# The property must "exist", i.e. it must be provided by service or client.
+auto_properties=


### PR DESCRIPTION
As per user request: automatically add properties to all new log entries.
New setting - default empty - lists properties that should be added automatically to each new log entry.
``org.phoebus.logbook.olog.ui/auto_properties``