### PR TITLE
Bug fix in save-and-restore delete node handling

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
@@ -443,7 +443,6 @@ public class SaveAndRestoreController implements Initializable, NodeChangedListe
 
             @Override
             public void succeeded() {
-                parent.getChildren().removeAll(items);
                 List<Tab> tabsToRemove = new ArrayList<>();
                 List<Tab> visibleTabs = tabPane.getTabs();
                 for (Tab tab : visibleTabs) {
@@ -454,8 +453,9 @@ public class SaveAndRestoreController implements Initializable, NodeChangedListe
                         }
                     }
                 }
-                changesInProgress.set(false);
                 tabPane.getTabs().removeAll(tabsToRemove);
+                parent.getChildren().removeAll(items);
+                changesInProgress.set(false);
             }
 
             @Override


### PR DESCRIPTION
Fixes: open tabs not closed when corresponding nodes in the TreeView are deleted.