### PR TITLE
UI updates to alarm log table

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
@@ -53,7 +53,6 @@ public class AlarmLogSearchJob implements JobRunnable {
     public static Job submit(RestHighLevelClient client, final String pattern, Boolean isNodeTable, ObservableMap<Keys, String> searchParameters,
             final Consumer<List<AlarmLogTableType>> alarmMessageHandler,
             final BiConsumer<String, Exception> errorHandler) {
-
         return JobManager.schedule("searching alarm log messages for : " + pattern,
                 new AlarmLogSearchJob(client, pattern, isNodeTable, searchParameters, alarmMessageHandler, errorHandler));
     }
@@ -111,22 +110,17 @@ public class AlarmLogSearchJob implements JobRunnable {
                     }
                 }
                 if (key.equals("pv")) {
-                    if (isNodeTable == true) {
+                    if (isNodeTable) {
                         value = "*".concat(value).concat("*");
                         boolQuery.must(QueryBuilders.wildcardQuery("config", value));
                         configSet = true;
                     }
                     continue;
                 }
-                if(!key.equals(Keys.CONFIG.getName())){
-                    boolQuery.must(QueryBuilders.matchQuery(key, value));
-                }
-                else{
-                    boolQuery.must(QueryBuilders.wildcardQuery(key, value));
-                }
+                boolQuery.must(QueryBuilders.matchQuery(key, value));
             }
         }
-        if (configSet == false) {
+        if (!configSet) {
             boolQuery.must(QueryBuilders.wildcardQuery("config", searchPattern));
         }
         boolQuery.must(QueryBuilders.rangeQuery("message_time").from(from).to(to));

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
@@ -118,7 +118,12 @@ public class AlarmLogSearchJob implements JobRunnable {
                     }
                     continue;
                 }
-                boolQuery.must(QueryBuilders.matchQuery(key, value));
+                if(!key.equals(Keys.CONFIG.getName())){
+                    boolQuery.must(QueryBuilders.matchQuery(key, value));
+                }
+                else{
+                    boolQuery.must(QueryBuilders.wildcardQuery(key, value));
+                }
             }
         }
         if (configSet == false) {

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.java
@@ -3,10 +3,12 @@ package org.phoebus.applications.alarm.logging.ui;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.phoebus.framework.nls.NLS;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.ui.docking.DockItem;
@@ -24,7 +26,9 @@ public class AlarmLogTable implements AppInstance {
     AlarmLogTable(final AlarmLogTableApp app) {
         this.app = app;
         try {
+            ResourceBundle resourceBundle = NLS.getMessages(Messages.class);
             FXMLLoader loader = new FXMLLoader();
+            loader.setResources(resourceBundle);
             loader.setLocation(this.getClass().getResource("AlarmLogTable.fxml"));
             loader.setControllerFactory(clazz -> {
                 try {

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -249,6 +249,7 @@ public class AlarmLogTableController {
         searchParameters.put(Keys.HOST, "*");
         searchParameters.put(Keys.STARTTIME, TimeParser.format(java.time.Duration.ofDays(7)));
         searchParameters.put(Keys.ENDTIME, TimeParser.format(java.time.Duration.ZERO));
+        searchParameters.put(Keys.CONFIG, "*");
         advancedSearchViewController.setSearchParameters(searchParameters);
 
         query.setText(searchParameters.entrySet().stream().sorted(Map.Entry.comparingByKey()).map((e) -> {
@@ -318,6 +319,7 @@ public class AlarmLogTableController {
         searchParameters.put(Keys.HOST, "*");
         searchParameters.put(Keys.STARTTIME, TimeParser.format(java.time.Duration.ofDays(7)));
         searchParameters.put(Keys.ENDTIME, TimeParser.format(java.time.Duration.ZERO));
+        searchParameters.put(Keys.CONFIG, "*");
 
         query.setText(searchParameters.entrySet().stream().sorted(Map.Entry.comparingByKey()).map((e) -> {
             return e.getKey().getName().trim() + "=" + e.getValue().trim();

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -2,6 +2,8 @@ package org.phoebus.applications.alarm.logging.ui;
 
 import static org.phoebus.applications.alarm.logging.ui.AlarmLogTableApp.logger;
 
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.scene.control.ProgressIndicator;
 import org.phoebus.util.time.TimeParser;
 import java.util.Arrays;
 import java.util.List;
@@ -9,8 +11,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javafx.beans.binding.Bindings;
-import javafx.beans.value.ChangeListener;
+
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
@@ -105,6 +106,10 @@ public class AlarmLogTableController {
     private Job alarmLogSearchJob;
     private RestHighLevelClient searchClient;
 
+    @FXML
+    private ProgressIndicator progressIndicator;
+    private SimpleBooleanProperty searchInProgress = new SimpleBooleanProperty(false);
+
     public AlarmLogTableController(RestHighLevelClient client){
         setClient(client);
     }
@@ -152,8 +157,8 @@ public class AlarmLogTableController {
                 });
         tableView.getColumns().add(messageCol);
         
-      timeCol = new TableColumn<>("Time");
-      timeCol.setCellValueFactory(
+        timeCol = new TableColumn<>("Time");
+        timeCol.setCellValueFactory(
               new Callback<CellDataFeatures<AlarmLogTableType, String>, ObservableValue<String>>() {
                   @Override
                   public ObservableValue<String> call(CellDataFeatures<AlarmLogTableType, String> alarmMessage) {
@@ -164,7 +169,7 @@ public class AlarmLogTableController {
                 	  return null;
                   }
               });
-      tableView.getColumns().add(timeCol);
+        tableView.getColumns().add(timeCol);
         
         msgTimeCol = new TableColumn<>("Message Time");
         msgTimeCol.setCellValueFactory(
@@ -249,7 +254,6 @@ public class AlarmLogTableController {
         searchParameters.put(Keys.HOST, "*");
         searchParameters.put(Keys.STARTTIME, TimeParser.format(java.time.Duration.ofDays(7)));
         searchParameters.put(Keys.ENDTIME, TimeParser.format(java.time.Duration.ZERO));
-        searchParameters.put(Keys.CONFIG, "*");
         advancedSearchViewController.setSearchParameters(searchParameters);
 
         query.setText(searchParameters.entrySet().stream().sorted(Map.Entry.comparingByKey()).map((e) -> {
@@ -261,7 +265,7 @@ public class AlarmLogTableController {
             .map((e) -> e.getKey().getName().trim() + "=" + e.getValue().trim())
             .collect(Collectors.joining("&"))));
 
-	query.setOnKeyPressed(new EventHandler<KeyEvent>() {
+	    query.setOnKeyPressed(new EventHandler<KeyEvent>() {
             @Override
             public void handle(KeyEvent keyEvent) {
                 if (keyEvent.getCode() == KeyCode.ENTER)  {
@@ -270,14 +274,21 @@ public class AlarmLogTableController {
             }
         });
 
-        peroidicSearch();
+	    progressIndicator.visibleProperty().bind(searchInProgress);
+        searchInProgress.addListener((observable, oldValue, newValue) -> {
+            tableView.setDisable(newValue.booleanValue());
+        });
+
+        search.disableProperty().bind(searchInProgress);
+
+        periodicSearch();
     }
 
     private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture<?> runningTask;
 
-    private void peroidicSearch() {
-        logger.info("Starting a peroidic search for alarm messages : " + searchString);
+    private void periodicSearch() {
+        logger.info("Starting a periodic search for alarm messages : " + searchString);
         if (runningTask != null) {
             runningTask.cancel(true);
         }
@@ -292,7 +303,11 @@ public class AlarmLogTableController {
                sortColType = sortTableCol.getSortType();
             }
             alarmLogSearchJob = AlarmLogSearchJob.submit(searchClient, searchString, isNodeTable, searchParameters,
-                    result -> Platform.runLater(() -> setAlarmMessages(result)), (url, ex) -> {
+                    result -> Platform.runLater(() -> {
+                        setAlarmMessages(result);
+                        searchInProgress.set(false);
+                        }), (url, ex) -> {
+                        searchInProgress.set(false);
                         logger.log(Level.WARNING, "Shutting down alarm log message scheduler.", ex);
                         runningTask.cancel(true);
                     });
@@ -319,7 +334,6 @@ public class AlarmLogTableController {
         searchParameters.put(Keys.HOST, "*");
         searchParameters.put(Keys.STARTTIME, TimeParser.format(java.time.Duration.ofDays(7)));
         searchParameters.put(Keys.ENDTIME, TimeParser.format(java.time.Duration.ZERO));
-        searchParameters.put(Keys.CONFIG, "*");
 
         query.setText(searchParameters.entrySet().stream().sorted(Map.Entry.comparingByKey()).map((e) -> {
             return e.getKey().getName().trim() + "=" + e.getValue().trim();
@@ -390,7 +404,8 @@ public class AlarmLogTableController {
 
     @FXML
     public void search() {
-	tableView.getSortOrder().clear();
+        searchInProgress.set(true);
+	    tableView.getSortOrder().clear();
         updateQuery();
     }
 	

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableQueryUtil.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableQueryUtil.java
@@ -13,8 +13,7 @@ public class AlarmLogTableQueryUtil {
         HOST("host"),
         COMMAND("command"),
         STARTTIME("start"),
-        ENDTIME("end"),
-        CONFIG("config");
+        ENDTIME("end");
 
         private final String name;
 

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableQueryUtil.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableQueryUtil.java
@@ -1,18 +1,24 @@
 package org.phoebus.applications.alarm.logging.ui;
 
-import java.time.Instant;
-import java.time.temporal.TemporalAmount;
-import java.util.function.Function;
-import org.phoebus.util.time.TimeParser;
-
 public class AlarmLogTableQueryUtil {
 
     // Ordered search keys
-    public static enum Keys {
-        PV("pv"), SEVERITY("severity"), MESSAGE("message"), CURRENTSEVERITY("current_severity"), CURRENTMESSAGE("current_message"), USER("user"), HOST("host"), COMMAND("command"), STARTTIME("start"), ENDTIME("end");
+    public enum Keys {
+        PV("pv"),
+        SEVERITY("severity"),
+        MESSAGE("message"),
+        CURRENTSEVERITY("current_severity"),
+        CURRENTMESSAGE("current_message"),
+        USER("user"),
+        HOST("host"),
+        COMMAND("command"),
+        STARTTIME("start"),
+        ENDTIME("end"),
+        CONFIG("config");
+
         private final String name;
 
-        private Keys(String name) {
+        Keys(String name) {
             this.name = name;
         };
 
@@ -22,44 +28,7 @@ public class AlarmLogTableQueryUtil {
 
         @Override
         public String toString() {
-            return this.toString();
+            return getName();
         }
-    }
-
-    private static class KeyParser implements Function<String, String> {
-
-        @Override
-        public String apply(String t) {
-            if (t.contains("=")) {
-                return t.split("=")[0];
-            } else {
-                return t;
-            }
-        }
-
-    }
-
-    private static class ValueParser implements Function<String, String> {
-
-        @Override
-        public String apply(String t) {
-
-            if (t.contains("=")) {
-                String key = t.split("=")[0];
-                String value = t.split("=")[1];
-                if (key.equals(Keys.STARTTIME.getName()) || key.equals(Keys.ENDTIME.getName())) {
-                    Object time = TimeParser.parseInstantOrTemporalAmount(value);
-                    if (time instanceof Instant) {
-                        return String.valueOf(((Instant)time).toEpochMilli()/1000);
-                    } else if (time instanceof TemporalAmount) {
-                        return String.valueOf(Instant.now().minus((TemporalAmount)time).toEpochMilli()/1000);
-                    }
-                }
-                return value;
-            } else {
-                return "*";
-            }
-        }
-
     }
 }

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/Messages.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/Messages.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.phoebus.applications.alarm.logging.ui;
+
+import org.phoebus.framework.nls.NLS;
+
+public class Messages {
+
+    static
+    {
+        // initialize resource bundle
+        NLS.initializeMessages(Messages.class);
+    }
+
+    private Messages()
+    {
+    }
+}

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AdvancedSearchView.fxml
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AdvancedSearchView.fxml
@@ -34,21 +34,21 @@
                 <children>
                     <Label text="PV:" GridPane.rowIndex="0" />
                     <TextField fx:id="searchPV" GridPane.columnSpan="2" GridPane.rowIndex="1" />
-                    <Label text="Severity:" GridPane.rowIndex="2" />
+                    <Label text="%Severity" GridPane.rowIndex="2" />
                     <TextField fx:id="searchSeverity" GridPane.columnSpan="2" GridPane.rowIndex="3" />
-                    <Label text="Message:" GridPane.rowIndex="4" />
+                    <Label text="%Message" GridPane.rowIndex="4" />
                     <TextField fx:id="searchMessage" GridPane.columnSpan="2" GridPane.rowIndex="5" />
-                    <Label text="Current Severity:" GridPane.rowIndex="6" />
+                    <Label text="%CurrentSeverity" GridPane.rowIndex="6" />
                     <TextField fx:id="searchCurrentSeverity" GridPane.columnSpan="2" GridPane.rowIndex="7" />
-                    <Label text="Current Message:" GridPane.rowIndex="8" />
+                    <Label text="%CurrentMessage" GridPane.rowIndex="8" />
                     <TextField fx:id="searchCurrentMessage" GridPane.columnSpan="2" GridPane.rowIndex="9" />
-                    <Label text="User:" GridPane.rowIndex="10" />
+                    <Label text="%User" GridPane.rowIndex="10" />
                     <TextField fx:id="searchUser" GridPane.columnSpan="2" GridPane.rowIndex="11" />
-                    <Label text="Host:" GridPane.rowIndex="12" />
+                    <Label text="%Host" GridPane.rowIndex="12" />
                     <TextField fx:id="searchHost" GridPane.columnSpan="2" GridPane.rowIndex="13" />
-                    <Label text="Command:" GridPane.rowIndex="14" />
+                    <Label text="%Command" GridPane.rowIndex="14" />
                     <TextField fx:id="searchCommand" GridPane.columnSpan="2" GridPane.rowIndex="15" />
-                    <Label text="Time:" GridPane.columnSpan="2" GridPane.rowIndex="16">
+                    <Label text="%Time" GridPane.columnSpan="2" GridPane.rowIndex="16">
                         <GridPane.margin>
                             <Insets top="5.0" />
                         </GridPane.margin>
@@ -64,7 +64,7 @@
                             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                         </rowConstraints>
                         <children>
-                            <Label text="Start Time:" GridPane.rowIndex="0">
+                            <Label text="%StartTime" GridPane.rowIndex="0">
                                 <GridPane.margin>
                                     <Insets />
                                 </GridPane.margin></Label>
@@ -72,7 +72,7 @@
                                 <GridPane.margin>
                                     <Insets />
                                 </GridPane.margin></TextField>
-                            <Label text="End Time:" GridPane.rowIndex="1" />
+                            <Label text="%EndTime" GridPane.rowIndex="1" />
                             <TextField fx:id="endTime" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1">
                                 <GridPane.margin>
                                     <Insets />

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.fxml
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.fxml
@@ -18,13 +18,16 @@
                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="ALWAYS" />
              </rowConstraints>
              <children>
-                 <Label alignment="CENTER_RIGHT" contentDisplay="CENTER" text="Query: " GridPane.columnIndex="0" GridPane.halignment="RIGHT" GridPane.vgrow="NEVER" />
+                 <Label alignment="CENTER_RIGHT" contentDisplay="CENTER" text="%Query" GridPane.columnIndex="0" GridPane.halignment="RIGHT" GridPane.vgrow="NEVER">
+               <GridPane.margin>
+                  <Insets right="5.0" />
+               </GridPane.margin></Label>
                  <TextField fx:id="query" onAction="#updateQuery" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" HBox.hgrow="ALWAYS">
                      <GridPane.margin>
                          <Insets bottom="10.0" top="10.0" />
                      </GridPane.margin>
                  </TextField>
-                 <Button fx:id="search" maxHeight="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#search" prefHeight="25.0" text="Search" GridPane.columnIndex="2">
+                 <Button fx:id="search" maxHeight="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#search" prefHeight="25.0" text="%Search" GridPane.columnIndex="2">
                      <GridPane.margin>
                          <Insets left="3.0" />
                      </GridPane.margin>
@@ -49,9 +52,12 @@
                     <columnResizePolicy>
                         <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
                     </columnResizePolicy>
+                    <placeholder>
+                        <Label text="%NoSearchResults" />
+                    </placeholder>
                 </TableView>
             </children>
         </GridPane>
-        <fx:include source="AdvancedSearchView.fxml" fx:id="advancedSearchView"/>
+        <fx:include fx:id="advancedSearchView" source="AdvancedSearchView.fxml" />
     </items>
 </SplitPane>

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.fxml
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.fxml
@@ -6,58 +6,68 @@
 
 <SplitPane fx:id="topLevelNode" dividerPositions="0.6105960264900663" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="623.0" prefWidth="757.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.phoebus.applications.alarm.logging.ui.AlarmLogTableController">
      <items>
+         <fx:include fx:id="advancedSearchView" source="AdvancedSearchView.fxml" />
          <GridPane fx:id="ViewSearchPane">
              <columnConstraints>
-                 <ColumnConstraints minWidth="10.0" prefWidth="60.0" />
-                 <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" prefWidth="100.0" />
-                 <ColumnConstraints minWidth="10.0" prefWidth="60" />
-                 <ColumnConstraints minWidth="10.0" prefWidth="60" />
+                 <ColumnConstraints />
+                 <ColumnConstraints />
+                 <ColumnConstraints hgrow="ALWAYS" />
+                 <ColumnConstraints />
              </columnConstraints>
              <rowConstraints>
                  <RowConstraints minHeight="10.0" prefHeight="30.0" />
                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="ALWAYS" />
              </rowConstraints>
              <children>
-                 <Label alignment="CENTER_RIGHT" contentDisplay="CENTER" text="%Query" GridPane.columnIndex="0" GridPane.halignment="RIGHT" GridPane.vgrow="NEVER">
+                 <Label alignment="CENTER_RIGHT" contentDisplay="CENTER" text="%Query" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.vgrow="NEVER">
                <GridPane.margin>
-                  <Insets right="5.0" />
+                  <Insets left="10.0" right="5.0" />
                </GridPane.margin></Label>
-                 <TextField fx:id="query" onAction="#updateQuery" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" HBox.hgrow="ALWAYS">
+                 <TextField fx:id="query" onAction="#updateQuery" GridPane.columnIndex="2" GridPane.hgrow="ALWAYS" HBox.hgrow="ALWAYS">
                      <GridPane.margin>
                          <Insets bottom="10.0" top="10.0" />
                      </GridPane.margin>
                  </TextField>
-                 <Button fx:id="search" maxHeight="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#search" prefHeight="25.0" text="%Search" GridPane.columnIndex="2">
+                 <Button fx:id="search" maxHeight="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#search" prefHeight="25.0" text="%Search" GridPane.columnIndex="3">
                      <GridPane.margin>
-                         <Insets left="3.0" />
+                         <Insets left="3.0" right="3.0" />
                      </GridPane.margin>
                  </Button>
-                 <Button fx:id="resize" alignment="TOP_LEFT" contentDisplay="TOP" layoutX="331.0" layoutY="2.0" mnemonicParsing="false" onMouseClicked="#resize" prefHeight="25.0" prefWidth="25.0" text="&gt;" GridPane.columnIndex="3" GridPane.halignment="RIGHT" />
-                 <TableView fx:id="tableView" GridPane.columnSpan="4" GridPane.rowIndex="1" VBox.vgrow="ALWAYS">
-                     <columns>
-                         <TableColumn fx:id="configCol" minWidth="50.0" prefWidth="75.0" text="Config" />
-                         <TableColumn fx:id="pvCol" minWidth="50.0" prefWidth="75.0" text="Pv" />
-                         <TableColumn fx:id="severityCol" minWidth="50.0" prefWidth="75.0" text="Severity" />
-                         <TableColumn fx:id="messageCol" minWidth="50.0" prefWidth="75.0" text="Message" />
-                         <TableColumn fx:id="valueCol" minWidth="50.0" prefWidth="75.0" text="Value" />
-                         <TableColumn fx:id="timeCol" minWidth="50.0" prefWidth="75.0" text="Time" />
-                         <TableColumn fx:id="msgTimeCol" minWidth="50.0" prefWidth="75.0" text="Message Time" />
-                         <TableColumn fx:id="currentSeverityCol" minWidth="50.0" prefWidth="75.0" text="Current Severity" />
-                         <TableColumn fx:id="currentMessageCol" minWidth="50.0" prefWidth="75.0" text="Current Message" />
-                         <TableColumn fx:id="mode" minWidth="50.0" prefWidth="75.0" text="Mode" />
-                         <TableColumn fx:id="commandCol" minWidth="50.0" prefWidth="75.0" text="Command" />
-                         <TableColumn fx:id="userCol" minWidth="50.0" prefWidth="75.0" text="User" />
-                         <TableColumn fx:id="hostCol" minWidth="50.0" prefWidth="75.0" text="Host" />
-                    </columns>
-                    <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                    </columnResizePolicy>
-                    <placeholder>
-                        <Label text="%NoSearchResults" />
-                    </placeholder>
-                </TableView>
+                 <Button fx:id="resize" alignment="TOP_LEFT" contentDisplay="TOP" layoutX="331.0" layoutY="2.0" mnemonicParsing="false" onMouseClicked="#resize" text="&gt;" GridPane.columnIndex="0" GridPane.halignment="LEFT">
+               <GridPane.margin>
+                  <Insets left="3.0" />
+               </GridPane.margin></Button>
+                 <StackPane GridPane.columnSpan="4" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" GridPane.vgrow="ALWAYS" VBox.vgrow="ALWAYS">
+                     <children>
+                         <VBox alignment="CENTER">
+                             <ProgressIndicator fx:id="progressIndicator" />
+                         </VBox>
+                         <TableView fx:id="tableView">
+                             <columns>
+                                 <TableColumn fx:id="configCol" minWidth="50.0" prefWidth="75.0" text="%Config" />
+                                 <TableColumn fx:id="pvCol" minWidth="50.0" prefWidth="75.0" text="PV" />
+                                 <TableColumn fx:id="severityCol" minWidth="50.0" prefWidth="75.0" text="%Severity" />
+                                 <TableColumn fx:id="messageCol" minWidth="50.0" prefWidth="75.0" text="%Message" />
+                                 <TableColumn fx:id="valueCol" minWidth="50.0" prefWidth="75.0" text="%Value" />
+                                 <TableColumn fx:id="timeCol" minWidth="50.0" prefWidth="75.0" text="%Time" />
+                                 <TableColumn fx:id="msgTimeCol" minWidth="50.0" prefWidth="75.0" text="%MessageTime" />
+                                 <TableColumn fx:id="currentSeverityCol" minWidth="50.0" prefWidth="75.0" text="%CurrentSeverity" />
+                                 <TableColumn fx:id="currentMessageCol" minWidth="50.0" prefWidth="75.0" text="%CurrentMessage" />
+                                 <TableColumn fx:id="mode" minWidth="50.0" prefWidth="75.0" text="%Mode" />
+                                 <TableColumn fx:id="commandCol" minWidth="50.0" prefWidth="75.0" text="%Command" />
+                                 <TableColumn fx:id="userCol" minWidth="50.0" prefWidth="75.0" text="%User" />
+                                 <TableColumn fx:id="hostCol" minWidth="50.0" prefWidth="75.0" text="%Host" />
+                             </columns>
+                             <columnResizePolicy>
+                                 <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                             </columnResizePolicy>
+                             <placeholder>
+                                 <Label text="%NoSearchResults" />
+                             </placeholder>
+                         </TableView>
+                     </children>
+                 </StackPane>
             </children>
         </GridPane>
-        <fx:include fx:id="advancedSearchView" source="AdvancedSearchView.fxml" />
     </items>
 </SplitPane>

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages.properties
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2020 European Spallation Source ERIC.
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#
+
+NoSearchResults=No Search Results
+Search=Search
+Query=Query: 

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages.properties
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages.properties
@@ -15,7 +15,20 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #
-
+Command=Command
+Config=Config
+CurrentMessage=Current Message
+CurrentSeverity=Current Severity
+EndTime=End Time
+Host=Host
+Message=Message
+MessageTime=Message Time
+Mode=Mode
 NoSearchResults=No Search Results
-Search=Search
 Query=Query: 
+Search=Search
+Severity=Severity
+StartTime=Start Time
+Time=Time
+User=User
+Value=Value


### PR DESCRIPTION
Some minor changes:
1) Added progress indicator to visualize ongoing/finished search. Applies only when search is explicitly invoked by user, i.e. not for periodic search.
2) Moved "query editor" to left to be consistent with Log Entry Table app.

NOTE: some of the changes in commit ``24b0cfb`` have been rolled back in ``67e3c5a`` as I discovered that they are not needed.