### PR TITLE
#2062 Have databrowser legend respect trace hidden property

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LegendPart.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LegendPart.java
@@ -72,6 +72,9 @@ public class LegendPart<XTYPE extends Comparable<XTYPE>> extends PlotPart
         int max_width = 1; // Start with 1 pixel to avoid later div-by-0
         for (Trace<XTYPE> trace : traces)
         {
+            if (!trace.isVisible()) {
+                continue;
+            }
             final int width = metrics.stringWidth(trace.getLabel());
             if (width > max_width)
                 max_width = width;
@@ -112,6 +115,9 @@ public class LegendPart<XTYPE extends Comparable<XTYPE>> extends PlotPart
         int x = bounds.x, y = bounds.y + base_offset;
         for (Trace<XTYPE> trace : traces)
         {
+            if (!trace.isVisible()) {
+                continue;
+            }
 			gc.setColor(GraphicsUtils.convert(trace.getColor()));
             gc.drawString(trace.getLabel(), x, y);
             x += grid_x;


### PR DESCRIPTION
Fix for https://github.com/ControlSystemStudio/phoebus/issues/2062

Checks each trace isVisible value before drawing trace in the data browser legend