### PR TITLE
PVA name server hooks

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/PVAClientMain.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClientMain.java
@@ -209,6 +209,9 @@ public class PVAClientMain
         }
     }
 
+    /** @param args Command line args
+     *  @throws Exception on error
+     */
     public static void main(final String[] args) throws Exception
     {
         LogManager.getLogManager().readConfiguration(PVASettings.class.getResourceAsStream("/pva_logging.properties"));

--- a/core/pva/src/main/java/org/epics/pva/client/ServerInfo.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ServerInfo.java
@@ -32,16 +32,19 @@ public class ServerInfo
         this.guid = guid;
     }
 
+    /** @return Guid */
     public Guid getGuid()
     {
         return guid;
     }
 
+    /** @return Version */
     public int getVersion()
     {
         return version;
     }
 
+    /** @return TCP addresses of this server */
     public Collection<InetSocketAddress> getAddresses()
     {
         return addresses;

--- a/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
+++ b/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
@@ -40,8 +40,11 @@ public class PVAHeader
 
     /** Segmented message? Else: Single */
     public static final byte FLAG_SEGMENT_MASK  = 3 << 4;
+    /** Segment hint */
     public static final byte FLAG_FIRST      = 1 << 4;
+    /** Segment hint */
     public static final byte FLAG_LAST       = 2 << 4;
+    /** Segment hint */
     public static final byte FLAG_MIDDLE     = 3 << 4;
 
     /** Server message? Else: Client */

--- a/core/pva/src/main/java/org/epics/pva/common/SearchRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SearchRequest.java
@@ -23,11 +23,17 @@ import org.epics.pva.data.PVAString;
 @SuppressWarnings("nls")
 public class SearchRequest
 {
+    /** Sequence number */
     public int seq;
+    /** Is it a unicast? */
     public boolean unicast;
+    /** Is reply required? */
     public boolean reply_required;
+    /** Address of client */
     public InetSocketAddress client;
+    /** Names requested in search */
     public String[] name;
+    /** Client IDs for names */
     public int[] cid;
 
     /** Check search request
@@ -124,6 +130,13 @@ public class SearchRequest
         return search;
     }
 
+    /** @param unicast Unicast?
+     *  @param seq Sequence number
+     *  @param cid Client ID
+     *  @param name PV name
+     *  @param address client's address
+     *  @param buffer Buffer into which to encode
+     */
     public static void encode(final boolean unicast, final int seq, final int cid, final String name, final InetSocketAddress address, final ByteBuffer buffer)
     {
         // Create with zero payload size, to be patched later

--- a/core/pva/src/main/java/org/epics/pva/common/UDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/common/UDPHandler.java
@@ -23,6 +23,7 @@ import org.epics.pva.data.Hexdump;
 @SuppressWarnings("nls")
 abstract public class UDPHandler
 {
+    /** Keep running? */
     protected volatile boolean running = true;
 
     /** Read, decode, handle messages
@@ -104,9 +105,19 @@ abstract public class UDPHandler
         }
     }
 
+    /** Handle a message
+     *
+     *  @param from Source of message
+     *  @param version Version
+     *  @param command Command/request
+     *  @param payload Payload
+     *  @param buffer Byte buffer
+     *  @return Handled?
+     */
     abstract protected boolean handleMessage(final InetSocketAddress from, final byte version,
                                              final byte command, final int payload, final ByteBuffer buffer);
 
+    /** Close */
     public void close()
     {
         running = false;

--- a/core/pva/src/main/java/org/epics/pva/data/Convert.java
+++ b/core/pva/src/main/java/org/epics/pva/data/Convert.java
@@ -12,6 +12,9 @@ package org.epics.pva.data;
  */
 public class Convert
 {
+    /** @param array Original array
+     *  @return Converted array
+     */
     public static float[] toFloat(final double[] array)
     {
         final float[] cvt = new float[array.length];
@@ -20,6 +23,9 @@ public class Convert
         return cvt;
     }
 
+    /** @param array Original array
+     *  @return Converted array
+     */
     public static long[] toLong(final double[] array)
     {
         final long[] cvt = new long[array.length];
@@ -28,6 +34,9 @@ public class Convert
         return cvt;
     }
 
+    /** @param array Original array
+     *  @return Converted array
+     */
     public static int[] toInt(final double[] array)
     {
         final int[] cvt = new int[array.length];
@@ -36,6 +45,9 @@ public class Convert
         return cvt;
     }
 
+    /** @param array Original array
+     *  @return Converted array
+     */
     public static short[] toShort(final double[] array)
     {
         final short[] cvt = new short[array.length];
@@ -44,6 +56,9 @@ public class Convert
         return cvt;
     }
 
+    /** @param array Original array
+     *  @return Converted array
+     */
     public static byte[] toByte(final double[] array)
     {
         final byte[] cvt = new byte[array.length];

--- a/core/pva/src/main/java/org/epics/pva/data/Hexdump.java
+++ b/core/pva/src/main/java/org/epics/pva/data/Hexdump.java
@@ -27,6 +27,9 @@ public class Hexdump
 {
     private static final int ELEMENTS_PER_LINE = 16;
 
+    /** @param buffer Bytes
+     *  @return Hex representation
+     */
     public static String toHex(final ByteBuffer buffer)
     {
         final StringBuilder out = new StringBuilder();
@@ -34,6 +37,9 @@ public class Hexdump
         return out.toString();
     }
 
+    /** @param buffer Bytes
+     *  @param out Where hex representation is added
+     */
     public static void hex(final ByteBuffer buffer, final StringBuilder out)
     {
         final int start = buffer.position();
@@ -59,11 +65,17 @@ public class Hexdump
         buffer.rewind();
     }
 
+    /** @param bytes Bytes
+     *  @return Hex representation
+     */
     public static String toAscii(final byte... bytes)
     {
         return toAscii(ByteBuffer.wrap(bytes)); // byte order does not matter, only byte-wise access
     }
 
+    /** @param buffer Bytes
+     *  @return Hex representation
+     */
     public static String toAscii(final ByteBuffer buffer)
     {
         final StringBuilder out = new StringBuilder();
@@ -71,6 +83,9 @@ public class Hexdump
         return out.toString();
     }
 
+    /** @param buffer Bytes
+     *  @param out Where hex representation is added
+     */
     public static void ascii(final ByteBuffer buffer, final StringBuilder out)
     {
         final int start = buffer.position();
@@ -95,11 +110,17 @@ public class Hexdump
         buffer.rewind();
     }
 
+    /** @param bytes Bytes
+     *  @return Hex representation
+     */
     public static String toHexdump(final byte... bytes)
     {
         return toHexdump(ByteBuffer.wrap(bytes)); // byte order does not matter, only byte-wise access
     }
 
+    /** @param buffer Bytes
+     *  @return Hex representation
+     */
     public static String toHexdump(final ByteBuffer buffer)
     {
         final StringBuilder out = new StringBuilder();
@@ -107,6 +128,9 @@ public class Hexdump
         return out.toString();
     }
 
+    /** @param buffer Bytes
+     *  @param out Where hex representation is added
+     */
     public static void hexdump(final ByteBuffer buffer, final StringBuilder out)
     {
         final int start = buffer.position();
@@ -165,6 +189,9 @@ public class Hexdump
         return buf.toString();
     }
 
+    /** @param buffer Bytes
+     *  @return Hex representation is added
+     */
     public static String toCompactHexdump(final ByteBuffer buffer)
     {
         String string = toHexdump(buffer);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAAddress.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAAddress.java
@@ -21,6 +21,9 @@ import java.nio.ByteBuffer;
 @SuppressWarnings("nls")
 public class PVAAddress
 {
+    /** @param address Address to encode
+     *  @param buffer Target buffer
+     */
     public static void encode(final InetAddress address, final ByteBuffer buffer)
     {
         final int start = buffer.position();
@@ -44,6 +47,10 @@ public class PVAAddress
             throw new RuntimeException("Network address serialized as " + len + " bytes: " + address);
     }
 
+    /** @param buffer Source buffer
+     *  @return Decoded address
+     *  @throws Exception on error
+     */
     public static InetAddress decode(final ByteBuffer buffer) throws Exception
     {
         // 128-bit IPv6 address

--- a/core/pva/src/main/java/org/epics/pva/data/PVABitSet.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVABitSet.java
@@ -15,6 +15,9 @@ import java.util.BitSet;
  */
 public class PVABitSet
 {
+    /** @param bits BitSet
+     *  @param buffer Target buffer
+     */
     public static void encodeBitSet(final BitSet bits, final ByteBuffer buffer)
     {
         final byte[] bytes = bits.toByteArray();
@@ -22,6 +25,9 @@ public class PVABitSet
         buffer.put(bits.toByteArray());
     }
 
+    /** @param buffer Source buffer
+     *  @return Decoded bits
+     */
     public static BitSet decodeBitSet(final ByteBuffer buffer)
     {
         final int size = PVASize.decodeSize(buffer);

--- a/core/pva/src/main/java/org/epics/pva/data/PVABool.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVABool.java
@@ -16,8 +16,15 @@ import java.util.BitSet;
 @SuppressWarnings("nls")
 public class PVABool extends PVAData
 {
+    /** Type descriptor */
     public static final byte FIELD_DESC_TYPE = (byte)0b00000000;
 
+    /** @param name Name of 'bool' to decode
+     *  @param field_desc  Field description
+     *  @param buffer Source buffer
+     *  @return Decoded PVABool or PVABoolArray
+     *  @throws Exception on error
+     */
     public static PVAData decodeType(final String name, final byte field_desc, final ByteBuffer buffer) throws Exception
     {
         final PVAFieldDesc.Array array = PVAFieldDesc.Array.forFieldDesc(field_desc);
@@ -30,11 +37,15 @@ public class PVABool extends PVAData
 
     private volatile boolean value;
 
+    /** @param name Name */
     public PVABool(final String name)
     {
         this(name, false);
     }
 
+    /** @param name Name
+     *  @param value Initial value
+     */
     public PVABool(final String name, final boolean value)
     {
         super(name);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAByte.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAByte.java
@@ -19,11 +19,18 @@ public class PVAByte extends PVANumber
     private final boolean unsigned;
     private volatile byte value;
 
+    /** @param name Name
+     *  @param unsigned Unsigned?
+     */
     public PVAByte(final String name, final boolean unsigned)
     {
         this(name, unsigned, (byte)0);
     }
 
+    /** @param name Name
+     *  @param unsigned Unsigned?
+     *  @param value Initial value
+     */
     public PVAByte(final String name, final boolean unsigned, final byte value)
     {
         super(name);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAComplex.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAComplex.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 @SuppressWarnings("nls")
 class PVAComplex
 {
+    /** Type descriptor */
     public static final byte FIELD_DESC_TYPE = (byte)0b10000000;
 
     public static final byte BOUNDED_STRING = 0b011;

--- a/core/pva/src/main/java/org/epics/pva/data/PVAData.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAData.java
@@ -21,8 +21,10 @@ import java.util.BitSet;
 @SuppressWarnings("nls")
 public abstract class PVAData
 {
+    /** Name */
     protected final String name;
 
+    /** @param name Name for data item */
     protected PVAData(final String name)
     {
         this.name = name;

--- a/core/pva/src/main/java/org/epics/pva/data/PVADataWithID.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVADataWithID.java
@@ -12,8 +12,10 @@ package org.epics.pva.data;
  */
 abstract class PVADataWithID extends PVAData
 {
+    /** Type ID */
     protected volatile short type_id = 0;
 
+    /** @param name Name */
     protected PVADataWithID(final String name)
     {
         super(name);

--- a/core/pva/src/main/java/org/epics/pva/data/PVADouble.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVADouble.java
@@ -18,11 +18,15 @@ public class PVADouble extends PVANumber
 {
     private volatile double value;
 
+    /** @param name Name for data item */
     public PVADouble(final String name)
     {
         this(name, Double.NaN);
     }
 
+    /** @param name Name for data item
+     *  @param value Initial value
+     */
     public PVADouble(final String name, final double value)
     {
         super(name);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAFieldDesc.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAFieldDesc.java
@@ -12,20 +12,30 @@ package org.epics.pva.data;
  */
 public interface PVAFieldDesc
 {
+    /** Null */
     public static final byte NULL_TYPE_CODE = (byte)0xFF;
+    /** Only ID */
     public static final byte ONLY_ID_TYPE_CODE = (byte)0xFE;
+    /** Full type */
     public static final byte FULL_WITH_ID_TYPE_CODE = (byte)0xFD;
+    /** Full tagged type */
     public static final byte FULL_TAGGED_ID_TYPE_CODE = (byte)0xFC;
 
-    // Largest defined FULL_TYPE_CODE:
-    // 0b10011011 = 0x9B = complex 100, fixed-size array 11, bounded string 011
+    /** Largest defined FULL_TYPE_CODE:
+     *  <pre>0b10011011 = 0x9B = complex 100, fixed-size array 11, bounded string 011</pre>
+     */
     public static final byte FULL_TYPE_CODE_MAX = (byte)0xDF;
 
+    /** Array type encoding */
     public enum Array
     {
+        /** Fixed size array */
         FIXED_SIZE((byte)0b00011000),
+        /** Array with upper size bound */
         BOUNDED_SIZE((byte)0b00010000),
+        /** Variable sized array */
         VARIABLE_SIZE((byte)0b00001000),
+        /** Scalar, no array */
         SCALAR((byte)0b00000000);
 
         final byte mask;
@@ -35,12 +45,18 @@ public interface PVAFieldDesc
             this.mask = mask;
         }
 
+        /** @param field_desc Other array field descriptor
+         *  @return Same array type?
+         */
         public boolean matches(final byte field_desc)
         {
             final byte type = (byte) (field_desc & 0b00011000);
             return type == mask;
         }
 
+        /** @param field_desc Field descriptor
+         *  @return Array
+         */
         public static Array forFieldDesc(final byte field_desc)
         {
             final byte type = (byte) (field_desc & 0b00011000);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAFloat.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAFloat.java
@@ -16,6 +16,7 @@ import java.util.BitSet;
 @SuppressWarnings("nls")
 public class PVAFloat extends PVANumber
 {
+    /** Type descriptor */
     public static final byte FIELD_DESC_TYPE = (byte)0b01000000;
 
     static PVAData decodeType(final String name, final byte field_desc, final ByteBuffer buffer) throws Exception
@@ -43,12 +44,16 @@ public class PVAFloat extends PVANumber
 
     private volatile float value;
 
+    /** @param name Name
+     *  @param value Initial value
+     */
     public PVAFloat(final String name, final float value)
     {
         super(name);
         this.value = value;
     }
 
+    /** @param name Name */
     public PVAFloat(final String name)
     {
         this(name, Float.NaN);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAInt.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAInt.java
@@ -16,6 +16,7 @@ import java.util.BitSet;
 @SuppressWarnings("nls")
 public class PVAInt extends PVANumber
 {
+    /** Type descriptor */
     public static final byte FIELD_DESC_TYPE = (byte)0b00100000;
 
     static PVAData decodeType(final String name, final byte field_desc, final ByteBuffer buffer) throws Exception
@@ -57,21 +58,32 @@ public class PVAInt extends PVANumber
     private final boolean unsigned;
     private volatile int value;
 
+    /** @param name Name */
     public PVAInt(final String name)
     {
         this(name, false, 0);
     }
 
+    /** @param name Name
+     *  @param value Initial value
+     */
     public PVAInt(final String name, final int value)
     {
         this(name, false, value);
     }
 
+    /** @param name Name
+     *  @param unsigned Unsigned?
+     */
     public PVAInt(final String name, final boolean unsigned)
     {
         this(name, unsigned, 0);
     }
 
+    /** @param name Name
+     *  @param unsigned Unsigned?
+     *  @param value Initial value
+     */
     public PVAInt(final String name, final boolean unsigned, final int value)
     {
         super(name);

--- a/core/pva/src/main/java/org/epics/pva/data/PVALong.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVALong.java
@@ -19,16 +19,24 @@ public class PVALong extends PVANumber
     private final boolean unsigned;
     private volatile long value;
 
+    /** @param name Name */
     public PVALong(final String name)
     {
         this(name, false);
     }
 
+    /** @param name Name
+     *  @param unsigned Unsigned?
+     */
     public PVALong(final String name, final boolean unsigned)
     {
         this(name, unsigned, 0);
     }
 
+    /** @param name Name
+     *  @param unsigned Unsigned?
+     *  @param value Initial value
+     */
     public PVALong(final String name, final boolean unsigned, final long value)
     {
         super(name);

--- a/core/pva/src/main/java/org/epics/pva/data/PVANumber.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVANumber.java
@@ -13,6 +13,7 @@ package org.epics.pva.data;
 @SuppressWarnings("nls")
 abstract public class PVANumber extends PVAData
 {
+    /** @param name Name for data item */
     protected PVANumber(final String name)
     {
         super(name);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAShort.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAShort.java
@@ -19,6 +19,10 @@ public class PVAShort extends PVANumber
     private final boolean unsigned;
     private volatile short value;
 
+    /** @param name Name
+     *  @param unsigned Unsigned?
+     *  @param value Initial value
+     */
     public PVAShort(final String name, final boolean unsigned, final short value)
     {
         super(name);
@@ -26,6 +30,9 @@ public class PVAShort extends PVANumber
         this.value = value;
     }
 
+    /** @param name Name
+     *  @param unsigned Unsigned?
+     */
     public PVAShort(final String name, final boolean unsigned)
     {
         this(name, unsigned, (short)0);

--- a/core/pva/src/main/java/org/epics/pva/data/PVASize.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVASize.java
@@ -35,6 +35,9 @@ public class PVASize
             return 1 + 4;
     }
 
+    /** @param size Size to encode
+     *  @param buffer Target buffer
+     */
     public static final void encodeSize(final int size, final ByteBuffer buffer)
     {
         if (size == -1)
@@ -46,6 +49,9 @@ public class PVASize
             buffer.put((byte)-2).putInt(size);
     }
 
+    /** @param buffer Source buffer
+     *  @return Decoded size
+     */
     public static final int decodeSize(final ByteBuffer buffer)
     {
         byte b = buffer.get();

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStatus.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStatus.java
@@ -16,20 +16,33 @@ import java.util.Objects;
 @SuppressWarnings("nls")
 public class PVAStatus
 {
+    /** "OK" status */
     public static final PVAStatus StatusOK = new PVAStatus(Type.OK, "", "");
 
+    /** Type or severity of status message */
     public enum Type
     {
+        /** OK */
         OK,
+        /** Warning */
         WARNING,
+        /** Error */
         ERROR,
+        /** Fatal */
         FATAL;
     }
 
+    /** Type */
     public final Type type;
+    /** Message */
     public final String message;
+    /** Stack trace */
     public final String stacktrace;
 
+    /** @param type Type
+     *  @param message Message
+     *  @param stacktrace Stack trace
+     */
     public PVAStatus(final Type type, final String message, final String stacktrace)
     {
         this.type = type;
@@ -43,6 +56,7 @@ public class PVAStatus
         return type == Type.OK  ||  type == Type.WARNING;
     }
 
+    /** @param buffer Target buffer */
     public void encode(final ByteBuffer buffer)
     {
         // When OK and no message, assume there's also no stacktrace
@@ -56,6 +70,9 @@ public class PVAStatus
         }
     }
 
+    /** @param buffer Source buffer
+     *  @return Decoded status
+     */
     public static PVAStatus decode(final ByteBuffer buffer)
     {
         final byte b = buffer.get();

--- a/core/pva/src/main/java/org/epics/pva/data/PVAString.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAString.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 @SuppressWarnings("nls")
 public class PVAString extends PVAData
 {
+    /** Type descriptor */
     public static final byte FIELD_DESC_TYPE = (byte)0b01100000;
 
     /** @param string Text
@@ -74,11 +75,15 @@ public class PVAString extends PVAData
 
     private volatile String value;
 
+    /** @param name Name for data item */
     public PVAString(final String name)
     {
         this(name, null);
     }
 
+    /** @param name Name for data item
+     *  @param value Initial value
+     */
     public PVAString(final String name, final String value)
     {
         super(name);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStructureArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStructureArray.java
@@ -24,6 +24,12 @@ import java.util.logging.Level;
 @SuppressWarnings("nls")
 public class PVAStructureArray extends PVADataWithID implements PVAArray
 {
+    /** @param types PVATypeRegistry
+     *  @param name Name
+     *  @param buffer Source buffer
+     *  @return Decoded structure array
+     *  @throws Exception on error
+     */
     public static PVAStructureArray decodeType(final PVATypeRegistry types, final String name, final ByteBuffer buffer) throws Exception
     {
         final PVAData element_type = types.decodeType("", buffer);
@@ -43,6 +49,10 @@ public class PVAStructureArray extends PVADataWithID implements PVAArray
      */
     private volatile PVAStructure[] elements;
 
+    /** @param name Name
+     *  @param element_type Type of array elements
+     *  @param elements Initial elements
+     */
     public PVAStructureArray(final String name, final PVAStructure element_type, final PVAStructure... elements)
     {
         super(name);

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStructures.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStructures.java
@@ -15,8 +15,9 @@ import java.time.Instant;
 @SuppressWarnings("nls")
 public class PVAStructures
 {
+    /** Type name for time stamp */
     public static final String TIME_T = "time_t";
-    
+
     /** @param structure Potential "time_t" structure
      *  @return Instant or <code>null</code>
      */
@@ -31,10 +32,11 @@ public class PVAStructures
         }
         return null;
     }
-    
-    
+
+
+    /** Type name for enum */
     public static final String ENUM_T = "enum_t";
-    
+
     /** @param structure Potential "enum_t" structure
      *  @return Selected option or <code>null</code>
      */
@@ -54,8 +56,9 @@ public class PVAStructures
         return null;
     }
 
+    /** Type name for alarm info */
     public static final String ALARM_T = "alarm_t";
-    
+
     /** @param structure Potential "alarm_t" structure
      *  @return Alarm info or <code>null</code>
      */

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
@@ -22,21 +22,27 @@ public class PVATimeStamp extends PVAStructure
     private final PVALong secs;
     private final PVAInt nano;
 
+    /** 'now' */
     public PVATimeStamp()
     {
         this(Instant.now());
     }
 
+    /** @param time Instant */
     public PVATimeStamp(final Instant time)
     {
         this("timeStamp", time);
     }
 
+    /** @param name Name for 'now' */
     public PVATimeStamp(final String name)
     {
         this(name, Instant.now());
     }
 
+    /** @param name Name
+     *  @param time Time
+     */
     public PVATimeStamp(final String name, final Instant time)
     {
         super(name, "time_t",

--- a/core/pva/src/main/java/org/epics/pva/proxy/PVAProxy.java
+++ b/core/pva/src/main/java/org/epics/pva/proxy/PVAProxy.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -249,12 +250,15 @@ public class PVAProxy
     /** @param seq Client's search sequence
      *  @param cid Client channel ID or -1
      *  @param name Channel name or <code>null</code>
-     *  @param addr Client's address and TCP port
+     *  @param client Client's address and TCP port
+     *  @param reply_sender Callback for TCP address of server
      *  @return <code>true</code> if the search request was handled
      */
-    private boolean handleSearchRequest(final int seq, final int cid, final String name, final InetSocketAddress addr)
+    private boolean handleSearchRequest(final int seq, final int cid, final String name,
+                                        final InetSocketAddress client,
+                                        final Consumer<InetSocketAddress> reply_sender)
     {
-        logger.log(Level.INFO, () -> addr + " searches for " + name + " (CID " + cid + ", seq " + seq + ")");
+        logger.log(Level.INFO, () -> client + " searches for " + name + " (CID " + cid + ", seq " + seq + ")");
         if (name.equals(prefix+"QUIT"))
         {
             quit.countDown();

--- a/core/pva/src/main/java/org/epics/pva/proxy/PVAProxy.java
+++ b/core/pva/src/main/java/org/epics/pva/proxy/PVAProxy.java
@@ -76,6 +76,7 @@ import org.epics.pva.server.ServerPV;
 @SuppressWarnings("nls")
 public class PVAProxy
 {
+    /** Logger */
     public static Logger logger = Logger.getLogger(PVAProxy.class.getPackage().getName());
 
     // Developed to test if the PVA server and client API
@@ -242,6 +243,7 @@ public class PVAProxy
     /** Map of PV name to proxy */
     private final ConcurrentHashMap<String, ProxyChannel> proxies = new ConcurrentHashMap<>();
 
+    /** Create proxy */
     public PVAProxy()
     {
         prefix = PVASettings.get("PREFIX", prefix);
@@ -287,7 +289,7 @@ public class PVAProxy
         }
     }
 
-    public void run() throws Exception
+    private void run() throws Exception
     {
         System.out.println("PVA Proxy");
         System.out.println("");
@@ -322,6 +324,9 @@ public class PVAProxy
         }
     }
 
+    /** @param args Command line args
+     *  @throws Exception on error
+     */
     public static void main(String[] args) throws Exception
     {
         LogManager.getLogManager().readConfiguration(PVASettings.class.getResourceAsStream("/pva_logging.properties"));

--- a/core/pva/src/main/java/org/epics/pva/server/Guid.java
+++ b/core/pva/src/main/java/org/epics/pva/server/Guid.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 @SuppressWarnings("nls")
 public class Guid
 {
+    /** Empty Guid */
     public static final Guid EMPTY = new Guid(new byte[]{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
 
     // Random number generator in holder to defer initialization

--- a/core/pva/src/main/java/org/epics/pva/server/PVAServer.java
+++ b/core/pva/src/main/java/org/epics/pva/server/PVAServer.java
@@ -35,6 +35,7 @@ import org.epics.pva.data.PVAStructure;
 @SuppressWarnings("nls")
 public class PVAServer implements AutoCloseable
 {
+    /** Common thread pool */
     public static ForkJoinPool POOL = ForkJoinPool.commonPool();
 
     private final Guid guid = new Guid();

--- a/core/pva/src/main/java/org/epics/pva/server/SearchHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/SearchHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2020-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,6 +8,7 @@
 package org.epics.pva.server;
 
 import java.net.InetSocketAddress;
+import java.util.function.Consumer;
 
 /** Invoked when client sends a generic 'list servers'
  *  as well as a specific PV name search
@@ -15,13 +16,25 @@ import java.net.InetSocketAddress;
 @FunctionalInterface
 public interface SearchHandler
 {
-    /** @param seq Client's search sequence
+    /** Server invokes this for every received name search.
+     *
+     *  <p>Implementation can check the name and either
+     *  ignore the search, or invoke the reply callback
+     *  with the TCP address of the server that provides
+     *  the requested PV.
+     *
+     *  <p>Will also be invoked for "List all PVs" searches
+     *  (name = null), but can only handle searches with
+     *  actual names.
+     *
+     *  @param seq Client's search sequence
      *  @param cid Client channel ID or -1
      *  @param name Channel name or <code>null</code>
-     *  @param addr Client's address and TCP port
+     *  @param client Client's address
+     *  @param reply_sender Callback for TCP address of server
      *  @return <code>true</code> if the search request was handled,
      *          i.e. the name was recognized and the request does not need
      *          to be forwarded or passed to anybody else
      */
-    public boolean handleSearchRequest(int seq, int cid, String name, InetSocketAddress addr);
+    public boolean handleSearchRequest(int seq, int cid, String name, InetSocketAddress client, Consumer<InetSocketAddress> reply_sender);
 }

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -135,13 +135,12 @@ class ServerTCPHandler extends TCPHandler
             super.handleApplicationMessage(command, buffer);
     }
 
-    void submitSearchReply(final Guid guid, final int seq, final int cid)
+    void submitSearchReply(final Guid guid, final int seq, final int cid, final InetSocketAddress server_address)
     {
         final RequestEncoder encoder = (version, buffer) ->
         {
             logger.log(Level.FINER, "Sending TCP search reply");
-            final InetSocketAddress any = new InetSocketAddress(0);
-            SearchResponse.encode(guid, seq, cid, any.getAddress(), any.getPort(), buffer);
+            SearchResponse.encode(guid, seq, cid, server_address.getAddress(), server_address.getPort(), buffer);
         };
         submit(encoder);
     }

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPListener.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,10 +45,7 @@ class ServerTCPListener
     private final ServerSocketChannel server_socket;
 
     /** Server's TCP address on which clients can connect */
-    final InetAddress response_address;
-
-    /** Server's TCP port on which clients can connect */
-    final int response_port;
+    private final InetSocketAddress local_address;
 
     private volatile boolean running = true;
     private volatile Thread listen_thread;
@@ -59,15 +56,19 @@ class ServerTCPListener
 
         server_socket = createSocket();
 
-        final InetSocketAddress local_address = (InetSocketAddress) server_socket.getLocalAddress();
-        response_address = local_address.getAddress();
-        response_port = local_address.getPort();
+        local_address = (InetSocketAddress) server_socket.getLocalAddress();
         logger.log(Level.CONFIG, "Listening on TCP " + local_address);
 
         // Start accepting connections
-        listen_thread = new Thread(this::listen, "TCP-listener " + response_address + ":" + response_port);
+        listen_thread = new Thread(this::listen, "TCP-listener " + local_address.getAddress() + ":" + local_address.getPort());
         listen_thread.setDaemon(true);
         listen_thread.start();
+    }
+
+    /** @return Server's TCP address on which clients can connect */
+    public InetSocketAddress getResponseAddress()
+    {
+        return local_address;
     }
 
     // How to check if the desired TCP server port is already in use?

--- a/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -236,15 +236,15 @@ class ServerUDPHandler extends UDPHandler
      *  @param guid This server's GUID
      *  @param seq Client search request sequence number
      *  @param cid Client's channel ID or -1
-     *  @param tcp TCP connection where client can connect to this server
+     *  @param server TCP address where client can connect to server
      *  @param client Address of client's UDP port
      */
-    public void sendSearchReply(final Guid guid, final int seq, final int cid, final ServerTCPListener tcp, final InetSocketAddress client)
+    public void sendSearchReply(final Guid guid, final int seq, final int cid, final InetSocketAddress server, final InetSocketAddress client)
     {
         synchronized (send_buffer)
         {
             send_buffer.clear();
-            SearchResponse.encode(guid, seq, cid, tcp.response_address, tcp.response_port, send_buffer);
+            SearchResponse.encode(guid, seq, cid, server.getAddress(), server.getPort(), send_buffer);
             send_buffer.flip();
             logger.log(Level.FINER, () -> "Sending UDP search reply to " + client + "\n" + Hexdump.toHexdump(send_buffer));
 

--- a/core/pva/src/test/java/org/epics/pva/server/SearchMonitorDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/server/SearchMonitorDemo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2020-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,12 +7,41 @@
  ******************************************************************************/
 package org.epics.pva.server;
 
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
 import java.util.logging.LogManager;
 
 import org.epics.pva.PVASettings;
 
 /** PVA Server Demo that logs all received search requests
+ *
+ *  Can also demo a basic name server:
+ *
+ *  1) Start ioc as
+ *     EPICS_PVA_SERVER_PORT=5078 EPICS_PVA_BROADCAST_PORT=5079  ./softIocPVA -m N='' -d src/test/resources/demo.db
+ *
+ *  2) Check that basic 'get' does not reach it
+ *     pvxget ramp
+ *
+ *  3) Start this name server with command line args
+ *     ramp 127.0.0.1:5078 saw 127.0.0.1:5078
+ *
+ *  4) Check that basic 'get' now reaches name server via UDP and then gets redirected to IOC
+ *     pvxget ramp
+ *
+ *  5) Check 'get' also reaches name server via TCP and then gets redirected to IOC
+ *     EPICS_PVA_BROADCAST_PORT=9876 EPICS_PVA_NAME_SERVERS="127.0.0.1:5076" ./pvxget ramp
+ *
+ *  Typical Server with PVs:
+ *  UDP search -> UDP reply with this server's TCP address
+ *  TCP search -> TCP reply with "0.0.0.0:0" to indicate "Use this TCP connection"
+ *
+ *  Name Server
+ *  UDP search -> UDP reply with TCP address of the PV's host
+ *  TCP search -> TCP reply with TCP address of the PV's host
  *
  *  @author Kay Kasemir
  */
@@ -25,28 +54,64 @@ public class SearchMonitorDemo
         System.setProperty("EPICS_PVA_SERVER_PORT", "5076");
 
         LogManager.getLogManager().readConfiguration(PVASettings.class.getResourceAsStream("/pva_logging.properties"));
+        PVASettings.logger.setLevel(Level.ALL);
 
+        // Configure the "name server" from list of name, addr, name, addr, ...
+        final Map<String, InetSocketAddress> pvs = new HashMap<>();
+        if (args.length % 2 != 0  ||
+            (args.length > 0  &&  args[0].startsWith("-h")))
+        {
+            System.out.println("USAGE: SearchMonitorDemo name addr name addr name addr ...");
+            System.out.println();
+            System.out.println("  name: PV Name");
+            System.out.println("  addr: Servers TCP address in form '127.0.0.1:port'");
+            return;
+        }
+        for (int i=0; i<args.length; i += 2)
+        {
+            final String pv = args[i];
+            final int sep = args[i+1].indexOf(':');
+            if (sep < 0)
+            {
+                System.out.println("Cannot parse 'IP:port' from '" + args[i+1] + "'");
+                return;
+            }
+            final InetSocketAddress addr = new InetSocketAddress(args[i+1].substring(0, sep),
+                                                                 Integer.parseInt(args[i+1].substring(sep+1)));
+            System.out.println(pv + " is served by " + addr);
+            pvs.put(pv, addr);
+        }
+
+
+        // Start PVA server with custom search handler
         final CountDownLatch done = new CountDownLatch(1);
-
-        final SearchHandler search_handler = (seq, cid, name, addr) ->
+        final SearchHandler search_handler = (seq, cid, name, addr, reply_sender) ->
         {
             System.out.println(addr + " searches for " + name + " (seq " + seq + ")");
+            // Quit when receiving search for name "QUIT"
             if (name.equals("QUIT"))
                 done.countDown();
-            // Proceed with default search handler
-            return false;
+
+            // Check "name server"
+            final InetSocketAddress server_addr = pvs.get(name);
+            if (server_addr != null)
+            {
+                System.out.println(" --> Sending client to " + server_addr);
+                reply_sender.accept(server_addr);
+            }
+
+            // Done, don't proceed with default search handler
+            return true;
         };
 
-        System.out.println("Run 'pvget' with");
-        System.out.println("EPICS_PVA_BROADCAST_PORT=" + PVASettings.EPICS_PVAS_BROADCAST_PORT);
-        System.out.println("Run 'pvget QUIT' to stop");
-
         try
-        (
-            // Create PVA Server (auto-closed)
-            final PVAServer server = new PVAServer(search_handler);
-        )
+        (   final PVAServer server = new PVAServer(search_handler)  )
         {
+            System.out.println("For UDP search, run 'pvget' or 'pvxget' with");
+            System.out.println("EPICS_PVA_BROADCAST_PORT=" + PVASettings.EPICS_PVAS_BROADCAST_PORT);
+            System.out.println("For TCP search, set EPICS_PVA_NAME_SERVERS = " + server.getTCPAddress());
+            System.out.println("or other IP address of this host and same port.");
+            System.out.println("Run 'pvget QUIT' to stop");
             done.await();
         }
 

--- a/core/pva/src/test/java/org/epics/pva/server/SearchMonitorDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/server/SearchMonitorDemo.java
@@ -20,28 +20,35 @@ import org.epics.pva.PVASettings;
  *
  *  Can also demo a basic name server:
  *
+ *  <pre>
  *  1) Start ioc as
  *     EPICS_PVA_SERVER_PORT=5078 EPICS_PVA_BROADCAST_PORT=5079  ./softIocPVA -m N='' -d src/test/resources/demo.db
  *
  *  2) Check that basic 'get' does not reach it
  *     pvxget ramp
  *
- *  3) Start this name server with command line args
- *     ramp 127.0.0.1:5078 saw 127.0.0.1:5078
+ *  3) Start this name server with command line args, either from IDE or like this:
+ *     ant clean testlib
+ *     java -cp target/core-pva-test.jar org.epics.pva.server.SearchMonitorDemo ramp 127.0.0.1:5078 saw 127.0.0.1:5078
  *
  *  4) Check that basic 'get' now reaches name server via UDP and then gets redirected to IOC
  *     pvxget ramp
  *
  *  5) Check 'get' also reaches name server via TCP and then gets redirected to IOC
  *     EPICS_PVA_BROADCAST_PORT=9876 EPICS_PVA_NAME_SERVERS="127.0.0.1:5076" ./pvxget ramp
+ *  </pre>
  *
  *  Typical Server with PVs:
+ *  <pre>
  *  UDP search -> UDP reply with this server's TCP address
  *  TCP search -> TCP reply with "0.0.0.0:0" to indicate "Use this TCP connection"
+ *  </pre>
  *
  *  Name Server
+ *  <pre>
  *  UDP search -> UDP reply with TCP address of the PV's host
  *  TCP search -> TCP reply with TCP address of the PV's host
+ *  </pre>
  *
  *  @author Kay Kasemir
  */


### PR DESCRIPTION
Prepare PVA server to allow use as name server:

 1) Start ioc as
```
EPICS_PVA_SERVER_PORT=5078 EPICS_PVA_BROADCAST_PORT=5079  ./softIocPVA -m N='' -d src/test/resources/demo.db
```

2) Check that basic 'get' does not reach it
```
pvxget ramp
```

3) Start this name server with command line args, either from IDE or like this:
```
ant clean testlib
java -cp target/core-pva-test.jar org.epics.pva.server.SearchMonitorDemo ramp 127.0.0.1:5078 saw 127.0.0.1:5078
```

4) Check that basic 'get' now reaches name server via UDP and then gets redirected to IOC
```
pvxget ramp
```

5) Check 'get' also reaches name server via TCP and then gets redirected to IOC
```
EPICS_PVA_BROADCAST_PORT=9876 EPICS_PVA_NAME_SERVERS="127.0.0.1:5076" ./pvxget ramp
```


While at it, fixed javadoc warnings in core-pva