### PR TITLE
Warn about invalid resource URI, avoid NPE

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/workbench/ApplicationService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/workbench/ApplicationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -108,6 +108,11 @@ public class ApplicationService
     public static List<AppResourceDescriptor> getApplications(final URI resource)
     {
         final String path = resource.getPath();
+        if (path == null)
+        {
+            logger.log(Level.WARNING, "Invalid resource URI '" + resource + "', missing path");
+            return Collections.emptyList();
+        }
         final String ext = path.substring(path.lastIndexOf(".") + 1).toLowerCase();
         if (INSTANCE.extensions.containsKey(ext))
             return INSTANCE.extensions.get(ext);

--- a/core/launcher/src/main/java/org/phoebus/product/Launcher.java
+++ b/core/launcher/src/main/java/org/phoebus/product/Launcher.java
@@ -139,7 +139,7 @@ public class Launcher
                         throw new Exception("Missing -main name");
                     final String main = iter.next();
                     iter.remove();
-                    
+
                     // Locate Main class and its main()
                     final Class<?> main_class = Class.forName(main);
                     final Method main_method = main_class.getDeclaredMethod("main", String[].class);
@@ -213,9 +213,9 @@ public class Launcher
         System.out.println();
         System.out.println("Examples:");
         System.out.println("-resource '/path/to/file'                                                    - Opens that file with the default application.");
-        System.out.println("-resource 'file:/path/to/file'                                               - Same, but makes the 'file' schema specific.");
+        System.out.println("-resource 'file:/absolute/path/to/file'                                      - Same, but makes the 'file' schema specific.");
         System.out.println("-resource 'http://my.site/path/to/file'                                      - Reads web link, opens with default application.");
-        System.out.println("-resource 'file:/path/to/file?app=display_runtime&MACRO1=value+1&MACRO2=abc' - Opens file with 'display_runtime' app, passing macros.");
+        System.out.println("-resource 'file:/abs/path/file?app=display_runtime&MACRO1=value+1&MACRO2=xy' - Opens file with 'display_runtime' app, passing macros.");
         System.out.println("-resource 'pv://?sim://sine&app=probe'                                       - Opens the 'sim://sine' PV with 'probe'.");
         System.out.println("-resource 'pv://?Fred&sim://sine&app=pv_table'                               - Opens two PVs PV with 'pv_table'.");
         System.out.println("-resource '...&target=window'                                                - Opens resource in separate window.");


### PR DESCRIPTION
User tried to start with command line option `-resource 'file:./somefile.bob?MACRO=value'`.
This failed with
```
... NullPointerException: Cannot invoke "String.lastIndexOf(String)" because "path" is null
at org.phoebus.framework.workbench.ApplicationService.getApplications(ApplicationService.java:111)
```

Reason is that "file:./...." is not a valid URI. Would have to be "file://./....", which then leads to the follow-up problem that relative paths don't work well since you can't be certain what the current working directory might be.
So the Launcher `-help` output has been tweaked to suggest using absolute paths.

Back to the original error, this fix will print a slightly more useful warning instead of NPE. 