### PR TITLE
Add value of DESC (if non-null and non-empty) to pv_value in widget tooltip

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
@@ -22,6 +22,7 @@ import org.csstudio.display.builder.representation.Preferences;
 import org.csstudio.display.builder.representation.javafx.JFXPreferences;
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
+import org.epics.vtype.Display;
 import org.epics.vtype.Time;
 import org.phoebus.framework.macros.MacroHandler;
 import org.phoebus.framework.macros.MacroValueProvider;
@@ -108,6 +109,11 @@ public class TooltipSupport
                 if (time != null)
                     buf.append(", ").append(TimestampFormats.FULL_FORMAT.format(time.getTimestamp()));
 
+                String display = Display.displayOf(vtype).getDescription();
+                // Description is non-null only for pva.
+                if(display != null && !display.isEmpty()){
+                    buf.append(System.lineSeparator()).append(display);
+                }
                 spec = spec.replace("$(pv_value)", buf.toString());
             }
             final Widget widget = tooltip_property.getWidget();

--- a/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
@@ -234,6 +234,7 @@ public class Decoders
         String units;
         NumberFormat format;
         Range display, control, alarm, warn;
+        String description = "";
 
         // Decode display_t display
         PVAStructure section = struct.get("display");
@@ -282,6 +283,11 @@ public class Decoders
                     : createNumberFormat(str.get());
             }
 
+            PVAString pvaStringDescription = section.get("description");
+            if(pvaStringDescription != null){
+                description = pvaStringDescription.get();
+            }
+
             display = Range.of(getDoubleValue(section, "limitLow", Double.NaN),
                                getDoubleValue(section, "limitHigh", Double.NaN));
         }
@@ -312,7 +318,7 @@ public class Decoders
         else
             alarm = warn = Range.undefined();
 
-        return Display.of(display, alarm, warn, control, units, format);
+        return Display.of(display, alarm, warn, control, units, format, description);
     }
 
     /** @param struct Structure


### PR DESCRIPTION
If PV defines the DESC field, and if it is non-empty, it's value will be shown in the widget tooltip. Implementation proposes to put the string on a separate line:

![Screenshot 2022-08-12 at 15 26 12](https://user-images.githubusercontent.com/35602960/184364218-21d58922-efbd-44c0-ba0a-9c7a41a537fb.png)

NOTE: works only over pva.

The value of DESC is read from the recently added ``description`` field of the ``Display`` class in the VType lib.
