### PR TITLE
Wrong cursor set in Olog attachements preview pane

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
@@ -142,7 +142,7 @@ public class AttachmentsPreviewController {
             if (((ReadOnlyBooleanProperty) event).get()) {
                 splitPane.getScene().setCursor(Cursor.HAND);
             } else {
-                splitPane.getScene().setCursor(Cursor.MOVE);
+                splitPane.getScene().setCursor(Cursor.DEFAULT);
             }
         });
 


### PR DESCRIPTION
When user moves mouse into an image attachments preview, the cursor changes to "HAND". Leaving it switches to wong cursor.

This PR is a fix.