### PR TITLE
PVA decompress jpeg

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/Codec.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/Codec.java
@@ -124,10 +124,8 @@ abstract public class Codec
             return new PVADoubleArray("doubleValue", doubles);
 
         default:
-            System.out.println("Cannot decode compressed data for orig data type  " + orig_data_type);
+            throw new Exception("Cannot decode compressed data for orig data type  " + orig_data_type);
         }
-
-        return value;
     }
 
     /** De-compress byte array

--- a/core/pv/src/main/java/org/phoebus/pv/pva/Codec.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/Codec.java
@@ -33,16 +33,16 @@ abstract public class Codec
     private static final int[] BYTES_PER_SAMPLE =
     {
         0,
-        Byte.BYTES,     // byte
-        Short.BYTES,    // int16
-        Integer.BYTES,  // int32
-        Long.BYTES,     // int64
-        Byte.BYTES,     // ubyte
-        Short.BYTES,    // uint16
-        Integer.BYTES,  // uint32
-        Long.BYTES,     // uint64
-        Float.BYTES,    // float
-        Double.BYTES    // double
+        Byte.BYTES,     //  1 byte
+        Short.BYTES,    //  2 int16
+        Integer.BYTES,  //  3 int32
+        Long.BYTES,     //  4 int64
+        Byte.BYTES,     //  5 ubyte
+        Short.BYTES,    //  6 uint16
+        Integer.BYTES,  //  7 uint32
+        Long.BYTES,     //  8 uint64
+        Float.BYTES,    //  9 float
+        Double.BYTES    // 10 double
     };
 
     /** De-compress value

--- a/core/pv/src/main/java/org/phoebus/pv/pva/ImageDecoder.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/ImageDecoder.java
@@ -49,9 +49,17 @@ public class ImageDecoder
     // Could just use VImageType.values()[i+1] instead of color_mode_types[i], but
     // (a) there are more VImageType values than defined color modes, and
     // (b) the NTNDArray specification for color mode might eventually change
-    private static final VImageType color_mode_types[] = { VImageType.TYPE_MONO, VImageType.TYPE_BAYER,
-            VImageType.TYPE_RGB1, VImageType.TYPE_RGB2, VImageType.TYPE_RGB3, VImageType.TYPE_YUV444,
-            VImageType.TYPE_YUV422, VImageType.TYPE_YUV411 };
+    private static final VImageType color_mode_types[] =
+    {
+        VImageType.TYPE_MONO,
+        VImageType.TYPE_BAYER,
+        VImageType.TYPE_RGB1,
+        VImageType.TYPE_RGB2,
+        VImageType.TYPE_RGB3,
+        VImageType.TYPE_YUV444,
+        VImageType.TYPE_YUV422,
+        VImageType.TYPE_YUV411
+    };
 
     /** @param struct Structure with image
      *  @return VType for image
@@ -167,6 +175,8 @@ public class ImageDecoder
                 Codec codec = null;
                 if (name.get().equalsIgnoreCase("lz4"))
                     codec = new LZ4Codec();
+                else if (name.get().equalsIgnoreCase("jpeg"))
+                    codec = new JPEGCodec();
                 else
                     logger.log(Level.WARNING, "NDArray codec '" + name.get() + "' is not implemented");
 

--- a/core/pv/src/main/java/org/phoebus/pv/pva/JPEGCodec.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/JPEGCodec.java
@@ -9,14 +9,15 @@ package org.phoebus.pv.pva;
 
 import static org.phoebus.pv.PV.logger;
 
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
 import java.io.ByteArrayInputStream;
 import java.util.logging.Level;
 
+import javax.imageio.ImageIO;
+
 import org.epics.pva.data.PVAByteArray;
 import org.epics.pva.data.PVAData;
-
-import javafx.scene.image.Image;
-import javafx.scene.image.PixelReader;
 
 /** PVA NDArray codec for JPEG-compressed data
  *
@@ -41,6 +42,9 @@ public class JPEGCodec extends Codec
         return value;
     }
 
+    //private static int updates = 0;
+    //private static long avg_ns = 0;
+
     @Override
     public byte[] decompress(final byte[] data, final int decompressed_size) throws Exception
     {
@@ -49,29 +53,60 @@ public class JPEGCodec extends Codec
         // {  out.write(data); }
 
         final ByteArrayInputStream in = new ByteArrayInputStream(data);
-        final Image image = new Image(in);
-        final int width = (int) image.getWidth();
-        final int height = (int) image.getHeight();
+
+//        long start = System.nanoTime();
+        final byte[] result;
+
+//        // Expand using JavaFX Image
+//        // - Adds UI dependency to what's otherwise a non-UI module
+//        // - With 1024 x 1024 pixel sim detector image, this took about 13..20 ms
+//        final Image image = new Image(in);
+//        final int width = (int) image.getWidth();
+//        final int height = (int) image.getHeight();
+//        if (width * height != decompressed_size)
+//            throw new Exception("Expected JPEG with size " + decompressed_size + " but got " +
+//                                width + " x " + height + " = " + (width * height) + " bytes");
+//
+//        result = new byte[decompressed_size];
+//        final PixelReader pixels = image.getPixelReader();
+//        for (int y=0; y<height; ++y)
+//            for (int x=0; x<width; ++x)
+//            {
+//                final int rgba = pixels.getArgb(x, y);
+//                // Area detector only uses lower 8 bits
+//                result[x+y*width] = (byte) (rgba & 0xFF);
+//            }
+
+        // Expand using AWT API
+        // + Is strictly speaking UI, but no dependency beyond standard JRE
+        // + With 1024 x 1024 pixel sim detector image, this took about 2.5 .. 3.0 ms
+        final BufferedImage image = ImageIO.read(in);
+        final int width = image.getWidth();
+        final int height = image.getHeight();
         if (width * height != decompressed_size)
+            throw new Exception("Expected JPEG with size " + decompressed_size + " but got " +
+                                width + " x " + height + " = " + (width * height) + " bytes");
+
+        final int type = image.getType();
+        if (type == BufferedImage.TYPE_BYTE_GRAY)
         {
-            logger.log(Level.WARNING,
-                       "Expected JPEG with size " + decompressed_size + " but got " +
-                       width + " x " + height + " = " + (width * height) + " bytes");
-            return data;
+            final DataBufferByte buf = (DataBufferByte) image.getData().getDataBuffer();
+            result = buf.getData();
+            if (result.length != decompressed_size)
+                logger.log(Level.WARNING,
+                        "Expected " + decompressed_size + " expanded JPEG bytes but got " +
+                        result.length);
         }
+        else
+            throw new Exception("Expected TYPE_BYTE_GRAY but got type code " + type);
 
-        final PixelReader pixels = image.getPixelReader();
-        final byte[] result = new byte[decompressed_size];
-        for (int y=0; y<height; ++y)
-            for (int x=0; x<width; ++x)
-            {
-                final int rgba = pixels.getArgb(x, y);
-                // Area detector only uses lower 8 bits
-                result[x+y*width] = (byte) (rgba & 0xFF);
-            }
-
-        if (logger.isLoggable(Level.FINE))
-            logger.log(Level.FINE, "JPEG expands " + data.length + " into " + decompressed_size + " bytes");
+//        long ns = System.nanoTime() - start;
+//        avg_ns = (avg_ns + ns)/2;
+//        if (++updates > 10)
+//        {
+//            updates = 0;
+//            System.out.println(avg_ns/1e6 + " ms");
+//        }
 
         return result;
     }

--- a/core/pv/src/main/java/org/phoebus/pv/pva/JPEGCodec.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/JPEGCodec.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.pv.pva;
+
+import static org.phoebus.pv.PV.logger;
+
+import java.io.ByteArrayInputStream;
+import java.util.logging.Level;
+
+import org.epics.pva.data.PVAByteArray;
+import org.epics.pva.data.PVAData;
+
+import javafx.scene.image.Image;
+import javafx.scene.image.PixelReader;
+
+/** PVA NDArray codec for JPEG-compressed data
+ *
+ *  <p>Standard Java library only supports ZIP.
+ *  Area detector provides binaries/JNI interface
+ *  for JPEG, but that would add a hard to maintain
+ *  dependency on binaries.
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class JPEGCodec extends Codec
+{
+    @Override
+    public PVAData decompress(PVAByteArray value, int orig_data_type, int value_count) throws Exception
+    {
+        // Area detector codec plugin only supports JPEG for 8 bit data types
+        if (orig_data_type == 1  ||  orig_data_type == 5)
+            return super.decompress(value, orig_data_type, value_count);
+
+        logger.log(Level.WARNING, "JPEG decoding is only supported for original data types byte and ubyte, not " + orig_data_type);
+        return value;
+    }
+
+    @Override
+    public byte[] decompress(final byte[] data, final int decompressed_size) throws Exception
+    {
+        // Dump raw JPG file to debug
+        // try (FileOutputStream out = new FileOutputStream("/tmp/data.jpg"))
+        // {  out.write(data); }
+
+        final ByteArrayInputStream in = new ByteArrayInputStream(data);
+        final Image image = new Image(in);
+        final int width = (int) image.getWidth();
+        final int height = (int) image.getHeight();
+        if (width * height != decompressed_size)
+        {
+            logger.log(Level.WARNING,
+                       "Expected JPEG with size " + decompressed_size + " but got " +
+                       width + " x " + height + " = " + (width * height) + " bytes");
+            return data;
+        }
+
+        final PixelReader pixels = image.getPixelReader();
+        final byte[] result = new byte[decompressed_size];
+        for (int y=0; y<height; ++y)
+            for (int x=0; x<width; ++x)
+            {
+                final int rgba = pixels.getArgb(x, y);
+                // Area detector only uses lower 8 bits
+                result[x+y*width] = (byte) (rgba & 0xFF);
+            }
+
+        if (logger.isLoggable(Level.FINE))
+            logger.log(Level.FINE, "JPEG expands " + data.length + " into " + decompressed_size + " bytes");
+
+        return result;
+    }
+}

--- a/core/pv/src/main/java/org/phoebus/pv/pva/JPEGCodec.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/JPEGCodec.java
@@ -20,7 +20,7 @@ import org.epics.pva.data.PVAByteArray;
 import org.epics.pva.data.PVAData;
 
 /** PVA NDArray codec for JPEG-compressed data
- * *
+ *
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
@@ -89,8 +89,8 @@ public class JPEGCodec extends Codec
             result = buf.getData();
             if (result.length != decompressed_size)
                 logger.log(Level.WARNING,
-                        "Expected " + decompressed_size + " expanded JPEG bytes but got " +
-                        result.length);
+                           "Expected " + decompressed_size + " expanded JPEG bytes but got " +
+                           result.length);
         }
         else
             throw new Exception("Expected TYPE_BYTE_GRAY but got type code " + type);

--- a/core/pv/src/main/java/org/phoebus/pv/pva/JPEGCodec.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/JPEGCodec.java
@@ -20,12 +20,7 @@ import org.epics.pva.data.PVAByteArray;
 import org.epics.pva.data.PVAData;
 
 /** PVA NDArray codec for JPEG-compressed data
- *
- *  <p>Standard Java library only supports ZIP.
- *  Area detector provides binaries/JNI interface
- *  for JPEG, but that would add a hard to maintain
- *  dependency on binaries.
- *
+ * *
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
@@ -78,7 +73,7 @@ public class JPEGCodec extends Codec
 //            }
 
         // Expand using AWT API
-        // + Is strictly speaking UI, but no dependency beyond standard JRE
+        // + Is strictly speaking UI and also old API, but no dependency beyond standard JRE
         // + With 1024 x 1024 pixel sim detector image, this took about 2.5 .. 3.0 ms
         final BufferedImage image = ImageIO.read(in);
         final int width = image.getWidth();

--- a/core/pv/src/main/java/org/phoebus/pv/pva/LZ4Codec.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/LZ4Codec.java
@@ -7,10 +7,7 @@
  ******************************************************************************/
 package org.phoebus.pv.pva;
 
-import static org.phoebus.pv.PV.logger;
-
 import java.io.ByteArrayInputStream;
-import java.util.logging.Level;
 
 import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream;
 
@@ -25,7 +22,6 @@ import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream
  *
  *  @author Kay Kasemir
  */
-@SuppressWarnings("nls")
 public class LZ4Codec extends Codec
 {
     @Override
@@ -47,9 +43,6 @@ public class LZ4Codec extends Codec
                 expanded += batch;
             }
         }
-
-        if (logger.isLoggable(Level.FINE))
-            logger.log(Level.FINE, "LZ4 expands " + data.length + " into " + expanded + " bytes");
 
         return result;
     }

--- a/core/pv/src/main/java/org/phoebus/pv/pva/LZ4Codec.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/LZ4Codec.java
@@ -49,7 +49,7 @@ public class LZ4Codec extends Codec
         }
 
         if (logger.isLoggable(Level.FINE))
-            logger.log(Level.FINE, "LZ4 expands " + expanded + " into " + decompressed_size + " bytes");
+            logger.log(Level.FINE, "LZ4 expands " + data.length + " into " + expanded + " bytes");
 
         return result;
     }


### PR DESCRIPTION
.. so now LZ4 and JPEG compression is supported for area detector images