### PR TITLE
Fix issue with reading in autocomplete preferences

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/AutocompletePreferences.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/AutocompletePreferences.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.framework.autocomplete;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
+import org.phoebus.framework.preferences.PreferencesReader;
+
+/** Autocomplete Preferences
+ *  @author Tynan Ford
+ */
+@SuppressWarnings("nls")
+public class AutocompletePreferences
+{
+    /** Logger for the 'autocomplete' package */
+    public static final Logger logger = Logger.getLogger(AutocompletePreferences.class.getPackageName());
+
+    @Preference public static boolean enable_loc_pv_proposals;
+    @Preference public static boolean enable_sim_pv_proposals;
+    @Preference public static boolean enable_sys_pv_proposals;
+    @Preference public static boolean enable_pva_pv_proposals;
+    @Preference public static boolean enable_mqtt_pv_proposals;
+    @Preference public static boolean enable_formula_proposals;
+
+    static
+    {
+        final PreferencesReader prefs = AnnotatedPreferences.initialize(AutocompletePreferences.class, "/autocomplete_preferences.properties");
+    }
+}

--- a/core/framework/src/main/java/org/phoebus/framework/autocomplete/PVProposalService.java
+++ b/core/framework/src/main/java/org/phoebus/framework/autocomplete/PVProposalService.java
@@ -11,7 +11,7 @@ import java.util.ServiceLoader;
 
 import org.phoebus.framework.preferences.PreferencesReader;
 import org.phoebus.framework.spi.PVProposalProvider;
-import org.phoebus.framework.workbench.WorkbenchPreferences;
+import org.phoebus.framework.autocomplete.AutocompletePreferences;
 
 /** Autocompletion Service for PVs
  *  @author Kay Kasemir
@@ -24,7 +24,7 @@ public class PVProposalService extends ProposalService
     private PVProposalService()
     {
         // Enable built-in proposal providers
-        final PreferencesReader prefs = new PreferencesReader(WorkbenchPreferences.class, "/autocomplete_preferences.properties");
+        final PreferencesReader prefs = new PreferencesReader(AutocompletePreferences.class, "/autocomplete_preferences.properties");
         if (prefs.getBoolean("enable_loc_pv_proposals"))
             providers.add(LocProposalProvider.INSTANCE);
         if (prefs.getBoolean("enable_sim_pv_proposals"))


### PR DESCRIPTION
Possible fix for https://github.com/ControlSystemStudio/phoebus/issues/2168

Copied Preferences class from workbench here: https://github.com/ControlSystemStudio/phoebus/blob/master/core/framework/src/main/java/org/phoebus/framework/workbench/WorkbenchPreferences.java 

And updated it for auto_complete settings found here: https://control-system-studio.readthedocs.io/en/latest/preference_properties.html#framework-autocomplete