### PR TITLE
Add tags to alarm configuration

### DIFF
--- a/app/alarm/Readme.md
+++ b/app/alarm/Readme.md
@@ -239,7 +239,8 @@ The full config topic JSON format for a alarm tree leaf:
         "guidance": [{"title": String, "details": String}],
         "displays": [{"title": String, "details": String}],
         "commands": [{"title": String, "details": String}],
-        "actions":  [{"title": String, "details": String}]
+        "actions":  [{"title": String, "details": String}],
+        "tags":     [{"title": String, "details": String}]"
     }
 
 The full config topic JSON format for a alarm tree node:
@@ -250,7 +251,8 @@ The full config topic JSON format for a alarm tree node:
         "guidance": [{"title": String, "details": String}],
         "displays": [{"title": String, "details": String}],
         "commands": [{"title": String, "details": String}],
-        "actions":  [{"title": String, "details": String}]
+        "actions":  [{"title": String, "details": String}],
+        "tags":     [{"title": String, "details": String}]
     }
 
 The configuration of an alarm tree leaf, i.e. a PV, will

--- a/app/alarm/examples/alarm_configuration.xsd
+++ b/app/alarm/examples/alarm_configuration.xsd
@@ -85,6 +85,14 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
+    <xs:element name="tags" minOccurs="0">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="title" />
+                <xs:element ref="detail" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
     <xs:element name="delay" type="xs:integer" />
     <xs:element name="title" type="xs:string" />
     <xs:element name="detail" type="xs:string" />

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClientLeaf.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClientLeaf.java
@@ -63,6 +63,7 @@ public class AlarmClientLeaf extends AlarmTreeItemWithState<ClientState> impleme
         pv.setDisplays(new ArrayList<>(getDisplays()));
         pv.setCommands(new ArrayList<>(getCommands()));
         pv.setActions(new ArrayList<>(getActions()));
+        pv.setTags(new ArrayList<>(getTags()));
         return pv;
     }
 

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmConfigMessage.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmConfigMessage.java
@@ -38,6 +38,7 @@ public class AlarmConfigMessage {
     private List<AlarmDetail> displays;
     private List<AlarmDetail> commands;
     private List<AlarmDetail> actions;
+    private List<AlarmDetail> tags;
 
     private String delete;
 
@@ -152,6 +153,14 @@ public class AlarmConfigMessage {
         this.actions = actions;
     }
 
+    public List<AlarmDetail> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<AlarmDetail> tags) {
+        this.tags = tags;
+    }
+
     public String getDelete() {
         return delete;
     }
@@ -194,6 +203,7 @@ public class AlarmConfigMessage {
                 ", displays=" + displays +
                 ", commands=" + commands +
                 ", actions=" + actions +
+                ", tags=" + tags +
                 ", delete=" + delete + "]";
     }
 

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmMessage.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmMessage.java
@@ -48,6 +48,7 @@ public class AlarmMessage implements Serializable{
     private List<AlarmDetail> displays;
     private List<AlarmDetail> commands;
     private List<AlarmDetail> actions;
+    private List<AlarmDetail> tags;
 
     private String delete;
 
@@ -175,6 +176,14 @@ public class AlarmMessage implements Serializable{
         this.commands = commands;
     }
 
+    public List<AlarmDetail> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<AlarmDetail> tags) {
+        this.tags = tags;
+    }
+
     public List<AlarmDetail> getActions() {
         return actions;
     }
@@ -287,6 +296,7 @@ public class AlarmMessage implements Serializable{
             configMessage.setDisplays(displays);
             configMessage.setCommands(commands);
             configMessage.setActions(actions);
+            configMessage.setTags(tags);
             return configMessage;
         } else {
             return null;
@@ -304,7 +314,7 @@ public class AlarmMessage implements Serializable{
             stateMessage.setCurrent_severity(current_severity);
             stateMessage.setCurrent_message(current_message);
             stateMessage.setMode(mode);
-            stateMessage.setNotify(notify);
+	        stateMessage.setNotify(notify);
             stateMessage.setLatch(latch);
             return stateMessage;
         } else {
@@ -407,6 +417,8 @@ public class AlarmMessage implements Serializable{
         private List<AlarmDetail> commands;
         @JsonIgnore
         private List<AlarmDetail> actions;
+        @JsonIgnore
+        private List<AlarmDetail> tags;
     }
 
     @Override

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/AlarmTreeItem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/AlarmTreeItem.java
@@ -50,7 +50,10 @@ abstract public class AlarmTreeItem<STATE extends BasicState>
 
     private List<TitleDetail> commands = Collections.emptyList();
 
+    private List<TitleDetail> tags = Collections.emptyList();
+
     private List<TitleDetailDelay> actions = Collections.emptyList();
+
 
     /** Constructor for item or leaf
      *
@@ -210,6 +213,19 @@ abstract public class AlarmTreeItem<STATE extends BasicState>
     public List<TitleDetailDelay> getActions()
     {
         return actions;
+    }
+
+    public boolean setTags(final List<TitleDetail> tags)
+    {
+        if (this.tags.equals(tags))
+            return false;
+        this.tags = tags;
+        return true;
+    }
+
+    public List<TitleDetail> getTags()
+    {
+        return tags;
     }
 
     @Override

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/json/JsonModelReader.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/json/JsonModelReader.java
@@ -125,6 +125,13 @@ public class JsonModelReader
         else
             changed |= node.setActions(parseTitleDetailDelay(jn));
 
+
+        jn = json.get(JsonTags.TAGS);
+            if (jn == null)
+                changed |= node.setTags(Collections.emptyList());
+            else
+                changed |= node.setTags(parseTitleDetail(jn));
+    
         return changed;
     }
 

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/json/JsonModelWriter.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/json/JsonModelWriter.java
@@ -116,6 +116,7 @@ public class JsonModelWriter
             writeTitleDetail(jg, JsonTags.GUIDANCE, item.getGuidance());
             writeTitleDetail(jg, JsonTags.DISPLAYS, item.getDisplays());
             writeTitleDetail(jg, JsonTags.COMMANDS, item.getCommands());
+            writeTitleDetail(jg, JsonTags.TAGS, item.getTags());
             writeTitleDetailDelay(jg, JsonTags.ACTIONS, item.getActions());
 
             jg.writeEndObject();

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/json/JsonTags.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/json/JsonTags.java
@@ -25,6 +25,7 @@ public interface JsonTags
     public static final String ANNUNCIATING = "annunciating";
     public static final String COMMAND = "command";
     public static final String COMMANDS = "commands";
+    public static final String TAGS = "tags";
     public static final String COUNT = "count";
     public static final String CURRENT_MESSAGE = "current_message";
     public static final String CURRENT_SEVERITY = "current_severity";

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelReader.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelReader.java
@@ -198,15 +198,12 @@ public class XmlModelReader
         }
 
         for (final Element child : XMLUtil.getChildElements(node, TAG_TAGS))
-        td.add(getTD(child));
+            td.add(getTD(child));
 
-        if (td.size() > 0)
-        {
+        if (td.size() > 0) {
             component.setTags(td);
             td = new ArrayList<>();
         }
-
-
 
         ArrayList<TitleDetailDelay> tdd = new ArrayList<>();
         for (final Element child : XMLUtil.getChildElements(node, TAG_ACTIONS))
@@ -217,7 +214,6 @@ public class XmlModelReader
             component.setActions(tdd);
             tdd = new ArrayList<>();
         }
-
     }
 
     private void processPV(final AlarmClientNode parent, final Element node) throws Exception
@@ -354,8 +350,6 @@ public class XmlModelReader
             pv.setTags(td);
             td = new ArrayList<>();
         }
-
-
 
         ArrayList<TitleDetailDelay> tdd = new ArrayList<>();
         for (final Element child : XMLUtil.getChildElements(node, TAG_ACTIONS))

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelReader.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelReader.java
@@ -60,6 +60,7 @@ public class XmlModelReader
     public static final String TAG_DISPLAY = "display";
     public static final String TAG_COMMAND = "command";
     public static final String TAG_ACTIONS = "automated_action";
+    public static final String TAG_TAGS = "tags";
 
     // TitleDetail specific tags.
     public static final String TAG_TITLE = "title";
@@ -196,6 +197,17 @@ public class XmlModelReader
             td = new ArrayList<>();
         }
 
+        for (final Element child : XMLUtil.getChildElements(node, TAG_TAGS))
+        td.add(getTD(child));
+
+        if (td.size() > 0)
+        {
+            component.setTags(td);
+            td = new ArrayList<>();
+        }
+
+
+
         ArrayList<TitleDetailDelay> tdd = new ArrayList<>();
         for (final Element child : XMLUtil.getChildElements(node, TAG_ACTIONS))
             tdd.add(getTDD(child));
@@ -205,6 +217,7 @@ public class XmlModelReader
             component.setActions(tdd);
             tdd = new ArrayList<>();
         }
+
     }
 
     private void processPV(final AlarmClientNode parent, final Element node) throws Exception
@@ -332,6 +345,17 @@ public class XmlModelReader
             pv.setCommands(td);
             td = new ArrayList<>();
         }
+
+        for (final Element child : XMLUtil.getChildElements(node, TAG_TAGS))
+            td.add(getTD(child));
+
+        if (td.size() > 0)
+        {
+            pv.setTags(td);
+            td = new ArrayList<>();
+        }
+
+
 
         ArrayList<TitleDetailDelay> tdd = new ArrayList<>();
         for (final Element child : XMLUtil.getChildElements(node, TAG_ACTIONS))

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelWriter.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelWriter.java
@@ -127,6 +127,16 @@ public class XmlModelWriter implements Closeable
             getTitleDetailDelayListXML(actions, XmlModelReader.TAG_ACTIONS);
         }
 
+        // Write XML for Guidance
+        final List<TitleDetail> tags = item.getTags();
+
+        if (!tags.isEmpty())
+        {
+            getTitleDetailListXML(tags, XmlModelReader.TAG_TAGS);
+        }
+
+        
+
     }
 
     private void getTitleDetailListXML(final List<TitleDetail> tdList, final String itemSubType) throws Exception

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelWriter.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/model/xml/XmlModelWriter.java
@@ -134,9 +134,6 @@ public class XmlModelWriter implements Closeable
         {
             getTitleDetailListXML(tags, XmlModelReader.TAG_TAGS);
         }
-
-        
-
     }
 
     private void getTitleDetailListXML(final List<TitleDetail> tdList, final String itemSubType) throws Exception

--- a/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelReaderTest.java
+++ b/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelReaderTest.java
@@ -78,6 +78,10 @@ public class AlarmModelReaderTest
 	+ "        <enabled>true</enabled>\n"
 	+ "        <latching>true</latching>\n"
 	+ "        <annunciating>true</annunciating>\n"
+	+ "        <tags>\n"
+	+ "          <title>a3pv1 Tag 1</title>\n"
+	+ "          <details>a3pv1 Tag Detail 1</details>\n"
+	+ "        </tags>\n"
 	+ "      </pv>\n"
 	+ "    </component>\n"
 	+ "    <pv name=\"a2pv1\">\n"
@@ -174,6 +178,12 @@ public class AlarmModelReaderTest
 		assertTrue(a3pv1.isEnabled());
 		assertTrue(a3pv1.isLatching());
 		assertTrue(a3pv1.isAnnunciating());
+
+		final List<TitleDetail> a3pv1_tags = ((AlarmTreeItem<?>)a3pv1).getTags();
+		assertEquals("a3pv1 Tag 1", a3pv1_tags.get(0).title);
+		assertEquals("a3pv1 Tag Detail 1", a3pv1_tags.get(0).detail);
+
+
 
 		final AlarmTreeLeaf a2pv1 = (AlarmTreeLeaf) area2.getChild("a2pv1");
 

--- a/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelReaderTest.java
+++ b/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelReaderTest.java
@@ -183,8 +183,6 @@ public class AlarmModelReaderTest
 		assertEquals("a3pv1 Tag 1", a3pv1_tags.get(0).title);
 		assertEquals("a3pv1 Tag Detail 1", a3pv1_tags.get(0).detail);
 
-
-
 		final AlarmTreeLeaf a2pv1 = (AlarmTreeLeaf) area2.getChild("a2pv1");
 
 		assertEquals("a2pv1", ((AlarmTreeItem<?>) a2pv1).getName());

--- a/app/alarm/ui/doc/index.rst
+++ b/app/alarm/ui/doc/index.rst
@@ -356,7 +356,25 @@ Suggested PV template::
         field(INP,  "0")
         field(PINI, "YES")
     }
- 
+
+Tags
+----
+
+Each alarm may optionally have one or more tags assigned to it. This field is an arbitrary tag/value
+pair that can contain any additional information an operator may find useful for handling the alarm,
+especially when it comes to searching for alarms by tag. Examples include additional information
+on the location/sector the alarm is coming from, or being able to tag multiple alarms for a scheduled
+maintenance period.
+
+ * Title:
+   A short title for the tag, for example Scheduled for Maintenance.
+
+
+ * Detail:
+   A slightly longer text providing additional information for the tag, for example the
+   date and time of the maintenance.
+
+
 Inclusions
 ^^^^^^^^^^
 The Phoebus alarm server supports Xinclude, allowing for the breakup of hierarchies into multiple files.

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/DuplicatePVAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/DuplicatePVAction.java
@@ -56,6 +56,7 @@ class DuplicatePVAction extends MenuItem
             template.setDisplays(original.getDisplays());
             template.setCommands(original.getCommands());
             template.setActions(original.getActions());
+            template.setTags(original.getTags());
 
             // Request adding new PV
             final String new_path = AlarmTreePath.makePath(original.getParent().getPathName(), new_name);

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/ItemConfigDialog.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/ItemConfigDialog.java
@@ -55,7 +55,7 @@ class ItemConfigDialog extends Dialog<Boolean>
     private Spinner<Integer> delay, count;
     private TextField filter;
     private ComboBox<String> relative_date;
-    private final TitleDetailTable guidance, displays, commands;
+    private final TitleDetailTable guidance, displays, commands, tags;
     private final TitleDetailDelayTable actions;
 
     public ItemConfigDialog(final AlarmClient model, final AlarmTreeItem<?> item)
@@ -227,6 +227,12 @@ class ItemConfigDialog extends Dialog<Boolean>
         actions.setPrefHeight(100);
         layout.add(actions, 0, row++, 2, 1);
 
+        // Commands:
+        layout.add(new Label("Tags:"), 0, row++);
+        tags = new TitleDetailTable(item.getTags());
+        tags.setPrefHeight(100);
+        layout.add(tags, 0, row++, 2, 1);
+
         // Dialog is quite high; allow scroll
         final ScrollPane scroll = new ScrollPane(layout);
 
@@ -294,6 +300,7 @@ class ItemConfigDialog extends Dialog<Boolean>
         config.setDisplays(displays.getItems());
         config.setCommands(commands.getItems());
         config.setActions(actions.getItems());
+        config.setTags(tags.getItems());
 
         try
         {


### PR DESCRIPTION
## Description
This PR will allow the inclusion of tags into alarm configurations. Tags are arbitrary tag/value pairs of information that can help operators better handle alarms, but that don't currently fit well elsewhere in the configuration. They can also be helpful when searching for a group of similarly tagged alarms, that would be difficult to group together otherwise. Tags are an optional feature, alarms will continue to work just fine without any set if not needed.

## Screenshots
![alarmtagsfull](https://user-images.githubusercontent.com/89539359/139467215-4b91ab0b-0d04-4e28-a1d5-c4c5c285eef0.png)

