### PR TITLE
Changes to allow window geometry specification along with target=window

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -115,11 +115,14 @@ public class DisplayRuntimeInstance implements AppInstance
         DockPane dock_pane = null;
         if (prefTarget != null)
         {
-            if (prefTarget.equals("window"))
+            if (prefTarget.startsWith("window"))
             {
                 // Open new Stage in which this app will be opened, its DockPane is a new active one
                 final Stage new_stage = new Stage();
-                DockStage.configureStage(new_stage);
+                if (prefTarget.length() > 6)
+                    DockStage.configureStage(new_stage, prefTarget.substring(7));
+                else
+                    DockStage.configureStage(new_stage, null);
                 new_stage.show();
             }
             else

--- a/core/framework/src/main/java/org/phoebus/framework/macros/Macros.java
+++ b/core/framework/src/main/java/org/phoebus/framework/macros/Macros.java
@@ -42,7 +42,7 @@ public class Macros implements MacroValueProvider
     private final Map<String, String> macros = new LinkedHashMap<>();
 
     /** Regular expression for valid macro names */
-    public final static Pattern MACRO_NAME_PATTERN = Pattern.compile("[A-Za-z][A-Za-z0-9_.\\-\\[\\]]*");
+    public final static Pattern MACRO_NAME_PATTERN = Pattern.compile("[A-Za-z][A-Za-z0-9_.\\@\\+%\\-\\[\\]]*");
 
     /** Check macro name
      *

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -970,7 +970,7 @@ public class PhoebusApplication extends Application {
                 if (end < 0)
                     end = query.length();
                 final String target = query.substring(i + 7, end);
-                if (!target.equals("window")) {
+                if (!target.startsWith("window")) {
                     // Should the new panel open in a specific, named pane?
                     final DockPane existing = DockStage.getDockPaneByName(target);
                     if (existing != null)


### PR DESCRIPTION
Minor changes to allow window geometry, size and position, to be specified when using target=window. Optional geometry parameters can be specified in a similar manner to that used with X windows e.g.

target=window@1038x442%100x100

This enables windows to be popped up with sizes that match the GUI and at standard starting positions.
