### PR TITLE
CSSTUDIO-1721: If the Tank Widget Background Color is set to Transparent it does not display correctly

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTTank.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTTank.java
@@ -92,6 +92,9 @@ public class RTTank extends Canvas
         if (image != null)
             synchronized (image)
             {
+                // Clear the canvas for e.g. transparent pixels (otherwise image appears drawn over previous)
+                gc.clearRect(0, 0, gc.getCanvas().getWidth(), gc.getCanvas().getHeight());
+                // Draw the updated image
                 gc.drawImage(image, 0, 0);
             }
     };


### PR DESCRIPTION
fix: tank widget looks mangled when background is set transparent, due to how transparent pixels blend over opaque pixels

What I'm doing is explicitly clearing the canvas between redraws...Now, if there's a more efficient way to do this, I'm not sure...may be a way to do it with masks, but it's not something I'm terribly confident would work as it's not something I'm personally super experienced with in e.g. Photoshop.