### PR TITLE
Display: Support 'class' for array/struct properties

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
@@ -22,6 +22,7 @@ import org.csstudio.display.builder.editor.DisplayEditor;
 import org.csstudio.display.builder.editor.EditorGUI;
 import org.csstudio.display.builder.editor.EditorUtil;
 import org.csstudio.display.builder.editor.Messages;
+import org.csstudio.display.builder.editor.WidgetSelectionHandler;
 import org.csstudio.display.builder.editor.actions.ActionDescription;
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.ModelPlugin;
@@ -389,7 +390,17 @@ public class DisplayEditorInstance implements AppInstance
             // (which triggers editor UI updates, so perform in UI thread)
             final DisplayModel model = editor_gui.getDisplayEditor().getModel();
             if (model != null)
-                Platform.runLater( () ->  WidgetClassesService.getWidgetClasses().apply(model) );
+                Platform.runLater( () ->
+                {
+                    // Save/restore selection to force update of property panel
+                    final WidgetSelectionHandler selection = editor_gui.getDisplayEditor().getWidgetSelectionHandler();
+                    final List<Widget> save = selection.getSelection();
+                    selection.clear();
+                    // Apply class settings
+                    WidgetClassesService.getWidgetClasses().apply(model);
+                    // Restore selection
+                    selection.setSelection(save);
+                });
         });
     }
 

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -386,9 +386,10 @@ public class DisplayEditorInstance implements AppInstance
         ModelThreadPool.getExecutor().execute(() ->
         {
             // get widget classes and apply to model
+            // (which triggers editor UI updates, so perform in UI thread)
             final DisplayModel model = editor_gui.getDisplayEditor().getModel();
             if (model != null)
-                WidgetClassesService.getWidgetClasses().apply(model);
+                Platform.runLater( () ->  WidgetClassesService.getWidgetClasses().apply(model) );
         });
     }
 

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -499,18 +499,21 @@ public class PropertyPanelSection extends GridPane
      *  @param property Property (on primary widget)
      *  @param other Zero or more additional widgets that have same type of property
      *  @param structureIndex Index of the array structure (element) being added. It is meaningful
-     *                        only for properties instance of {@link StructuredWidgetProperty}.
+     *                        only for properties instance of {@link StructuredWidgetProperty}
+     *  @param indentationLevel Indentation level
      */
     private void createPropertyUI(
         final UndoableActionManager undo,
         final WidgetProperty<?> property,
         final List<Widget> other,
         final int structureIndex,
-        final int indentationLevel
-    ) {
+        final int indentationLevel)
+    {
         // Skip runtime properties
         if (property.getCategory() == WidgetPropertyCategory.RUNTIME)
             return;
+
+        // System.out.println("Index " + structureIndex + ", level " + indentationLevel + ": " + property.getPath());
 
         final Label label = new Label(property.getDescription());
         label.setMaxWidth(Double.MAX_VALUE);
@@ -567,9 +570,7 @@ public class PropertyPanelSection extends GridPane
             field = rules_field;
         }
         else if (property instanceof StructuredWidgetProperty)
-        {   // Don't allow editing structures and their elements in class mode
-            if (class_mode)
-                return;
+        {
             final StructuredWidgetProperty struct = (StructuredWidgetProperty) property;
             final Label header = new Label(struct.getDescription() + ( structureIndex > 0 ? " " + String.valueOf(1 + structureIndex) : ""));
             header.getStyleClass().add("structure_property_name");
@@ -589,9 +590,7 @@ public class PropertyPanelSection extends GridPane
             return;
         }
         else if (property instanceof ArrayWidgetProperty)
-        {   // Don't allow editing arrays and their elements in class mode
-            if (class_mode)
-                return;
+        {
             @SuppressWarnings("unchecked")
             final ArrayWidgetProperty<WidgetProperty<?>> array = (ArrayWidgetProperty<WidgetProperty<?>>) property;
 
@@ -611,6 +610,18 @@ public class PropertyPanelSection extends GridPane
 
             fillHeaderIndent(indentationLevel, row);
             add(label, indentationLevel, row, 4 - indentationLevel, 1);
+
+            if (class_mode)
+            {
+                final CheckBox check = new CheckBox();
+                check.setPadding(new Insets(0, 5, 0, 0));
+                check.setTooltip(use_class_tooltip);
+                final WidgetPropertyBinding<?,?> binding = new UseWidgetClassBinding(undo, check, spinner, property, other);
+                bindings.add(binding);
+                binding.bind();
+                add(check, 3, row);
+            }
+
             add(spinner, 4, row, 2 - indentationLevel, 1);
 
             Separator separator = new Separator();
@@ -683,14 +694,20 @@ public class PropertyPanelSection extends GridPane
         {
             if (class_mode)
             {   // Class definition mode:
-                // Check box for 'use_class'
-                final CheckBox check = new CheckBox();
-                check.setPadding(new Insets(0, 5, 0, 0));
-                check.setTooltip(use_class_tooltip);
-                final WidgetPropertyBinding<?,?> binding = new UseWidgetClassBinding(undo, check, field, property, other);
-                bindings.add(binding);
-                binding.bind();
-                add(check, 3, row);
+                // Check box for 'use_class', but only on the top level
+                // For nested properties inside an array or struct,
+                // the class behavior is controlled at the top-level
+                // for the complete array or struct
+                if (indentationLevel == 0)
+                {
+                    final CheckBox check = new CheckBox();
+                    check.setPadding(new Insets(0, 5, 0, 0));
+                    check.setTooltip(use_class_tooltip);
+                    final WidgetPropertyBinding<?,?> binding = new UseWidgetClassBinding(undo, check, field, property, other);
+                    bindings.add(binding);
+                    binding.bind();
+                    add(check, 3, row);
+                }
             }
             else
             {   // Display file mode:

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -612,7 +612,7 @@ public class PropertyPanelSection extends GridPane
             add(label, indentationLevel, row, 4 - indentationLevel, 1);
 
             if (class_mode)
-            {
+            {   // Checkbox to select if array is included in class definition
                 final CheckBox check = new CheckBox();
                 check.setPadding(new Insets(0, 5, 0, 0));
                 check.setTooltip(use_class_tooltip);
@@ -620,6 +620,16 @@ public class PropertyPanelSection extends GridPane
                 bindings.add(binding);
                 binding.bind();
                 add(check, 3, row);
+            }
+            else
+            {   // Show if property is set by the class, not editable.
+                final Label indicator = new Label();
+                indicator.setPadding(new Insets(0, 5, 0, 0));
+                indicator.setTooltip(using_class_tooltip);
+                final WidgetPropertyBinding<?,?> binding = new ShowWidgetClassBinding(spinner, property, indicator);
+                bindings.add(binding);
+                binding.bind();
+                add(indicator, 3, row);
             }
 
             add(spinner, 4, row, 2 - indentationLevel, 1);

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/UseWidgetClassBinding.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/UseWidgetClassBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,13 +55,14 @@ public class UseWidgetClassBinding extends WidgetPropertyBinding<CheckBox, Widge
         updateFromModel();
         jfx_node.setOnAction(event ->
         {
+            final boolean use_class = jfx_node.isSelected();
             updating = true;
-            property_field.setDisable(! jfx_node.isSelected());
-            undo.execute(new UseClassAction(widget_property, jfx_node.isSelected()));
+            property_field.setDisable(! use_class);
+            undo.execute(new UseClassAction(widget_property, use_class));
             for (Widget w : other)
             {
                 final WidgetProperty<?> other_prop = w.getProperty(widget_property.getName());
-                undo.execute(new UseClassAction(other_prop, jfx_node.isSelected()));
+                undo.execute(new UseClassAction(other_prop, use_class));
             }
             updating = false;
         });

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/undo/UseClassAction.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/undo/UseClassAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2017 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,8 +7,6 @@
  *******************************************************************************/
 package org.csstudio.display.builder.editor.undo;
 
-import org.csstudio.display.builder.model.ArrayWidgetProperty;
-import org.csstudio.display.builder.model.StructuredWidgetProperty;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.phoebus.ui.undo.UndoableAction;
 
@@ -34,34 +32,12 @@ public class UseClassAction extends UndoableAction
     @Override
     public void run()
     {
-        useClassDeep(property, use_class);
+        property.useWidgetClass(use_class);
     }
 
     @Override
     public void undo()
     {
-        useClassDeep(property, !use_class);
-    }
-
-    /** Set the use-class flag on property and descend into array and structure elements
-     *  @param prop Property
-     *  @param use Use class settings?
-     */
-    @SuppressWarnings("unchecked")
-    private void useClassDeep(final WidgetProperty<?> prop, final boolean use)
-    {
-        prop.useWidgetClass(use);
-        if (prop instanceof ArrayWidgetProperty<?>)
-        {
-            final ArrayWidgetProperty<WidgetProperty<?>> arr = (ArrayWidgetProperty<WidgetProperty<?>>) prop;
-            for (WidgetProperty<?> element : arr.getValue())
-                useClassDeep(element, use);
-        }
-        else if (prop instanceof StructuredWidgetProperty)
-        {
-            final StructuredWidgetProperty struct = (StructuredWidgetProperty) prop;
-            for (WidgetProperty<?> element : struct.getValue())
-                useClassDeep(element, use);
-        }
+        property.useWidgetClass(!use_class);
     }
 }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/undo/UseClassAction.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/undo/UseClassAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.editor.undo;
 
+import org.csstudio.display.builder.model.ArrayWidgetProperty;
+import org.csstudio.display.builder.model.StructuredWidgetProperty;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.phoebus.ui.undo.UndoableAction;
 
@@ -32,12 +34,34 @@ public class UseClassAction extends UndoableAction
     @Override
     public void run()
     {
-        property.useWidgetClass(use_class);
+        useClassDeep(property, use_class);
     }
 
     @Override
     public void undo()
     {
-        property.useWidgetClass(!use_class);
+        useClassDeep(property, !use_class);
+    }
+
+    /** Set the use-class flag on property and descend into array and structure elements
+     *  @param prop Property
+     *  @param use Use class settings?
+     */
+    @SuppressWarnings("unchecked")
+    private void useClassDeep(final WidgetProperty<?> prop, final boolean use)
+    {
+        prop.useWidgetClass(use);
+        if (prop instanceof ArrayWidgetProperty<?>)
+        {
+            final ArrayWidgetProperty<WidgetProperty<?>> arr = (ArrayWidgetProperty<WidgetProperty<?>>) prop;
+            for (WidgetProperty<?> element : arr.getValue())
+                useClassDeep(element, use);
+        }
+        else if (prop instanceof StructuredWidgetProperty)
+        {
+            final StructuredWidgetProperty struct = (StructuredWidgetProperty) prop;
+            for (WidgetProperty<?> element : struct.getValue())
+                useClassDeep(element, use);
+        }
     }
 }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
@@ -122,6 +122,15 @@ public class ArrayWidgetProperty<WPE extends WidgetProperty<?>> extends WidgetPr
     }
 
     @Override
+    public void useWidgetClass(boolean use_class)
+    {
+        // Update overall array as well as each element
+        super.useWidgetClass(use_class);
+        for (WPE element : value)
+            element.useWidgetClass(use_class);
+    }
+
+    @Override
     protected List<WPE> restrictValue(final List<WPE> requested_value)
     {
         if (requested_value instanceof CopyOnWriteArrayList)

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
@@ -195,6 +195,8 @@ public class ArrayWidgetProperty<WPE extends WidgetProperty<?>> extends WidgetPr
     /** @param element Element to add to end of list */
     public void addElement(final WPE element)
     {
+        // New elements get same class behavior as the array
+        element.useWidgetClass(use_class);
         value.add(element);
         firePropertyChange(null, Arrays.asList(element));
     }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
@@ -112,15 +112,6 @@ public class ArrayWidgetProperty<WPE extends WidgetProperty<?>> extends WidgetPr
     }
 
     @Override
-    public boolean isUsingWidgetClass()
-    {   // Array uses class if any elements use it
-        for (WidgetProperty<?> element : value)
-            if (element.isUsingWidgetClass())
-                return true;
-        return false;
-    }
-
-    @Override
     public boolean isDefaultValue()
     {
         // Array has 'default' value if it contains

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/ArrayWidgetProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -239,8 +239,7 @@ public class ArrayWidgetProperty<WPE extends WidgetProperty<?>> extends WidgetPr
                     element.setValueFromObject(el_value);
             }
 
-            // Notify listeners of the whole array
-            firePropertyChange(this, null, this.value);
+            // Listeners already received remove/add/set events
         }
         catch (Throwable ex)
         {

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/StructuredWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/StructuredWidgetProperty.java
@@ -76,6 +76,15 @@ public class StructuredWidgetProperty extends WidgetProperty<List<WidgetProperty
         return true;
     }
 
+    @Override
+    public void useWidgetClass(boolean use_class)
+    {
+        // Update overall structure as well as each element
+        super.useWidgetClass(use_class);
+        for (WidgetProperty<?> element : value)
+            element.useWidgetClass(use_class);
+    }
+
     /** @return <code>true</code> if all elements are read-only */
     @Override
     public boolean isReadonly()

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/StructuredWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/StructuredWidgetProperty.java
@@ -66,16 +66,6 @@ public class StructuredWidgetProperty extends WidgetProperty<List<WidgetProperty
         super(descriptor, widget, elements);
     }
 
-    /** @return <code>true</code> if any element is using class support */
-    @Override
-    public boolean isUsingWidgetClass()
-    {
-        for (WidgetProperty<?> element : value)
-            if (element.isUsingWidgetClass())
-                return true;
-        return false;
-    }
-
     /** @return <code>true</code> if all elements have default value */
     @Override
     public boolean isDefaultValue()

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/StructuredWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/StructuredWidgetProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -142,35 +142,42 @@ public class StructuredWidgetProperty extends WidgetProperty<List<WidgetProperty
     @Override
     public void setValueFromObject(final Object new_value) throws Exception
     {
-        if (new_value instanceof List)
-        {   // Allow assignment of another structure's value, i.e. list with same elements
-            final List<?> new_elements = (List<?>)new_value;
-            if (new_elements.size() != value.size())
-                throw new Exception("Elements of structure " + getName() + " must provide " + value.size() + " elements, got " + new_elements.size());
-            for (int i=0; i<value.size(); ++i)
-            {
-                final WidgetProperty<?> element = value.get(i);
-                final Object new_object = new_elements.get(i);
-                if (element.getClass() != new_object.getClass())
-                    throw new Exception("Cannot set structure " + getName() + "." + element.getName() + " to " + new_object);
+        final List<?> new_elements;
 
-                final WidgetProperty<?> new_element = (WidgetProperty<?>)new_object;
-                if (element.getName() != new_element.getName())
-                    throw new Exception("Cannot set structure " + getName() + "." + element.getName() + " to " + new_element.getName());
-                try
-                {
-                    element.setValueFromObject(new_element.getValue());
-                }
-                catch (Exception ex)
-                {
-                    throw new Exception("Cannot set structure " + getName() + "." + element.getName() + " to " + new_element, ex);
-                }
-            }
-            // Notify listeners of the whole array
-            firePropertyChange(this, null, this.value);
+        // May use other struct or list with elements
+        if (new_value instanceof StructuredWidgetProperty)
+        {
+            final StructuredWidgetProperty other = (StructuredWidgetProperty) new_value;
+            new_elements = other.value;
         }
+        else if (new_value instanceof List)
+            new_elements = (List<?>)new_value;
         else
             throw new Exception("Elements of structure " + getName() + " cannot be assigned from " + new_value);
+
+        // Either way, element count and names of elements must match this struct
+        if (new_elements.size() != value.size())
+            throw new Exception("Elements of structure " + getName() + " must provide " + value.size() + " elements, got " + new_elements.size());
+        for (int i=0; i<value.size(); ++i)
+        {
+            final WidgetProperty<?> element = value.get(i);
+            final Object new_object = new_elements.get(i);
+            if (element.getClass() != new_object.getClass())
+                throw new Exception("Cannot set structure " + getName() + "." + element.getName() + " to " + new_object);
+
+            final WidgetProperty<?> new_element = (WidgetProperty<?>)new_object;
+            if (element.getName() != new_element.getName())
+                throw new Exception("Cannot set structure " + getName() + "." + element.getName() + " to " + new_element.getName());
+            try
+            {
+                element.setValueFromObject(new_element.getValue());
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Cannot set structure " + getName() + "." + element.getName() + " to " + new_element, ex);
+            }
+        }
+        // Listeners have been notified about each element in setValueFromObject
     }
 
     @Override

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -227,15 +227,7 @@ public abstract class WidgetProperty<T extends Object> extends PropertyChangeHan
      */
     public void useWidgetClass(final boolean use_class)
     {
-        if (this.use_class == use_class)
-            return;
-
         this.use_class = use_class;
-
-        // Editor for class model needs update, runtime doesn't
-        final DisplayModel model = getWidget().checkDisplayModel();
-        if (model != null  &&  model.isClassModel())
-            firePropertyChange(null, null);
     }
 
     /** @return Is value of this property following

--- a/app/display/model/src/main/resources/examples/classes.bcf
+++ b/app/display/model/src/main/resources/examples/classes.bcf
@@ -153,39 +153,6 @@ Properties are marked to be included in the class definition.</text>
       </font>
     </font>
   </widget>
-  <widget type="multi_state_led" version="2.0.0">
-    <name>GOOD_BAD_ERROR</name>
-    <x>130</x>
-    <y>340</y>
-    <width use_class="true">50</width>
-    <height use_class="true">30</height>
-    <states use_class="true">
-      <state>
-        <value use_class="true">0</value>
-        <label use_class="true">Good</label>
-        <color use_class="true">
-          <color name="OK" red="0" green="255" blue="0">
-          </color>
-        </color>
-      </state>
-      <state>
-        <value use_class="true">1</value>
-        <label use_class="true">Bad</label>
-        <color use_class="true">
-          <color name="MINOR" red="255" green="128" blue="0">
-          </color>
-        </color>
-      </state>
-      <state>
-        <value use_class="true">2</value>
-        <label use_class="true">Error</label>
-        <color use_class="true">
-          <color name="MAJOR" red="255" green="0" blue="0">
-          </color>
-        </color>
-      </state>
-    </states>
-  </widget>
   <widget type="label" version="2.0.0">
     <name>Label_2</name>
     <text>GOOD_BAD_ERROR</text>
@@ -195,5 +162,38 @@ Properties are marked to be included in the class definition.</text>
       <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
       </font>
     </font>
+  </widget>
+  <widget type="multi_state_led" version="2.0.0">
+    <name>GOOD_BAD_ERROR</name>
+    <x>130</x>
+    <y>340</y>
+    <width use_class="true">50</width>
+    <height use_class="true">30</height>
+    <states use_class="true">
+      <state use_class="true">
+        <value use_class="true">0</value>
+        <label use_class="true">Good</label>
+        <color use_class="true">
+          <color name="OK" red="0" green="255" blue="0">
+          </color>
+        </color>
+      </state>
+      <state use_class="true">
+        <value use_class="true">1</value>
+        <label use_class="true">Bad</label>
+        <color use_class="true">
+          <color name="MINOR" red="255" green="128" blue="0">
+          </color>
+        </color>
+      </state>
+      <state use_class="true">
+        <value use_class="true">2</value>
+        <label use_class="true">Error</label>
+        <color use_class="true">
+          <color name="MAJOR" red="255" green="0" blue="0">
+          </color>
+        </color>
+      </state>
+    </states>
   </widget>
 </display>

--- a/app/display/model/src/main/resources/examples/classes.bcf
+++ b/app/display/model/src/main/resources/examples/classes.bcf
@@ -153,4 +153,47 @@ Properties are marked to be included in the class definition.</text>
       </font>
     </font>
   </widget>
+  <widget type="multi_state_led" version="2.0.0">
+    <name>GOOD_BAD_ERROR</name>
+    <x>130</x>
+    <y>340</y>
+    <width use_class="true">50</width>
+    <height use_class="true">30</height>
+    <states use_class="true">
+      <state>
+        <value use_class="true">0</value>
+        <label use_class="true">Good</label>
+        <color use_class="true">
+          <color name="OK" red="0" green="255" blue="0">
+          </color>
+        </color>
+      </state>
+      <state>
+        <value use_class="true">1</value>
+        <label use_class="true">Bad</label>
+        <color use_class="true">
+          <color name="MINOR" red="255" green="128" blue="0">
+          </color>
+        </color>
+      </state>
+      <state>
+        <value use_class="true">2</value>
+        <label use_class="true">Error</label>
+        <color use_class="true">
+          <color name="MAJOR" red="255" green="0" blue="0">
+          </color>
+        </color>
+      </state>
+    </states>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_2</name>
+    <text>GOOD_BAD_ERROR</text>
+    <y>340</y>
+    <width>120</width>
+    <font>
+      <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
+      </font>
+    </font>
+  </widget>
 </display>

--- a/app/display/model/src/main/resources/examples/monitors_led.bob
+++ b/app/display/model/src/main/resources/examples/monitors_led.bob
@@ -607,7 +607,7 @@ For Multi-State LEDs, the states can be predefined via a class.</text>
     <width use_class="true">50</width>
     <height use_class="true">30</height>
     <border_alarm_sensitive>false</border_alarm_sensitive>
-    <states use_class="true">
+    <states>
       <state>
         <value>0</value>
         <label>Good</label>

--- a/app/display/model/src/main/resources/examples/monitors_led.bob
+++ b/app/display/model/src/main/resources/examples/monitors_led.bob
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
   <name>LED</name>
-  <width>650</width>
-  <height>650</height>
+  <width>980</width>
+  <height>682</height>
   <widget type="label" version="2.0.0">
     <name>Label</name>
     <class>TITLE</class>
@@ -532,7 +532,7 @@ except that the border follows the outline of the LED.</text>
     <width>26</width>
     <height>26</height>
     <off_color use_class="true">
-      <color red="105" green="74" blue="44">
+      <color name="Off" red="60" green="100" blue="60">
       </color>
     </off_color>
     <on_color use_class="true">
@@ -549,14 +549,14 @@ except that the border follows the outline of the LED.</text>
   </widget>
   <widget type="led" version="2.0.0">
     <name>BoolLED_12</name>
-    <class>FAILURE</class>
+    <class>ERROR</class>
     <pv_name>sim://flipflop(2)</pv_name>
     <x>893</x>
     <y>70</y>
     <width>26</width>
     <height>26</height>
     <off_color use_class="true">
-      <color red="105" green="74" blue="44">
+      <color name="Off" red="60" green="100" blue="60">
       </color>
     </off_color>
     <on_color use_class="true">
@@ -567,17 +567,19 @@ except that the border follows the outline of the LED.</text>
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label_26</name>
-    <text>FAILURE</text>
+    <text>ERROR</text>
     <x>880</x>
     <y>50</y>
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label_27</name>
-    <text>Predefined LED classes can be used to get consistent indications for "Good/Bad", "On/Off" type of indicators.</text>
+    <text>Predefined LED classes can be used to get consistent indications for "Good/Bad", "On/Off" type of indicators.
+
+For Multi-State LEDs, the states can be predefined via a class.</text>
     <x>610</x>
     <y>144</y>
     <width>360</width>
-    <height>60</height>
+    <height>96</height>
     <font>
       <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
       </font>
@@ -595,5 +597,48 @@ except that the border follows the outline of the LED.</text>
     <pv_name>sim://flipflop(2)</pv_name>
     <x>680</x>
     <y>110</y>
+  </widget>
+  <widget type="multi_state_led" version="2.0.0">
+    <name>LED (Multi State)</name>
+    <class>GOOD_BAD_ERROR</class>
+    <pv_name>sim://ramp(0, 2, 1)</pv_name>
+    <x>660</x>
+    <y>280</y>
+    <width use_class="true">50</width>
+    <height use_class="true">30</height>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <states use_class="true">
+      <state>
+        <value>0</value>
+        <label>Good</label>
+        <color>
+          <color name="OK" red="0" green="255" blue="0">
+          </color>
+        </color>
+      </state>
+      <state>
+        <value>1</value>
+        <label>Bad</label>
+        <color>
+          <color name="MINOR" red="255" green="128" blue="0">
+          </color>
+        </color>
+      </state>
+      <state>
+        <value>2</value>
+        <label>Error</label>
+        <color>
+          <color name="MAJOR" red="255" green="0" blue="0">
+          </color>
+        </color>
+      </state>
+    </states>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_29</name>
+    <text>GOOD_BAD_ERROR</text>
+    <x>610</x>
+    <y>250</y>
+    <width>150</width>
   </widget>
 </display>


### PR DESCRIPTION
Widget classes used to only support scalar properties like X position, Width, "On" color of a binary LED.

Now classes can be used with array/struct properties like the list of symbol files for a Symbol widget or the states of a MultiStateLED.

In the class editor, the whole array can be selected to be included in the class definition
![class_edit](https://user-images.githubusercontent.com/1932421/174811790-eeb593f4-0cb2-4a04-976f-ae9918cf3719.png)

When then editing displays, selecting the class applies the complete array to the widget
![class_use](https://user-images.githubusercontent.com/1932421/174815774-77f291a7-10af-4314-ab9b-808fe775c637.png)

Similar example: Multi state LED with states set by class
![class_use2](https://user-images.githubusercontent.com/1932421/174816327-f3194fa1-4c4e-4c64-9669-4f1b18e217ec.png)


Fixes #2297