### PR TITLE
Increment version of log4j

### DIFF
--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -519,7 +519,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
-      <version>2.14.1</version>
+      <version>${log4j-to-slf4j.version}</version>
     </dependency>
 
     <!--JUL bindings for sfl4j-->

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <skipITTests>true</skipITTests>
     <guava.version>31.0.1-jre</guava.version>
+    <log4j-to-slf4j.version>2.17.1</log4j-to-slf4j.version>
   </properties>
   <build>
     <plugins>

--- a/services/alarm-logger/pom.xml
+++ b/services/alarm-logger/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
-      <version>2.14.1</version>
+      <version>${log4j-to-slf4j.version}</version>
     </dependency>
 
     <!--JUL bindings for sfl4j-->


### PR DESCRIPTION
Updating to 2.17.1 which according to https://logging.apache.org/log4j/2.x/security.html is "fixed".

We're not directly using log4j at all, it's only dragged in via the og4j-to-slf4j connector to route messages from other dependencies, but simply having log4j 2.14 in the file system causes computer security scans to alert.