### PR TITLE
Lazy loading of log attachments

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryCalenderViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryCalenderViewController.java
@@ -4,7 +4,6 @@ import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.application.Platform;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableMap;
@@ -13,12 +12,10 @@ import javafx.fxml.FXMLLoader;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
-import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -53,13 +50,13 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import static org.phoebus.logbook.olog.ui.LogbookQueryUtil.*;
+import static org.phoebus.logbook.olog.ui.LogbookQueryUtil.Keys;
 import static org.phoebus.ui.time.TemporalAmountPane.Type.TEMPORAL_AMOUNTS_AND_NOW;
 
 /**
  * A controller for a log entry table with a collapsible advance search section.
- * @author Kunal Shroff
  *
+ * @author Kunal Shroff
  */
 public class LogEntryCalenderViewController extends LogbookSearchController {
 
@@ -95,10 +92,10 @@ public class LogEntryCalenderViewController extends LogbookSearchController {
     @FXML
     private AdvancedSearchViewController advancedSearchViewController;
 
-    public LogEntryCalenderViewController(LogClient logClient){
+    public LogEntryCalenderViewController(LogClient logClient) {
         setClient(logClient);
     }
-    
+
     @FXML
     public void initialize() {
 
@@ -126,15 +123,12 @@ public class LogEntryCalenderViewController extends LogbookSearchController {
                     loader.setControllerFactory(clazz -> {
                         try {
                             if (clazz.isAssignableFrom(SingleLogEntryDisplayController.class)) {
-                                return clazz.getConstructor(String.class).newInstance(getClient().getServiceUrl());
-                            }
-                            else if(clazz.isAssignableFrom(AttachmentsPreviewController.class)){
-                                return clazz.getConstructor().newInstance();
-                            }
-                            else if(clazz.isAssignableFrom(LogEntryDisplayController.class)){
                                 return clazz.getConstructor(LogClient.class).newInstance(getClient());
-                            }
-                            else if(clazz.isAssignableFrom(LogPropertiesController.class)){
+                            } else if (clazz.isAssignableFrom(AttachmentsPreviewController.class)) {
+                                return clazz.getConstructor().newInstance();
+                            } else if (clazz.isAssignableFrom(LogEntryDisplayController.class)) {
+                                return clazz.getConstructor(LogClient.class).newInstance(getClient());
+                            } else if (clazz.isAssignableFrom(LogPropertiesController.class)) {
                                 return clazz.getConstructor().newInstance();
                             }
                         } catch (Exception e) {
@@ -166,7 +160,7 @@ public class LogEntryCalenderViewController extends LogbookSearchController {
             String styleSheetResource = LogbookUIPreferences.calendar_view_item_stylesheet;
             URL url = this.getClass().getResource(styleSheetResource);
             // url may be null...
-            if(url != null){
+            if (url != null) {
                 agenda.getStylesheets().add(this.getClass().getResource(styleSheetResource).toString());
             }
         } catch (Exception e) {
@@ -327,10 +321,10 @@ public class LogEntryCalenderViewController extends LogbookSearchController {
                 appointment.withEndLocalDateTime(
                         LocalDateTime.ofInstant(logentry.getCreatedDate().plusSeconds(2400), ZoneId.systemDefault()));
                 List<String> logbookNames = getLogbookNames();
-                if(logbookNames !=null && !logbookNames.isEmpty()){
+                if (logbookNames != null && !logbookNames.isEmpty()) {
                     int index = logbookNames.indexOf(logentry.getLogbooks().iterator().next().getName());
-                    if(index >= 0 && index <= 22){
-                        appointment.setAppointmentGroup(appointmentGroupMap.get(String.format("group%02d",(index+1))));
+                    if (index >= 0 && index <= 22) {
+                        appointment.setAppointmentGroup(appointmentGroupMap.get(String.format("group%02d", (index + 1))));
                     } else {
                         appointment.setAppointmentGroup(appointmentGroupMap.get(String.format("group%02d", 23)));
                     }
@@ -349,7 +343,7 @@ public class LogEntryCalenderViewController extends LogbookSearchController {
         agenda.appointments().setAll(map.keySet());
     }
 
-    private List<String> getLogbookNames(){
+    private List<String> getLogbookNames() {
         try {
             return getClient().listLogbooks().stream().map(l -> l.getName()).collect(Collectors.toList());
         } catch (Exception e) {

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTable.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTable.java
@@ -49,7 +49,7 @@ public class LogEntryTable implements AppInstance {
                         }
                         else if(clazz.isAssignableFrom(SingleLogEntryDisplayController.class))
                         {
-                            return clazz.getConstructor(String.class).newInstance(app.getClient().getServiceUrl());
+                            return clazz.getConstructor(LogClient.class).newInstance(app.getClient());
                         }
                         else if(clazz.isAssignableFrom(LogEntryDisplayController.class))
                         {

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SingleLogEntryDisplayController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SingleLogEntryDisplayController.java
@@ -13,14 +13,26 @@ import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.VBox;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
+import org.phoebus.logbook.Attachment;
+import org.phoebus.logbook.LogClient;
 import org.phoebus.logbook.LogEntry;
 import org.phoebus.logbook.Logbook;
+import org.phoebus.logbook.LogbookException;
 import org.phoebus.logbook.Property;
 import org.phoebus.logbook.Tag;
+import org.phoebus.olog.es.api.model.OlogAttachment;
+import org.phoebus.olog.es.api.model.OlogLog;
 import org.phoebus.ui.javafx.ImageCache;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static org.phoebus.util.time.TimestampFormats.SECONDS_FORMAT;
@@ -67,11 +79,12 @@ public class SingleLogEntryDisplayController extends HtmlAwareController {
     private Button copyURLButton;
 
     private LogEntry logEntry;
+    private LogClient logClient;
 
-    public SingleLogEntryDisplayController(String serviceUrl) {
-        super(serviceUrl);
+    public SingleLogEntryDisplayController(LogClient logClient) {
+        super(logClient.getServiceUrl());
+        this.logClient = logClient;
     }
-
 
     @FXML
     public void initialize() {
@@ -88,6 +101,9 @@ public class SingleLogEntryDisplayController extends HtmlAwareController {
 
         // Always expand properties pane.
         attachmentsPane.setExpanded(true);
+        // Get the attachments from service
+        Collection<Attachment> attachments = fetchAttachments();
+        ((OlogLog)logEntry).setAttachments(attachments);
         attachmentsPreviewController
                 .setAttachments(FXCollections.observableArrayList(logEntry.getAttachments()));
 
@@ -147,5 +163,34 @@ public class SingleLogEntryDisplayController extends HtmlAwareController {
         final ClipboardContent content = new ClipboardContent();
         content.putString(LogbookUIPreferences.web_client_root_URL + "/" + logEntry.getId());
         Clipboard.getSystemClipboard().setContent(content);
+    }
+
+    /**
+     * Retrieves the actual attachments from the remote service and copies them to temporary files. The idea is that attachments
+     * should be retrieved when user requests to see the details, not in connection to a log entry search.
+     * @return A {@link Collection} of {@link Attachment}s holding the attachment content.
+     */
+    private Collection<Attachment> fetchAttachments(){
+        Collection<Attachment> attachments = logEntry.getAttachments().stream()
+                .filter( (attachment) -> {
+                    return attachment.getName() != null && !attachment.getName().isEmpty();
+                })
+                .map((attachment) -> {
+                    OlogAttachment fileAttachment = new OlogAttachment();
+                    fileAttachment.setContentType(attachment.getContentType());
+                    fileAttachment.setThumbnail(false);
+                    fileAttachment.setFileName(attachment.getName());
+                    try {
+                        Path temp = Files.createTempFile("phoebus", attachment.getName());
+                        Files.copy(logClient.getAttachment(logEntry.getId(), attachment.getName()), temp, StandardCopyOption.REPLACE_EXISTING);
+                        fileAttachment.setFile(temp.toFile());
+                        temp.toFile().deleteOnExit();
+                    } catch (LogbookException | IOException e) {
+                        Logger.getLogger(SingleLogEntryDisplayController.class.getName())
+                                .log(Level.WARNING, "Failed to retrieve attachment " + fileAttachment.getFileName() ,e);
+                    }
+                    return fileAttachment;
+                }).collect(Collectors.toList());
+        return attachments;
     }
 }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/AttachmentsViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/AttachmentsViewController.java
@@ -92,7 +92,6 @@ public class AttachmentsViewController {
      *                 are subject to removal when the log entry has been committed.
      */
     public AttachmentsViewController(LogEntry logEntry) {
-        attachments.addAll(logEntry.getAttachments());
         attachmentsToDelete.addAll(logEntry.getAttachments());
     }
 


### PR DESCRIPTION
A search for log entries should not retrieve attachments from remote service as this time consuming and puts load on network and server. Moreover, user might not be interested in all attachments anyway.

This PR defers retrieval of attachment data: only when a log entry is selected the attachments are downloaded (asynchronously) and added to the UI.