### PR TITLE
PVA beacons

### DIFF
--- a/core/pva/pvasearchmonitor
+++ b/core/pva/pvasearchmonitor
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+JAR=`echo target/core-pva*.jar`
+if [ -r "$JAR" ]
+then
+    # Echo use jar file
+    java -jar $JAR "$@"
+else
+    # Use build output
+    java -cp target/classes org.epics.pva.server.PVASearchMonitorMain "$@"
+fi

--- a/core/pva/pvasearchmonitor
+++ b/core/pva/pvasearchmonitor
@@ -4,7 +4,7 @@ JAR=`echo target/core-pva*.jar`
 if [ -r "$JAR" ]
 then
     # Echo use jar file
-    java -jar $JAR "$@"
+    java -cp $JAR org.epics.pva.server.PVASearchMonitorMain "$@"
 else
     # Use build output
     java -cp target/classes org.epics.pva.server.PVASearchMonitorMain "$@"

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -171,6 +171,33 @@ public class PVASettings
     /** Maximum number of array elements shown when printing data */
     public static int EPICS_PVA_MAX_ARRAY_FORMATTING = 256;
 
+    /** Range of beacon periods in seconds recognized as "fast, new" beacons
+     *  that re-start searches for disconnected channels.
+     *
+     *  <p>The first beacon received from a server has a nominal period of 0.
+     *  Newly started servers send beacons every ~15 seconds.
+     *  After about 5 minutes they relax the beacon period to ~180 seconds.
+     *
+     *  <p>The criteria for restarting searches is min &lt;= period &lt max.
+     *  A min..max range of 0..30 recognizes the initial and ~15 second beacons
+     *  as new.
+     *  A range of 1..30 would ignore the initial beacon but re-start searches
+     *  on 15 sec beacons.
+     *  A min..max range of 0..0 would disable the re-start of searches.
+     */
+    public static int EPICS_PVA_FAST_BEACON_MIN = 0,
+                      EPICS_PVA_FAST_BEACON_MAX = 30;
+
+    /** Maximum age of beacons in seconds
+     *
+     *  <p>Beacon information older than this,
+     *  i.e. beacons that have not been received again
+     *  for this time are removed from the cache to preserve
+     *  memory. If they re-appear, they will be considered
+     *  new beacons
+     */
+    public static int EPICS_PVA_MAX_BEACON_AGE = 300;
+
     static
     {
         EPICS_PVA_ADDR_LIST = get("EPICS_PVA_ADDR_LIST", EPICS_PVA_ADDR_LIST);
@@ -183,6 +210,9 @@ public class PVASettings
         EPICS_PVA_CONN_TMO = get("EPICS_PVA_CONN_TMO", EPICS_PVA_CONN_TMO);
         EPICS_PVA_MAX_ARRAY_FORMATTING = get("EPICS_PVA_MAX_ARRAY_FORMATTING", EPICS_PVA_MAX_ARRAY_FORMATTING);
         EPICS_PVA_SEND_BUFFER_SIZE = get("EPICS_PVA_SEND_BUFFER_SIZE", EPICS_PVA_SEND_BUFFER_SIZE);
+        EPICS_PVA_FAST_BEACON_MIN = get("EPICS_PVA_FAST_BEACON_MIN", EPICS_PVA_FAST_BEACON_MIN);
+        EPICS_PVA_FAST_BEACON_MAX = get("EPICS_PVA_FAST_BEACON_MAX", EPICS_PVA_FAST_BEACON_MAX);
+        EPICS_PVA_MAX_BEACON_AGE = get("EPICS_PVA_MAX_BEACON_AGE", EPICS_PVA_MAX_BEACON_AGE);
     }
 
     /** Get setting from property, environment or default

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -178,7 +178,7 @@ public class PVASettings
      *  Newly started servers send beacons every ~15 seconds.
      *  After about 5 minutes they relax the beacon period to ~180 seconds.
      *
-     *  <p>The criteria for restarting searches is min &lt;= period &lt max.
+     *  <p>The criteria for restarting searches is min &lt;= period &lt; max.
      *  A min..max range of 0..30 recognizes the initial and ~15 second beacons
      *  as new.
      *  A range of 1..30 would ignore the initial beacon but re-start searches

--- a/core/pva/src/main/java/org/epics/pva/client/BeaconTracker.java
+++ b/core/pva/src/main/java/org/epics/pva/client/BeaconTracker.java
@@ -75,7 +75,7 @@ public class BeaconTracker
             // to re-start searches.
             // Long running servers will only emit beacons every 3 minutes.
             // By the time we confirm that it's a 3 minute period (i.e. after 6 minutes),
-            // we have long re-sent the initial burst of searches.            
+            // we have long re-sent the initial burst of searches.
             // Is this a newly started server..
             final boolean is_new_server = period > 0  &&  period < 30;
             // .. and we see it for the first time?
@@ -107,7 +107,7 @@ public class BeaconTracker
                       : null;
 
         final Instant now = Instant.now();
-        
+
         // Locate or create beacon info for that GUID
         final BeaconInfo info = beacons.computeIfAbsent(guid, s -> new BeaconInfo(guid, server, changes));
 
@@ -141,7 +141,7 @@ public class BeaconTracker
         }
         // Log detail, if available
         if (detail != null)
-            logger.log(Level.FINE, "Beacon check\n" + getTable(now, info.guid, detail));
+            logger.log(Level.FINE, "Beacon update\n" + getTable(now, info.guid, detail));
 
         // Search or not?
         return something_changed;
@@ -157,7 +157,7 @@ public class BeaconTracker
             final long age = Duration.between(info.last, now).getSeconds();
             if (age > 180) // TODO beacon_cleanup_period
             {
-                logger.log(Level.FINE,
+                logger.log(Level.FINER,
                            () -> "Removing beacon info " + info.guid + " (" + info.address + "), last seen " + age + " seconds ago");
                 infos.remove();
             }

--- a/core/pva/src/main/java/org/epics/pva/client/BeaconTracker.java
+++ b/core/pva/src/main/java/org/epics/pva/client/BeaconTracker.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+
+package org.epics.pva.client;
+
+import static org.epics.pva.PVASettings.logger;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+import org.epics.pva.server.Guid;
+
+/** Track received beacons
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class BeaconTracker
+{
+    /** Info about one tracked beacon
+     *
+     *  Server is identified by GUID
+     */
+    private static class BeaconInfo
+    {
+        /** Server's unique ID */
+        final Guid guid;
+
+        /** Address that sent beacon, likely server's UDP address */
+        InetSocketAddress address;
+
+        /** Change increment reported by server */
+        int changes;
+
+        /** Time of last beacon */
+        Instant last = null;
+
+        /** Period of beacon before the last one */
+        long previous_period = 0;
+
+        /** Period (seconds) of last beacon */
+        long period = 0;
+
+        BeaconInfo(final Guid guid, final InetSocketAddress address, final int changes)
+        {
+            this.guid = guid;
+            this.address = address;
+            this.changes = changes;
+        }
+
+        /** Update beacon period because we just received another one
+         *  @return Does this indicate a "new" beacon?
+         */
+        boolean updatePeriod()
+        {
+            final Instant now = Instant.now();
+            if (last == null)
+                period = 0;
+            else
+                period = Duration.between(last, now).getSeconds();
+            last = now;
+
+            // Is this a newly started server..
+            final boolean is_new_server = period > 0  &&  period < 30;
+            // .. and we see it for the first time?
+            final boolean was_new_server = previous_period > 0  &&  previous_period < 30;
+            previous_period = period;
+            return is_new_server  && !was_new_server;
+        }
+    }
+
+    private final ConcurrentHashMap<Guid, BeaconInfo> beacons = new ConcurrentHashMap<>();
+
+    /** Check if a received beacon indicates a new server landscape
+     *  @param guid  Globally unique ID of the server
+     *  @param server Server that sent a beacon
+     *  @param changes Change count, increments & rolls over as server has different channels
+     *
+     *  @return Should we restart searches for unresolved PVs?
+     */
+    public boolean check(final Guid guid, final InetSocketAddress server, final int changes)
+    {
+        String detail = logger.isLoggable(Level.SEVERE)
+                      ? " *"
+                      : null;
+
+        final BeaconInfo info = beacons.computeIfAbsent(guid, s -> new BeaconInfo(guid, server, changes));
+
+        boolean something_changed = info.updatePeriod();
+        if (something_changed && detail != null)
+            detail += " (new fast period)";
+        if (! server.equals(info.address))
+        {
+            if (detail != null)
+                detail += " (new address)";
+            info.address = server;
+            something_changed = true;
+        }
+        if (changes != info.changes)
+        {
+            if (detail != null)
+                detail += " (new changes)";
+            info.changes = changes;
+            something_changed = true;
+        }
+
+        if (detail != null)
+            logger.log(Level.SEVERE, "Beacon check\n" + getTable(info.guid, detail));
+
+        // Search or not?
+        return something_changed;
+    }
+
+    // TODO Delete old beacon info
+
+    /** @param active ID of server that just sent a beacon or <code>null</code> if nothing new
+     *  @param detail Detail of what's new or <code>null</code> if nothing new
+     *  @return Tabular list of beacons, optionally highlighting the 'active' server with 'detail'
+     */
+    private String getTable(final Guid active, final String detail)
+    {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("GUID                     IP                              Changes Period\n");
+        for (BeaconInfo info : beacons.values())
+        {
+            buf.append(String.format("%s %-35s %3d %4d s",
+                                     info.guid.asText(),
+                                     info.address,
+                                     info.changes,
+                                     info.period));
+            if (info.guid.equals(active))
+                buf.append(" ")
+                   .append(detail);
+            buf.append("\n");
+        }
+        return buf.toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        return getTable(null, null);
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/client/BeaconTracker.java
+++ b/core/pva/src/main/java/org/epics/pva/client/BeaconTracker.java
@@ -102,7 +102,7 @@ public class BeaconTracker
     /** Check if a received beacon indicates a new server landscape
      *  @param guid  Globally unique ID of the server
      *  @param server Server that sent a beacon
-     *  @param changes Change count, increments & rolls over as server has different channels
+     *  @param changes Change count, increments and rolls over as server adds new channels
      *
      *  @return Should we restart searches for unresolved PVs?
      */

--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -225,7 +225,7 @@ class ChannelSearch
             // If search for channel has settled to the long period, restart
             final int count = searched.search_counter.updateAndGet(val -> val >= MAX_SEARCH_RESET ? BOOST_SEARCH_COUNT : val);
             if (count == BOOST_SEARCH_COUNT)
-                logger.log(Level.FINE, () -> "Restart search for " + searched.channel.getName());
+                logger.log(Level.FINE, () -> "Restart search for '" + searched.channel.getName() + "'");
 
             // Not sending search right now:
             //   search(channel);

--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -32,9 +32,18 @@ import org.epics.pva.data.Hexdump;
  *
  *  <p>Maintains thread that periodically issues search requests
  *  for registered channels.
- *
- *  <p>Details of search timing are based on
- *  https://github.com/epics-base/epicsCoreJava/blob/master/pvAccessJava/src/org/epics/pvaccess/client/impl/remote/search/SimpleChannelSearchManagerImpl.java
+ *  Search periods match the design of https://github.com/mdavidsaver/pvxs,
+ *  repeating searches for missing channels after 1, 2, 3, ..., 30 seconds
+ *  and then continuing every 30 seconds.
+ *  The exact period is not a multiple of 1000ms but 1000+-25ms to randomly
+ *  distribute searches from different clients.
+ *  Once the search plateaus at 30 seconds, which takes about 7.6 to 7.9 minutes,
+ *  the search can be "boosted" back to 1, 2, 3, ... seconds.
+ *  Since long running servers issue beacons every ~3 minutes,
+ *  every existing PVA server on the network will appear "new" when a client
+ *  receives its first beacon within ~3 minutes after startup.
+ *  Such beacons are ignored for the ~7 minutes where the search period settles
+ *  to avoid unnecessary network traffic.
  *
  *  <p>Can send search requests to unicast (IPv4 and IPv6), multicast (4 & 6), broadcast (IPv4 only).
  *  Since only StandardProtocolFamily.INET sockets support IPv4 multicast,
@@ -55,19 +64,39 @@ import org.epics.pva.data.Hexdump;
 @SuppressWarnings("nls")
 class ChannelSearch
 {
+    /** Basic search period is one second */
+    private static final int SEARCH_PERIOD_MS = 1000;
+
+    /** Search period jitter to avoid multiple clients all searching at the same period */
+    private static final int SEARCH_JITTER_MS = 25;
+
+    /** Minimum search for a channel is ASAP, then incrementing by 1 */
+    private static final int MIN_SEARCH_PERIOD = 0;
+
+    /** Maximum and eternal search period is every 30 sec */
+    private static final int MAX_SEARCH_PERIOD = 30;
+
     /** Channel that's being searched */
     private class SearchedChannel
     {
-        final AtomicInteger search_counter;
+        /** Search period in seconds.
+         *  Steps up from 0 to MAX_SEARCH_PERIOD and then stays at MAX_SEARCH_PERIOD
+         */
+        final AtomicInteger search_period = new AtomicInteger(1);
+
+        /** Seconds spent in the current state.
+         *  Incremented for every run of the search thread.
+         *  If it reaches the current search_period,
+         *  a search is performed and search_period updated
+         *  to the next one.
+         */
+        final AtomicInteger seconds_in_state = new AtomicInteger(0);
+
         final AtomicInteger tcp_search_counter = new AtomicInteger(0);
         final PVAChannel channel;
 
         SearchedChannel(final PVAChannel channel)
         {
-            // Counter of 0 means the next regular search will increment
-            // to 1 (no search), then 2 (power of two -> search).
-            // So it'll "soon" perform a regular search.
-            this.search_counter = new AtomicInteger(0);
             this.channel = channel;
             // Not starting an _immediate_ search in here because
             // this needs to be added to searched_channels first.
@@ -82,38 +111,6 @@ class ChannelSearch
     private final ClientUDPHandler udp;
 
     private final Function<InetSocketAddress, ClientTCPHandler> tcp_provider;
-
-    /** Basic search period */
-    private static final int SEARCH_PERIOD_MS = 225;
-
-    /** Search period jitter to avoid multiple clients all searching at the same period */
-    private static final int SEARCH_JITTER_MS = 25;
-
-    /** Exponential search intervals
-     *
-     *  <p>Search counter for a channel is incremented each SEARCH_PERIOD_MS.
-     *  When counter is a power of 2, search request is sent.
-     *  Counter starts at 1, and first search period increments to 2:
-     *     0 ms increments to 2 -> Search!
-     *   225 ms increments to 3 -> No search
-     *   450 ms increments to 4 -> Search (~0.5 sec after last)
-     *   675 ms increments to 5 -> No search
-     *   900 ms increments to 6 -> No search
-     *  1125 ms increments to 7 -> No search
-     *  1350 ms increments to 8 -> Search (~ 1 sec after last)
-     *  ...
-     *
-     *  <p>So the time between searches is roughly 0.5 seconds,
-     *  1 second, 2, 4, 8, 15, 30 seconds.
-     *
-     *  <p>Once the search count reaches 256, it's reset to 129.
-     *  This means it then takes 128 periods to again reach 256
-     *  for the next search, so searches end up being issued
-     *  roughly every 128*0.225 = 30 seconds.
-     */
-    private static final int BOOST_SEARCH_COUNT = 1,
-                             MAX_SEARCH_COUNT = 256,
-                             MAX_SEARCH_RESET = 129;
 
     /** Map of searched channels by channel ID */
     private ConcurrentHashMap<Integer, SearchedChannel> searched_channels = new ConcurrentHashMap<>();
@@ -223,10 +220,14 @@ class ChannelSearch
         for (SearchedChannel searched : searched_channels.values())
         {
             // If search for channel has settled to the long period, restart
-            final int count = searched.search_counter.updateAndGet(val -> val >= MAX_SEARCH_RESET ? BOOST_SEARCH_COUNT : val);
-            if (count == BOOST_SEARCH_COUNT)
+            final int period = searched.search_period.updateAndGet(val -> val >= MAX_SEARCH_PERIOD
+                                                                        ? MIN_SEARCH_PERIOD
+                                                                        : val);
+            if (period == MIN_SEARCH_PERIOD)
+            {
+                searched.seconds_in_state.set(0);
                 logger.log(Level.FINE, () -> "Restart search for '" + searched.channel.getName() + "'");
-
+            }
             // Not sending search right now:
             //   search(channel);
             // Instead, scheduling it to be searched again real soon for a few times.
@@ -236,21 +237,25 @@ class ChannelSearch
         }
     }
 
-    private static boolean isPowerOfTwo(final int x)
-    {
-        return x > 0  &&  (x & (x - 1)) == 0;
-    }
-
     /** Invoked by timer: Check searched channels for the next one to handle */
     private void runSearches()
     {
+        // TODO Collect searched channels, then issue one search message for all of them
+        // (several for UDP as we reach max packet size)
         for (SearchedChannel searched : searched_channels.values())
         {
-            final int counter = searched.search_counter.updateAndGet(val -> val >= MAX_SEARCH_COUNT ? MAX_SEARCH_RESET : val+1);
-            if (isPowerOfTwo(counter))
+            // Stayed long enough in current search period?
+            final int secs = searched.seconds_in_state.incrementAndGet();
+            if (secs >= searched.search_period.get())
             {
-                logger.log(Level.FINER, () -> "Searching... " + searched.channel);
+                logger.log(Level.FINE, () -> "Searching... " + searched.channel);
                 search(searched.channel);
+
+                // Move to next search period, plateau at MAX_SEARCH_PERIOD
+                searched.seconds_in_state.set(0);
+                searched.search_period.updateAndGet(p -> p < MAX_SEARCH_PERIOD
+                                                           ? p + 1
+                                                           : MAX_SEARCH_PERIOD);
             }
         }
     }
@@ -318,7 +323,7 @@ class ChannelSearch
         synchronized (send_buffer)
         {
             final int seq = search_sequence.incrementAndGet();
-            logger.log(Level.FINE, "Search Request #" + seq + " for " + channel);
+            logger.log(Level.FINE, "UDP Search Request #" + seq + " for " + channel);
             sendSearch(seq, channel.getCID(), channel.getName());
         }
     }

--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -222,8 +222,11 @@ class ChannelSearch
     {
         for (SearchedChannel searched : searched_channels.values())
         {
-            logger.log(Level.FINE, () -> "Restart search for " + searched.channel.getName());
-            searched.search_counter.set(BOOST_SEARCH_COUNT);
+            // If search for channel has settled to the long period, restart
+            final int count = searched.search_counter.updateAndGet(val -> val >= MAX_SEARCH_RESET ? BOOST_SEARCH_COUNT : val);
+            if (count == BOOST_SEARCH_COUNT)
+                logger.log(Level.FINE, () -> "Restart search for " + searched.channel.getName());
+
             // Not sending search right now:
             //   search(channel);
             // Instead, scheduling it to be searched again real soon for a few times.

--- a/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 import org.epics.pva.PVASettings;
@@ -62,8 +61,6 @@ class ClientTCPHandler extends TCPHandler
 
     /** Server's GUID */
     private volatile Guid guid;
-
-    private final AtomicInteger server_changes = new AtomicInteger(-1);
 
     /** Description of data types used with this PVA server */
     private final PVATypeRegistry types = new PVATypeRegistry();
@@ -179,15 +176,7 @@ class ClientTCPHandler extends TCPHandler
         return false;
     }
 
-    /** Check if the server's beacon indicates changes
-     *  @param changes Change counter from beacon
-     *  @return <code>true</code> if this suggests new channels on the server
-     */
-    public boolean checkBeaconChanges(final int changes)
-    {
-        return server_changes.getAndSet(changes) != changes;
-    }
-
+    /** @return {@link PVATypeRegistry} for this TCP connection */
     public PVATypeRegistry getTypeRegistry()
     {
         return types;

--- a/core/pva/src/main/java/org/epics/pva/client/ClientUDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientUDPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,8 +27,9 @@ import org.epics.pva.common.SearchResponse;
 import org.epics.pva.common.UDPHandler;
 import org.epics.pva.data.Hexdump;
 import org.epics.pva.data.PVAAddress;
-import org.epics.pva.data.PVAFieldDesc;
+import org.epics.pva.data.PVAData;
 import org.epics.pva.data.PVAString;
+import org.epics.pva.data.PVATypeRegistry;
 import org.epics.pva.server.Guid;
 
 /** Sends and receives search replies, monitors beacons
@@ -235,11 +236,26 @@ class ClientUDPHandler extends UDPHandler
             return false;
         }
 
-        final byte server_status_desc = buffer.get();
-        if (server_status_desc != PVAFieldDesc.NULL_TYPE_CODE)
-            logger.log(Level.WARNING, "PVA Server " + from + " sent beacon with server status field description");
-
-        logger.log(Level.FINE, () -> "Received Beacon #" + sequence + " from " + server + " " + guid + ", " + changes + " changes");
+        try
+        {
+            // Decode optional server status (likely null)
+            final PVATypeRegistry types = new PVATypeRegistry();
+            final PVAData server_status = types.decodeType("", buffer);
+            if (server_status != null)
+                server_status.decode(types, buffer);
+            logger.log(Level.FINE, () ->
+            {
+                return "Received Beacon #" + sequence + " from " + server + " " +
+                        guid +
+                        ", version " + version + ", " +
+                        changes + " changes" +
+                        (server_status == null ? "" : ", status " + server_status);
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.log(Level.WARNING, "PVA Server " + from + " sent beacon with broken server status", ex);
+        }
         beacon_handler.handleBeacon(server, guid, changes);
 
         return true;

--- a/core/pva/src/main/java/org/epics/pva/client/PVAClientMain.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClientMain.java
@@ -273,10 +273,10 @@ public class PVAClientMain
                     setLogLevel(Level.WARNING);
                     break;
                 case 1:
-                    setLogLevel(Level.CONFIG);
+                    setLogLevel(Level.INFO);
                     break;
                 case 2:
-                    setLogLevel(Level.INFO);
+                    setLogLevel(Level.CONFIG);
                     break;
                 case 3:
                     setLogLevel(Level.FINE);

--- a/core/pva/src/main/java/org/epics/pva/server/Guid.java
+++ b/core/pva/src/main/java/org/epics/pva/server/Guid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,11 +73,10 @@ public class Guid
         return Arrays.equals(guid, other.guid);
     }
 
-    @Override
-    public String toString()
+    /** @return GUID as "FE1A.." type text */
+    public String asText()
     {
         final StringBuilder buf = new StringBuilder(35);
-        buf.append("GUID 0x");
         for (byte b : guid)
         {
             final int i = Byte.toUnsignedInt(b);
@@ -86,5 +85,12 @@ public class Guid
             buf.append(Integer.toHexString(i).toUpperCase());
         }
         return buf.toString();
+    }
+
+    /** @return String representation "GUID 0xFE1A.." */
+    @Override
+    public String toString()
+    {
+        return "GUID 0x" + asText();
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/server/PVASearchMonitorMain.java
+++ b/core/pva/src/main/java/org/epics/pva/server/PVASearchMonitorMain.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.epics.pva.server;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+
+import org.epics.pva.PVASettings;
+
+/** PVA Search monitor
+ *
+ *  May be called as
+ *    java -cp core-pva.jar org.epics.pva.server.PVASearchMonitorMain
+ *  or from Phoebus product via
+ *    phoebus.sh -main org.epics.pva.server.PVASearchMonitorMain
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class PVASearchMonitorMain
+{
+    /** Recent search */
+    private static class SearchInfo implements Comparable<SearchInfo>
+    {
+        /** PV Name */
+        final String name;
+
+        /** How often some client has searched for it */
+        final AtomicLong count = new AtomicLong();
+
+        /** Client that searched most recently */
+        volatile InetSocketAddress client;
+
+        /** Time of last search */
+        volatile Instant last = null;
+
+        SearchInfo(final String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public int compareTo(final SearchInfo other)
+        {
+            final long diff = other.count.get() - count.get();
+            if (diff < 0)
+                return -1;
+            if (diff > 0)
+                return 1;
+            return 0;
+        }
+    }
+
+    /** Map of PV name to search info */
+    private static final ConcurrentHashMap<String, SearchInfo> searches = new ConcurrentHashMap<>();
+
+    private static void help()
+    {
+        System.out.println("USAGE: pvasearchmonitor [options]");
+        System.out.println();
+        System.out.println("Options:");
+        System.out.println("  -h             Help");
+        System.out.println("  -p <seconds>   Update period (default 10 seconds)");
+        System.out.println("  -1             Update once, then quit");
+        System.out.println("  -v <level>     Verbosity, level 0-5");
+        System.out.println();
+        System.out.println("Waits for the specified period,");
+        System.out.println("then prints information about received search requests.");
+    }
+
+    private static void setLogLevel(final Level level)
+    {
+        PVASettings.logger.setLevel(level);
+    }
+
+    /** Command line entry point
+     *  @param args Arguments
+     *  @throws Exception on error
+     */
+    public static void main(String[] args) throws Exception
+    {
+        LogManager.getLogManager().readConfiguration(PVASettings.class.getResourceAsStream("/pva_logging.properties"));
+        setLogLevel(Level.WARNING);
+        long update_period = 10;
+        boolean once = false;
+
+        for (int i=0; i<args.length; ++i)
+        {
+            final String arg = args[i];
+            if (arg.startsWith("-h"))
+            {
+                help();
+                return;
+            }
+            if (arg.startsWith("-1"))
+                once = true;
+            else if (arg.startsWith("-p") && (i+1) < args.length)
+                update_period = Long.parseLong(args[i+1]);
+            else if (arg.startsWith("-v") && (i+1) < args.length)
+            {
+                switch (Integer.parseInt(args[i+1]))
+                {
+                case 0:
+                    setLogLevel(Level.WARNING);
+                    break;
+                case 1:
+                    setLogLevel(Level.CONFIG);
+                    break;
+                case 2:
+                    setLogLevel(Level.INFO);
+                    break;
+                case 3:
+                    setLogLevel(Level.FINE);
+                    break;
+                case 4:
+                    setLogLevel(Level.FINER);
+                    break;
+                case 5:
+                default:
+                    setLogLevel(Level.ALL);
+                }
+                ++i;
+            }
+        }
+
+        final CountDownLatch done = new CountDownLatch(1);
+
+        final SearchHandler search_handler = (seq, cid, name, addr, reply_sender) ->
+        {
+            // Quit when receiving search for name "QUIT"
+            if (name.equals("QUIT"))
+                done.countDown();
+
+            final SearchInfo search = searches.computeIfAbsent(name, n -> new SearchInfo(name));
+            search.count.incrementAndGet();
+            search.last = Instant.now();
+            search.client = addr;
+
+            // Done, don't proceed with default search handler
+            return true;
+        };
+
+        try
+        (   final PVAServer server = new PVAServer(search_handler)  )
+        {
+            System.out.println("Monitoring search requests for " + update_period + " seconds...");
+            if (! once)
+                System.out.println("Run 'pvget QUIT' to stop");
+            while (! done.await(update_period, TimeUnit.SECONDS))
+            {
+                System.out.println("\nCount Name                 Last Client                                Age");
+                final Instant now = Instant.now();
+                searches.values()
+                        .stream()
+                        .sorted()
+                        .forEach(info ->
+                {
+                    System.out.format("%5d %-20s %-35s %6d sec\n",
+                                      info.count.get(),
+                                      info.name,
+                                      info.client.toString(),
+                                      now.getEpochSecond() - info.last.getEpochSecond());
+                });
+                if (once)
+                    break;
+            }
+        }
+
+        System.out.println("Done.");
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
@@ -136,6 +136,9 @@ class ServerUDPHandler extends UDPHandler
             return handleOriginTag(from, version, payload, buffer);
         case PVAHeader.CMD_SEARCH:
             return handleSearch(from, version, payload, buffer);
+        case PVAHeader.CMD_BEACON:
+            // Clients may send or forward beacons, server ignores them
+            break;
         default:
             logger.log(Level.WARNING, "PVA Client " + from + " sent UDP packet with unknown command 0x" + Integer.toHexString(command));
         }

--- a/core/pva/src/main/resources/pva_logging.properties
+++ b/core/pva/src/main/resources/pva_logging.properties
@@ -11,7 +11,7 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 # 1: date, 2: source, 3: logger, 4: level, 5: message, 6:thrown
 # Adding the logger name [%3$s] can be useful to determine which logger to _disable_,
 #
-java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s [%3$s] %5$s%6$s%n
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS.%1tN %4$s [%3$s] %5$s%6$s%n
 #
 # but otherwise the source is more useful to locate the originating code.
 # java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s [%2$s] %5$s%6$s%n


### PR DESCRIPTION
Change beacon timing to match PVXS:
New servers send beacon every 15 seconds, after 5 minutes settling to 180 sec.
Clients repeat searches after 1, 2, 3, 4, ... 30 seconds, then continuing every 30 secs.
Clients track beacons. Beacons from servers seen for the first time or at 15 sec period to indicate new server will "boost" searches that have settled to 30 sec.

New command line tools:
`pvaclient beacons` to display received beacon statistics.
`pvasearchmonitor` displays searches ala 'caSnooper' for CA.