### PR TITLE
Restore of snapshot fix for pva

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -95,6 +95,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -601,7 +602,7 @@ public class SnapshotController implements NodeChangedListener {
                     final PV pv = pvs.get(getPVKey(e.pvNameProperty().get(), e.readOnlyProperty().get()^e.readonlyOverrideProperty().get()));
                     if (entry.getValue() != null) {
                         try {
-                            pv.pv.write(Utilities.toRawValue(entry.getValue()));
+                            pv.pv.asyncWrite(Utilities.toRawValue(entry.getValue())).get();
                         } catch (Exception writeException) {
                             restoreFailed.add(entry.getPVName());
                         } finally {


### PR DESCRIPTION
In save&restore a restore operation will handle write failures when using ca. Since the pva implementation behaves differently, write failures are not handled and user may believe all is well.

This is a fix. Verified both for ca and pva.