### PR TITLE
Bugfix for plot label rendering

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LegendPart.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LegendPart.java
@@ -67,8 +67,20 @@ public class LegendPart<XTYPE extends Comparable<XTYPE>> extends PlotPart
         gc.setFont(font);
         final FontMetrics metrics = gc.getFontMetrics();
         base_offset = metrics.getLeading() + metrics.getAscent();
-        final int max_height = metrics.getHeight();
 
+        computeGrid(gc, traces);
+
+        gc.setFont(orig_font);
+
+        final int items = traces.size();
+        final int items_per_row = Math.max(1, bounds_width / grid_x); // Round down, counting full items
+        final int rows = (items + items_per_row-1) / items_per_row;   // Round up
+        return rows * grid_y;
+    }
+
+    private void computeGrid(final Graphics2D gc, final List<Trace<XTYPE>> traces){
+        final FontMetrics metrics = gc.getFontMetrics();
+        final int max_height = metrics.getHeight();
         int max_width = 1; // Start with 1 pixel to avoid later div-by-0
         for (Trace<XTYPE> trace : traces)
         {
@@ -82,13 +94,6 @@ public class LegendPart<XTYPE extends Comparable<XTYPE>> extends PlotPart
         // Arrange in grid with some extra space
         grid_x = max_width + max_height / 2;
         grid_y = max_height;
-
-        gc.setFont(orig_font);
-
-        final int items = traces.size();
-        final int items_per_row = Math.max(1, bounds_width / grid_x); // Round down, counting full items
-        final int rows = (items + items_per_row-1) / items_per_row;   // Round up
-        return rows * grid_y;
     }
 
     /** Paint the legend
@@ -106,6 +111,9 @@ public class LegendPart<XTYPE extends Comparable<XTYPE>> extends PlotPart
         // Anything to draw?
         if (bounds.height <= 0)
         	return;
+
+        // Need to compute grid since labels may have changed in case unit string was added when PV connects.
+        computeGrid(gc, traces);
 
         final Color orig_color = gc.getColor();
         final Font orig_font = gc.getFont();


### PR DESCRIPTION
In case the PVs configured for an X/Y plot are not connected when the widget is first rendered, the trace labels are rendered using the PV names only. Then, once the PVs connect, a unit may be available, which effectively changes the length of the label strings. At this point the "layout" of the labels must be recomputed to avoid the situation as in attached images.

This PR attempts to fix the issue.

![Screenshot 2022-03-03 at 17 24 40](https://user-images.githubusercontent.com/35602960/156609990-67cf5c45-82d6-4717-b9e2-fdde349a63e1.png)
![Screenshot 2022-03-03 at 17 25 10](https://user-images.githubusercontent.com/35602960/156609995-39857e59-23c8-4ab9-8f5c-33ef22caed36.png)
