### PR TITLE
Channel Finder error and refresh

### DIFF
--- a/app/channel/utility/pom.xml
+++ b/app/channel/utility/pom.xml
@@ -24,6 +24,11 @@
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
+      <artifactId>core-ui</artifactId>
+      <version>4.6.6-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
       <version>4.6.6-SNAPSHOT</version>
     </dependency>

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddProperty2ChannelsJob.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddProperty2ChannelsJob.java
@@ -4,7 +4,6 @@
 package org.phoebus.channelfinder.utility;
 
 import java.util.Collection;
-import java.util.function.BiConsumer;
 
 import org.phoebus.channelfinder.ChannelFinderClient;
 import org.phoebus.channelfinder.Property;
@@ -22,7 +21,7 @@ public class AddProperty2ChannelsJob extends JobRunnableWithCancel {
     private final ChannelFinderClient client;
     private final Property property;
     private final Collection<String> channelNames;
-    private final BiConsumer<String, Exception> errorHandler;
+    private final Runnable onSuccess;
 
     /**
      * Submit a job to add a Property to a channel or a group of channels
@@ -30,26 +29,26 @@ public class AddProperty2ChannelsJob extends JobRunnableWithCancel {
      * @param client - channelfinder client, which this job be submitted to
      * @param channelNames - collection of channels to which the property is to be added
      * @param property - the property to be added to the channels
-     * @param errorHandler - error handler
+     * @param onSuccess - called on success
      * @return {@link Job}
      */
     public static Job submit(ChannelFinderClient client,
                                 final Collection<String> channelNames,
                                 final Property property,
-                                final BiConsumer<String, Exception> errorHandler)
+                                final Runnable onSuccess)
     {
         return JobManager.schedule("Adding property : " + property.getName() + " to " + channelNames.size() + " channels",
-                new AddProperty2ChannelsJob(client, channelNames, property, errorHandler));
+                new AddProperty2ChannelsJob(client, channelNames, property, onSuccess));
     }
 
     private AddProperty2ChannelsJob(ChannelFinderClient client,
                                     Collection<String> channels,
                                     Property property,
-                                    BiConsumer<String, Exception> errorHandler)
+                                    final Runnable onSuccess)
     {
         super();
         this.client = client;
-        this.errorHandler = errorHandler;
+        this.onSuccess = onSuccess;
         this.channelNames = channels;
         this.property = property;
     }
@@ -73,13 +72,9 @@ public class AddProperty2ChannelsJob extends JobRunnableWithCancel {
                 ChannelErrorHandler.displayError(
                     "Failed to add property '" + property.getName() + "' = '" + property.getValue() + "'",
                     thrown);
+                return;
             }
+            onSuccess.run();
         };
-    }
-
-    @Override
-    public BiConsumer<String, Exception> getErrorHandler()
-    {
-        return errorHandler;
     }
 }

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddProperty2ChannelsJob.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddProperty2ChannelsJob.java
@@ -64,7 +64,16 @@ public class AddProperty2ChannelsJob extends JobRunnableWithCancel {
     public Runnable getRunnable()
     {
         return () -> {
-            client.update(Property.Builder.property(property), channelNames);
+            try
+            {
+                client.update(Property.Builder.property(property), channelNames);
+            }
+            catch (Throwable thrown)
+            {
+                ChannelErrorHandler.displayError(
+                    "Failed to add property '" + property.getName() + "' = '" + property.getValue() + "'",
+                    thrown);
+            }
         };
     }
 

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddTag2ChannelsJob.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddTag2ChannelsJob.java
@@ -1,13 +1,13 @@
 package org.phoebus.channelfinder.utility;
 
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
 import org.phoebus.channelfinder.ChannelFinderClient;
 import org.phoebus.channelfinder.Tag;
 import org.phoebus.framework.jobs.Job;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.jobs.JobRunnableWithCancel;
-
-import java.util.Collection;
-import java.util.function.BiConsumer;
 
 /**
  *
@@ -57,7 +57,16 @@ public class AddTag2ChannelsJob extends JobRunnableWithCancel {
     public Runnable getRunnable()
     {
         return () -> {
-            client.update(Tag.Builder.tag(tag), channelNames);
+            try
+            {
+                client.update(Tag.Builder.tag(tag), channelNames);
+            }
+            catch (Throwable thrown)
+            {
+                ChannelErrorHandler.displayError(
+                    "Failed to add property '" + tag.getName() + "'",
+                    thrown);
+            }
         };
     }
 

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddTag2ChannelsJob.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddTag2ChannelsJob.java
@@ -1,7 +1,6 @@
 package org.phoebus.channelfinder.utility;
 
 import java.util.Collection;
-import java.util.function.BiConsumer;
 
 import org.phoebus.channelfinder.ChannelFinderClient;
 import org.phoebus.channelfinder.Tag;
@@ -18,7 +17,7 @@ public class AddTag2ChannelsJob extends JobRunnableWithCancel {
     private final ChannelFinderClient client;
     private final Tag tag;
     private final Collection<String> channelNames;
-    private final BiConsumer<String, Exception> errorHandler;
+    private final Runnable onSuccess;
 
     /**
      * submit a job to add a tag to a channel or a group of channels
@@ -26,23 +25,23 @@ public class AddTag2ChannelsJob extends JobRunnableWithCancel {
      * @param client - channelfinder client, which this job be submitted to
      * @param channelNames - collection of channels to which the tag is to be added
      * @param tag - the tag to be added
-     * @param errorHandler - error handler
+     * @param onSuccess - called on success
      * @return Job
      */
     public static Job submit(ChannelFinderClient client,
                                 final Collection<String> channelNames,
                                 final Tag tag,
-                                final BiConsumer<String, Exception> errorHandler)
+                                final Runnable onSuccess)
     {
         return JobManager.schedule("Adding tag : " + tag.getName() + " to " + channelNames.size() + " channels",
-                new AddTag2ChannelsJob(client, channelNames, tag, errorHandler));
+                new AddTag2ChannelsJob(client, channelNames, tag, onSuccess));
     }
 
-    private AddTag2ChannelsJob(ChannelFinderClient client, Collection<String> channels, Tag tag, BiConsumer<String, Exception> errorHandler)
+    private AddTag2ChannelsJob(ChannelFinderClient client, Collection<String> channels, Tag tag, Runnable onSuccess)
     {
         super();
         this.client = client;
-        this.errorHandler = errorHandler;
+        this.onSuccess = onSuccess;
         this.channelNames = channels;
         this.tag = tag;
     }
@@ -66,13 +65,9 @@ public class AddTag2ChannelsJob extends JobRunnableWithCancel {
                 ChannelErrorHandler.displayError(
                     "Failed to add property '" + tag.getName() + "'",
                     thrown);
+                return;
             }
+            onSuccess.run();
         };
-    }
-
-    @Override
-    public BiConsumer<String, Exception> getErrorHandler()
-    {
-        return errorHandler;
     }
 }

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddTag2ChannelsJob.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/AddTag2ChannelsJob.java
@@ -63,7 +63,7 @@ public class AddTag2ChannelsJob extends JobRunnableWithCancel {
             catch (Throwable thrown)
             {
                 ChannelErrorHandler.displayError(
-                    "Failed to add property '" + tag.getName() + "'",
+                    "Failed to add tag '" + tag.getName() + "'",
                     thrown);
                 return;
             }

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/ChannelErrorHandler.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/ChannelErrorHandler.java
@@ -1,0 +1,40 @@
+package org.phoebus.channelfinder.utility;
+
+import org.phoebus.channelfinder.ChannelFinderException;
+import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
+
+/** Helper for handling channel finder errors */
+public class ChannelErrorHandler
+{
+    /** Given a nested exception, locate channel finder error
+     *
+     *  <p>Channel finder API wraps ChannelFinderException
+     *  in RuntimeException. Recover the underlying error,
+     *  or provide plain Exception that can be caught.
+     *
+     *  @param ex (Runtime)Exception thrown by API
+     *  @return ChannelFinderException or a plain Exception
+     */
+    public static Exception findChannelFinderError(Throwable ex)
+    {
+        while (ex != null)
+        {
+            if (ex instanceof ChannelFinderException)
+                return (ChannelFinderException) ex;
+            ex = ex.getCause();
+        }
+        return new Exception(ex);
+    }
+
+    /** Display error dialog
+     *  @param info Description of failed operation
+     *  @param thrown Error thrown by API
+     */
+    public static void displayError(String info, Throwable thrown)
+    {
+        final Exception ex = findChannelFinderError(thrown);
+        if (ex instanceof ChannelFinderException)
+            info += "\nWeb service status: " + ((ChannelFinderException)ex).getStatus();
+        ExceptionDetailsErrorDialog.openError("Channel Finder Error", info, ex);
+    }
+}

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/ChannelErrorHandler.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/ChannelErrorHandler.java
@@ -2,6 +2,9 @@ package org.phoebus.channelfinder.utility;
 
 import org.phoebus.channelfinder.ChannelFinderException;
 import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
+import org.phoebus.ui.docking.DockStage;
+
+import javafx.scene.Node;
 
 /** Helper for handling channel finder errors */
 public class ChannelErrorHandler
@@ -35,6 +38,11 @@ public class ChannelErrorHandler
         final Exception ex = findChannelFinderError(thrown);
         if (ex instanceof ChannelFinderException)
             info += "\nWeb service status: " + ((ChannelFinderException)ex).getStatus();
-        ExceptionDetailsErrorDialog.openError("Channel Finder Error", info, ex);
+
+        // Can't easily position the dialog on top of the channel table, channel tree etc.
+        // because the JFX node was not passed into the *ChannelsJob.
+        // Next best approach is to position it on top of the main window.
+        final Node parent = DockStage.getDockStages().get(0).getScene().getRoot();
+        ExceptionDetailsErrorDialog.openError(parent, "Channel Finder Error", info, ex);
     }
 }

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/RemovePropertyChannelsJob.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/RemovePropertyChannelsJob.java
@@ -3,14 +3,14 @@
  */
 package org.phoebus.channelfinder.utility;
 
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
 import org.phoebus.channelfinder.ChannelFinderClient;
 import org.phoebus.channelfinder.Property;
 import org.phoebus.framework.jobs.Job;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.jobs.JobRunnableWithCancel;
-
-import java.util.Collection;
-import java.util.function.BiConsumer;
 
 
 /**
@@ -24,7 +24,6 @@ public class RemovePropertyChannelsJob extends JobRunnableWithCancel {
     private final Property property;
     private final Collection<String> channelNames;
     private final BiConsumer<String, Exception> errorHandler;
-    
 
     /**
      * submit a job to remove a Property from a channel or a group of channels
@@ -59,14 +58,23 @@ public class RemovePropertyChannelsJob extends JobRunnableWithCancel {
     @Override
     public String getName()
     {
-        return "Removing property : " + property.getName() + " to " + channelNames.size() + " channels";
+        return "Removing property : " + property.getName() + " from " + channelNames.size() + " channels";
     }
 
     @Override
     public Runnable getRunnable()
     {
         return () -> {
-            client.delete(Property.Builder.property(property), channelNames);
+            try
+            {
+                client.delete(Property.Builder.property(property), channelNames);
+            }
+            catch (Throwable thrown)
+            {
+                ChannelErrorHandler.displayError(
+                    "Failed to remove property '" + property.getName() + "'",
+                    thrown);
+            }
         };
     }
 

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/RemovePropertyChannelsJob.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/RemovePropertyChannelsJob.java
@@ -4,7 +4,6 @@
 package org.phoebus.channelfinder.utility;
 
 import java.util.Collection;
-import java.util.function.BiConsumer;
 
 import org.phoebus.channelfinder.ChannelFinderClient;
 import org.phoebus.channelfinder.Property;
@@ -23,7 +22,7 @@ public class RemovePropertyChannelsJob extends JobRunnableWithCancel {
     private final ChannelFinderClient client;
     private final Property property;
     private final Collection<String> channelNames;
-    private final BiConsumer<String, Exception> errorHandler;
+    private final Runnable onSuccess;
 
     /**
      * submit a job to remove a Property from a channel or a group of channels
@@ -31,26 +30,26 @@ public class RemovePropertyChannelsJob extends JobRunnableWithCancel {
      * @param client - channelfinder client, which this job be submitted to
      * @param channelNames - collection of channels to which the property is to be removed
      * @param property - the property to be removed
-     * @param errorHandler - error handler
+     * @param onSuccess - called on success
      * @return Job
      */
      public static Job submit(ChannelFinderClient client,
                                 final Collection<String> channelNames,
                                 final Property property,
-                                final BiConsumer<String, Exception> errorHandler)
+                                final Runnable onSuccess)
     {
         return JobManager.schedule("Removing property : " + property.getName() + " to " + channelNames.size() + " channels",
-                new RemovePropertyChannelsJob(client, channelNames, property, errorHandler));
+                new RemovePropertyChannelsJob(client, channelNames, property, onSuccess));
     }
 
     private RemovePropertyChannelsJob(ChannelFinderClient client,
                                       Collection<String> channels,
                                       Property property,
-                                      BiConsumer<String, Exception> errorHandler)
+                                      Runnable onSuccess)
     {
         super();
         this.client = client;
-        this.errorHandler = errorHandler;
+        this.onSuccess = onSuccess;
         this.channelNames = channels;
         this.property = property;
     }
@@ -74,13 +73,9 @@ public class RemovePropertyChannelsJob extends JobRunnableWithCancel {
                 ChannelErrorHandler.displayError(
                     "Failed to remove property '" + property.getName() + "'",
                     thrown);
+                return;
             }
+            onSuccess.run();
         };
-    }
-
-    @Override
-    public BiConsumer<String, Exception> getErrorHandler()
-    {
-        return errorHandler;
     }
 }

--- a/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/RemoveTagChannelsJob.java
+++ b/app/channel/utility/src/main/java/org/phoebus/channelfinder/utility/RemoveTagChannelsJob.java
@@ -1,13 +1,13 @@
 package org.phoebus.channelfinder.utility;
 
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
 import org.phoebus.channelfinder.ChannelFinderClient;
 import org.phoebus.channelfinder.Tag;
 import org.phoebus.framework.jobs.Job;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.jobs.JobRunnableWithCancel;
-
-import java.util.Collection;
-import java.util.function.BiConsumer;
 
 /**
  * A job to remove tag from a list of channels
@@ -51,14 +51,23 @@ public class RemoveTagChannelsJob extends JobRunnableWithCancel {
     @Override
     public String getName()
     {
-        return "Removing tag : " + tag.getName() + " to " + channelNames.size() + " channels";
+        return "Removing tag : " + tag.getName() + " from " + channelNames.size() + " channels";
     }
 
     @Override
     public Runnable getRunnable()
     {
         return () -> {
-            client.delete(Tag.Builder.tag(tag), channelNames);
+            try
+            {
+                client.delete(Tag.Builder.tag(tag), channelNames);
+            }
+            catch (Throwable thrown)
+            {
+                ChannelErrorHandler.displayError(
+                    "Failed to remove tag '" + tag.getName() + "'",
+                    thrown);
+            }
         };
     }
 

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
@@ -7,7 +7,6 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
-import javafx.scene.control.Label;
 import org.phoebus.channel.views.ChannelTableApp;
 import org.phoebus.channelfinder.Channel;
 import org.phoebus.channelfinder.ChannelUtil;
@@ -23,7 +22,6 @@ import org.phoebus.framework.preferences.AnnotatedPreferences;
 import org.phoebus.framework.preferences.Preference;
 import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.ui.application.ContextMenuService;
-import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.spi.ContextMenuEntry;
 
@@ -35,6 +33,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.SeparatorMenuItem;
@@ -50,7 +49,7 @@ import javafx.util.Callback;
 
 /**
  * Controller for the file browser app
- * 
+ *
  * @author Kunal Shroff
  *
  */
@@ -127,6 +126,13 @@ public class ChannelTableController extends ChannelFinderController {
         }
     }
 
+    /** Refresh table after editing */
+    private void refresh() {
+        // TODO Ideally, this should 'refresh' by performing the search again
+        //      while keeping the selection and scroll position...
+        search();
+    }
+
     private Job addPropertyJob;
     private Job addTagJob;
     private Job removePropertyJob;
@@ -159,7 +165,7 @@ public class ChannelTableController extends ChannelFinderController {
                 AddProperty2ChannelsJob.submit(getClient(),
                         channelNames,
                         property,
-                        (url, ex) -> ExceptionDetailsErrorDialog.openError("ChannelFinder Query Error", ex.getMessage(), ex));
+                        this::refresh);
 
             });
         });
@@ -182,7 +188,7 @@ public class ChannelTableController extends ChannelFinderController {
                 AddTag2ChannelsJob.submit(getClient(),
                         channelNames,
                         tag,
-                        (url, ex) -> ExceptionDetailsErrorDialog.openError("ChannelFinder Query Error", ex.getMessage(), ex));
+                        this::refresh);
 
             });
         });
@@ -203,7 +209,7 @@ public class ChannelTableController extends ChannelFinderController {
                 RemovePropertyChannelsJob.submit(getClient(),
                         channelNames,
                         property,
-                        (url, ex) -> ExceptionDetailsErrorDialog.openError("ChannelFinder Query Error", ex.getMessage(), ex));
+                        this::refresh);
 
             });
         });
@@ -225,7 +231,7 @@ public class ChannelTableController extends ChannelFinderController {
                 RemoveTagChannelsJob.submit(getClient(),
                         channelNames,
                         tag,
-                        (url, ex) -> ExceptionDetailsErrorDialog.openError("ChannelFinder Query Error", ex.getMessage(), ex));
+                        this::refresh);
 
             });
         });
@@ -243,7 +249,7 @@ public class ChannelTableController extends ChannelFinderController {
                     List<Object> pvs = SelectionService.getInstance().getSelection().getSelections().stream().map(s -> {
                         return AdapterService.adapt(s, entry.getSupportedType()).get();
                     }).collect(Collectors.toList());
-                    // set the selection 
+                    // set the selection
                     SelectionService.getInstance().setSelection(tableView, pvs);
                     entry.call(SelectionService.getInstance().getSelection());
                     // reset the selection

--- a/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
+++ b/app/channel/views/src/main/java/org/phoebus/channel/views/ui/ChannelTableController.java
@@ -25,6 +25,7 @@ import org.phoebus.ui.application.ContextMenuService;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.spi.ContextMenuEntry;
 
+import javafx.application.Platform;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
@@ -126,11 +127,24 @@ public class ChannelTableController extends ChannelFinderController {
         }
     }
 
+    /** Row to select in the table after a 'refresh' completes fetching updated data */
+    private int selected_row_after_refresh = -1;
+
     /** Refresh table after editing */
     private void refresh() {
-        // TODO Ideally, this should 'refresh' by performing the search again
-        //      while keeping the selection and scroll position...
-        search();
+        // Called at the end of a background job which added/removed tags or properties
+        Platform.runLater(() ->
+        {
+            // On UI thread, save the selected row index
+            selected_row_after_refresh = tableView.getSelectionModel().getSelectedIndex();
+            // There might be a more efficient way to search for just the selected channel,
+            // updating only the affected row.
+            // A complete re-search, however, tends to be quick and most important
+            // we do re-select the same row.
+            // Search will be performed on background thread ...
+            search();
+            // .. and on success invoke setChannels(), which then restores the selected row
+        });
     }
 
     private Job addPropertyJob;
@@ -311,6 +325,14 @@ public class ChannelTableController extends ChannelFinderController {
             count.setText(String.valueOf(channels.size() + "+"));
         } else {
             count.setText(String.valueOf(channels.size()));
+        }
+
+        // If this is the result of a 'refresh', restore row selection
+        if (selected_row_after_refresh >= 0)
+        {
+            tableView.getSelectionModel().clearAndSelect(selected_row_after_refresh);
+            tableView.scrollTo(selected_row_after_refresh);
+            selected_row_after_refresh = -1;
         }
     }
 


### PR DESCRIPTION
Fixes #2225

If adding/removing a property or tag fails, for example because of wrong password, there's now an error dialog:

![Screen Shot 2022-05-09 at 8 03 16 PM](https://user-images.githubusercontent.com/1932421/167517418-044596c6-52d4-463c-b745-c178bec2ac9a.png)

If the operation succeeds, the table is refreshed.