### PR TITLE
Fix Olog attachment when created from display

### DIFF
--- a/app/display/adapters/src/main/java/org/csstudio/display/builder/util/DisplayBuilderAdapterFactory.java
+++ b/app/display/adapters/src/main/java/org/csstudio/display/builder/util/DisplayBuilderAdapterFactory.java
@@ -59,19 +59,19 @@ public class DisplayBuilderAdapterFactory implements AdapterFactory {
             LogEntryBuilder log = log()
                     .title(LogbookPreferences.auto_title ? "Display Screenshot for : " + selectionInfo.getName() : "")
                     .appendDescription(getBody(selectionInfo));
+            try
+            {
+                final File image_file = selectionInfo.getImage() == null ? null : new Screenshot(selectionInfo.getImage()).writeToTempfile("image");
+                log.attach(AttachmentImpl.of(image_file));
+            } catch (Exception e)
+            {
+                logger.log(Level.WARNING, "Failed to build a log entry from this Display Builder selection ", e);
+            }
             if(LogbookPreferences.auto_property) {
                 Map<String, String> attributes = new HashMap<>();
                 attributes.put("name",selectionInfo.getName());
                 attributes.put("file",selectionInfo.toURI().toString());
                 log.appendProperty(PropertyImpl.of("resource", attributes));
-                try
-                {
-                    final File image_file = selectionInfo.getImage() == null ? null : new Screenshot(selectionInfo.getImage()).writeToTempfile("image");
-                    log.attach(AttachmentImpl.of(image_file));
-                } catch (Exception e)
-                {
-                    logger.log(Level.WARNING, "Failed to build a log entry from this Display Builder selection ", e);
-                }
             }
             return Optional.of(adapterType.cast(log.build()));
         }


### PR DESCRIPTION
The DisplayBuilderAdapterFactory will suppress attachment of OPI screen shot if auto_property is not set to true. This seems a bit odd. Attachments and properties should be independent.