### PR TITLE
Support copy of multiple PVs to clipboard

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
@@ -47,11 +47,14 @@ import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.javafx.PrintAction;
 import org.phoebus.ui.spi.ContextMenuEntry;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import static org.csstudio.display.builder.runtime.WidgetRuntime.logger;
 
@@ -153,24 +156,22 @@ class ContextMenuSupport
 
         items.add(new SeparatorMenuItem());
 
-        // Add PV-based contributions
-        String pv_name = "";
         // Does widget have a PV name?
         final Optional<WidgetProperty<String>> name_prop = widget.checkProperty(CommonWidgetProperties.propPVName);
-        if (name_prop.isPresent())
-            pv_name = name_prop.get().getValue();
-        else
-        {   // See if there are runtime PVs, pick the first one
-            for (RuntimePV pv : runtime.getPVs())
-            {
-                pv_name = pv.getName();
-                break;
-            }
+        List<ProcessVariable> processVariables;
+        if (name_prop.isPresent()){
+            processVariables = List.of(new ProcessVariable(name_prop.get().getValue()));
         }
-        if (!pv_name.isEmpty())
+        else
+        {   // Add all PVs referenced by the widget.
+            Collection<RuntimePV> runtimePvs = runtime.getPVs();
+            processVariables =
+                    runtimePvs.stream().map(runtimePV -> new ProcessVariable(runtimePV.getName())).collect(Collectors.toList());
+        }
+        if (!processVariables.isEmpty())
         {
             // Set the 'selection' to the PV of this widget
-            SelectionService.getInstance().setSelection(DisplayRuntimeApplication.NAME, List.of(new ProcessVariable(pv_name)));
+            SelectionService.getInstance().setSelection(DisplayRuntimeApplication.NAME, processVariables);
             // Add PV-based menu entries
             ContextMenuHelper.addSupportedEntries(node, menu);
             items.add(new SeparatorMenuItem());
@@ -205,16 +206,9 @@ class ContextMenuSupport
 
         items.add(new SaveSnapshotAction(model_parent));
 
-        String display_info;
         try
         {
             final DisplayModel model = widget.getDisplayModel();
-            final String name = model.getDisplayName();
-            final String input =  model.getUserData(DisplayModel.USER_DATA_INPUT_FILE);
-            if (Objects.equals(name, input))
-                display_info = "Display '" + name + "'";
-            else
-                display_info = "Display '" + name + "' (" + input + ")";
 
             // Add context menu actions based on the selection (i.e. email, logbook, etc...)
             final Selection originalSelection = SelectionService.getInstance().getSelection();
@@ -237,7 +231,7 @@ class ContextMenuSupport
         }
         catch (Exception ex)
         {
-            display_info = "See attached display";
+            logger.log(Level.WARNING, "Failed to construct context menu actions", ex);
         }
 
         items.add(new SeparatorMenuItem());

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvAndValueToClipboard.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvAndValueToClipboard.java
@@ -86,7 +86,7 @@ public class ContextMenuPvAndValueToClipboard extends ContextMenuPvToClipboard
                 logger.log(Level.WARNING, "Cannot show value for " + pv);
             }
 
-            buf.append("\n");
+            buf.append(System.lineSeparator());
         }
         return buf.toString();
     }

--- a/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvToClipboard.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/ContextMenuPvToClipboard.java
@@ -53,7 +53,7 @@ public class ContextMenuPvToClipboard implements ContextMenuEntry
 
     protected String createText(final List<ProcessVariable> pvs)
     {
-        return pvs.stream().map(ProcessVariable::getName).collect(Collectors.joining(" "));
+        return pvs.stream().map(ProcessVariable::getName).collect(Collectors.joining(System.lineSeparator()));
     }
 
     @Override


### PR DESCRIPTION
As per user request:
For widgets where multiple PVs are configured, the context menu items "Copy PV..." should include all PVs, not only the first one encountered in the list of PVs.

Items are separated by new line char.