### PR TITLE
#715 checking for PVAStructureArray before PVAArray

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVAStructureHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVAStructureHelper.java
@@ -69,29 +69,28 @@ public class PVAStructureHelper
                 actual = (PVAStructure) field;
             else if (field instanceof PVANumber)
                 return Decoders.decodeNumber(struct, (PVANumber) field);
+            else if (field instanceof PVAStructureArray)
+            {
+                if (elementIndex.isPresent())
+                {
+                    actual = ((PVAStructureArray) field).get()[elementIndex.get()];
+                }
+            }
             else if (field instanceof PVAArray)
-                return Decoders.decodeArray(struct, (PVAArray) field);
+            {
+                if (elementIndex.isPresent())
+                {
+                    return decodeNTArray(struct, elementIndex.get());
+                }
+                else
+                {
+                    return Decoders.decodeArray(struct, (PVAArray) field);
+                }
+            }
             else if (field instanceof PVAString)
                 return Decoders.decodeString(struct, (PVAString) field);
         }
 
-        // Handle element references in arrays
-        if (elementIndex.isPresent())
-        {
-            final PVAData field = struct.get(name_helper.getField());
-            if (field instanceof PVAStructureArray)
-            {
-                actual = ((PVAStructureArray) field).get()[elementIndex.get()];
-            }
-            else if(field instanceof PVAArray)
-            {
-                return decodeNTArray(actual, elementIndex.get());
-            }
-            else
-            {
-                throw new Exception("Expected struct array for field " + name_helper.getField() + ", got " + struct);
-            }
-        }
         // Handle normative types
         String type = actual.getStructureName();
         if (type.startsWith("epics:nt/"))


### PR DESCRIPTION
@kasemir 

I added some changed to the PVAStructureHelper.

I check for PVAStructureArray, before checking for PVAArray, since it is a more specific implementation.

In the future, I think we need to review and move various bits of the PVAStructureHelper to the Decoders.
i.e. the part which handled the special case of the the PVAStructureArray should be a case in the decoders.decodeArray(....)

What are you thoughts?