### PR TITLE
Plot config dialog optional in data browser

### DIFF
--- a/app/databrowser/doc/index.rst
+++ b/app/databrowser/doc/index.rst
@@ -116,8 +116,8 @@ and miscellaneous settings. Changes performed in this panel will be persisted wh
 Runtime Properties Dialog
 -------------------------
 
-Another way to change plot properties is to use the runtime properties dialog. This launched by clicking on the
-plot area and press letter "o" on the keyboard:
+If enabled through the preference setting ``org.csstudio.trends.databrowser3/config_dialog_supported``, plot settings may
+also be changed using the runtime properties dialog. To launch the dialog, click on the plot area and then press letter "o":
 
 .. image:: images/runtime_properties_dialog.png
    :width: 400

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
@@ -70,6 +70,7 @@ public class Preferences
     @Preference public static boolean prompt_for_raw_data_request;
     @Preference public static boolean prompt_for_visibility;
     public static final List<TimePreset> time_presets = new ArrayList<>();
+    @Preference public static boolean config_dialog_supported;
 
     static
     {

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java
@@ -130,6 +130,8 @@ public class Perspective extends SplitPane
         // As pane is resized, assert that the minimzed left or bottom region stays minimized
         widthProperty().addListener(prop -> Platform.runLater(() -> autoMinimizeLeft()));
         heightProperty().addListener(prop -> Platform.runLater(() -> autoMinimizeBottom()));
+
+        plot.setConfigDialogSupported(org.csstudio.trends.databrowser3.preferences.Preferences.config_dialog_supported);
     }
 
     /** @return {@link Model} */

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/plot/ModelBasedPlot.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/plot/ModelBasedPlot.java
@@ -7,20 +7,8 @@
  ******************************************************************************/
 package org.csstudio.trends.databrowser3.ui.plot;
 
-import static org.csstudio.trends.databrowser3.Activator.logger;
-
-import java.text.MessageFormat;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.logging.Level;
-
+import javafx.application.Platform;
+import javafx.scene.control.Button;
 import org.csstudio.javafx.rtplot.Annotation;
 import org.csstudio.javafx.rtplot.Axis;
 import org.csstudio.javafx.rtplot.AxisRange;
@@ -37,8 +25,19 @@ import org.csstudio.trends.databrowser3.model.Model;
 import org.csstudio.trends.databrowser3.model.ModelItem;
 import org.csstudio.trends.databrowser3.preferences.Preferences;
 
-import javafx.application.Platform;
-import javafx.scene.control.Button;
+import java.text.MessageFormat;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Level;
+
+import static org.csstudio.trends.databrowser3.Activator.logger;
 
 /** Data Browser 'Plot' that displays the samples in a {@link Model}.
  *  <p>
@@ -73,9 +72,9 @@ public class ModelBasedPlot
      */
     private final ReentrantReadWriteLock trace_lock = new InstrumentedReadWriteLock();
 
-    /** Initialize plot
-     *  @param parent Parent widget
-     *  @throws Exception
+    /**
+     * Initialize plot
+     *  @param active
      */
     public ModelBasedPlot(final boolean active)
     {
@@ -459,5 +458,14 @@ public class ModelBasedPlot
     public void dispose()
     {
         plot.dispose();
+    }
+
+    /**
+     * Sets the <code>configDialogSupported</code> flag of the {@link org.csstudio.javafx.rtplot.RTPlot}.
+     * @param configDialogSupported <code>true</code> if the plot configuration dialog should be launched on
+     *                                   key press (o), otherwise <code>false</code>.
+     */
+    public void setConfigDialogSupported(boolean configDialogSupported){
+        plot.setConfigDialogSupported(configDialogSupported);
     }
 }

--- a/app/databrowser/src/main/resources/databrowser_preferences.properties
+++ b/app/databrowser/src/main/resources/databrowser_preferences.properties
@@ -126,3 +126,7 @@ prompt_for_visibility = true
 # Format:
 # Text for shortcut,start_spec|Another shortcut,start_spec
 time_span_shortcuts=30 Minutes,-30 min|1 Hour,-1 hour|12 Hours,-12 hour|1 Day,-1 days|7 Days,-7 days
+
+# Determines if the plot runtime config dialog is supported. Defaults to false as the Data Browser
+# offers the same functionality through its configuration tabs.
+config_dialog_supported=false

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
@@ -63,6 +63,12 @@ public class  RTPlot<XTYPE extends Comparable<XTYPE>> extends BorderPane
     private boolean handle_keys = false;
 	private TextField axisLimitsField; //Field for adjusting the limits of the axes
 	private final Pane center = new Pane();
+    /**
+     * Flag indicating whether the plot should launch the configuration dialog or not on
+     * key press (o). For the Data Browser app this may not be wanted as the
+     * various tabs provide the same functionality.
+     */
+	private boolean configDialogSupported = true;
 
     /** Constructor
      *  @param active Active mode where plot reacts to mouse/keyboard?
@@ -230,7 +236,7 @@ public class  RTPlot<XTYPE extends Comparable<XTYPE>> extends BorderPane
             plot.getUndoableActionManager().undoLast();
         else if (event.getCode() == KeyCode.Y)
             plot.getUndoableActionManager().redoLast();
-        else if (event.getCode() == KeyCode.O)
+        else if (event.getCode() == KeyCode.O && configDialogSupported)
             showConfigurationDialog();
         else if (event.getCode() == KeyCode.T)
             showToolbar(! isToolbarVisible());
@@ -592,5 +598,14 @@ public class  RTPlot<XTYPE extends Comparable<XTYPE>> extends BorderPane
     */
     public void resetAxisRanges(){
         plot.resetAxisRanges();
+    }
+
+    /**
+     * Sets the {@link #configDialogSupported} flag.
+     * @param configDialogSupported <code>true</code> if the dialog should be launched on
+     *                                   key press (o), otherwise <code>false</code>.
+     */
+    public void setConfigDialogSupported(boolean configDialogSupported){
+        this.configDialogSupported = configDialogSupported;
     }
 }


### PR DESCRIPTION
New preference setting:
``org.csstudio.trends.databrowser3/config_dialog_supported``

Defaults to ``false`` in the context of the data browser.