### PR TITLE
PVA: Support search via TCP

### DIFF
--- a/core/pva/README.md
+++ b/core/pva/README.md
@@ -61,6 +61,9 @@ Key configuration parameters:
 
 `EPICS_PVA_AUTO_ADDR_LIST`: 'YES' (default) or 'NO'. 
 
+`EPICS_PVA_NAME_SERVERS`: Space-separated list of TCP name servers, provided as IP address followed by optional ":port". Client will connect to each address and send name searches before using the `EPICS_PVA_ADDR_LIST` for UDP searches.
+Set `EPICS_PVA_ADDR_LIST` to empty and `EPICS_PVA_AUTO_ADDR_LIST=NO` to use only the TCP name servers.
+
 `EPICS_PVA_BROADCAST_PORT`: PVA client UDP port (default 5076) for sending name searches and receiving beacons.
 
 `EPICS_PVAS_BROADCAST_PORT`: PVA server UDP port (default 5076) for name searches and beacons.

--- a/core/pva/README.md
+++ b/core/pva/README.md
@@ -62,7 +62,7 @@ Key configuration parameters:
 `EPICS_PVA_AUTO_ADDR_LIST`: 'YES' (default) or 'NO'. 
 
 `EPICS_PVA_NAME_SERVERS`: Space-separated list of TCP name servers, provided as IP address followed by optional ":port". Client will connect to each address and send name searches before using the `EPICS_PVA_ADDR_LIST` for UDP searches.
-Set `EPICS_PVA_ADDR_LIST` to empty and `EPICS_PVA_AUTO_ADDR_LIST=NO` to use only the TCP name servers.
+Set `EPICS_PVA_ADDR_LIST` to empty and `EPICS_PVA_AUTO_ADDR_LIST=NO` to use only the TCP name servers and avoid all UDP traffic. This is a client-side option. Server will always allow search messages via its TCP port.
 
 `EPICS_PVA_BROADCAST_PORT`: PVA client UDP port (default 5076) for sending name searches and receiving beacons.
 

--- a/core/pva/README.md
+++ b/core/pva/README.md
@@ -103,9 +103,9 @@ IPv6 Support
 
 Both the server and client support IPv6, which at this time needs to be enabled
 by configuring the `EPICS_PVAS_INTF_ADDR_LIST` of the server respectively the
-`EPICS_PVA_ADDR_LIST` of the client to provide the desired IPv6 addresses.
+`EPICS_PVA_ADDR_LIST` and/or `EPICS_PVA_NAME_SERVERS` of the client to provide the desired IPv6 addresses.
 
-See Javadoc of `EPICS_PVAS_INTF_ADDR_LIST` and `EPICS_PVA_ADDR_LIST` in `PVASettings`
+See Javadoc of `EPICS_PVAS_INTF_ADDR_LIST`, `EPICS_PVA_ADDR_LIST` and `EPICS_PVA_NAME_SERVERS` in `PVASettings`
 for details.
 
 Command-line Example

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -80,10 +80,9 @@ public class PVASettings
      *  <p>Example entries:
      *
      *  <pre>
-     *  192.168.10.20              Send name lookups to that TCP address, EPICS_PVA_SERVER_PORT (d3fault 5075)
-     *
-     *  ::1                        Search to IPv6 localhost at EPICS_PVA_SERVER_PORT
-     *  [::1]:9876                 Same with non-standard port
+     *  192.168.10.20    Send name lookups to that IPv4 TCP address at EPICS_PVA_SERVER_PORT (default 5075)
+     *  ::1              Search to IPv6 localhost at EPICS_PVA_SERVER_PORT
+     *  [::1]:9876       Same with non-standard port
      *  </pre>
      */
     public static String EPICS_PVA_NAME_SERVERS = "";

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -76,6 +76,15 @@ public class PVASettings
      *  Space separated list of addresses, each with optional port.
      *  To search for channels, client will connect to each one via TCP
      *  and send the search request.
+     *
+     *  <p>Example entries:
+     *
+     *  <pre>
+     *  192.168.10.20              Send name lookups to that TCP address, EPICS_PVA_SERVER_PORT (d3fault 5075)
+     *
+     *  ::1                        Search to IPv6 localhost at EPICS_PVA_SERVER_PORT
+     *  [::1]:9876                 Same with non-standard port
+     *  </pre>
      */
     public static String EPICS_PVA_NAME_SERVERS = "";
 

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -55,7 +55,6 @@ public class PVASettings
      *  but note that a network interface must be provided via
      *  `[ff02::42:1]@iface`, the client will not automatically multicast
      *  on each network interface.
-     *  </pre>
      */
     public static String EPICS_PVA_ADDR_LIST = "";
 

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -71,6 +71,14 @@ public class PVASettings
      */
     public static boolean EPICS_PVA_AUTO_ADDR_LIST = true;
 
+    /** List of TCP name servers
+     *
+     *  Space separated list of addresses, each with optional port.
+     *  To search for channels, client will connect to each one via TCP
+     *  and send the search request.
+     */
+    public static String EPICS_PVA_NAME_SERVERS = "";
+
     /** PVA client port for sending name searches and receiving beacons */
     public static int EPICS_PVA_BROADCAST_PORT = 5076;
 
@@ -160,6 +168,7 @@ public class PVASettings
     {
         EPICS_PVA_ADDR_LIST = get("EPICS_PVA_ADDR_LIST", EPICS_PVA_ADDR_LIST);
         EPICS_PVA_AUTO_ADDR_LIST = get("EPICS_PVA_AUTO_ADDR_LIST", EPICS_PVA_AUTO_ADDR_LIST);
+        EPICS_PVA_NAME_SERVERS = get("EPICS_PVA_NAME_SERVERS", EPICS_PVA_NAME_SERVERS);
         EPICS_PVA_SERVER_PORT = get("EPICS_PVA_SERVER_PORT", EPICS_PVA_SERVER_PORT);
         EPICS_PVAS_INTF_ADDR_LIST = get("EPICS_PVAS_INTF_ADDR_LIST", EPICS_PVAS_INTF_ADDR_LIST).trim();
         EPICS_PVA_BROADCAST_PORT = get("EPICS_PVA_BROADCAST_PORT", EPICS_PVA_BROADCAST_PORT);

--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -218,6 +218,10 @@ class ChannelSearch
     /** Invoked by timer: Check searched channels for the next one to handle */
     private void runSearches()
     {
+        // Shortcut search, avoid log messages when lists are empty
+        if (unicast_search_addresses.isEmpty()  &&  b_or_mcast_search_addresses.isEmpty())
+            return;
+
         for (SearchedChannel searched : searched_channels.values())
         {
             final int counter = searched.search_counter.updateAndGet(val -> val >= MAX_SEARCH_COUNT ? MAX_SEARCH_RESET : val+1);

--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -64,7 +64,7 @@ class ChannelSearch
     }
 
     /** Search request sequence number */
-    static final AtomicInteger search_sequence = new AtomicInteger();
+    private static final AtomicInteger search_sequence = new AtomicInteger();
 
     private final ClientUDPHandler udp;
 

--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -64,7 +64,7 @@ class ChannelSearch
     }
 
     /** Search request sequence number */
-    private static final AtomicInteger search_sequence = new AtomicInteger();
+    static final AtomicInteger search_sequence = new AtomicInteger();
 
     private final ClientUDPHandler udp;
 

--- a/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
@@ -42,7 +42,8 @@ import org.epics.pva.server.Guid;
 class ClientTCPHandler extends TCPHandler
 {
     private static final CommandHandlers<ClientTCPHandler> handlers =
-        new CommandHandlers<>(new ValidationHandler(),
+        new CommandHandlers<>(new SearchResponseHandler(),
+                              new ValidationHandler(),
                               new ValidatedHandler(),
                               new EchoHandler(),
                               new CreateChannelHandler(),
@@ -126,7 +127,6 @@ class ClientTCPHandler extends TCPHandler
         socket.socket().setKeepAlive(true);
         return socket;
     }
-
 
     /** @return Client context */
     PVAClient getClient()

--- a/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
@@ -61,7 +61,7 @@ class ClientTCPHandler extends TCPHandler
     private final CopyOnWriteArrayList<PVAChannel> channels = new CopyOnWriteArrayList<>();
 
     /** Server's GUID */
-    private final Guid guid;
+    private volatile Guid guid;
 
     private final AtomicInteger server_changes = new AtomicInteger(-1);
 
@@ -156,6 +156,27 @@ class ClientTCPHandler extends TCPHandler
     public Guid getGuid()
     {
         return guid;
+    }
+
+    /** Update the Guid
+     *
+     *  <p>The Guid of a server is fixed,
+     *  but this TCP handler may start out with Guid.EMPTY
+     *  to issue searches to an IP address.
+     *  Upon the first successful search reply,
+     *  we set the Guid based on the search reply.
+     *
+     *  @param search_reply_guid Guid from search reply
+     *  @return <code>true</code> if this updated the Guid from EMPTY
+     */
+    public boolean updateGuid(final Guid search_reply_guid)
+    {
+        if (guid.equals(Guid.EMPTY))
+        {
+            guid = search_reply_guid;
+            return true;
+        }
+        return false;
     }
 
     /** Check if the server's beacon indicates changes
@@ -287,7 +308,7 @@ class ClientTCPHandler extends TCPHandler
             // configure it
             send_buffer.order(buffer.order());
 
-            logger.log(Level.FINE, () -> "Server Version " + server_version + " sent set-byte-order to " + send_buffer.order());
+            logger.log(Level.FINE, () -> "Server Version " + server_version + " sets byte order to " + send_buffer.order());
             // Payload indicates if the server will send messages in that same order,
             // or might change order for each message.
             // We always adapt based on the flags of each received message,

--- a/core/pva/src/main/java/org/epics/pva/client/ClientUDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientUDPHandler.java
@@ -23,6 +23,7 @@ import org.epics.pva.common.AddressInfo;
 import org.epics.pva.common.Network;
 import org.epics.pva.common.PVAHeader;
 import org.epics.pva.common.SearchRequest;
+import org.epics.pva.common.SearchResponse;
 import org.epics.pva.common.UDPHandler;
 import org.epics.pva.data.Hexdump;
 import org.epics.pva.data.PVAAddress;
@@ -296,7 +297,7 @@ class ClientUDPHandler extends UDPHandler
     {
         try
         {
-            final SearchResponseDecoder response = new SearchResponseDecoder(payload, buffer);
+            final SearchResponse response = SearchResponse.decode(payload, buffer);
 
             // Did server sent specific address? Otherwise use remote address
             InetSocketAddress server = response.server;

--- a/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
@@ -175,10 +175,14 @@ public class PVAClient implements AutoCloseable
                 {
                     logger.log(Level.FINE, () -> "Searching for " + channel + " via TCP " + tcp.getRemoteAddress());
 
-                    // Share search seq. ID with UDP searches
-                    final int seq = ChannelSearch.search_sequence.incrementAndGet();
+                    // Search sequence identifies the potentially repeated UDP.
+                    // TCP search is once only, so PVXS always sends 0x66696E64 = "find".
+                    // We send "look".
+                    final int seq = 0x6C6F6F6B;
+
                     // Use 'any' reply address since reply will be via this TCP socket
                     final InetSocketAddress response_address = new InetSocketAddress(0);
+                    
                     SearchRequest.encode(true, seq, channel.getCID(), channel.getName(), response_address , buffer);
                 };
                 tcp.submit(search_request);

--- a/core/pva/src/main/java/org/epics/pva/client/SearchResponseDecoder.java
+++ b/core/pva/src/main/java/org/epics/pva/client/SearchResponseDecoder.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.epics.pva.client;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+import org.epics.pva.data.PVAAddress;
+import org.epics.pva.data.PVABool;
+import org.epics.pva.data.PVAString;
+import org.epics.pva.server.Guid;
+
+/** Decode a server's SEARCH reply
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class SearchResponseDecoder
+{
+    /** Server GUID */
+    public final Guid guid;
+
+    /** Search Sequence ID */
+    public final int seq;
+
+    /** Server's address, may be  all zero (any local) */
+    public final InetSocketAddress server;
+
+    /** Did server reply that channels are found, or did it send negative response? */
+    public final boolean found;
+
+    /** Channel IDs (client IDs) that server reports as found */
+    public final int[] cid;
+
+    /** Decode search response
+     *
+     *  @param payload Size of valid payload (may be less than buffer.remaining())
+     *  @param buffer {@link ByteBuffer}
+     *  @throws Exception on error
+     */
+    public SearchResponseDecoder(final int payload, final ByteBuffer buffer) throws Exception
+    {
+        // Expect GUID + seqID + IP address + port + "tcp" + found + count ( + int[count] )
+        if (payload < 12 + 4 + 16 + 2 + 4 + 1 + 2)
+            throw new Exception("PVA Server sent only " + payload + " bytes for search reply");
+
+        // Server GUID
+        guid = new Guid(buffer);
+
+        // Search Sequence ID
+        seq = buffer.getInt();
+
+        // Server's address and port
+        final InetAddress addr;
+        try
+        {
+            addr = PVAAddress.decode(buffer);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("PVA Server sent search reply with invalid address", ex);
+        }
+        final int port = Short.toUnsignedInt(buffer.getShort());
+
+        // Use address from reply unless it's a generic local address
+        if (addr.isAnyLocalAddress())
+            server = new InetSocketAddress(port);
+        else
+            server = new InetSocketAddress(addr, port);
+
+        final String protocol = PVAString.decodeString(buffer);
+        if (! "tcp".equals(protocol))
+            throw new Exception("PVA Server sent search reply #" + seq + " for protocol '" + protocol + "'");
+
+        // Server may reply with list of PVs that it does _not_ have...
+        found = PVABool.decodeBoolean(buffer);
+
+        final int count = Short.toUnsignedInt(buffer.getShort());
+        cid = new int[count];
+        for (int i=0; i<count; ++i)
+            cid[i] = buffer.getInt();
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/client/SearchResponseDecoder.java
+++ b/core/pva/src/main/java/org/epics/pva/client/SearchResponseDecoder.java
@@ -53,9 +53,7 @@ class SearchResponseDecoder
         int pos = buffer.position();
         if (pos < PVAHeader.HEADER_SIZE)
             throw new Exception("Cannot peek into PVA header of search reply, size is " + pos);
-        buffer.position(pos - PVAHeader.HEADER_SIZE);
-        version = buffer.get(1);
-        buffer.position(pos);
+        version = buffer.get(pos + 1 - PVAHeader.HEADER_SIZE);
 
         // Expect GUID + seqID + IP address + port + "tcp" + found + count ( + int[count] )
         if (payload < 12 + 4 + 16 + 2 + 4 + 1 + 2)

--- a/core/pva/src/main/java/org/epics/pva/client/SearchResponseHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/SearchResponseHandler.java
@@ -15,6 +15,7 @@ import java.util.logging.Level;
 
 import org.epics.pva.common.CommandHandler;
 import org.epics.pva.common.PVAHeader;
+import org.epics.pva.common.SearchResponse;
 
 /** Handle a server's SEARCH reply
  *
@@ -36,10 +37,10 @@ class SearchResponseHandler implements CommandHandler<ClientTCPHandler>
     @Override
     public void handleCommand(final ClientTCPHandler tcp, final ByteBuffer buffer) throws Exception
     {
-        final SearchResponseDecoder response;
+        final SearchResponse response;
         try
         {
-            response = new SearchResponseDecoder(buffer.remaining(), buffer);
+            response = SearchResponse.decode(buffer.remaining(), buffer);
         }
         catch (Exception ex)
         {

--- a/core/pva/src/main/java/org/epics/pva/client/SearchResponseHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/SearchResponseHandler.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.epics.pva.client;
+
+import static org.epics.pva.PVASettings.logger;
+
+import java.nio.ByteBuffer;
+import java.util.logging.Level;
+
+import org.epics.pva.common.CommandHandler;
+import org.epics.pva.common.PVAHeader;
+
+/** Handle a server's SEARCH reply
+ *
+ *  <p>Registered to handle the TCP request to searches.
+ *  See {@link ChannelSearch} and {@link ClientUDPHandler}
+ *  for UDP search and reply.
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class SearchResponseHandler implements CommandHandler<ClientTCPHandler>
+{
+    @Override
+    public byte getCommand()
+    {
+        return PVAHeader.CMD_SEARCH_RESPONSE;
+    }
+
+    @Override
+    public void handleCommand(final ClientTCPHandler tcp, final ByteBuffer buffer) throws Exception
+    {
+        final SearchResponseDecoder response;
+        try
+        {
+            response = new SearchResponseDecoder(buffer.remaining(), buffer);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("PVA Server " + tcp + " sent invalid search reply", ex);
+        }
+
+        if (response.found)
+        {
+            for (int cid : response.cid)
+            {
+                final PVAChannel channel = tcp.getClient().getChannel(cid);
+
+                if (channel == null)
+                    logger.log(Level.FINE, "Got search response for unknown CID " + cid + " from " + response.server + " " + response.guid);
+                else
+                    logger.log(Level.FINE, "Got search response for " + channel + " from " + response.server + " " + response.guid);
+                // TODO search_response.handleSearchResponse(cid, server, version, guid);
+            }
+        }
+
+        tcp.markAlive();
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/client/SearchResponseHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/SearchResponseHandler.java
@@ -47,6 +47,12 @@ class SearchResponseHandler implements CommandHandler<ClientTCPHandler>
             throw new Exception("PVA Server " + tcp + " sent invalid search reply", ex);
         }
 
+        // If reply is "*:port", then use this TCP connection's address.
+        // Client will find existing TCP connection via that address and re-use it.
+        // This is the expected case when directly connecting to a PVA server via
+        // its TCP port.
+        // Otherwise, in case we queried a name server which then points to the actual PVA server,
+        // use address as provided, and connect to it or re-use in case we already have a TCP connection to that address:port.
         InetSocketAddress server = response.server;
         if (server.getAddress().isAnyLocalAddress())
             server = tcp.getRemoteAddress();

--- a/core/pva/src/main/java/org/epics/pva/common/Network.java
+++ b/core/pva/src/main/java/org/epics/pva/common/Network.java
@@ -183,7 +183,7 @@ public class Network
      *  @param search_list String with space-separated list of addresses
      *  @param default_port Port to use when address 'search_list' entry does not specify one
      *  @return {@link InetSocketAddress} list
-     *  @see #parseAddress(String)
+     *  @see #parseAddress(String, int)
      */
     public static List<AddressInfo> parseAddresses(final String search_list, final int default_port)
     {

--- a/core/pva/src/main/java/org/epics/pva/common/Network.java
+++ b/core/pva/src/main/java/org/epics/pva/common/Network.java
@@ -106,14 +106,15 @@ public class Network
      *  </pre>
      *
      *  @param setting Address "IP:port,TTL@iface" to parse
+     *  @param default_port Port to use when 'setting' does not specify one
      *  @return {@link AddressInfo}
      *  @throws Exception on error
      */
-    public static AddressInfo parseAddress(final String setting) throws Exception
+    public static AddressInfo parseAddress(final String setting, final int default_port) throws Exception
     {
         NetworkInterface iface = null;
         int ttl = 1;
-        int port = PVASettings.EPICS_PVA_BROADCAST_PORT;
+        int port = default_port;
 
         String parsed = setting;
         // Optional @interface
@@ -180,17 +181,20 @@ public class Network
     /** Parse network addresses
      *
      *  @param search_list String with space-separated list of addresses
+     *  @param default_port Port to use when address 'search_list' entry does not specify one
      *  @return {@link InetSocketAddress} list
      *  @see #parseAddress(String)
      */
-    public static List<AddressInfo> parseAddresses(final String search_list)
+    public static List<AddressInfo> parseAddresses(final String search_list, final int default_port)
     {
+        // If search_list is empty, search_addresses will be [ "" ] with one empty entry
         final String[] search_addresses = search_list.split("\\s+");
         final List<AddressInfo> addresses = new ArrayList<>();
         for (String search : search_addresses)
             try
             {
-                addresses.add(parseAddress(search));
+                if (! search.isEmpty())
+                    addresses.add(parseAddress(search, default_port));
             }
             catch (Exception ex)
             {

--- a/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
+++ b/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -126,6 +126,9 @@ public class PVAHeader
 
     /** Size of common PVA message header */
     public static final int HEADER_SIZE = 8;
+
+    /** Offset from start of common PVA message header to byte version */
+    public static final int HEADER_OFFSET_VERSION = 1;
 
     /** Offset from start of common PVA message header to int payload_size */
     public static final int HEADER_OFFSET_PAYLOAD_SIZE = 4;

--- a/core/pva/src/main/java/org/epics/pva/common/SearchRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SearchRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -115,7 +115,7 @@ public class SearchRequest
             {
                 final int cid = buffer.getInt();
                 final String name = PVAString.decodeString(buffer);
-                logger.log(Level.FINER, () -> "PVA Client " + from + " sent search #" + search.seq + " for " + name + " [" + cid + "]");
+                logger.log(Level.FINER, () -> "PVA Client " + from + " sent search #" + search.seq + " for " + name + " [cid " + cid + "]");
                 search.name[i] = name;
                 search.cid[i] = cid;
             }

--- a/core/pva/src/main/java/org/epics/pva/common/SearchResponse.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SearchResponse.java
@@ -44,6 +44,7 @@ public class SearchResponse
      *
      *  @param payload Size of valid payload (may be less than buffer.remaining())
      *  @param buffer {@link ByteBuffer}
+     *  @return {@link SearchResponse}
      *  @throws Exception on error
      */
     public static SearchResponse decode(final int payload, final ByteBuffer buffer) throws Exception

--- a/core/pva/src/main/java/org/epics/pva/common/SearchResponse.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SearchResponse.java
@@ -5,13 +5,12 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
-package org.epics.pva.client;
+package org.epics.pva.common;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
-import org.epics.pva.common.PVAHeader;
 import org.epics.pva.data.PVAAddress;
 import org.epics.pva.data.PVABool;
 import org.epics.pva.data.PVAString;
@@ -21,25 +20,25 @@ import org.epics.pva.server.Guid;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-class SearchResponseDecoder
+public class SearchResponse
 {
     /** Server's protocol version */
-    public final int version;
+    public int version;
 
     /** Server GUID */
-    public final Guid guid;
+    public Guid guid;
 
     /** Search Sequence ID */
-    public final int seq;
+    public int seq;
 
     /** Server's address, may be  all zero (any local) */
-    public final InetSocketAddress server;
+    public InetSocketAddress server;
 
     /** Did server reply that channels are found, or did it send negative response? */
-    public final boolean found;
+    public boolean found;
 
     /** Channel IDs (client IDs) that server reports as found */
-    public final int[] cid;
+    public int[] cid;
 
     /** Decode search response
      *
@@ -47,23 +46,24 @@ class SearchResponseDecoder
      *  @param buffer {@link ByteBuffer}
      *  @throws Exception on error
      */
-    public SearchResponseDecoder(final int payload, final ByteBuffer buffer) throws Exception
+    public static SearchResponse decode(final int payload, final ByteBuffer buffer) throws Exception
     {
+        final SearchResponse result = new SearchResponse();
         // Get 'version' from within the PV
         int pos = buffer.position();
         if (pos < PVAHeader.HEADER_SIZE)
             throw new Exception("Cannot peek into PVA header of search reply, size is " + pos);
-        version = buffer.get(pos + 1 - PVAHeader.HEADER_SIZE);
+        result.version = buffer.get(pos - PVAHeader.HEADER_SIZE + PVAHeader.HEADER_OFFSET_VERSION);
 
         // Expect GUID + seqID + IP address + port + "tcp" + found + count ( + int[count] )
         if (payload < 12 + 4 + 16 + 2 + 4 + 1 + 2)
             throw new Exception("PVA Server sent only " + payload + " bytes for search reply");
 
         // Server GUID
-        guid = new Guid(buffer);
+        result.guid = new Guid(buffer);
 
         // Search Sequence ID
-        seq = buffer.getInt();
+        result.seq = buffer.getInt();
 
         // Server's address and port
         final InetAddress addr;
@@ -79,20 +79,62 @@ class SearchResponseDecoder
 
         // Use address from reply unless it's a generic local address
         if (addr.isAnyLocalAddress())
-            server = new InetSocketAddress(port);
+            result.server = new InetSocketAddress(port);
         else
-            server = new InetSocketAddress(addr, port);
+            result.server = new InetSocketAddress(addr, port);
 
         final String protocol = PVAString.decodeString(buffer);
         if (! "tcp".equals(protocol))
-            throw new Exception("PVA Server sent search reply #" + seq + " for protocol '" + protocol + "'");
+            throw new Exception("PVA Server sent search reply #" + result.seq + " for protocol '" + protocol + "'");
 
         // Server may reply with list of PVs that it does _not_ have...
-        found = PVABool.decodeBoolean(buffer);
+        result.found = PVABool.decodeBoolean(buffer);
 
         final int count = Short.toUnsignedInt(buffer.getShort());
-        cid = new int[count];
+        result.cid = new int[count];
         for (int i=0; i<count; ++i)
-            cid[i] = buffer.getInt();
+            result.cid[i] = buffer.getInt();
+
+        return result;
+    }
+
+    /** Encode a search response
+     *  @param guid This server's GUID
+     *  @param seq Client search request sequence number
+     *  @param cid Client's channel ID or -1
+     *  @param address Address where client can connect to access the channel
+     *  @param port Associated TCP port
+     *  @param buffer Buffer into which search response will be encoded
+     */
+    public static void encode(final Guid guid, final int seq, final int cid,
+                              final InetAddress address, final int port,
+                              final ByteBuffer buffer)
+    {
+        PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_SERVER, PVAHeader.CMD_SEARCH_RESPONSE, 12+4+16+2+4+1+2+ (cid < 0 ? 0 : 4));
+
+        // Server GUID
+        guid.encode(buffer);
+
+        // Search Sequence ID
+        buffer.putInt(seq);
+
+        // Server's address and port
+        PVAAddress.encode(address, buffer);
+        buffer.putShort((short)port);
+
+        // Protocol
+        PVAString.encodeString("tcp", buffer);
+
+        // Found
+        PVABool.encodeBoolean(cid >= 0, buffer);
+
+        // int[] cid;
+        if (cid < 0)
+            buffer.putShort((short)0);
+        else
+        {
+            buffer.putShort((short)1);
+            buffer.putInt(cid);
+        }
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -166,7 +166,7 @@ abstract public class TCPHandler
     {
         try
         {
-            Thread.currentThread().setName("TCP sender " + socket.getRemoteAddress());
+            Thread.currentThread().setName("TCP sender from " + socket.getLocalAddress() + " to " + socket.getRemoteAddress());
             logger.log(Level.FINER, Thread.currentThread().getName() + " started");
             while (true)
             {
@@ -205,7 +205,7 @@ abstract public class TCPHandler
      */
     protected void send(final ByteBuffer buffer) throws Exception
     {
-        logger.log(Level.FINER, () -> Thread.currentThread().getName() + ":\n" + Hexdump.toHexdump(buffer));
+        logger.log(Level.FINER, () -> Thread.currentThread().getName() + " sends:\n" + Hexdump.toHexdump(buffer));
 
         // Original AbstractCodec.send() mentions
         // Microsoft KB article KB823764:
@@ -275,7 +275,7 @@ abstract public class TCPHandler
                 }
                 // .. then decode
                 receive_buffer.flip();
-                logger.log(Level.FINER, () -> Thread.currentThread().getName() + ":\n" + Hexdump.toHexdump(receive_buffer));
+                logger.log(Level.FINER, () -> Thread.currentThread().getName() + " received:\n" + Hexdump.toHexdump(receive_buffer));
 
                 // While buffer may contain more data,
                 // limit it to the end of this message to prevent

--- a/core/pva/src/main/java/org/epics/pva/server/Guid.java
+++ b/core/pva/src/main/java/org/epics/pva/server/Guid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,8 @@ import java.util.Arrays;
 @SuppressWarnings("nls")
 public class Guid
 {
+    public static final Guid EMPTY = new Guid(new byte[]{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+
     // Random number generator in holder to defer initialization
     private static class Holder
     {
@@ -37,6 +39,16 @@ public class Guid
     public Guid(final ByteBuffer buffer)
     {
         buffer.get(guid);
+    }
+
+    /** Set Guid from value
+     *  @param value 12-byte Guid value
+     */
+    private Guid(final byte[] value)
+    {
+        if (value.length != guid.length)
+            throw new IllegalArgumentException("Need 12, got " + guid.length + " bytes");
+        System.arraycopy(value, 0, guid, 0, guid.length);
     }
 
     /** @param buffer Buffer into which to encode Guid */

--- a/core/pva/src/main/java/org/epics/pva/server/SearchCommandHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/SearchCommandHandler.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.epics.pva.server;
+
+import java.nio.ByteBuffer;
+
+import org.epics.pva.common.CommandHandler;
+import org.epics.pva.common.PVAHeader;
+import org.epics.pva.common.SearchRequest;
+
+/** Handle client's SEARCH command received via TCP
+ *  @author Kay Kasemir
+ */
+class SearchCommandHandler implements CommandHandler<ServerTCPHandler>
+{
+    @Override
+    public byte getCommand()
+    {
+        return PVAHeader.CMD_SEARCH;
+    }
+
+    @Override
+    public void handleCommand(final ServerTCPHandler tcp, final ByteBuffer buffer) throws Exception
+    {
+        final byte version = buffer.get(PVAHeader.HEADER_OFFSET_VERSION);
+        final int payload_size = buffer.getInt(PVAHeader.HEADER_OFFSET_PAYLOAD_SIZE);
+
+        final SearchRequest search = SearchRequest.decode(tcp.getRemoteAddress(), version, payload_size, buffer);
+
+        if (search.name != null)
+            for (int i=0; i<search.name.length; ++i)
+                tcp.getServer().handleSearchRequest(search.seq, search.cid[i], search.name[i],
+                                                    search.client, tcp);
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
@@ -62,7 +62,7 @@ class ServerUDPHandler extends UDPHandler
     {
         this.search_handler = search_handler;
 
-        for (AddressInfo info : Network.parseAddresses(PVASettings.EPICS_PVAS_INTF_ADDR_LIST))
+        for (AddressInfo info : Network.parseAddresses(PVASettings.EPICS_PVAS_INTF_ADDR_LIST, PVASettings.EPICS_PVAS_BROADCAST_PORT))
         {
             // First should be non-multicast addresses that create the IPv4 and/or IPv6 channel
             if (! info.getAddress().getAddress().isMulticastAddress())

--- a/core/pva/src/test/java/org/epics/pva/common/NetworkTest.java
+++ b/core/pva/src/test/java/org/epics/pva/common/NetworkTest.java
@@ -36,20 +36,20 @@ public class NetworkTest
     @Test
     public void testIPv4() throws Exception
     {
-        AddressInfo addr = Network.parseAddress("127.0.0.1");
+        AddressInfo addr = Network.parseAddress("127.0.0.1", PVASettings.EPICS_PVA_BROADCAST_PORT);
         System.out.println(addr);
         assertEquals("127.0.0.1", addr.getAddress().getHostString());
         assertEquals(PVASettings.EPICS_PVA_BROADCAST_PORT, addr.getAddress().getPort());
         assertFalse(addr.isBroadcast());
 
-        addr = Network.parseAddress("127.0.0.1:5086");
+        addr = Network.parseAddress("127.0.0.1:5086", PVASettings.EPICS_PVA_BROADCAST_PORT);
         System.out.println(addr);
         assertEquals("127.0.0.1", addr.getAddress().getHostString());
         assertEquals(5086, addr.getAddress().getPort());
         assertFalse(addr.isBroadcast());
 
 
-        addr = Network.parseAddress("224.0.2.3@127.0.0.1");
+        addr = Network.parseAddress("224.0.2.3@127.0.0.1", PVASettings.EPICS_PVA_BROADCAST_PORT);
         System.out.println(addr);
         assertEquals("224.0.2.3", addr.getAddress().getHostString());
         assertTrue(addr.getAddress().getAddress().isMulticastAddress());
@@ -62,7 +62,7 @@ public class NetworkTest
         assertTrue(iface_addr.contains("127.0.0.1"));
         assertFalse(addr.isBroadcast());
 
-        addr = Network.parseAddress("127.0.0.255");
+        addr = Network.parseAddress("127.0.0.255", PVASettings.EPICS_PVA_BROADCAST_PORT);
         System.out.println(addr);
         assertEquals("127.0.0.255", addr.getAddress().getHostString());
         assertTrue(addr.isBroadcast());
@@ -71,29 +71,29 @@ public class NetworkTest
     @Test
     public void testIPv6() throws Exception
     {
-        AddressInfo addr = Network.parseAddress("[::1]");
+        AddressInfo addr = Network.parseAddress("[::1]", PVASettings.EPICS_PVA_BROADCAST_PORT);
         System.out.println(addr);
         assertEquals("0:0:0:0:0:0:0:1", addr.getAddress().getHostString());
         assertEquals(PVASettings.EPICS_PVA_BROADCAST_PORT, addr.getAddress().getPort());
         assertFalse(addr.isBroadcast());
 
-        addr = Network.parseAddress("::1");
+        addr = Network.parseAddress("::1", 9876);
         System.out.println(addr);
         assertEquals("0:0:0:0:0:0:0:1", addr.getAddress().getHostString());
-        assertEquals(PVASettings.EPICS_PVA_BROADCAST_PORT, addr.getAddress().getPort());
+        assertEquals(9876, addr.getAddress().getPort());
         assertFalse(addr.isBroadcast());
 
-        addr = Network.parseAddress("[::1]:5086");
+        addr = Network.parseAddress("[::1]:5086", PVASettings.EPICS_PVA_BROADCAST_PORT+2);
         System.out.println(addr);
         assertEquals("0:0:0:0:0:0:0:1", addr.getAddress().getHostString());
         assertEquals(5086, addr.getAddress().getPort());
         assertFalse(addr.isBroadcast());
 
-        addr = Network.parseAddress("ff02::42:1");
+        addr = Network.parseAddress("ff02::42:1", PVASettings.EPICS_PVA_BROADCAST_PORT+3);
         System.out.println(addr);
         assertEquals("ff02:0:0:0:0:0:42:1", addr.getAddress().getHostString());
         assertTrue(addr.getAddress().getAddress().isMulticastAddress());
-        assertEquals(PVASettings.EPICS_PVA_BROADCAST_PORT, addr.getAddress().getPort());
+        assertEquals(PVASettings.EPICS_PVA_BROADCAST_PORT+3, addr.getAddress().getPort());
         assertFalse(addr.isBroadcast());
 
         final NetworkInterface lo = Network.getLoopback();
@@ -101,7 +101,7 @@ public class NetworkTest
             System.out.println("Skipping loopback test");
         else
         {
-            addr = Network.parseAddress("[ff02::42:1]:5099@" + lo.getDisplayName());
+            addr = Network.parseAddress("[ff02::42:1]:5099@" + lo.getDisplayName(), PVASettings.EPICS_PVA_BROADCAST_PORT);
             System.out.println(addr);
             assertEquals("ff02:0:0:0:0:0:42:1", addr.getAddress().getHostString());
             assertTrue(addr.getAddress().getAddress().isMulticastAddress());
@@ -122,7 +122,7 @@ public class NetworkTest
     {
         final String spec = "0.0.0.0 :: 224.0.1.1,1@127.0.0.1 [ff02::42:1],1@::1";
         System.out.println("Result of parsing '" + spec + "':");
-        final List<AddressInfo> infos = Network.parseAddresses(spec);
+        final List<AddressInfo> infos = Network.parseAddresses(spec, PVASettings.EPICS_PVA_BROADCAST_PORT);
         for (AddressInfo info : infos)
             System.out.println(info);
         assertEquals(4, infos.size());


### PR DESCRIPTION
Server will always allow name lookups via its TCP port.
Client, as before, defaults to lookup via UDP (...ADDR_LIST, AUTO_ADDR_LIST), but now also checks EPICS_PVA_NAME_SERVERS for a list of TCP addresses.
Supports both IPv4 and IPv6.
Server and client have been tested with PVXS server & client for both IPv4 and 6.