### PR TITLE
Bug fix rules dialog, probably due to JavaFX 18

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/RulesDialog.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/RulesDialog.java
@@ -81,7 +81,7 @@ import javafx.scene.layout.VBox;
 public class RulesDialog extends Dialog<List<RuleInfo>>
 {
     /** Expression info as property-based item for table */
-    public abstract static class ExprItem<T>
+    protected abstract static class ExprItem<T>
     {
         final protected StringProperty boolExp = new SimpleStringProperty();
         final protected SimpleObjectProperty<Node> field = new SimpleObjectProperty<>();
@@ -223,7 +223,7 @@ public class RulesDialog extends Dialog<List<RuleInfo>>
     }
 
     /** Modifiable RuleInfo */
-    public static class RuleItem
+    protected static class RuleItem
     {
         public List<ExprItem<?>> expressions;
         public List<PVTableItem> pvs;

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/RulesDialog.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/RulesDialog.java
@@ -81,7 +81,7 @@ import javafx.scene.layout.VBox;
 public class RulesDialog extends Dialog<List<RuleInfo>>
 {
     /** Expression info as property-based item for table */
-    private abstract static class ExprItem<T>
+    public abstract static class ExprItem<T>
     {
         final protected StringProperty boolExp = new SimpleStringProperty();
         final protected SimpleObjectProperty<Node> field = new SimpleObjectProperty<>();
@@ -223,7 +223,7 @@ public class RulesDialog extends Dialog<List<RuleInfo>>
     }
 
     /** Modifiable RuleInfo */
-    private static class RuleItem
+    public static class RuleItem
     {
         public List<ExprItem<?>> expressions;
         public List<PVTableItem> pvs;


### PR DESCRIPTION
Opening the rules dialog on a widget with existing rules throws an exception like:

``java.lang.RuntimeException: java.lang.IllegalAccessException: class com.sun.javafx.reflect.Trampoline cannot access a member of class org.csstudio.display.builder.editor.properties.RulesDialog$ExprItem with modifiers "public"``

This seems to be related to the JavaFX 16 -> 18 update.

Fix is to declare some inner classes of RulesDialog as protected instead of private.