### PR TITLE
Image axes from pv

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/ImageWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/ImageWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFile;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propInteractive;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLimitsFromPV;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMaximum;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMinimum;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.runtimePropConfigure;
@@ -409,6 +410,7 @@ public class ImageWidget extends PVWidget
     private volatile WidgetProperty<ColorMap> data_colormap;
     private volatile ColorBarProperty color_bar;
     private volatile AxisWidgetProperty x_axis, y_axis;
+    private volatile WidgetProperty<Boolean> limits_from_pv;
     private volatile WidgetProperty<Integer> data_width, data_height;
     private volatile WidgetProperty<InterpolationType> data_interpolation;
     private volatile WidgetProperty<VImageType> data_color_mode;
@@ -440,6 +442,7 @@ public class ImageWidget extends PVWidget
         properties.add(color_bar = new ColorBarProperty(this));
         properties.add(x_axis = new XAxisWidgetProperty(this));
         properties.add(y_axis = new YAxisWidgetProperty(this));
+        properties.add(limits_from_pv = propLimitsFromPV.createProperty(this, false)); // 'true' would be preferred but breaks existing displays
         properties.add(data_width = propDataWidth.createProperty(this, 100));
         properties.add(data_height = propDataHeight.createProperty(this, 100));
         properties.add(data_interpolation = propInterpolationType.createProperty(this, InterpolationType.AUTOMATIC));
@@ -529,6 +532,12 @@ public class ImageWidget extends PVWidget
     public AxisWidgetProperty propYAxis()
     {
         return y_axis;
+    }
+
+    /** @return 'limits_from_pv' property */
+    public WidgetProperty<Boolean> propLimitsFromPV()
+    {
+        return limits_from_pv;
     }
 
     /** @return 'data_width' property */

--- a/app/display/model/src/main/resources/examples/plots_image.bob
+++ b/app/display/model/src/main/resources/examples/plots_image.bob
@@ -274,29 +274,6 @@ the value range.</text>
     </rois>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>Label_8</name>
-    <text>For PVAccess, a PV that serves an NTNDArray will provide
-both the image data and the width &amp; height information.
-(This is currently limited to byte[] data.
- For NTNDArray with short, int, etc., you need to read
- pva://that_pv/value to get just the data array,
- and configure the data width and height).
-
-For PVAccess or Channel Access, the data can be a waveform
-that contains the pixels values starting with the top-left pixel,
-followed by the pixels of the top row, then the second row
-and so on.
-
-The image data width and height need to be configured for
-waveform PVs.
-For NTNDArray PVs, the image size is provided by the PV.</text>
-    <x>201</x>
-    <y>921</y>
-    <width>421</width>
-    <height>279</height>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label_9</name>
     <class>SECTION</class>
     <text>PV, Data</text>
     <x>201</x>
@@ -311,6 +288,45 @@ For NTNDArray PVs, the image size is provided by the PV.</text>
       </color>
     </foreground_color>
     <transparent use_class="true">true</transparent>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <text>The pixel data is an array that starts with the top-left pixel, followed by the pixels of the top row, then the second row and so on.
+    
+For PVAccess, a PV that serves an NTNDArray will provide not only the pixel data but also the width, height, signed/unsigned information and color mode.
+
+For Channel Access, the waveform PV only provides pixels. The data width, height, signedness and color mode need to be configured via properties of the image widget.
+</text>
+    <x>201</x>
+    <y>921</y>
+    <width>421</width>
+    <height>209</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <class>SECTION</class>
+    <text>Axes</text>
+    <x>201</x>
+    <y>1130</y>
+    <width>171</width>
+    <font use_class="true">
+      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <text>When the "Limits from PV" property of the widget is set, the X axis will range from 0 to the width of the image in pixels and the Y axis from 0 to the height. The origin will be placed in the top-left corner.
+
+When "Limits from PV" is not set, the range of the X and Y axes can be configured independently from the image size. This allows for example a calibration of pixel positions in millimeters.
+The axis direction can be inverted by swapping the axis minimum and maximum limit.
+</text>
+    <x>201</x>
+    <y>1150</y>
+    <width>421</width>
+    <height>209</height>
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label_10</name>

--- a/app/display/model/src/main/resources/examples/plots_image.bob
+++ b/app/display/model/src/main/resources/examples/plots_image.bob
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
   <name>Image Widget</name>
-  <width>1100</width>
-  <height>1200</height>
+  <width>1090</width>
+  <height>1430</height>
   <widget type="label" version="2.0.0">
     <name>Label</name>
     <class>TITLE</class>
@@ -322,11 +322,13 @@ For Channel Access, the waveform PV only provides pixels. The data width, height
 
 When "Limits from PV" is not set, the range of the X and Y axes can be configured independently from the image size. This allows for example a calibration of pixel positions in millimeters.
 The axis direction can be inverted by swapping the axis minimum and maximum limit.
+
+To set an axis limit relative to the image pixel size, one can use rules or scripts that take inputs from formula PVs '=imageWidth(`pva://...Image`)' or '=imageHeight(`pva://...Image`)' and then write for example the 'x_axis.maximum' or 'y_axis.minimum' property of the widget.
 </text>
-    <x>201</x>
+    <x>200</x>
     <y>1150</y>
-    <width>421</width>
-    <height>209</height>
+    <width>422</width>
+    <height>280</height>
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label_10</name>

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -424,13 +424,19 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
     {
         final VType value = model_widget.runtimePropValue().getValue();
         if (value instanceof VNumberArray)
-            image_plot.setValue(model_widget.propDataWidth().getValue(),
-                                model_widget.propDataHeight().getValue(),
+        {
+            // Can't get size from PV, use data_width, .._height
+            final int width = model_widget.propDataWidth().getValue();
+            final int height = model_widget.propDataHeight().getValue();
+            if (model_widget.propLimitsFromPV().getValue())
+                image_plot.setAxisRange(0.0, width, height, 0.0);
+            image_plot.setValue(width, height,
                                 ((VNumberArray) value).getData(),
                                 model_widget.propDataUnsigned().getValue(),
                                 model_widget.propDataColorMode().getValue());
+        }
         else if (value instanceof VImage)
-        {
+        {   // Use VImage metadata
             final VImage image = (VImage) value;
             boolean isUnsigned;
             switch (image.getDataType())
@@ -444,7 +450,12 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
             	default:
             		isUnsigned = false;
             }
-            image_plot.setValue(image.getWidth(), image.getHeight(), image.getData(),
+
+            final int width = image.getWidth();
+            final int height = image.getHeight();
+            if (model_widget.propLimitsFromPV().getValue())
+                image_plot.setAxisRange(0.0, width, height, 0.0);
+            image_plot.setValue(width, height, image.getData(),
                                 isUnsigned, image.getVImageType());
         }
         else if (value != null)

--- a/core/formula/src/main/java/org/csstudio/apputil/formula/areadetector/ImageHeightFunction.java
+++ b/core/formula/src/main/java/org/csstudio/apputil/formula/areadetector/ImageHeightFunction.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.apputil.formula.areadetector;
+
+import org.epics.vtype.VImage;
+
+/** A formula function for fetching height of VImage
+ *  @author Kay Kasemir
+ */
+public class ImageHeightFunction extends ImageWidthFunction
+{
+    @Override
+    public String getName()
+    {
+        return "imageHeight";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Fetch height of image";
+    }
+
+    @Override
+    protected int getImageInfo(final VImage image)
+    {
+        return image.getHeight();
+    }
+}

--- a/core/formula/src/main/java/org/csstudio/apputil/formula/areadetector/ImageWidthFunction.java
+++ b/core/formula/src/main/java/org/csstudio/apputil/formula/areadetector/ImageWidthFunction.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.apputil.formula.areadetector;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.csstudio.apputil.formula.spi.FormulaFunction;
+import org.epics.vtype.Display;
+import org.epics.vtype.VImage;
+import org.epics.vtype.VInt;
+import org.epics.vtype.VType;
+
+/** A formula function for fetching width of VImage
+ *  @author Kay Kasemir
+ */
+public class ImageWidthFunction implements FormulaFunction
+{
+    @Override
+    public String getCategory()
+    {
+        return "areaDetector";
+    }
+
+    @Override
+    public String getName()
+    {
+        return "imageWidth";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Fetch width of image";
+    }
+
+    @Override
+    public List<String> getArguments()
+    {
+        return List.of("image");
+    }
+
+    /** Fetch info (width, height, ...) from image
+     *
+     *  Subclass can override
+     *
+     *  @param image Image
+     *  @return info
+     */
+    protected int getImageInfo(final VImage image)
+    {
+        return image.getWidth();
+    }
+
+    @Override
+    public VType compute(final VType... args) throws Exception
+    {
+        if (args.length != 1 || ! (args[0] instanceof VImage))
+            throw new Exception("Function " + getName() +
+                    " takes VImage but received " + Arrays.toString(args));
+
+        final VImage image = (VImage) args[0];
+        return VInt.of(getImageInfo(image), image.getAlarm(), image.getTime(), Display.none());
+    }
+}

--- a/core/formula/src/main/resources/META-INF/services/org.csstudio.apputil.formula.spi.FormulaFunction
+++ b/core/formula/src/main/resources/META-INF/services/org.csstudio.apputil.formula.spi.FormulaFunction
@@ -27,6 +27,8 @@ org.csstudio.apputil.formula.math.Pow
 # Other functions
 org.csstudio.apputil.formula.demo.Factorial
 org.csstudio.apputil.formula.areadetector.ADDataTypeMappingFunction
+org.csstudio.apputil.formula.areadetector.ImageWidthFunction
+org.csstudio.apputil.formula.areadetector.ImageHeightFunction
 
 # String
 org.csstudio.apputil.formula.string.StringFunction


### PR DESCRIPTION
Adds a `limits_from_pv` property to the image widget that sets the axis min/max to reflect the pixel coordinates with origin in the upper left corner.
With PVA, the image size is taken from the PV. With Channel Access, the `data_width` and `data_height` properties are used.

To remain compatible with existing displays, the default is `limits_from_pv=false`.
As before, that allows setting the `x_axis.minimum`, `y_axis.maximum` etc. either manually or from scripts and rules.
For scripts or rules that want to use the pixel dimensions, a new pair of `imageWidth(VImage)` and `imageHeight(VImage)` formula functions have been added.