### PR TITLE
Add Dockerfile and use docker in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,17 +2,24 @@ name: Phoebus build
 
 on: [push, pull_request]
 
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: lgomezwhl/phoebus-ci:latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: '11'
     - name: Build
-      run: mvn --batch-mode install
+      run: mvn -Pdocker-tests --batch-mode install
     - name: Publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -1,0 +1,21 @@
+Docker
+===============
+
+In an effort to ensure consistency of deployment, testing and build environments, we have a Dockerfile that developers
+may use to build a docker image. The following instructions assume that the developer is using linux and has Docker installed::
+
+    cd misc/
+    sudo docker build -t phoebus:latest .
+    sudo docker run -it phoebus:latest
+
+
+
+From another shell(make sure to leave the previous shell open)::
+
+    sudo docker cp phoebus [CONTAINER_ID]:/
+
+
+You may also pull the following image from docker hub if you don't want to build the image yourself::
+
+   sudo docker pull lgomezwhl/phoebus-ci:latest
+

--- a/docs/source/eclipse_debugging.rst
+++ b/docs/source/eclipse_debugging.rst
@@ -1,0 +1,42 @@
+Eclipse Debugging
+=================
+
+Download Eclipse Oxygen 4.7.1a or later from http://download.eclipse.org/eclipse/downloads/
+
+Start Eclipse like this::
+
+   export JAVA_HOME=/path/to/your/jdk-9-or-later
+   export PATH="$JAVA_HOME/bin:$PATH"
+   eclipse/eclipse -consoleLog
+
+Check Eclipse Preferences::
+
+    Java, Installed JREs: JDK 9-or-later should be the default
+    Java, Compiler: JDK Compliance should be "9" or higher
+
+Debugging with Eclipse
+
+This assumes the project has been imported as a maven project into Eclipse(see instructions in README)::
+
+    1. Open Eclipse
+    2. Go to `Run->External Tools->External Run COnfigurations`
+    3. Create a new `Program` configuration. Set location to `usr/bin/java` on linux.
+       This is the location of the Java executable. For any other OS, it should not be too hard
+       to find that directory.
+    4. Set `Working Directory` to `phoebus/phoebus-product/target`.
+    5. Set arguments to:
+    ```
+    --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true
+    -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 -jar path_to_repo/phoebus/phoebus-product/target/product-4.6.6-SNAPSHOT.jar
+    ```
+    6. Click `Run`. The Eclipse console should output a port number. Write it down; we'll use it for
+       debugging later on.
+    7. Go to `Debug Configurations`
+    8. Create a new `Remote Java Application`
+    9. Click on the `Source` tab and make sure all of the sub-modules/projects of the phoebus project
+       are checked. This will allow you to travel through source code when debugging code in Eclipse.
+    10. For port, add the port from step 6.
+    11. Click `Debug`
+
+
+Now this should connect to your JVM process you started on step 6 and you start debugging your code. Happy debugging!

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,8 @@ Developer Documentation:
    localization
    preference_properties
    changelog
+   docker
+   eclipse_debugging
 
 Appendix
 ========

--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04
+RUN apt update
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+RUN apt-get install -y openjdk-11-jdk
+RUN apt-get install -y maven
+RUN apt-get install -y openjfx
+RUN echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/" >> /root/.bashrc

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,25 @@
         </plugins>
       </build>
     </profile>
+        <!-- The docker-tests profile sets the ignore_local_ipv6
+        environment variable to true since IPV6 is not supported in Github Actions at the moment. See ticket #2161 -->
+    <profile>
+      <id>docker-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.20</version>
+            <configuration>
+              <systemPropertyVariables>
+                <ignore_local_ipv6>true</ignore_local_ipv6>
+               </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   <!-- a profile for generating javadocs and sources -->
   <profile>
     <id>docs</id>


### PR DESCRIPTION
As discussed in #2156, some unit tests do not pass in a docker image since there are multiple issues related to IPV6. This PR addresses those issues.

During this process, I also learned that GitHub Actions has some issues related to Maven network timeouts. See https://github.com/actions/virtual-environments/issues/1499. Specifically in our case GitHub Actions would hang forever(until eventually it times out) when we used the new `docker-tests` profile when running maven. The new flags in `MAVEN_OPTS` seems to fix it. I don't know if there is something in those flags that we shouldn't be doing, so please give me feedback if there is. I pretty much stole the config from here https://github.com/Ericsson/ecchronos/pull/275.

Hope these changes make sense.
Thanks
Lorenzo