### PR TITLE
Databrowser: Use actual plot for Print and Snapshot context menu

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java
@@ -198,8 +198,9 @@ public class Perspective extends SplitPane
             items.addAll(add_data);
 
             items.add(new SeparatorMenuItem());
-            items.add(new PrintAction(plot.getPlot()));
-            items.add(new SaveSnapshotAction(plot.getPlot()));
+            // Get screenshot of actual plot without optional toolbar
+            items.add(new PrintAction(plot.getPlot().getCenter()));
+            items.add(new SaveSnapshotAction(plot.getPlot().getCenter()));
 
             SelectionService.getInstance().setSelection(this, Arrays.asList(DatabrowserSelection.of(model, plot)));
             List<ContextMenuEntry> supported = ContextMenuService.getInstance().listSupportedContextMenuEntries();


### PR DESCRIPTION
.. excluding the optionally visible toolbar.