### PR TITLE
CSSTUDIO-1706: Empty widget field (precision) causes warning message

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/IntegerWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/IntegerWidgetProperty.java
@@ -63,8 +63,14 @@ public class IntegerWidgetProperty extends MacroizedWidgetProperty<Integer>
     @Override
     protected Integer parseExpandedSpecification(final String text) throws Exception
     {
+
+        if(text != null && text.isBlank())
+        {   // If the value read from the .bob is empty then it should return the default
+            return default_value;
+        }
+
         try
-        {   // Should be integer..
+        {   // Otherwise try to parse to an integer
             return Integer.valueOf(text);
         }
         catch (final NumberFormatException ex)

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/IntegerWidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/IntegerWidgetProperty.java
@@ -64,8 +64,10 @@ public class IntegerWidgetProperty extends MacroizedWidgetProperty<Integer>
     protected Integer parseExpandedSpecification(final String text) throws Exception
     {
 
-        if(text != null && text.isBlank())
+        if(text.isBlank())
         {   // If the value read from the .bob is empty then it should return the default
+            // note we should hard-fail here; there shouldn't be a null value by this point,
+            // and Integer.valueOf(null) throws an NPE instead of NumberFormatException.
             return default_value;
         }
 


### PR DESCRIPTION
fix: when blank integer widget properties are parsed (e.g. an empty node in a .bob file such as the precision property of the spinner widget), then an exception is thrown instead of the default value