### PR TITLE
Alarm examples: Replace deprecated --zookeeper option ...

### DIFF
--- a/app/alarm/examples/create_alarm_topics.sh
+++ b/app/alarm/examples/create_alarm_topics.sh
@@ -11,15 +11,15 @@ config=$1
 # Create the compacted topics.
 for topic in "$1"
 do
-    kafka/bin/kafka-topics.sh  --zookeeper localhost:2181 --create --replication-factor 1 --partitions 1 --topic $topic
-    kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --entity-type topics --alter --entity-name $topic \
+    kafka/bin/kafka-topics.sh  --bootstrap-server localhost:9092 --create --replication-factor 1 --partitions 1 --topic $topic
+    kafka/bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type topics --alter --entity-name $topic \
            --add-config cleanup.policy=compact,segment.ms=10000,min.cleanable.dirty.ratio=0.01,min.compaction.lag.ms=1000
 done
 
 # Create the deleted topics
 for topic in "${1}Command" "${1}Talk"
 do
-    kafka/bin/kafka-topics.sh  --zookeeper localhost:2181 --create --replication-factor 1 --partitions 1 --topic $topic
-    kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --entity-type topics --alter --entity-name $topic \
+    kafka/bin/kafka-topics.sh  --bootstrap-server localhost:9092 --create --replication-factor 1 --partitions 1 --topic $topic
+    kafka/bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type topics --alter --entity-name $topic \
            --add-config cleanup.policy=delete,segment.ms=10000,min.cleanable.dirty.ratio=0.01,min.compaction.lag.ms=1000,retention.ms=20000,delete.retention.ms=1000,file.delete.delay.ms=1000
 done

--- a/app/alarm/examples/delete_alarm_topics.sh
+++ b/app/alarm/examples/delete_alarm_topics.sh
@@ -22,8 +22,10 @@ fi
 
 config=$1
 
+# ...State was used earlier.
+# With recent setups, you might get a "... does not exist" error which can be ignored
 for topic in "$1" "${1}State" "${1}Command" "${1}Talk"
 do
-    kafka/bin/kafka-topics.sh  --zookeeper localhost:2181 --delete --topic $topic
+    kafka/bin/kafka-topics.sh  --bootstrap-server localhost:9092 --delete --topic $topic
 done
 

--- a/app/alarm/examples/list_topics.sh
+++ b/app/alarm/examples/list_topics.sh
@@ -1,1 +1,1 @@
-kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --describe
+kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --describe


### PR DESCRIPTION
with  --bootstrap-server
Note that port number also needs to change from 2181 to 9092,
otherwise zookeeper gives strange messages
```
WARN Exception causing close of session 0x0: Unreasonable length = 308375649 (org.apache.zookeeper.server.NIOServerCnxn)
```
and clients will hang

Thanks to @ffeldbauer , #2279