### PR TITLE
Fix log4j-core dependency

### DIFF
--- a/app/trends/rich-adapters/pom.xml
+++ b/app/trends/rich-adapters/pom.xml
@@ -24,11 +24,6 @@
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
-      <artifactId>app-email-ui</artifactId>
-      <version>4.6.6-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.phoebus</groupId>
       <artifactId>core-logbook</artifactId>
       <version>4.6.6-SNAPSHOT</version>
     </dependency>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -337,23 +337,6 @@
       <version>0.15.2</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/com.atlassian.commonmark/commonmark -->
-    <dependency>
-      <groupId>com.atlassian.commonmark</groupId>
-      <artifactId>commonmark</artifactId>
-      <version>0.15.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.atlassian.commonmark</groupId>
-      <artifactId>commonmark-ext-gfm-tables</artifactId>
-      <version>0.15.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.atlassian.commonmark</groupId>
-      <artifactId>commonmark-ext-image-attributes</artifactId>
-      <version>0.15.2</version>
-    </dependency>
-
     <!-- Display Builder -->
     <dependency>
       <groupId>org.controlsfx</groupId>

--- a/services/save-and-restore/pom.xml
+++ b/services/save-and-restore/pom.xml
@@ -43,7 +43,7 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
+			<artifactId>spring-boot-starter</artifactId>
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework.boot</groupId>
@@ -51,6 +51,7 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -62,9 +63,38 @@
 			</exclusions>
 		</dependency>
 
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-log4j2</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.15.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.15.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-jul</artifactId>
+			<version>2.15.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->


### PR DESCRIPTION
According to https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot only log4j-core is affected, so any dependencies to (for instance) log4j-api should be OK.

This PR fixes transitive dependency to log4j-core, which I have found only in the save&restore service.

Also included is removal of duplicates of dependencies in poms, as well as a change that removes the dependency to vulnerable version of jackson-databind (as highlighted by Github dependency bot).