### PR TITLE
PVA client search update

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/BeaconTracker.java
+++ b/core/pva/src/main/java/org/epics/pva/client/BeaconTracker.java
@@ -162,7 +162,7 @@ public class BeaconTracker
         {
             final BeaconInfo info = infos.next().getValue();
             final long age = Duration.between(info.last, now).getSeconds();
-            if (age > 180) // TODO beacon_cleanup_period
+            if (age > PVASettings.EPICS_PVA_MAX_BEACON_AGE)
             {
                 logger.log(Level.FINER,
                            () -> "Removing beacon info " + info.guid + " (" + info.address + "), last seen " + age + " seconds ago");

--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -11,7 +11,9 @@ import static org.epics.pva.PVASettings.logger;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,6 +29,7 @@ import org.epics.pva.common.AddressInfo;
 import org.epics.pva.common.RequestEncoder;
 import org.epics.pva.common.SearchRequest;
 import org.epics.pva.data.Hexdump;
+import org.epics.pva.data.PVAString;
 
 /** Handler for search requests
  *
@@ -83,16 +86,6 @@ class ChannelSearch
          *  Steps up from 0 to MAX_SEARCH_PERIOD and then stays at MAX_SEARCH_PERIOD
          */
         final AtomicInteger search_period = new AtomicInteger(1);
-
-        /** Seconds spent in the current state.
-         *  Incremented for every run of the search thread.
-         *  If it reaches the current search_period,
-         *  a search is performed and search_period updated
-         *  to the next one.
-         */
-        final AtomicInteger seconds_in_state = new AtomicInteger(0);
-
-        final AtomicInteger tcp_search_counter = new AtomicInteger(0);
         final PVAChannel channel;
 
         SearchedChannel(final PVAChannel channel)
@@ -105,15 +98,38 @@ class ChannelSearch
         }
     }
 
-    /** Search request sequence number */
-    private static final AtomicInteger search_sequence = new AtomicInteger();
-
-    private final ClientUDPHandler udp;
-
-    private final Function<InetSocketAddress, ClientTCPHandler> tcp_provider;
-
-    /** Map of searched channels by channel ID */
+    /**  Map of searched channels by channel ID */
+    // TODO Remove, just use search_buckets?
     private ConcurrentHashMap<Integer, SearchedChannel> searched_channels = new ConcurrentHashMap<>();
+
+    /** Search buckets
+     *
+     *  <p>The {@link #current_search_bucket} selects the list
+     *  of channels to be searched by {@link #runSeaches()},
+     *  which runs roughly once per second, each time moving to
+     *  the next search bucket in a ring buffer fashion.
+     *
+     *  <p>Each searched channel is removed from the current bucket.
+     *  To be searched again, it is inserted into the appropriate
+     *  upcoming bucket, allowing for a maximum search
+     *  period of <code>MAX_SEARCH_PERIOD == search_buckets.size() - 2</code>.
+     *  The search bucket size is <code>MAX_SEARCH_PERIOD + 2</code>
+     *  so that a channel in bucket N can be moved to either
+     *  <code>N + MAX_SEARCH_PERIOD</code> or
+     *  <code>N + MAX_SEARCH_PERIOD + 1</code> to distribute searches
+     *  without putting the channel immediately back into bucket N
+     *  which would result in an endless loop.
+     *
+     *  <p>Access to either {@link #search_buckets} or {@link #current_search_bucket}
+     *  must SYNC on {@link #search_buckets}.
+     */
+    private final ArrayList<LinkedList<SearchedChannel>> search_buckets = new ArrayList<>();
+
+    /** Index of current search bucket, i.e. the one about to be searched.
+     *
+     *  <p>Access must SYNC on {@link #search_buckets}.
+     */
+    private final AtomicInteger current_search_bucket = new AtomicInteger();
 
     /** Timer used to periodically check channels and issue search requests */
     private final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(run ->
@@ -122,6 +138,10 @@ class ChannelSearch
         thread.setDaemon(true);
         return thread;
     });
+
+    private final ClientUDPHandler udp;
+
+    private final Function<InetSocketAddress, ClientTCPHandler> tcp_provider;
 
     /** Buffer for assembling search messages */
     private final ByteBuffer send_buffer = ByteBuffer.allocate(PVASettings.MAX_UDP_UNFRAGMENTED_SEND);
@@ -138,6 +158,12 @@ class ChannelSearch
     {
         this.udp = udp;
         this.tcp_provider = tcp_provider;
+
+        synchronized (search_buckets)
+        {
+            for (int i=0; i<MAX_SEARCH_PERIOD+2; ++i)
+                search_buckets.add(new LinkedList<>());
+        }
 
         // Searches sent to multicast (IPv4, IPv6) or broadcast addresses (IPv4) reach every PVA server
         // on that multicast group or bcast subnet.
@@ -189,11 +215,17 @@ class ChannelSearch
     public void register(final PVAChannel channel, final boolean now)
     {
         logger.log(Level.FINE, () -> "Register search for " + channel.getName() + " " + channel.getCID());
-        channel.setState(ClientChannelState.SEARCHING);
-        searched_channels.computeIfAbsent(channel.getCID(), id -> new SearchedChannel(channel));
-        // Issue immediate search request?
-        if (now)
-            search(channel);
+
+        final ClientChannelState old = channel.setState(ClientChannelState.SEARCHING);
+        if (old == ClientChannelState.SEARCHING)
+            logger.log(Level.WARNING, "Registering channel " + channel + " to be searched more than once ");
+
+        final SearchedChannel sc = searched_channels.computeIfAbsent(channel.getCID(), id -> new SearchedChannel(channel));
+
+        synchronized (search_buckets)
+        {
+            search_buckets.get(current_search_bucket.get()).add(sc);
+        }
     }
 
     /** Stop searching for channel
@@ -206,6 +238,13 @@ class ChannelSearch
         if (searched != null)
         {
             logger.log(Level.FINE, () -> "Unregister search for " + searched.channel.getName() + " " + channel_id);
+
+            synchronized (search_buckets)
+            {
+                for (LinkedList<SearchedChannel> bucket : search_buckets)
+                    bucket.remove(searched);
+            }
+
             return searched.channel;
         }
         return null;
@@ -225,8 +264,13 @@ class ChannelSearch
                                                                         : val);
             if (period == MIN_SEARCH_PERIOD)
             {
-                searched.seconds_in_state.set(0);
                 logger.log(Level.FINE, () -> "Restart search for '" + searched.channel.getName() + "'");
+                synchronized (search_buckets)
+                {
+                    final LinkedList<SearchedChannel> bucket = search_buckets.get(current_search_bucket.get());
+                    if (! bucket.contains(searched))
+                        bucket.add(searched);
+                }
             }
             // Not sending search right now:
             //   search(channel);
@@ -237,26 +281,92 @@ class ChannelSearch
         }
     }
 
+    /** List of channels to search, re-used within runSearches */
+    private final ArrayList<PVAChannel> to_search = new ArrayList<>();
+
     /** Invoked by timer: Check searched channels for the next one to handle */
     private void runSearches()
     {
-        // TODO Collect searched channels, then issue one search message for all of them
-        // (several for UDP as we reach max packet size)
-        for (SearchedChannel searched : searched_channels.values())
+        to_search.clear();
+        synchronized (search_buckets)
         {
-            // Stayed long enough in current search period?
-            final int secs = searched.seconds_in_state.incrementAndGet();
-            if (secs >= searched.search_period.get())
-            {
-                logger.log(Level.FINE, () -> "Searching... " + searched.channel);
-                search(searched.channel);
+            // Determine current search bucket
+            final int current = current_search_bucket.getAndUpdate(i -> (i + 1) % search_buckets.size());
+            final LinkedList<SearchedChannel> bucket = search_buckets.get(current);
 
-                // Move to next search period, plateau at MAX_SEARCH_PERIOD
-                searched.seconds_in_state.set(0);
-                searched.search_period.updateAndGet(p -> p < MAX_SEARCH_PERIOD
-                                                           ? p + 1
-                                                           : MAX_SEARCH_PERIOD);
+            // Remove searched channels from the current bucket
+            SearchedChannel sc;
+            while ((sc = bucket.poll()) != null)
+            {
+                if (sc.channel.getState() == ClientChannelState.SEARCHING  &&
+                    searched_channels.containsKey(sc.channel.getCID()))
+                {
+                    // Collect channels in 'to_search' for handling outside of sync. section
+                    to_search.add(sc.channel);
+
+                    // Determine next search period
+                    final int period = sc.search_period.updateAndGet(sec -> sec < MAX_SEARCH_PERIOD
+                                                                     ? sec + 1
+                                                                     : MAX_SEARCH_PERIOD);
+
+                    // Add to corresponding search bucket, or delay by one second
+                    // in case that search bucket is quite full
+                    final int i_n   = (current + period) % search_buckets.size();
+                    final int i_n_n = (i_n + 1)          % search_buckets.size();
+                    final LinkedList<SearchedChannel> next = search_buckets.get(i_n);
+                    final LinkedList<SearchedChannel> next_next = search_buckets.get(i_n_n);
+                    if (i_n == current  ||  i_n_n == current)
+                        throw new IllegalStateException("Current, next and nextnext search indices for " + sc.channel + " are " +
+                                                        current + ", " + i_n + ", " + i_n_n);
+                    if (next_next.size() < next.size())
+                        next_next.add(sc);
+                    else
+                        next.add(sc);
+                }
+                else
+                    logger.log(Level.FINE, "Dropping channel from search: " + sc.channel);
             }
+        }
+
+
+        // Search batch..
+        // Size of a search request is close to 50 bytes
+        // plus { int cid, string name } for each channel.
+        // Channel count is unsigned short, but we limit
+        // is to a signed short.
+        // Similar to PVXS, further limit payload to 1400 bytes
+        // to stay well below the ~1500 byte ethernet frame
+        int start = 0;
+        while (start < to_search.size())
+        {
+            int payload = 0;
+            int count = 0;
+            while (start + count < to_search.size()  &&  count < Short.MAX_VALUE-1)
+            {
+                final PVAChannel channel = to_search.get(start + count);
+                int size = 4 + PVAString.getEncodedSize(channel.getName());
+                if (payload + size < 50) // TODO 1400
+                {
+                    ++count;
+                    payload += size;
+                }
+                else if (count == 0)
+                {
+                    logger.log(Level.WARNING, "PV name exceeds search buffer size: " + channel);
+                    searched_channels.remove(channel.getCID());
+                    to_search.remove(start + count);
+                }
+                else
+                    break;
+            }
+            if (count == 0)
+                break;
+
+            final List<PVAChannel> batch = to_search.subList(start, start + count);
+            System.out.println(Instant.now() + " Search bucket " + current_search_bucket.get() + " " + batch);
+            for (PVAChannel channel : batch)
+                search(channel);
+            start += count;
         }
     }
 
@@ -284,10 +394,6 @@ class ChannelSearch
             final SearchedChannel searched = searched_channels.get(channel.getCID());
             if (searched == null)
                 continue;
-            // Compared to UDP, search only every other cycle
-            int count = searched.tcp_search_counter.incrementAndGet();
-            if (count % 2 != 0)
-                continue;
 
             final ClientTCPHandler tcp = tcp_provider.apply(name_server.getAddress());
 
@@ -297,7 +403,7 @@ class ChannelSearch
             {
                 final RequestEncoder search_request = (version, buffer) ->
                 {
-                    logger.log(Level.FINE, () -> "Searching for " + channel + " via TCP " + tcp.getRemoteAddress() + ", take " + count/2);
+                    logger.log(Level.FINE, () -> "Searching for " + channel + " via TCP " + tcp.getRemoteAddress());
 
                     // Search sequence identifies the potentially repeated UDP.
                     // TCP search is once only, so PVXS always sends 0x66696E64 = "find".
@@ -322,7 +428,9 @@ class ChannelSearch
         // Lock the send buffer to avoid concurrent use.
         synchronized (send_buffer)
         {
-            final int seq = search_sequence.incrementAndGet();
+            // For UDP, use bucket index to get a changing number that helps
+            // match up duplicate packets and allows debugging bucket usage
+            final int seq = current_search_bucket.get();
             logger.log(Level.FINE, "UDP Search Request #" + seq + " for " + channel);
             sendSearch(seq, channel.getCID(), channel.getName());
         }

--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -370,8 +370,6 @@ class ChannelSearch
                 break;
 
             final List<PVAChannel> batch = to_search.subList(start, start + count);
-            logger.log(Level.FINE, "Search bucket " + current_search_bucket.get() + " " + batch);
-
             // PVAChannel extends SearchRequest.Channel, so use List<PVAChannel> as Collection<SR.Channel>
             search((Collection<SearchRequest.Channel>) (List<? extends SearchRequest.Channel>)batch);
             start += count;
@@ -411,7 +409,7 @@ class ChannelSearch
 
                     // Search sequence identifies the potentially repeated UDP.
                     // TCP search is once only, so PVXS always sends 0x66696E64 = "find".
-                    // We send "look".
+                    // We send "look" ("kool" for little endian).
                     final int seq = 0x6C6F6F6B;
 
                     // Use 'any' reply address since reply will be via this TCP socket

--- a/core/pva/src/main/java/org/epics/pva/client/ClientUDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientUDPHandler.java
@@ -278,26 +278,25 @@ class ClientUDPHandler extends UDPHandler
         {
             if (local_multicast != null  &&  search != null  &&  search.unicast)
             {
-                if (search.name == null)
+                if (search.channels == null)
                 {
                     if (search.reply_required)
                     {
                         forward_buffer.clear();
-                        SearchRequest.encode(false, 0, -1, null, search.client, forward_buffer);
+                        SearchRequest.encode(false, 0, null, search.client, forward_buffer);
                         forward_buffer.flip();
                         logger.log(Level.FINER, () -> "Forward search to list servers to " + local_multicast + "\n" + Hexdump.toHexdump(forward_buffer));
                         send(forward_buffer, local_multicast);
                     }
                 }
                 else
-                    for (int i=0; i<search.name.length; ++i)
-                    {
-                        forward_buffer.clear();
-                        SearchRequest.encode(false, search.seq, search.cid[i], search.name[i], search.client, forward_buffer);
-                        forward_buffer.flip();
-                        logger.log(Level.FINER, () -> "Forward search to " + local_multicast + "\n" + Hexdump.toHexdump(forward_buffer));
-                        send(forward_buffer, local_multicast);
-                    }
+                {
+                    forward_buffer.clear();
+                    SearchRequest.encode(false, search.seq, search.channels, search.client, forward_buffer);
+                    forward_buffer.flip();
+                    logger.log(Level.FINER, () -> "Forward search to " + local_multicast + "\n" + Hexdump.toHexdump(forward_buffer));
+                    send(forward_buffer, local_multicast);
+                }
             }
         }
         catch (Exception ex)

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
+import org.epics.pva.common.SearchRequest;
 import org.epics.pva.data.PVADouble;
 import org.epics.pva.data.PVAString;
 import org.epics.pva.data.PVAStructure;
@@ -41,7 +42,7 @@ import org.epics.pva.data.PVAStructure;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class PVAChannel implements AutoCloseable
+public class PVAChannel extends SearchRequest.Channel implements AutoCloseable
 {
     /** Provider for the 'next' client channel ID
      *
@@ -53,9 +54,7 @@ public class PVAChannel implements AutoCloseable
     private static final AtomicInteger CID_Provider = new AtomicInteger(1);
 
     private final PVAClient client;
-    private final String name;
     private final ClientChannelListener listener;
-    private final int cid = CID_Provider.incrementAndGet();
     private volatile int sid = -1;
 
     /** State
@@ -74,8 +73,8 @@ public class PVAChannel implements AutoCloseable
 
     PVAChannel(final PVAClient client, final String name, final ClientChannelListener listener)
     {
+        super(CID_Provider.incrementAndGet(), name);
         this.client = client;
-        this.name = name;
         this.listener = listener;
     }
 
@@ -92,23 +91,10 @@ public class PVAChannel implements AutoCloseable
         return copy;
     }
 
-    /** @return Client channel ID */
-    int getCID()
-    {
-        return cid;
-    }
-
     /** @return Server channel ID */
     int getSID()
     {
         return sid;
-    }
-
-
-    /** @return Channel name */
-    public String getName()
-    {
-        return name;
     }
 
     /** @return {@link ClientChannelState} */

--- a/core/pva/src/main/java/org/epics/pva/common/SearchRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SearchRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,9 @@ import static org.epics.pva.PVASettings.logger;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.logging.Level;
 
 import org.epics.pva.data.PVAAddress;
@@ -23,6 +26,43 @@ import org.epics.pva.data.PVAString;
 @SuppressWarnings("nls")
 public class SearchRequest
 {
+    /** Channel with CID to be searched */
+    public static class Channel
+    {
+        /** Client ID */
+        protected final int cid;
+
+        /** Channel name */
+        protected final String name;
+
+        /** @param cid Client ID
+         *  @param name Channel name
+         */
+        public Channel(final int cid, final String name)
+        {
+            this.cid = cid;
+            this.name = name;
+        }
+
+        /** @return Client channel ID */
+        public int getCID()
+        {
+            return cid;
+        }
+
+        /** @return Channel name */
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "'" + name + "' [CID " + cid + "]";
+        }
+    };
+
     /** Sequence number */
     public int seq;
     /** Is it a unicast? */
@@ -31,10 +71,8 @@ public class SearchRequest
     public boolean reply_required;
     /** Address of client */
     public InetSocketAddress client;
-    /** Names requested in search */
-    public String[] name;
-    /** Client IDs for names */
-    public int[] cid;
+    /** Names requested in search, <code>null</code> for 'list' */
+    public List<Channel> channels;
 
     /** Check search request
      *
@@ -105,7 +143,7 @@ public class SearchRequest
 
         if (count == 0)
         {   // pvlist request
-            search.name = null;
+            search.channels = null;
             logger.log(Level.FINER, () -> "PVA Client " + from + " sent search #" + search.seq + " to list servers");
         }
         else
@@ -115,15 +153,13 @@ public class SearchRequest
                 logger.log(Level.WARNING, "PVA Client " + from + " sent search #" + search.seq + " for protocol '" + protocol + "', need 'tcp'");
                 return null;
             }
-            search.name = new String[count];
-            search.cid  = new int[count];
+            search.channels = new ArrayList<>(count);
             for (int i=0; i<count; ++i)
             {
                 final int cid = buffer.getInt();
                 final String name = PVAString.decodeString(buffer);
                 logger.log(Level.FINER, () -> "PVA Client " + from + " sent search #" + search.seq + " for " + name + " [cid " + cid + "]");
-                search.name[i] = name;
-                search.cid[i] = cid;
+                search.channels.add(new Channel(cid, name));
             }
         }
 
@@ -132,12 +168,11 @@ public class SearchRequest
 
     /** @param unicast Unicast?
      *  @param seq Sequence number
-     *  @param cid Client ID
-     *  @param name PV name
+     *  @param channels Channels to search, <code>null</code> for 'list'
      *  @param address client's address
      *  @param buffer Buffer into which to encode
      */
-    public static void encode(final boolean unicast, final int seq, final int cid, final String name, final InetSocketAddress address, final ByteBuffer buffer)
+    public static void encode(final boolean unicast, final int seq, final Collection<Channel> channels, final InetSocketAddress address, final ByteBuffer buffer)
     {
         // Create with zero payload size, to be patched later
         PVAHeader.encodeMessageHeader(buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_SEARCH, 0);
@@ -152,7 +187,7 @@ public class SearchRequest
         // Mark search message as unicast so that receiver will forward
         // it via local broadcast to other local listeners.
         // 0-bit for replyRequired, 7-th bit for "sent as unicast" (1)/"sent as broadcast/multicast" (0)
-        buffer.put((byte) ((unicast ? 0x80 : 0x00) | (cid < 0 ? 0x01 : 0x00)));
+        buffer.put((byte) ((unicast ? 0x80 : 0x00) | (channels == null ? 0x01 : 0x00)));
 
         // reserved
         buffer.put((byte) 0);
@@ -166,8 +201,9 @@ public class SearchRequest
         buffer.putShort((short)address.getPort());
 
         // string[] protocols with count as byte since < 254
-        // struct { int searchInstanceID, string channelName } channels[] with count as short?!
-        if (cid < 0)
+        // struct { int searchInstanceID, string channelName } channels[] with count as short
+        // No protocol and empty channels[] for 'list' aka 'discover' request
+        if (channels == null)
         {
             buffer.put((byte)0);
             buffer.putShort((short)0);
@@ -177,9 +213,12 @@ public class SearchRequest
             buffer.put((byte)1);
             PVAString.encodeString("tcp", buffer);
 
-            buffer.putShort((short)1);
-            buffer.putInt(cid);
-            PVAString.encodeString(name, buffer);
+            buffer.putShort((short)channels.size());
+            for (Channel channel : channels)
+            {
+                buffer.putInt(channel.cid);
+                PVAString.encodeString(channel.name, buffer);
+            }
         }
 
         // Update payload size

--- a/core/pva/src/main/java/org/epics/pva/server/PVAServer.java
+++ b/core/pva/src/main/java/org/epics/pva/server/PVAServer.java
@@ -35,6 +35,8 @@ import org.epics.pva.data.PVAStructure;
 @SuppressWarnings("nls")
 public class PVAServer implements AutoCloseable
 {
+    // TODO Implement beacons?
+
     /** Common thread pool */
     public static ForkJoinPool POOL = ForkJoinPool.commonPool();
 

--- a/core/pva/src/main/java/org/epics/pva/server/SearchCommandHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/SearchCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2021-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,9 +32,9 @@ class SearchCommandHandler implements CommandHandler<ServerTCPHandler>
 
         final SearchRequest search = SearchRequest.decode(tcp.getRemoteAddress(), version, payload_size, buffer);
 
-        if (search.name != null)
-            for (int i=0; i<search.name.length; ++i)
-                tcp.getServer().handleSearchRequest(search.seq, search.cid[i], search.name[i],
+        if (search.channels != null)
+            for (SearchRequest.Channel channel : search.channels)
+                tcp.getServer().handleSearchRequest(search.seq, channel.getCID(), channel.getName(),
                                                     search.client, tcp);
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerUDPHandler.java
@@ -15,6 +15,9 @@ import java.net.InetSocketAddress;
 import java.net.StandardProtocolFamily;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.logging.Level;
 
 import org.epics.pva.PVASettings;
@@ -176,24 +179,33 @@ class ServerUDPHandler extends UDPHandler
         if (search == null)
             return false;
 
-        if (search.name == null)
+        if (search.channels == null)
         {
             if (search.reply_required)
             {   // pvlist request
                 final boolean handled = server.handleSearchRequest(0, -1, null, search.client, null);
                 if (! handled  &&  search.unicast)
-                    PVAServer.POOL.submit(() -> forwardSearchRequest(0, -1, null, search.client));
+                    PVAServer.POOL.submit(() -> forwardSearchRequest(0, null, search.client));
             }
         }
         else
         {   // Channel search request
-            for (int i=0; i<search.name.length; ++i)
+            List<SearchRequest.Channel> forward = null;
+            for (SearchRequest.Channel channel : search.channels)
             {
-                final int cid = search.cid[i];
-                final String name = search.name[i];
-                final boolean handled = server.handleSearchRequest(search.seq, cid, name, search.client, null);
+                final boolean handled = server.handleSearchRequest(search.seq, channel.getCID(), channel.getName(), search.client, null);
                 if (! handled && search.unicast)
-                    PVAServer.POOL.submit(() -> forwardSearchRequest(search.seq, cid, name, search.client));
+                {
+                    if (forward == null)
+                        forward = new ArrayList<>();
+                    forward.add(channel);
+                }
+            }
+
+            if (forward != null)
+            {
+                final List<SearchRequest.Channel> to_forward = forward;
+                PVAServer.POOL.submit(() -> forwardSearchRequest(search.seq, to_forward, search.client));
             }
         }
 
@@ -209,11 +221,10 @@ class ServerUDPHandler extends UDPHandler
      *  allowing all servers on this host to reply.
      *
      *  @param seq Search sequence or 0
-     *  @param cid Channel ID or -1
-     *  @param name Name or <code>null</code>
+     *  @param channels Channel CIDs and names or <code>null</code> for 'list'
      *  @param address Client's address and port
      */
-    private void forwardSearchRequest(final int seq, final int cid, final String name, final InetSocketAddress address)
+    private void forwardSearchRequest(final int seq, final Collection<SearchRequest.Channel> channels, final InetSocketAddress address)
     {
         // TODO Remove the local IPv4 multicast re-send from the protocol, just use multicast from the start as with IPv6
         if (local_multicast == null)
@@ -221,7 +232,7 @@ class ServerUDPHandler extends UDPHandler
         synchronized (send_buffer)
         {
             send_buffer.clear();
-            SearchRequest.encode(false, seq, cid, name, address, send_buffer);
+            SearchRequest.encode(false, seq, channels, address, send_buffer);
             send_buffer.flip();
             logger.log(Level.FINER, () -> "Forward search to " + local_multicast + "\n" + Hexdump.toHexdump(send_buffer));
             try


### PR DESCRIPTION
Perform searches as implemented in PVXS client:
Distance searches by 1, then 2, 3, 4, ..., 30 seconds, but using "buckets" for the next ~30 seconds to spread searches out.
If a channels needs to be re-searched in an upcoming bucket that already has channels to be searched, while the next bucket has fewer, use that one, i.e. delay search by 1 second to spread them out.
At the same time, finally support adding more than one channel per search message.
Overall, this results in fewer and more spread out UDP messages.