### PR TITLE
Support `-resource xyz?target=window@800x600+100+300`

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,7 @@ import org.phoebus.ui.docking.DockItem;
 import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
 import org.phoebus.ui.docking.DockStage;
+import org.phoebus.ui.docking.Geometry;
 import org.phoebus.ui.javafx.ToolbarHelper;
 
 import javafx.application.Platform;
@@ -115,11 +116,14 @@ public class DisplayRuntimeInstance implements AppInstance
         DockPane dock_pane = null;
         if (prefTarget != null)
         {
-            if (prefTarget.equals("window"))
+            if (prefTarget.startsWith("window"))
             {
                 // Open new Stage in which this app will be opened, its DockPane is a new active one
                 final Stage new_stage = new Stage();
-                DockStage.configureStage(new_stage);
+                if (prefTarget.startsWith("window@"))
+                    DockStage.configureStage(new_stage, new Geometry(prefTarget.substring(7)));
+                else
+                    DockStage.configureStage(new_stage);
                 new_stage.show();
             }
             else

--- a/core/launcher/src/main/java/org/phoebus/product/Launcher.java
+++ b/core/launcher/src/main/java/org/phoebus/product/Launcher.java
@@ -235,6 +235,7 @@ public class Launcher
         System.out.println("-resource 'pv://?sim://sine&app=probe'                                       - Opens the 'sim://sine' PV with 'probe'.");
         System.out.println("-resource 'pv://?Fred&sim://sine&app=pv_table'                               - Opens two PVs PV with 'pv_table'.");
         System.out.println("-resource '...&target=window'                                                - Opens resource in separate window.");
+        System.out.println("-resource '...&target=window@800x600+200+150'                                - Opens resource in separate window sized 800 by 600 at x=200, y=150.");
         System.out.println("-resource '...&target=name_of_pane'                                          - Opens resource in named pane.");
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -970,7 +970,7 @@ public class PhoebusApplication extends Application {
                 if (end < 0)
                     end = query.length();
                 final String target = query.substring(i + 7, end);
-                if (!target.equals("window")) {
+                if (!target.startsWith("window")) {
                     // Should the new panel open in a specific, named pane?
                     final DockPane existing = DockStage.getDockPaneByName(target);
                     if (existing != null)

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,10 +19,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.logging.Level;
 
-import javafx.scene.control.SplitPane;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyCodeCombination;
-import javafx.scene.input.KeyCombination;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.workbench.Locations;
 import org.phoebus.ui.application.Messages;
@@ -34,6 +30,7 @@ import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.SplitPane;
 import javafx.scene.image.Image;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
@@ -117,6 +114,22 @@ public class DockStage
      */
     public static DockPane configureStage(final Stage stage, final DockItem... tabs)
     {
+        return configureStage(stage, new Geometry(null), tabs);
+    }
+
+    /** Helper to configure a Stage for docking
+     *
+     *  <p>Adds a Scene with a BorderPane layout and a DockPane in the center
+     *
+     *  @param stage Stage, should be empty
+     *  @param geometry_spec A geometry specification "{width}x{height}+{x}+{y}", see {@link Geometry}
+     *  @param tabs Zero or more initial {@link DockItem}s
+     *  @throws Exception on error
+     *
+     *  @return {@link DockPane} that was added to the {@link Stage}
+     */
+    public static DockPane configureStage(final Stage stage, final Geometry geometry, final DockItem... tabs)
+    {
         stage.getProperties().put(KEY_ID, createID("DockStage"));
 
         final DockPane pane = new DockPane(tabs);
@@ -141,9 +154,19 @@ public class DockStage
             }
         });
 
-        final Scene scene = new Scene(layout, 1600, 900);
+        final Scene scene = new Scene(layout, geometry.width, geometry.height);
         stage.setScene(scene);
         stage.setTitle(Messages.FixedTitle);
+        // Set position
+        stage.setX(geometry.x);
+        stage.setY(geometry.y);
+
+        // Force window to be visible
+        stage.show();
+        stage.toFront();
+        stage.setAlwaysOnTop(true);
+        stage.setAlwaysOnTop(false);
+
         Styles.setSceneStyle(scene);
         try
         {

--- a/core/ui/src/main/java/org/phoebus/ui/docking/Geometry.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/Geometry.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.ui.docking;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Geometry info
+ *
+ *  Uses a geometry specification <code>{width}x{height}+{x}+{y}</code>,
+ *  in a format similar to X11 <code>-geometry ..</code> argument.
+ *
+ *  For example <code>600x400+100+50</code> describes a window
+ *  sized 600 by 400 located at X=100, Y=50.
+ *
+ *  It is also allowed to provide only <code>{width}x{height}</code>
+ *  or <code>+{x}+{y}</code>
+ */
+ public class Geometry
+ {
+    // 09 x 09 + 09 + 09, group for each number, with both size and offset being optional
+    private static final Pattern SIZE_AND_OFFSET = Pattern.compile("(([0-9]+)x([0-9]+))?(\\+([0-9]+)\\+([0-9]+))?");
+
+    public int width = 1600;
+    public int height = 900;
+    public int x = 50;
+    public int y = 50;
+
+    /** @param spec geometry specification <code>{width}x{height}+{x}+{y}</code> */
+    public Geometry(final String spec)
+    {
+        if (spec != null)
+        {
+            final Matcher matcher = SIZE_AND_OFFSET.matcher(spec);
+            if (matcher.matches())
+            {
+                if (matcher.group(2) != null)
+                    width = Integer.parseInt(matcher.group(2));
+                if (matcher.group(3) != null)
+                    height = Integer.parseInt(matcher.group(3));
+                if (matcher.group(5) != null)
+                    x = Integer.parseInt(matcher.group(5));
+                if (matcher.group(6) != null)
+                    y = Integer.parseInt(matcher.group(6));
+            }
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return width + "x" + height + "+" + x + "+" + y;
+    }
+ }


### PR DESCRIPTION
In addition to plain "target=window" we now support "target=window@.."
with a geometry specification similar to the X11 `-geometry` paramter.

Format is `{width}x{height}+{x}+{y}`
or `{width}x{height}`
or `+{x}+{y}`


Update of #2341, avoids changing the MACRO_NAME_PATTERN, adds Launcher `-help`