### PR TITLE
Bug fix: unable to set golden tag in save&restore

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
@@ -369,7 +369,7 @@ public class SaveAndRestoreController implements Initializable, NodeChangedListe
      *
      * @param node The snapshot {@link Node} on which to toggle the "golden" property.
      */
-    private void toggleGoldenProperty(Node node) {
+    protected void toggleGoldenProperty(Node node) {
         try {
             Node updatedNode = saveAndRestoreService.tagSnapshotAsGolden(node,
                     !Boolean.parseBoolean(node.getProperty("golden")));

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreWithSplitController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreWithSplitController.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Stack;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class SaveAndRestoreWithSplitController extends SaveAndRestoreController {
@@ -312,5 +313,29 @@ public class SaveAndRestoreWithSplitController extends SaveAndRestoreController 
     protected void tagWithComment(ObservableList<MenuItem> tagList) {
         Node node = listView.getSelectionModel().getSelectedItem();
         tagWithComment(node, tagList);
+    }
+
+    /**
+     * Toggles the "golden" property of a snapshot as selected from the tree view.
+     */
+    @Override
+    protected void toggleGoldenProperty() {
+        toggleGoldenProperty(listView.getSelectionModel().getSelectedItem());
+    }
+
+    /**
+     * Toggles the "golden" property of the specified snapshot {@link Node}
+     *
+     * @param node The snapshot {@link Node} on which to toggle the "golden" property.
+     */
+    @Override
+    protected void toggleGoldenProperty(Node node) {
+        try {
+            Node updatedNode = saveAndRestoreService.tagSnapshotAsGolden(node,
+                    !Boolean.parseBoolean(node.getProperty("golden")));
+            nodeChanged(updatedNode);
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Failed to toggle golden property", e);
+        }
     }
 }

--- a/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
+++ b/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
@@ -12,7 +12,7 @@ httpClient.readTimeout=1000
 httpClient.connectTimeout=1000
 
 # Extract snapshots from TreeView to ListView
-splitSnapshot=true
+splitSnapshot=false
 
 
 # Sort snapshots in reverse order of created time. Last item comes first.


### PR DESCRIPTION
This is an issue only if the "split snapshot" view is used.