### PR TITLE
JavaFX 16 -> 18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <properties>
     <epics.version>7.0.7</epics.version>
     <vtype.version>1.0.4</vtype.version>
-    <openjfx.version>16</openjfx.version>
+    <openjfx.version>18</openjfx.version>
     <jackson.version>2.10.1</jackson.version>
     <batik.version>1.14</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
JavaFX 18 has just been released and I've run some basic testing on various platforms, see #2177.

As Mac users are moving to Monterrey, JavaFX 18 is a must as Phoebus crashes sooner or later on JavaFX 16.