### PR TITLE
Fix  #2180

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,16 +2,14 @@ name: Phoebus build
 
 on: [push, pull_request]
 
-
-env:
-  MAVEN_OPTS: -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-
-
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
       image: lgomezwhl/phoebus-ci:latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MAVEN_OPTS: -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
@@ -21,7 +19,5 @@ jobs:
     - name: Build
       run: mvn -Pdocker-tests --batch-mode install
     - name: Publish
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: mvn --batch-mode -DskipTests deploy
       if: ${{ github.repository == 'ControlSystemStudio/phoebus' && (github.ref == 'refs/heads/master' || github.ref == 'refs/tags/*') }}


### PR DESCRIPTION
This should(I think) fix our current issues in Github Actions. What's happening is I think the `env` variable is being overwritten and so the GitHub token is never stored in it. As per [documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenv).