### PR TITLE
Support classpath resource for log attribute mapping

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogPropertiesController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogPropertiesController.java
@@ -59,6 +59,10 @@ public class LogPropertiesController {
             final URL resource = getClass().getResource("log_property_attributes.properties");
             url = resource.toExternalForm();
         }
+        else if(url.startsWith("classpath:")){
+            final URL resource = getClass().getResource(url.substring("classpath:".length()));
+            url = resource.toExternalForm();
+        }
         try (InputStream input = new URL(url).openStream() ) {
             Properties prop = new Properties();
             prop.load(input);

--- a/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
+++ b/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
@@ -43,6 +43,8 @@ log_entry_calendar_display_name=
 # Log Entry property attribute types.
 # The preference should be a URL pointing to an attribute_type.properties file.
 # e.g. log_attribute_desc=file:///C:/phoebus/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/log_property_attributes.properties
+# Classpath resource is supported if specified like log_attribute_desc=classpath:my_attr.properties. In this
+# example the my_attr.properties file must be bundled as a classpath resource in the package org.phoebus.logbook.olog.ui.
 # This optional file describing special types associated with some property attributes.
 # 
 log_attribute_desc=


### PR DESCRIPTION
Specifying the org.phoebus.logbook.olog.ui/log_attribute_desc file using a file path is not the optimal option when building an installer using jpackage. I'd like to avoid having users of installation packages (Mac and Windows) configure this preference setting based on a file that they would need to create.

Consequently I added a possibility to add this as a classpath resource provided by a site specific customization jar. 