### PR TITLE
Bug fix for log search ordering

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookQueryUtil.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookQueryUtil.java
@@ -68,7 +68,7 @@ public class LogbookQueryUtil {
      */
     public static Map<String, String> parseQueryURI(URI query) {
         if (Strings.isNullOrEmpty(query.getQuery())) {
-            return Collections.emptyMap();
+            return new HashMap<>();
         } else {
             return Arrays.asList(query.getQuery().split("&")).stream()
                     .collect(Collectors.toMap(new KeyParser(), new ValueParser()));
@@ -84,7 +84,7 @@ public class LogbookQueryUtil {
      */
     public static Map<String, String> parseQueryString(String query) {
         if (Strings.isNullOrEmpty(query)) {
-            return Collections.emptyMap();
+            return new HashMap<>();
         } else {
             return Arrays.asList(query.split("&")).stream()
                     .collect(Collectors.toMap(new KeyParser(), new ValueParser()));
@@ -101,7 +101,7 @@ public class LogbookQueryUtil {
      */
     public static Map<String, String> parseHumanReadableQueryString(String query) {
         if (Strings.isNullOrEmpty(query)) {
-            return Collections.emptyMap();
+            return new HashMap<>();
         } else {
             return Arrays.asList(query.split("&")).stream()
                     .collect(Collectors.toMap(new KeyParser(), new SimpleValueParser()));

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/QueryParserTest.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/QueryParserTest.java
@@ -29,6 +29,11 @@ public class QueryParserTest {
         expectedMap.put("tag", "operation");
         assertEquals(expectedMap, queryParameters);
 
+        // Also test empty query
+        uri = URI.create("logbook://?");
+        queryParameters = LogbookQueryUtil.parseQueryURI(uri);
+        assertTrue(queryParameters.isEmpty());
+
     }
 
     @Test
@@ -85,5 +90,14 @@ public class QueryParserTest {
         query = "a=b&sort=down&C=D";
         modifiedQuery = LogbookQueryUtil.addSortOrder(query, true);
         assertEquals("a=b&C=D&sort=up", modifiedQuery);
+
+        // Also test empty query
+        query = "";
+        modifiedQuery = LogbookQueryUtil.addSortOrder(query, true);
+        assertEquals("sort=up", modifiedQuery);
+
+        query = null;
+        modifiedQuery = LogbookQueryUtil.addSortOrder(query, true);
+        assertEquals("sort=up", modifiedQuery);
     }
 }


### PR DESCRIPTION
If search field is empty, the LogbookQueryUtil would return a Map that cannot be modified to hold "sort" parameter.