### PR TITLE
CSSTUDIO-1717: Databrowser displays disconnected / paused PV as if it was valid

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVSamples.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVSamples.java
@@ -115,15 +115,17 @@ public class PVSamples extends PlotSamples
         if (lock.getReadHoldCount() <= 0  && ! lock.isWriteLockedByCurrentThread())
             logger.log(Level.WARNING, "Missing lock", new Exception("Stack Trace"));
 
+        // If the data point is 'real'/raw then return it
         final int raw_count = getRawSize();
         if (index < raw_count)
             return getRawSample(index);
-        // Last sample is valid, so it should still apply 'now'
+        // Else, create a 'virtual' point by transforming its
+        // timestamp to 'now' to display the currently implied value
         final PlotSample sample = getRawSample(raw_count-1);
         if (Instant.now().compareTo(sample.getPosition()) < 0)
             return sample;
         else
-            return new PlotSample(sample.getSource(), VTypeHelper.transformTimestampToNow(sample.getVType()));
+            return new PlotSample(sample.getSource(), VTypeHelper.transformTimestampToNow(sample.getVType()), true);
     }
 
     /** Get 'raw' sample, no continuation until 'now'

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PlotSample.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PlotSample.java
@@ -47,6 +47,11 @@ public class PlotSample implements PlotDataItem<Instant>
     /** Waveform index */
     private AtomicInteger waveform_index;
 
+    /** Designates if this is a real data point, or just a 'virtual' one
+     * created only for mechanical purposes (i.e. to connect the last data point to 'now')
+     */
+    private boolean isVirtualSample = false;
+
     /** Initialize with valid control system value
      *  @param waveform_index Waveform index
      *  @param source Info about the source of this sample
@@ -98,6 +103,12 @@ public class PlotSample implements PlotDataItem<Instant>
     public PlotSample(final String source, final VType value)
     {
         this(default_waveform_index, source, value);
+    }
+
+    public PlotSample(final String source, final VType value, boolean isVirtualSample)
+    {
+        this(default_waveform_index, source, value);
+        this.isVirtualSample = isVirtualSample;
     }
 
     /** Initialize with (error) info, creating a non-plottable sample 'now'
@@ -208,6 +219,11 @@ public class PlotSample implements PlotDataItem<Instant>
     public String getInfo()
     {
         return info;
+    }
+
+    @Override
+    public boolean isVirtual() {
+        return this.isVirtualSample;
     }
 
     @Override

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/data/PlotDataItem.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/data/PlotDataItem.java
@@ -45,4 +45,7 @@ public interface PlotDataItem<XTYPE extends Comparable<XTYPE>>
     {
         return Double.toString(getValue());
     };
+
+    /** @return if this data point is real or just a mechanical point, e.g. the 'now' point. */
+    public default boolean isVirtual() { return false; }
 }

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/TracePainter.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/TracePainter.java
@@ -507,12 +507,18 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
         {
             final PlotDataItem<XTYPE> item = data.get(i);
             final double value = item.getValue();
+            final XTYPE loc = item.getPosition();
             if (!Double.isNaN(value))
             {
                 final int x = clipX(Math.round(x_transform.transform(item.getPosition())));
                 final int y = clipY(y_axis.getScreenCoord(value));
                 if (x == last_x  &&  y == last_y)
                     continue;
+                // If the point is virtual, draw it without a size; drawing a virtual point visually
+                // implies the point is real data, and this often is not the case.
+                if(item.isVirtual()) {
+                    return;
+                }
                 switch (point_type)
                 {
                 case SQUARES:


### PR DESCRIPTION
fix: leading point at 'now' is rendered, incorrectly implying it is real data