### PR TITLE
Adding progress indicator for log entry submission

### DIFF
--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/write/LogEntryEditor.fxml
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/write/LogEntryEditor.fxml
@@ -51,8 +51,8 @@
         <children>
             <GridPane>
                 <!-- Progress indicator and completion message are not supposed to be visible simultaneously -->
-                <ProgressIndicator fx:id="progressIndicator" prefHeight="30" prefWidth="30" visible="false" />
-                <Label fx:id="completionMessageLabel" prefHeight="30" text="" textFill="red" visible="false" />
+                <ProgressIndicator fx:id="progressIndicator" prefHeight="30" prefWidth="30"/>
+                <Label fx:id="completionMessageLabel" prefHeight="30" text="Error Text" textFill="red"/>
             <columnConstraints>
                <ColumnConstraints />
             </columnConstraints>


### PR DESCRIPTION
As submission of log entry may take time (e.g. large attachments), a progress indicator is shown when user has pressed Submit button and while waiting for submission result. Submit and Cancel buttons disabled to avoid repeated submission or missed error message. 