### PR TITLE
Add getIconURL method for probe application

### DIFF
--- a/app/probe/src/main/java/org/phoebus/applications/probe/Probe.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/Probe.java
@@ -1,6 +1,7 @@
 package org.phoebus.applications.probe;
 
 import java.net.URI;
+import java.net.URL;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -34,6 +35,12 @@ public class Probe implements AppResourceDescriptor {
     @Override
     public String getDisplayName() {
         return DISPLAYNAME;
+    }
+
+    @Override
+    public URL getIconURL()
+    {
+        return getClass().getResource("/icons/probe.png");
     }
 
     @Override


### PR DESCRIPTION
![probe-no-icon](https://user-images.githubusercontent.com/38359458/157369433-42e8f92d-b5d5-404e-92fe-bb64e47cf20a.PNG)



This is a really minor cosmetic change. 

I noticed when the Probe application is included in the Top Resources, there is no icon. Added the getIconURL method to the Probe class to get the icon to appear


![probe-icon](https://user-images.githubusercontent.com/38359458/157369484-2a53faab-6aa9-49bb-a7ed-03727ba54db0.PNG)

