### PR TITLE
CSSTUDIO-1607: External viewer of attachments (movie clips, .pdf, office files)

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
@@ -129,8 +129,15 @@ public class AttachmentsPreviewController {
                     if(parts.length == 1 || !ApplicationService.getExtensionsHandledByExternalApp().contains(parts[parts.length - 1])){
                         // If there is no app configured for the file type, then use the default configured for the OS/User
                         try {
-                            Desktop.getDesktop().open(attachment.getFile());
-                            return;
+                            if(Desktop.isDesktopSupported()) {
+                                Desktop desktop = Desktop.getDesktop();
+                                if(desktop.isSupported(Desktop.Action.APP_OPEN_FILE)) {
+                                    Desktop.getDesktop().open(attachment.getFile());
+                                    return;
+                                }
+                            } else {
+                                ExceptionDetailsErrorDialog.openError(Messages.PreviewOpenErrorTitle, Messages.PreviewOpenErrorBody, null);
+                            }
                         } catch (IOException e) {
                             ExceptionDetailsErrorDialog.openError(Messages.PreviewOpenErrorTitle, Messages.PreviewOpenErrorBody, null);
                         }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
@@ -30,6 +30,7 @@ import javafx.embed.swing.SwingFXUtils;
 import javafx.fxml.FXML;
 import javafx.scene.Cursor;
 import javafx.scene.control.*;
+import javafx.scene.control.MenuItem;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
@@ -46,6 +47,7 @@ import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javax.imageio.ImageIO;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -120,13 +122,18 @@ public class AttachmentsPreviewController {
                         defaultApp.create(attachment.getFile().toURI());
                         return;
                     }
+
                     // If not internal apps are found look for external apps
                     String fileName = attachment.getFile().getName();
                     String[] parts = fileName.split("\\.");
                     if(parts.length == 1 || !ApplicationService.getExtensionsHandledByExternalApp().contains(parts[parts.length - 1])){
-                        // If there is no app configured for the file type, show an error message and return.
-                        ExceptionDetailsErrorDialog.openError(Messages.PreviewOpenErrorTitle, Messages.PreviewOpenErrorBody, null);
-                        return;
+                        // If there is no app configured for the file type, then use the default configured for the OS/User
+                        try {
+                            Desktop.getDesktop().open(attachment.getFile());
+                            return;
+                        } catch (IOException e) {
+                            ExceptionDetailsErrorDialog.openError(Messages.PreviewOpenErrorTitle, Messages.PreviewOpenErrorBody, null);
+                        }
                     }
                 }
                 ApplicationLauncherService.openFile(attachment.getFile(), false, null);

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
@@ -43,11 +43,11 @@ import org.phoebus.framework.workbench.ApplicationService;
 import org.phoebus.logbook.Attachment;
 import org.phoebus.logbook.olog.ui.write.AttachmentsViewController;
 import org.phoebus.ui.application.ApplicationLauncherService;
+import org.phoebus.ui.application.PhoebusApplication;
 import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -128,14 +128,12 @@ public class AttachmentsPreviewController {
                     String[] parts = fileName.split("\\.");
                     if(parts.length == 1 || !ApplicationService.getExtensionsHandledByExternalApp().contains(parts[parts.length - 1])){
                         // If there is no app configured for the file type, then use the default configured for the OS/User
+                        // Note: Do not use Desktop API, as using Java AWT can hang Phoebus / JavaFX Applications
                         try {
-                            if(Desktop.isDesktopSupported()) {
-                                Desktop.getDesktop().open(attachment.getFile());
-                                return;
-                            } else {
-                                ExceptionDetailsErrorDialog.openError(Messages.PreviewOpenErrorTitle, Messages.PreviewOpenErrorBody, null);
-                            }
-                        } catch (IOException | UnsupportedOperationException e) {
+                            PhoebusApplication.INSTANCE.getHostServices().showDocument(
+                                    attachment.getFile().toURI().getRawPath()
+                            );
+                        } catch (Exception e) {
                             ExceptionDetailsErrorDialog.openError(Messages.PreviewOpenErrorTitle, Messages.PreviewOpenErrorBody, null);
                         }
                     }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
@@ -130,15 +130,12 @@ public class AttachmentsPreviewController {
                         // If there is no app configured for the file type, then use the default configured for the OS/User
                         try {
                             if(Desktop.isDesktopSupported()) {
-                                Desktop desktop = Desktop.getDesktop();
-                                if(desktop.isSupported(Desktop.Action.APP_OPEN_FILE)) {
-                                    Desktop.getDesktop().open(attachment.getFile());
-                                    return;
-                                }
+                                Desktop.getDesktop().open(attachment.getFile());
+                                return;
                             } else {
                                 ExceptionDetailsErrorDialog.openError(Messages.PreviewOpenErrorTitle, Messages.PreviewOpenErrorBody, null);
                             }
-                        } catch (IOException e) {
+                        } catch (IOException | UnsupportedOperationException e) {
                             ExceptionDetailsErrorDialog.openError(Messages.PreviewOpenErrorTitle, Messages.PreviewOpenErrorBody, null);
                         }
                     }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsPreviewController.java
@@ -130,9 +130,8 @@ public class AttachmentsPreviewController {
                         // If there is no app configured for the file type, then use the default configured for the OS/User
                         // Note: Do not use Desktop API, as using Java AWT can hang Phoebus / JavaFX Applications
                         try {
-                            PhoebusApplication.INSTANCE.getHostServices().showDocument(
-                                    attachment.getFile().toURI().getRawPath()
-                            );
+                            String filePathString = attachment.getFile().toPath().toUri().toString();
+                            PhoebusApplication.INSTANCE.getHostServices().showDocument(filePathString);
                         } catch (Exception e) {
                             ExceptionDetailsErrorDialog.openError(Messages.PreviewOpenErrorTitle, Messages.PreviewOpenErrorBody, null);
                         }


### PR DESCRIPTION
refactor: delegate opening log attachments to desktop/user default instead of rendering error message