### PR TITLE
Edm auto-converter support for relative links

### DIFF
--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/AssetLocator.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/AssetLocator.java
@@ -26,6 +26,14 @@ import org.phoebus.framework.util.IOUtils;
 @SuppressWarnings("nls")
 public class AssetLocator
 {
+    private String prefix = "";
+
+    /** @param prefix Name prefix (parent folder) */
+    public void setPrefix(final String prefix)
+    {
+        this.prefix = prefix;
+    }
+
     /** @param name Display name.
      *  @return Display name with '.edl' added when missing or when there is a different ending
      */
@@ -52,6 +60,17 @@ public class AssetLocator
      *  @throws Exception on error
      */
     public File locate(final String name) throws Exception
+    {
+        // Check relative to parent
+        final String prefixed = prefix + (prefix.endsWith("/") ? name : "/" + name);
+        File result = doLocate(prefixed);
+        if (result != null)
+            return result;
+        // Fall back to plain name
+        return doLocate(name);
+    }
+
+    private File doLocate(final String name) throws Exception
     {
         for (String path : ConverterPreferences.paths)
         {

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/AssetLocator.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/AssetLocator.java
@@ -73,8 +73,6 @@ public class AssetLocator
                 {
                     if (ConverterPreferences.auto_converter_dir == null)
                         throw new Exception("Cannot download " + check + ", no auto_converter_dir");
-                    if (! ConverterPreferences.auto_converter_dir.isDirectory())
-                        throw new Exception("Cannot download " + check + ", missing auto_converter_dir " + ConverterPreferences.auto_converter_dir);
                     final File input = new File(ConverterPreferences.auto_converter_dir, name);
                     final File output_folder = input.getParentFile();
                     if (! output_folder.exists())

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/AssetLocator.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/AssetLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,21 +59,37 @@ public class AssetLocator
             logger.log(Level.FINE, "Check " + check);
             if (check.startsWith("http"))
             {
+                final InputStream stream;
                 try
                 {
-                    final InputStream stream = ModelResourceUtil.openURL(check);
+                    stream = ModelResourceUtil.openURL(check);
+                }
+                catch (Exception ex)
+                {
+                    // Check next search path entry
+                    continue;
+                }
+                try
+                {
                     if (ConverterPreferences.auto_converter_dir == null)
                         throw new Exception("Cannot download " + check + ", no auto_converter_dir");
                     if (! ConverterPreferences.auto_converter_dir.isDirectory())
                         throw new Exception("Cannot download " + check + ", missing auto_converter_dir " + ConverterPreferences.auto_converter_dir);
                     final File input = new File(ConverterPreferences.auto_converter_dir, name);
+                    final File output_folder = input.getParentFile();
+                    if (! output_folder.exists())
+                    {
+                        logger.log(Level.INFO, "Creating folder " + output_folder);
+                        if (! output_folder.mkdirs())
+                            throw new Exception("Cannot create folder " + output_folder + " to download " + check);
+                    }
                     logger.log(Level.INFO, "Downloading " + check + " into " + input);
                     IOUtils.copy(stream, new FileOutputStream(input));
                     return input;
                 }
                 catch (Exception ex)
                 {
-                    // Check next search path entry
+                    logger.log(Level.INFO, "Cannot download " + check, ex);
                 }
             }
             else

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,7 @@ public class ConverterPreferences
     public static final List<String> paths = new ArrayList<>();
 
     public static volatile File auto_converter_dir;
+    @Preference public static String auto_converter_strip;
 
     private static class FontMapping
     {
@@ -85,7 +86,7 @@ public class ConverterPreferences
             else
             {
                 auto_converter_dir = null;
-                logger.log(Level.WARNING, "EDM auto_converter_dir " + dir + " does not exist");
+                logger.log(Level.WARNING, "EDM auto_converter_dir " + dir + " does not exist and is thus ignored");
             }
         }
     }
@@ -100,8 +101,13 @@ public class ConverterPreferences
         {
             String line;
             while ((line = reader.readLine()) != null)
-                if (! line.startsWith("#"))
-                    paths.add(line);
+            {   // Skip empty lines and comments
+                line = line.strip();
+                if (line.isEmpty() ||
+                    line.startsWith("#"))
+                    continue;
+                paths.add(line);
+            }
         }
     }
 

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/EdmAutoConverter.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/EdmAutoConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -85,7 +85,14 @@ public class EdmAutoConverter implements DisplayAutoConverter
                 }
             }
             logger.log(Level.INFO, "For parent display " + parent_display + ", can " + display_file + " be auto-created from EDM file?");
-            return doConvert(parent_display, display_file);
+            if (parent_display != null)
+            {   // Since June 2021, EDM supports relative paths.
+                final String relative = new File(new File(parent_display).getParentFile(), display_file).getAbsolutePath();
+                final DisplayModel converted = doConvert(relative);
+                if (converted != null)
+                    return converted;
+            }
+            return doConvert(display_file);
         }
         finally
         {
@@ -93,10 +100,23 @@ public class EdmAutoConverter implements DisplayAutoConverter
         }
     }
 
-    private DisplayModel doConvert(final String parent_display, final String display_file) throws Exception
+    private DisplayModel doConvert(final String display_path) throws Exception
     {
-        // Assert that the target directory exists
-        ConverterPreferences.auto_converter_dir.mkdirs();
+        String display_file = display_path;
+        // Strip either complete path or specific prefix
+        if (ConverterPreferences.auto_converter_strip.isBlank())
+        {
+            int sep = display_file.lastIndexOf('/');
+            if (sep < 0)
+                sep = display_file.lastIndexOf('\\');
+            if (sep >= 0)
+                display_file = display_file.substring(sep + 1);
+        }
+        else
+        {
+            if (display_file.startsWith(ConverterPreferences.auto_converter_strip))
+                display_file = display_file.substring(ConverterPreferences.auto_converter_strip.length());
+        }
 
         // Check if we already have an auto-converted *.bob file, so use that instead of re-creating it
         final File already_converted = new File(ConverterPreferences.auto_converter_dir, display_file);
@@ -113,13 +133,14 @@ public class EdmAutoConverter implements DisplayAutoConverter
             return null;
 
         // Determine output file name in auto_converter_dir
-        final File output = new File(ConverterPreferences.auto_converter_dir, new File(display_file).getName());
+        final File output = new File(ConverterPreferences.auto_converter_dir, display_file);
 
         // Load colors
         EdmModel.reloadEdmColorFile(ConverterPreferences.colors_list,
                                     ModelResourceUtil.openResourceStream(ConverterPreferences.colors_list));
 
         // Convert EDM input
+        logger.log(Level.INFO, "Converting " + input + " into " + output);
         new EdmConverter(input, locator).write(output);
 
         // Return DisplayModel of the converted file

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/EdmAutoConverter.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/EdmAutoConverter.java
@@ -141,6 +141,7 @@ public class EdmAutoConverter implements DisplayAutoConverter
 
         // Convert EDM input
         logger.log(Level.INFO, "Converting " + input + " into " + output);
+        locator.setPrefix(new File(display_file).getParent());
         new EdmConverter(input, locator).write(output);
 
         // Return DisplayModel of the converted file

--- a/app/display/convert-edm/src/main/resources/edm_converter_preferences.properties
+++ b/app/display/convert-edm/src/main/resources/edm_converter_preferences.properties
@@ -11,6 +11,20 @@
 # When left empty, the auto-converter is disabled.
 auto_converter_dir=
 
+# Path (prefix) that will be stripped from the original
+# EDM file name before converting.
+# When empty, the complete path will be stripped.
+#
+# For example, assume we need to convert
+#  /path/to/original/vacuum/segment1/vac1.edl
+#
+# With an empty auto_converter_strip,
+# this will be converted into {auto_converter_dir}/vac1.edl
+#
+# With auto_converter_strip=/path/to/original,
+# it will be converted into {auto_converter_dir}/vacuum/segment1/vac1.edl
+auto_converter_strip=
+
 # EDM colors.list file
 # Must be defined to use converter.
 # May be a file system path or http:/.. link

--- a/app/display/convert-medm/doc/index.rst
+++ b/app/display/convert-medm/doc/index.rst
@@ -74,7 +74,7 @@ To use the EDM converter, add the following to your settings::
 For details, see full description of :ref:`preference_settings`.
 
 Each time you now try to open an ``*.edl`` file,
-the converter will create a ``*.bob`` file and then open it.
+the converter will create a ``*.bob`` file in the same location and then open it.
 
 For bulk conversions, you can use this command line invocation,
 which can convert a list of files, including complete directories::
@@ -113,22 +113,53 @@ the auto-converter will search for a file ``a.edl`` and auto-convert it.
 The next time around, the ``a.bob`` file exists and opens a little faster.
 This way, files are auto-converted on first access, on-demand.
 
-To enable the auto-converter, define a folder where the converted files will be stored via this setting::
+To enable the auto-converter, define a folder where the converted files will be stored
+as well as related settings::
 
     org.csstudio.display.converter.edm/auto_converter_dir=/path/to/AUTOCONVERTED_FILES
-    
-    # Additional EDM converter settings that you likely need:
-    org.csstudio.display.converter.edm/colors_list=/path/to/edm/colors.list
+    org.csstudio.display.converter.edm/auto_converter_strip=/some/prefix/to/strip    
     org.csstudio.display.converter.edm/edm_paths_config=/path/to/my_edm_search_paths.txt
-    
 
 With the auto-converter folder defined, each time the display builder
-needs to open a file ``*.bob`` that does not exist, it will try to
-auto-convert it by locating an ``*.edl`` file of the same base name
-along the ``edm_paths_config``. If an EDM file is found, it is converted.
+needs to open a file ``*.bob`` that does not exist,
+it will remove the ``auto_converter_strip`` prefix,
+and try to locate an ``*.edl`` file of that name along the ``edm_paths_config``.
+If an EDM file is found, it is converted and written to the ``auto_converter_dir``.
 In case the EDM file is found via an http link, it is first downloaded.
 On success, the resulting ``*.bob`` file is opened.
 When that display then refers to other EDM files,
 the same process is repeated.
 Converted files are stored in the ``auto_converter_dir``,
 they are thus only fetched and converted once.
+
+As an example, assume EDM files are located on a web server under
+``https://my.site.org/opi/edm`` and you want to start by opening
+``https://my.site.org/opi/edm/general/start.edl``.
+
+Use these example settings::
+
+    org.csstudio.display.converter.edm/auto_converter_dir=$(user.home)/AUTOCONVERTED_FILES
+    org.csstudio.display.converter.edm/auto_converter_strip=$(user.home)/AUTOCONVERTED_FILES
+    org.csstudio.display.converter.edm/edm_paths_config=https://my.site.org/opi/edm/paths.txt
+    
+where the file ``paths.txt`` on the server should include just one line::
+
+    https://my.site.org/opi/edm/
+
+To bootstrap access to the EDM displays from your display builder screens,
+use an action button labeled "EDM Displays"
+with an action to open ``$(user.home)/AUTOCONVERTED_FILES/general/start.bob``.
+When you first click that button, 
+``$(user.home)/AUTOCONVERTED_FILES/general/start.bob`` does not exist,
+and we attempt to auto-convert it from an EDM display:
+
+ * The ``auto_converter_strip`` prefix is removed, leaving
+   ``general/start.bob``
+ * Using the search path listed in the file provided by ``edm_paths_config``,
+   the corresponding EDM file is found as
+   ``https://my.site.org/opi/edm/general/start.edl``
+ * It is downloaded as ``$(user.home)/AUTOCONVERTED_FILES/general/start.edl``
+   and converted into ``$(user.home)/AUTOCONVERTED_FILES/general/start.bob``
+
+From now on, ``$(user.home)/AUTOCONVERTED_FILES/general/start.bob`` exists
+and simply opens right away.

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import org.csstudio.display.builder.representation.ToolkitRepresentation;
 import org.csstudio.display.builder.runtime.script.ScriptUtil;
 import org.phoebus.framework.jobs.CommandExecutor;
 import org.phoebus.framework.macros.MacroHandler;
+import org.phoebus.framework.macros.MacroOrSystemProvider;
 import org.phoebus.framework.macros.MacroValueProvider;
 import org.phoebus.framework.macros.Macros;
 
@@ -87,7 +88,7 @@ public class ActionUtil
             final Macros expanded = new Macros(action.getMacros());
             expanded.expandValues(source_widget.getEffectiveMacros());
             final Macros macros = Macros.merge(source_widget.getEffectiveMacros(), expanded);
-            expanded_path = MacroHandler.replace(macros, action.getFile());
+            expanded_path = MacroHandler.replace(new MacroOrSystemProvider(macros), action.getFile());
             logger.log(Level.FINER, "{0}, effective macros {1} ({2})", new Object[] { action, macros, expanded_path });
 
             // Resolve new display file relative to the source widget model (not 'top'!)


### PR DESCRIPTION
For about a year, EDM supported relative links, so the search path holds just one entry, the root folder.
This updates the auto-converter to also look for files-to-convert using relative links. 