### PR TITLE
Rectangle: Use either legacy "line" or "border"

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/OutlineSupport.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/OutlineSupport.java
@@ -1,6 +1,12 @@
 
 package org.csstudio.display.builder.model.widgets;
 
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLineColor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLineStyle;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLineWidth;
+
+import java.util.Optional;
+
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetConfigurator;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
@@ -8,11 +14,6 @@ import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.properties.LineStyle;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Element;
-
-import java.util.Optional;
-
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.*;
-import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLineColor;
 
 /**
  * A helper class for handling the outline "line" property or widgets
@@ -29,7 +30,6 @@ public class OutlineSupport {
      */
     public static void handleLegacyBorder(final Widget widget, final Element xml) throws Exception
     {
-
         // Style tends to be a number, but could also be "None".
         final Optional<String> style_text = XMLUtil.getChildString(xml, "border_style");
         if (!style_text.isPresent())
@@ -39,6 +39,15 @@ public class OutlineSupport {
 
         if ("none".equalsIgnoreCase(style_text.get()))
         {
+            return;
+        }
+
+        // There is a "border" configuration.
+        // Is there also a "line" configuration?
+        if (XMLUtil.getChildDouble(xml, "line_width").orElse(-1.0) >
+            XMLUtil.getChildDouble(xml, "border_width").orElse(-1.0))
+        {
+            // Ignore the smaller "border", use "line"
             return;
         }
 
@@ -52,6 +61,11 @@ public class OutlineSupport {
         }
 
         final Optional<Integer> xml_width = XMLUtil.getChildInteger(xml, "border_width");
+
+        // If there's a border_color, use that for the line_color
+        Element el = XMLUtil.getChildElement(xml, "border_color");
+        if (el != null)
+            widget.getProperty(propLineColor).readFromXML(null, el);
 
         switch (style)
         {
@@ -69,35 +83,30 @@ public class OutlineSupport {
                 xml_width.ifPresent(w -> {
                     widget.getProperty(propLineWidth).setValue(w);
                 });
-                widget.getProperty(propLineColor).setValue(WidgetColorService.getColor(NamedWidgetColors.TEXT));
                 break;
             case 8: // DOTTED
                 widget.getProperty(propLineStyle).setValue(LineStyle.DOT);
                 xml_width.ifPresent(w -> {
                     widget.getProperty(propLineWidth).setValue(w);
                 });
-                widget.getProperty(propLineColor).setValue(WidgetColorService.getColor(NamedWidgetColors.TEXT));
                 break;
             case 9: // DASHED
                 widget.getProperty(propLineStyle).setValue(LineStyle.DASH);
                 xml_width.ifPresent(w -> {
                     widget.getProperty(propLineWidth).setValue(w);
                 });
-                widget.getProperty(propLineColor).setValue(WidgetColorService.getColor(NamedWidgetColors.TEXT));
                 break;
             case 10: // DASH_DOT
                 widget.getProperty(propLineStyle).setValue(LineStyle.DASHDOT);
                 xml_width.ifPresent(w -> {
                     widget.getProperty(propLineWidth).setValue(w);
                 });
-                widget.getProperty(propLineColor).setValue(WidgetColorService.getColor(NamedWidgetColors.TEXT));
                 break;
             case 11: // DASH_DOT_DOT
                 widget.getProperty(propLineStyle).setValue(LineStyle.DASHDOTDOT);
                 xml_width.ifPresent(w -> {
                     widget.getProperty(propLineWidth).setValue(w);
                 });
-                widget.getProperty(propLineColor).setValue(WidgetColorService.getColor(NamedWidgetColors.TEXT));
                 break;
         }
     }


### PR DESCRIPTION
.. whichever has a larger "width". Used to ignore "line" and always use the "border" settings.
If indeed using the "border", now honors the "border_color" instead of always using black resp. "Text" color.

See  #2203 for screenshots