### PR TITLE
Updated dependencies due to vulnerability warnings

### DIFF
--- a/app/logbook/inmemory/pom.xml
+++ b/app/logbook/inmemory/pom.xml
@@ -13,9 +13,9 @@
       <version>4.6.6-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>21.0</version>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>31.0.1-jre</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/logbook/olog/client-es/pom.xml
+++ b/app/logbook/olog/client-es/pom.xml
@@ -63,11 +63,6 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>21.0</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/com.sun.xml.bind/jaxb-impl -->
         <dependency>
             <groupId>org.phoebus</groupId>
@@ -92,7 +87,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/app/logbook/olog/client/pom.xml
+++ b/app/logbook/olog/client/pom.xml
@@ -66,11 +66,6 @@
             <artifactId>javax.activation</artifactId>
             <version>1.2.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>21.0</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/app/logbook/olog/ui/pom.xml
+++ b/app/logbook/olog/ui/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>31.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.jfxtras</groupId>

--- a/app/logbook/ui/pom.xml
+++ b/app/logbook/ui/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>21.0</version>
+      <version>31.0.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.jfxtras</groupId>

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookQueryUtil.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookQueryUtil.java
@@ -10,7 +10,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.phoebus.util.time.TimeParser;
-import static org.phoebus.util.time.TimestampFormats.MILLI_FORMAT;
 
 import com.google.common.base.Strings;
 

--- a/app/save-and-restore/app/pom.xml
+++ b/app/save-and-restore/app/pom.xml
@@ -55,16 +55,6 @@
 			<version>1.19</version>
 		</dependency>
 
-
-		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
-		</dependency>
-
-
-
 		<dependency>
 			<groupId>org.epics</groupId>
 			<artifactId>vtype</artifactId>

--- a/services/save-and-restore/pom.xml
+++ b/services/save-and-restore/pom.xml
@@ -14,6 +14,7 @@
 
 	<properties>
 		<spring.boot.version>2.1.5.RELEASE</spring.boot.version>
+		<commons.collections.version>4.4</commons.collections.version>
 	</properties>
 
 	<dependencyManagement>
@@ -176,7 +177,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
+			<version>${commons.collections.version}</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
Tried to update protobuf version, but that apparently breaks something as data from the remote archiver appliance was not parsed as expected. Do not know why, requires more investigation. Building against protobuf 3.19.3 is fine though.

The mysql connector dependency is unchanged as I am unable to test the archiver service currently.