### PR TITLE
Alarm server Kafka error handling

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
@@ -127,8 +127,11 @@ public class AlarmSystem
     /** Heartbeat PV period in milliseconds */
     public static final long heartbeat_ms;
 
-    /** Nag period in seconds */
+    /** Nag period in milliseconds */
     public static final long nag_period_ms;
+
+    /** Connection validation period in seconds */
+    @Preference public static long connection_check_secs;
 
     /** Disable notify feature */
     @Preference public static boolean disable_notify_visible;

--- a/app/alarm/model/src/main/resources/alarm_preferences.properties
+++ b/app/alarm/model/src/main/resources/alarm_preferences.properties
@@ -92,6 +92,14 @@ heartbeat_secs=10
 # Set to 0 to disable  
 nag_period=00:15:00
 
+# Connection validation period in seconds
+#
+# Server will check the Kafka connection at this period.
+# After re-establishing the connection, it will
+# re-send the state of every alarm tree item.
+# Set to 0 to disable.
+connection_check_secs=5
+
 # To turn on disable notifications feature, set the value to true
 disable_notify_visible=false
 

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -20,7 +20,6 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.prefs.Preferences;
 
-
 import org.phoebus.applications.alarm.AlarmSystem;
 import org.phoebus.applications.alarm.client.ClientState;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
@@ -66,6 +65,7 @@ public class AlarmServerMain implements ServerModelListener
                         "\tmode             - Show mode.\n" +
                         "\tmode normal      - Select normal mode.\n" +
                         "\tmode maintenance - Select maintenance mode.\n" +
+                        "\tresend           - Re-send all PV states to clients (for tests after network issues).\n" +
                         "\trestart          - Re-load alarm configuration and restart.\n" +
                         "\tshutdown         - Shut alarm server down and exit.\n";
 
@@ -141,6 +141,8 @@ public class AlarmServerMain implements ServerModelListener
                 restart.offer(false);
             else if (args[0].equals("restart"))
                 restart.offer(true);
+            else if (args[0].equals("resend"))
+                model.resend(model.getRoot());
             else if (args[0].equals("mode"))
                 System.out.println(AlarmLogic.getMaintenanceMode() ? "Maintenance mode" : "Normal mode");
             else if (args[0].startsWith("h"))

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
@@ -201,7 +201,18 @@ class ServerModel
     /** Perform one check for updates */
     private void checkUpdates()
     {
-        final ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
+        final ConsumerRecords<String, String> records;
+        try
+        {
+            records = consumer.poll(Duration.ofMillis(100));
+        }
+        catch (Throwable ex)
+        {
+            // This typically doesn't happen, 'poll' will simply not return any new
+            // records while disconnected from Kafka...
+            logger.log(Level.WARNING, "Error reading updates from Kafka", ex);
+            return;
+        }
         for (ConsumerRecord<String, String> record : records)
         {
             final int sep = record.key().indexOf(':');


### PR DESCRIPTION
When the alarm server gets disconnected from Kafka, it cannot send alarm state updates.
One possible scenario:
Alarm server gets disconnected from Kafka (and clients as well).
Alarm server still has PV connections, one goes into alarm and then maybe out again. Alarm server latches alarm, but state update to Kafka is not possible (and clients wouldn't see it anyway right now because they are also disconnected).
Once Kafka returns online, it is unaware of the alarms. Newly started clients receive an outdated alarm state. Alarm server still tracks those alarms as active and will even emit the "There are N active alarms" messages every 15 minutes, clients annunciate it but show a different number of active alarms in the UI.

This update offers two additions:

A "resend" command in the alarm server can be invoked at any time to trigger a complete re-send of the state for each item in the alarm tree. It can be used to debug server/client inconsistencies.

More important, the alarm server monitors the Kafka connection. If it's lost, there's nothing it can do about that. But once it's restored, it performs a "resend" so Kafka and clients get updated to the most recent alarm server state, removing inconsistencies because of the dropped messages.
The Kafka client library offers no direct API to check the connection state, so a periodic "listTopics" call is used as suggested in https://stackoverflow.com/questions/38103198/how-to-check-kafka-consumer-state and other places. It can be configured and disabled via a new preference setting.