### PR TITLE
PVA TCP name search: Repeat similar to UDP because of gateway

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVA_Preferences.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVA_Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,13 +7,11 @@
  ******************************************************************************/
 package org.phoebus.pv.pva;
 
-import gov.aps.jca.Monitor;
-import org.phoebus.framework.preferences.PreferencesReader;
-import org.phoebus.pv.ca.JCA_PVFactory;
+import static org.phoebus.pv.PV.logger;
 
 import java.util.logging.Level;
 
-import static org.phoebus.pv.PV.logger;
+import org.phoebus.framework.preferences.PreferencesReader;
 
 /** Preferences for PVAccess
  *
@@ -34,6 +32,7 @@ public class PVA_Preferences
 
     private static final String EPICS_PVA_ADDR_LIST = "epics_pva_addr_list";
     private static final String EPICS_PVA_AUTO_ADDR_LIST = "epics_pva_auto_addr_list";
+    private static final String EPICS_PVA_NAME_SERVERS = "epics_pva_name_servers";
     private static final String EPICS_PVA_SERVER_PORT = "epics_pva_server_port";
     private static final String EPICS_PVA_BROADCAST_PORT = "epics_pva_broadcast_port";
     private static final String EPICS_PVA_CONN_TMO = "epics_pva_conn_tmo";
@@ -65,6 +64,10 @@ public class PVA_Preferences
         final String addr_list = prefs.get(EPICS_PVA_ADDR_LIST);
         setSystemProperty("EPICS_PVA_ADDR_LIST", addr_list);
         logger.log(Level.INFO, "PVA " + EPICS_PVA_ADDR_LIST + ": " + addr_list);
+
+        final String name_servers = prefs.get(EPICS_PVA_NAME_SERVERS);
+        setSystemProperty("EPICS_PVA_NAME_SERVERS", name_servers);
+        logger.log(Level.INFO, "PVA " + EPICS_PVA_NAME_SERVERS + ": " + name_servers);
 
         final String auto_addr = prefs.get(EPICS_PVA_AUTO_ADDR_LIST);
         setSystemProperty("EPICS_PVA_AUTO_ADDR_LIST", auto_addr);

--- a/core/pv/src/main/resources/pv_pva_preferences.properties
+++ b/core/pv/src/main/resources/pv_pva_preferences.properties
@@ -7,16 +7,38 @@
 # EPICS_PVA_AUTO_ADDR_LIST etc.
 # Defining preference values will override the environment
 # variables which allows consolidating PVA settings
-# with all the CS-Studio preference settings
+# with all the CS-Studio preference settings.
+#
+#
+# Network clients typically need to configure the first
+# three settings to successfully connect to PVA servers
+# on the local network.
 
 # PVAccess address list
 epics_pva_addr_list
 
-# PVAccess auto address list - ture/false
+# PVAccess auto address list - true/false
 epics_pva_auto_addr_list
 
-epics_pva_server_port
+# Name servers used for TCP name resolution
+epics_pva_name_servers
+
+# The following parameters should best be left
+# at their default.
+#
+# For details, see PVASettings in PV Access library.
+
+# Port used for UDP name searches and beacons
 epics_pva_broadcast_port
+
+# PV server's first TCP port
+epics_pva_server_port
+
+# Connection timeout in seconds
 epics_pva_conn_tmo
+
+# Maximum number of array elements shown when printing data
 epics_pva_max_array_formatting
+
+# TCP buffer size for sending data
 epics_pva_send_buffer_size

--- a/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
@@ -15,13 +15,12 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.logging.Level;
 
 import org.epics.pva.PVASettings;
 import org.epics.pva.common.AddressInfo;
 import org.epics.pva.common.Network;
-import org.epics.pva.common.RequestEncoder;
-import org.epics.pva.common.SearchRequest;
 import org.epics.pva.server.Guid;
 
 /** PV Access Client
@@ -45,8 +44,6 @@ public class PVAClient implements AutoCloseable
 {
     /** Default channel listener logs state changes */
     private static final ClientChannelListener DEFAULT_CHANNEL_LISTENER = (ch, state) ->  logger.log(Level.INFO, ch.toString());
-
-    private final List<AddressInfo> name_server_addresses;
 
     private final ClientUDPHandler udp;
 
@@ -78,14 +75,33 @@ public class PVAClient implements AutoCloseable
      */
     public PVAClient() throws Exception
     {
-        name_server_addresses = Network.parseAddresses(PVASettings.EPICS_PVA_NAME_SERVERS, PVASettings.EPICS_PVA_SERVER_PORT);
+        final List<AddressInfo> name_server_addresses = Network.parseAddresses(PVASettings.EPICS_PVA_NAME_SERVERS, PVASettings.EPICS_PVA_SERVER_PORT);
 
         final List<AddressInfo> udp_search_addresses = Network.parseAddresses(PVASettings.EPICS_PVA_ADDR_LIST, PVASettings.EPICS_PVA_BROADCAST_PORT);
         if (PVASettings.EPICS_PVA_AUTO_ADDR_LIST)
             udp_search_addresses.addAll(Network.getBroadcastAddresses(PVASettings.EPICS_PVA_BROADCAST_PORT));
 
+        // Handler for UDP traffic
         udp = new ClientUDPHandler(this::handleBeacon, this::handleSearchResponse);
-        search = new ChannelSearch(udp, udp_search_addresses);
+
+        // TCP traffic is handled by one ClientTCPHandler per address (IP, socket).
+        // Pass helper to channel search for getting such a handler.
+        final Function<InetSocketAddress, ClientTCPHandler> tcp_provider = the_addr ->
+            tcp_handlers.computeIfAbsent(the_addr, addr ->
+            {
+                try
+                {
+                    // If absent, create with initial empty GUID
+                    return new ClientTCPHandler(this, addr, Guid.EMPTY);
+                }
+                catch (Exception ex)
+                {
+                    logger.log(Level.WARNING, "Cannot connect to TCP " + addr, ex);
+                }
+                return null;
+
+            });
+        search = new ChannelSearch(udp, udp_search_addresses, tcp_provider, name_server_addresses);
 
         udp.start();
         search.start();
@@ -150,46 +166,7 @@ public class PVAClient implements AutoCloseable
         final PVAChannel channel = new PVAChannel(this, channel_name, listener);
         channels_by_id.putIfAbsent(channel.getCID(), channel);
 
-        // Search via TCP
-        for (AddressInfo name_server : name_server_addresses)
-        {
-            logger.log(Level.FINE, "Using TCP name server " + name_server.getAddress());
-
-            final ClientTCPHandler tcp = tcp_handlers.computeIfAbsent(name_server.getAddress(), addr ->
-            {
-                try
-                {
-                    return new ClientTCPHandler(this, addr, Guid.EMPTY);
-                }
-                catch (Exception ex)
-                {
-                    logger.log(Level.WARNING, "Cannot connect to TCP " + addr, ex);
-                }
-                return null;
-            });
-            // In case of connection errors (TCP connection blocked by firewall),
-            // tcp will be null
-            if (tcp != null)
-            {
-                final RequestEncoder search_request = (version, buffer) ->
-                {
-                    logger.log(Level.FINE, () -> "Searching for " + channel + " via TCP " + tcp.getRemoteAddress());
-
-                    // Search sequence identifies the potentially repeated UDP.
-                    // TCP search is once only, so PVXS always sends 0x66696E64 = "find".
-                    // We send "look".
-                    final int seq = 0x6C6F6F6B;
-
-                    // Use 'any' reply address since reply will be via this TCP socket
-                    final InetSocketAddress response_address = new InetSocketAddress(0);
-                    
-                    SearchRequest.encode(true, seq, channel.getCID(), channel.getName(), response_address , buffer);
-                };
-                tcp.submit(search_request);
-            }
-        }
-
-        // Register with UDP search
+        // Register with search
         search.register(channel, true);
         return channel;
     }


### PR DESCRIPTION
Gateway does not remember searches. On first search, it starts its own
searches on client side for unknown channels. Client to the gateway then
needs to send another search for the gateway to return the now known
channel.

When using UDP for searches, the searches are re-sent anyway because we expect some packet loss.
TCP now also re-sends searches to accommodate the gateway. Compared to UDP, the TCP searches are sent less often, though, since there is no packet loss.