### PR TITLE
Probe: Add PV context menu to copy Name, timestamp, value, alarm

### DIFF
--- a/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvAndValueToClipboard.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvAndValueToClipboard.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.applications.probe;
+
+import static org.phoebus.applications.probe.Probe.logger;
+
+import java.util.List;
+import java.util.logging.Level;
+
+import org.epics.vtype.Alarm;
+import org.epics.vtype.AlarmSeverity;
+import org.epics.vtype.Time;
+import org.epics.vtype.VType;
+import org.phoebus.core.types.ProcessVariable;
+import org.phoebus.pv.PV;
+import org.phoebus.pv.PVPool;
+import org.phoebus.ui.vtype.FormatOption;
+import org.phoebus.ui.vtype.FormatOptionHandler;
+import org.phoebus.util.time.TimestampFormats;
+
+/** Context menu entry for PV that copies PV name and value to clipboard
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class ContextMenuPvAndValueToClipboard extends ContextMenuPvToClipboard
+{
+    @Override
+    public String getName()
+    {
+        return Messages.CopyWithValue;
+    }
+
+    @Override
+    protected String createText(final List<ProcessVariable> pvs)
+    {
+        final StringBuilder buf = new StringBuilder();
+
+        for (ProcessVariable pv : pvs)
+        {
+            buf.append(pv.getName());
+
+            try
+            {
+                // A PV obtained from the PV pool might be new,
+                // needing time to connect before we can fetch a value.
+                // The context menu code is on the UI thread and cannot wait for a connection.
+                // This code is, however, invoked on for example a widget with an existing PV,
+                // so the PV is expected to be in the pool and already connected.
+                final PV active_pv = PVPool.getPV(pv.getName());
+                try
+                {
+                    // We expect the PV to already have a value which we can display right away
+                    final VType value = active_pv.read();
+                    if (value != null)
+                    {
+                        buf.append(" ");
+
+                        final Time time = Time.timeOf(value);
+                        if (time != null)
+                            buf.append(TimestampFormats.FULL_FORMAT.format(time.getTimestamp()))
+                               .append(" ");
+
+                        buf.append(FormatOptionHandler.format(value, FormatOption.DEFAULT, -1, true));
+
+                        final Alarm alarm = Alarm.alarmOf(value);
+                        if (alarm != null   &&  alarm.getSeverity() != AlarmSeverity.NONE)
+                            buf.append(" ")
+                               .append(alarm.getSeverity())
+                               .append("/")
+                               .append(alarm.getStatus());
+                    }
+                    // .. else: PV doesn't have a value right now. Don't wait, just don't show any data
+                }
+                finally
+                {
+                    PVPool.releasePV(active_pv);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.log(Level.WARNING, "Cannot show value for " + pv);
+            }
+
+            buf.append("\n");
+        }
+        return buf.toString();
+    }
+}

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvToClipboard.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvToClipboard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 
 // Not strictly related to probe, but seemed too small to start
-// its own application, so added it to the 'simplest' appliation
+// its own application, so added it to the 'simplest' application
 // which deals with PVs and already makes context menu contributions.
 
 /** Context menu entry for PV that copies PV name to clipboard
@@ -51,6 +51,11 @@ public class ContextMenuPvToClipboard implements ContextMenuEntry
         return supportedTypes;
     }
 
+    protected String createText(final List<ProcessVariable> pvs)
+    {
+        return pvs.stream().map(ProcessVariable::getName).collect(Collectors.joining(" "));
+    }
+
     @Override
     public void call(final Selection selection) throws Exception
     {
@@ -58,7 +63,7 @@ public class ContextMenuPvToClipboard implements ContextMenuEntry
 
         final Clipboard clipboard = Clipboard.getSystemClipboard();
         final ClipboardContent content = new ClipboardContent();
-        content.putString(pvs.stream().map(ProcessVariable::getName).collect(Collectors.joining(" ")));
+        content.putString(createText(pvs));
         clipboard.setContent(content);
     }
 }

--- a/app/probe/src/main/java/org/phoebus/applications/probe/Messages.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2021 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ public class Messages
     public static String Alarms;
     public static String ControlRange;
     public static String Copy;
+    public static String CopyWithValue;
     public static String DisplayRange;
     public static String EnumLbls;
     public static String Format;

--- a/app/probe/src/main/java/org/phoebus/applications/probe/Probe.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/Probe.java
@@ -20,6 +20,9 @@ import org.phoebus.ui.docking.DockPane;
 @SuppressWarnings("nls")
 public class Probe implements AppResourceDescriptor {
 
+    /** Common Logger */
+    public static final Logger logger = Logger.getLogger(Probe.class.getPackageName());
+
     public static final String NAME = "probe";
     public static final String DISPLAYNAME = Messages.Probe;
 
@@ -65,7 +68,7 @@ public class Probe implements AppResourceDescriptor {
         }
         catch (Exception ex)
         {
-            Logger.getLogger(Probe.class.getPackageName()).log(Level.WARNING, "Cannot create probe instance", ex);
+            logger.log(Level.WARNING, "Cannot create probe instance", ex);
         }
         return probe;
     }

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ProbeInstance.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ProbeInstance.java
@@ -1,8 +1,11 @@
 package org.phoebus.applications.probe;
 
+import static org.phoebus.applications.probe.Probe.logger;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
+import java.util.logging.Level;
 
 import org.phoebus.applications.probe.view.ProbeController;
 import org.phoebus.framework.nls.NLS;
@@ -20,6 +23,7 @@ import javafx.scene.control.TextField;
  * @author Kunal Shroff
  *
  */
+@SuppressWarnings("nls")
 public class ProbeInstance implements AppInstance {
 
     private final AppDescriptor appDescriptor;
@@ -42,7 +46,7 @@ public class ProbeInstance implements AppInstance {
             loader = new FXMLLoader(fxml, bundle);
             return loader.load();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.log(Level.SEVERE, "Cannot load FXML", e);
         }
         return null;
     }

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ProbeMenuEntry.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ProbeMenuEntry.java
@@ -18,6 +18,7 @@ import javafx.scene.image.Image;
  *
  * @author Kunal Shroff
  */
+@SuppressWarnings("nls")
 public class ProbeMenuEntry implements MenuEntry {
 
     @Override

--- a/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
@@ -1,11 +1,12 @@
 package org.phoebus.applications.probe.view;
 
+import static org.phoebus.applications.probe.Probe.logger;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
@@ -15,7 +16,6 @@ import org.epics.vtype.VEnum;
 import org.epics.vtype.VNumber;
 import org.epics.vtype.VType;
 import org.phoebus.applications.probe.Messages;
-import org.phoebus.applications.probe.Probe;
 import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.pv.PV;
@@ -116,8 +116,7 @@ public class ProbeController {
                 }
                 catch (Exception ex)
                 {
-                    Logger.getLogger(Probe.class.getPackageName())
-                    .log(Level.WARNING, "Cannot write '" + entered + "' to PV " + pv.getName(), ex);
+                    logger.log(Level.WARNING, "Cannot write '" + entered + "' to PV " + pv.getName(), ex);
                 }
                 break;
             default:

--- a/app/probe/src/main/resources/META-INF/services/org.phoebus.ui.spi.ContextMenuEntry
+++ b/app/probe/src/main/resources/META-INF/services/org.phoebus.ui.spi.ContextMenuEntry
@@ -1,2 +1,3 @@
 org.phoebus.applications.probe.ContextMenuPvToClipboard
+org.phoebus.applications.probe.ContextMenuPvAndValueToClipboard
 org.phoebus.applications.probe.ContextLaunchProbe

--- a/app/probe/src/main/resources/org/phoebus/applications/probe/messages.properties
+++ b/app/probe/src/main/resources/org/phoebus/applications/probe/messages.properties
@@ -2,6 +2,7 @@ Alarm=Alarm:
 Alarms=Alarms: 
 ControlRange=Control Range: 
 Copy=Copy PV to Clipboard
+CopyWithValue=Copy PV to Clipboard with Value
 DisplayRange=Display Range: 
 EnumLbls=Enumeration Labels:
 Format=Format: 


### PR DESCRIPTION
Similar to the "Copy PV to Clipboard" context menu entry, this adds "Copy PV to Clipboard with Value" as discussed in #1953

For array values, the number of displayed elements is limited by the `org.phoebus.ui/max_array_formatting` preference shared with other display tools.