### PR TITLE
fixing #2147

### DIFF
--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogObjectMappers.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogObjectMappers.java
@@ -52,12 +52,16 @@ public class OlogObjectMappers {
         public OlogProperty deserialize(JsonParser jp, DeserializationContext ctxt)
           throws IOException, JsonProcessingException {
             JsonNode node = jp.getCodec().readTree(jp);
+            // TODO throw error if either the property or attribute names are null
             String name = node.get("name").asText();
-            String owner = node.get("owner").asText();
-            String state = node.get("state").asText();
+            String owner = node.get("owner").isNull()? "" : node.get("owner").asText();
+            String state = node.get("state").isNull()? "" : node.get("state").asText();
             Map<String, String> attributes = new HashMap<String, String>();
             node.get("attributes").iterator().forEachRemaining(n -> {
-                attributes.put(n.get("name").asText(), n.get("value").asText());
+                attributes.put(
+                        n.get("name").asText(),
+                        n.get("value").isNull()? "" : n.get("value").asText()
+                );
             });
             return new OlogProperty(name, attributes);
         }
@@ -80,7 +84,7 @@ public class OlogObjectMappers {
                         try {
                             gen.writeStartObject();
                             gen.writeStringField("name", entry.getKey());
-                            gen.writeStringField("value", entry.getValue());
+                            gen.writeStringField("value", entry.getValue() == null ? "" : entry.getValue());
                             gen.writeEndObject();
                         } catch (IOException e) {
                             e.printStackTrace();

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogPropertiesController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogPropertiesController.java
@@ -215,7 +215,11 @@ public class LogPropertiesController {
                     }
                     private String getString()
                     {
-                        return getItem() == null ? "" : ((PropertyTreeNode)getItem()).getValue().toString();
+                        if (getItem() != null && ((PropertyTreeNode) getItem()).getValue() != null) {
+                            return ((PropertyTreeNode) getItem()).getValue();
+                        } else {
+                            return "";
+                        }
                     }
                 };
             }
@@ -283,7 +287,9 @@ public class LogPropertiesController {
         treeTableView.getRoot().getChildren().stream().forEach(node -> {
             Map<String, String> att = node.getChildren().stream()
                     .map(TreeItem::getValue)
-                    .collect(Collectors.toMap(PropertyTreeNode::getName, PropertyTreeNode::getValue));
+                    .collect(Collectors.toMap(
+                            PropertyTreeNode::getName,
+                            (PropertyTreeNode prop)-> prop.getValue() == null ? "" : prop.getValue()));
             Property property = PropertyImpl.of(node.getValue().getName(), att);
             treeProperties.add(property);
         });

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogPropertiesDemo.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogPropertiesDemo.java
@@ -45,6 +45,11 @@ public class LogPropertiesDemo extends ApplicationWrapper {
         databrowser.put("file", "sss");
         Property resourceProperty = PropertyImpl.of("Resource", databrowser);
 
+        Map<String, String> empty = new HashMap<>();
+        empty.put("name", null);
+        empty.put("file", "");
+        Property emptyProperty = PropertyImpl.of("empty", empty);
+
         ResourceBundle resourceBundle = NLS.getMessages(Messages.class);
         FXMLLoader loader = new FXMLLoader();
         loader.setResources(resourceBundle);
@@ -58,7 +63,7 @@ public class LogPropertiesDemo extends ApplicationWrapper {
         BooleanProperty editable = new SimpleBooleanProperty();
         checkBox.selectedProperty().bindBidirectional(editable);
 
-        controller.setProperties(Arrays.asList(track, experimentProperty, resourceProperty));
+        controller.setProperties(Arrays.asList(track, experimentProperty, resourceProperty, emptyProperty));
         editable.addListener((observable, oldValue, newValue) -> {
             controller.setEditable(newValue);
         });


### PR DESCRIPTION
@georgweiss  this should fix both the UI and the serialization of null values.
I allow null in values ( which are mapped as empty strings )

For owner and state, if the value is null should we just ignore/not set those fields?

If the property name or attribute name is null... this represent invalid data and we should throw some error. But the server validation should not allow such a situation to occur in the first place