### PR TITLE
ContextMenuHelper uses AdapterService to adapt before calling action

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
@@ -9,10 +9,15 @@ package org.phoebus.ui.application;
 
 import static org.phoebus.ui.application.PhoebusApplication.logger;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 
+import org.phoebus.framework.adapter.AdapterService;
+import org.phoebus.framework.selection.Selection;
 import org.phoebus.framework.selection.SelectionService;
+import org.phoebus.framework.selection.SelectionUtil;
 import org.phoebus.ui.docking.DockStage;
 import org.phoebus.ui.spi.ContextMenuEntry;
 
@@ -69,7 +74,13 @@ public class ContextMenuHelper
             {
                 try
                 {
-                    entry.call(SelectionService.getInstance().getSelection());
+                    List<Object> selection = new ArrayList<>();
+                    SelectionService.getInstance().getSelection()
+                            .getSelections().stream().forEach(s -> {
+                                AdapterService.adapt(s, entry.getSupportedType())
+                                        .ifPresent(found -> selection.add(found));
+                    });
+                    entry.call(SelectionUtil.createSelection(selection));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
The `ContextMenuService` already uses the `AdapterService` to figure out which actions should be included in the context menu... this is great!
I added another step such that when the included action is invoked, the ContextMenuService calls the AdapterService to convert the selection into the required type before executing the action. In the past each action had to retrieve the selection and handle the conversion itself...with this change we should be able to go back and simplify a lot of the context menu actions.