### PR TITLE
PVA: Check/clarify handling of byte order

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
+++ b/core/pva/src/main/java/org/epics/pva/common/PVAHeader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -124,7 +124,7 @@ public class PVAHeader
     public static final byte CMD_SUB_GET = 0x40;
 
 
-    /** Control message command to set byte order */
+    /** Control message command to set byte order, aka 'SetEndian' */
     public static final byte CTRL_SET_BYTE_ORDER = 2;
 
     /** Size of common PVA message header */
@@ -145,6 +145,7 @@ public class PVAHeader
      */
     public static void encodeMessageHeader(final ByteBuffer buffer, byte flags, final byte command, final int payload_size)
     {
+        // Indicate byte order within message header
         if (buffer.order() == ByteOrder.BIG_ENDIAN)
             flags |= FLAG_BIG_ENDIAN;
         else
@@ -168,6 +169,8 @@ public class PVAHeader
         if (buffer.position() < PVAHeader.HEADER_SIZE)
             return PVAHeader.HEADER_SIZE;
 
+        // Byte order of message is irrelevant for
+        // parsing the initial set of bytes
         final byte magic = buffer.get(0);
         if (magic != PVAHeader.PVA_MAGIC)
             throw new Exception(String.format("Message lacks magic 0x%02X, got 0x%02X", PVAHeader.PVA_MAGIC, magic));
@@ -184,6 +187,9 @@ public class PVAHeader
         if (is_server != expect_server)
                 throw new Exception(expect_server ? "Expected server message" : "Expected client message");
 
+        // With each received message, check the byte order
+        // and adjust buffer to read further content which usually
+        // contains data larger than byte-sized, so the order matters
         if ((flags & PVAHeader.FLAG_BIG_ENDIAN) == 0)
             buffer.order(ByteOrder.LITTLE_ENDIAN);
         else

--- a/core/pva/src/main/java/org/epics/pva/common/UDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/common/UDPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -75,6 +75,9 @@ abstract public class UDPHandler
 
             final byte version = buffer.get();
 
+            // After initial byte-sized header entries,
+            // adjust buffer byte order as indicated in message header
+            // to allow decoding of following data (size, payload)
             final byte flags = buffer.get();
             if ((flags & PVAHeader.FLAG_BIG_ENDIAN) != 0)
                 buffer.order(ByteOrder.BIG_ENDIAN);

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
@@ -64,9 +64,15 @@ class ServerTCPHandler extends TCPHandler
         submit((version, buffer) ->
         {
             logger.log(Level.FINE, () -> "Set byte order " + buffer.order());
+            // Payload size is used as byte order hint
+            // 0xFFFFFFFF: Client needs to check each message for byte order
+            // 0x00000000: Server sends each message in the same byte order,
+            //             but there's still a valid byte order flag,
+            //             so client is free to keep checking each message
+            final int size_used_as_hint = 0x00000000;
             PVAHeader.encodeMessageHeader(buffer,
                     (byte) (PVAHeader.FLAG_CONTROL | PVAHeader.FLAG_SERVER),
-                    PVAHeader.CTRL_SET_BYTE_ORDER, 0);
+                    PVAHeader.CTRL_SET_BYTE_ORDER, size_used_as_hint);
         });
         // .. and requesting connection validation
         submit((version, buffer) ->


### PR DESCRIPTION
PVXS update https://github.com/mdavidsaver/pvxs/pull/27 noted that the CTRL_SET_BYTE_ORDER hint is ignored by
existing implementations, always checking each received message for the byte order flag in the header.

Confirming/clarifying this in the java implementation, adding some FINE-level log messages.
Server now uses native byte order instead of the 'big endian' default.