### PR TITLE
check clean before restoring

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -347,7 +347,7 @@ public class PhoebusApplication extends Application {
         // If there's nothing to restore from a previous instance,
         // start with welcome
         monitor.updateTaskName(Messages.MonitorTaskTabs);
-        if (restoreState(memento))
+        if (application_parameters.contains("-clean") || restoreState(memento))
             show_welcome = false;
         if (show_welcome)
             new Welcome().create();
@@ -428,7 +428,6 @@ public class PhoebusApplication extends Application {
     private void handleParameters(final List<String> parameters) throws Exception {
         if (parameters.contains("-clean"))
         {   // Clean removes everything, including 'Welcome'
-            show_welcome = false;
             return;
         }
         // List of applications to launch as specified via cmd line args


### PR DESCRIPTION
#2184 changed the `-clean` behaviour. Now, the memento is always restored. I added a short-circuit back in to avoid loading the memento when `-clean` is requested, which I believe is the intended behaviour.

My apologies for the inactivity on #2162, I was suddenly ill and many thanks to @kasemir for picking that up with #2184.

