### PR TITLE
Alarm colors

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -33,16 +33,17 @@ import javafx.scene.paint.Color;
 @SuppressWarnings("nls")
 public class AlarmUI
 {
-    private static final double DARKEN = 0.5;
+    /** Factor used to adjust color brightness or saturation */
+    private static final double ADJUST = 0.5;
 
     // Next arrays follow the ordinal of SeverityLevel
     private static final Color[] severity_colors = new Color[]
     {
         createColor(Preferences.ok_severity_text_color),                                         // OK
-        createColor(Preferences.minor_severity_text_color)    .deriveColor(0, 1.0, DARKEN, 1.0), // MINOR_ACK
-        createColor(Preferences.major_severity_text_color)    .deriveColor(0, 1.0, DARKEN, 1.0), // MAJOR_ACK
-        createColor(Preferences.invalid_severity_text_color)  .deriveColor(0, 1.0, DARKEN, 1.0), // INVALID_ACK
-        createColor(Preferences.undefined_severity_text_color).deriveColor(0, 1.0, DARKEN, 1.0), // UNDEFINED_ACK
+        createColor(Preferences.minor_severity_text_color)    .deriveColor(0, 1.0, ADJUST, 1.0), // MINOR_ACK
+        createColor(Preferences.major_severity_text_color)    .deriveColor(0, 1.0, ADJUST, 1.0), // MAJOR_ACK
+        createColor(Preferences.invalid_severity_text_color)  .deriveColor(0, 1.0, ADJUST, 1.0), // INVALID_ACK
+        createColor(Preferences.undefined_severity_text_color).deriveColor(0, 1.0, ADJUST, 1.0), // UNDEFINED_ACK
         createColor(Preferences.minor_severity_text_color),                                      // MINOR
         createColor(Preferences.major_severity_text_color),                                      // MAJOR
         createColor(Preferences.invalid_severity_text_color),                                    // INVALID
@@ -74,14 +75,14 @@ public class AlarmUI
     private static final Background[] severity_backgrounds = new Background[]
     {
         null, // OK
-        new Background(new BackgroundFill(Color.rgb(180, 170,  70), CornerRadii.EMPTY, Insets.EMPTY)), // MINOR_ACK
-        new Background(new BackgroundFill(Color.rgb(255,  90,  90), CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR_ACK
-        new Background(new BackgroundFill(Color.rgb(255, 128, 255), CornerRadii.EMPTY, Insets.EMPTY)), // INVALID_ACK
-        new Background(new BackgroundFill(Color.rgb(255, 128, 255), CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED_ACK
-        new Background(new BackgroundFill(Color.rgb(207, 192,   0), CornerRadii.EMPTY, Insets.EMPTY)), // MINOR
-        new Background(new BackgroundFill(Color.rgb(255,   0,   0), CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR
-        new Background(new BackgroundFill(Color.rgb(255,   0, 255), CornerRadii.EMPTY, Insets.EMPTY)), // INVALID
-        new Background(new BackgroundFill(Color.rgb(255,   0, 255), CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED
+        new Background(new BackgroundFill(createColor(Preferences.minor_severity_text_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MINOR_ACK
+        new Background(new BackgroundFill(createColor(Preferences.major_severity_text_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR_ACK
+        new Background(new BackgroundFill(createColor(Preferences.invalid_severity_text_color)  .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // INVALID_ACK
+        new Background(new BackgroundFill(createColor(Preferences.undefined_severity_text_color).deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED_ACK
+        new Background(new BackgroundFill(createColor(Preferences.minor_severity_text_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MINOR
+        new Background(new BackgroundFill(createColor(Preferences.major_severity_text_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR
+        new Background(new BackgroundFill(createColor(Preferences.invalid_severity_text_color),                                    CornerRadii.EMPTY, Insets.EMPTY)), // INVALID
+        new Background(new BackgroundFill(createColor(Preferences.undefined_severity_text_color),                                  CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED
     };
 
     /** Icon for disabled alarms */

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,9 +7,12 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.ui;
 
+import java.util.Arrays;
+
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.model.SeverityLevel;
 import org.phoebus.security.authorization.AuthorizationService;
+import org.phoebus.ui.Preferences;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javafx.geometry.Insets;
@@ -30,19 +33,30 @@ import javafx.scene.paint.Color;
 @SuppressWarnings("nls")
 public class AlarmUI
 {
+    private static final double DARKEN = 0.5;
+
     // Next arrays follow the ordinal of SeverityLevel
     private static final Color[] severity_colors = new Color[]
     {
-        Color.rgb(  0, 100,   0), // OK
-        Color.rgb(120,  90,  10), // MINOR_ACK
-        Color.rgb(100,   0,   0), // MAJOR_ACK
-        Color.rgb(100,  50, 100), // INVALID_ACK
-        Color.rgb(100,  50, 100), // UNDEFINED_ACK
-        Color.rgb(207, 192,   0), // MINOR
-        Color.rgb(255,   0,   0), // MAJOR
-        Color.rgb(255,   0, 255), // INVALID
-        Color.rgb(255,   0, 255), // UNDEFINED
+        createColor(Preferences.ok_severity_text_color),                                         // OK
+        createColor(Preferences.minor_severity_text_color)    .deriveColor(0, 1.0, DARKEN, 1.0), // MINOR_ACK
+        createColor(Preferences.major_severity_text_color)    .deriveColor(0, 1.0, DARKEN, 1.0), // MAJOR_ACK
+        createColor(Preferences.invalid_severity_text_color)  .deriveColor(0, 1.0, DARKEN, 1.0), // INVALID_ACK
+        createColor(Preferences.undefined_severity_text_color).deriveColor(0, 1.0, DARKEN, 1.0), // UNDEFINED_ACK
+        createColor(Preferences.minor_severity_text_color),                                      // MINOR
+        createColor(Preferences.major_severity_text_color),                                      // MAJOR
+        createColor(Preferences.invalid_severity_text_color),                                    // INVALID
+        createColor(Preferences.undefined_severity_text_color)                                   // UNDEFINED
     };
+
+    private static Color createColor(int[] rgb)
+    {
+        if (rgb.length == 3)
+            return Color.rgb(rgb[0], rgb[1], rgb[2]);
+        else if (rgb.length == 4)
+            return Color.rgb(rgb[0], rgb[1], rgb[2], rgb[3]/255.0);
+        throw new IllegalStateException("Expecting R,G,B or R,G,B,A, got " + Arrays.toString(rgb));
+    }
 
     private static final Image[] severity_icons = new Image[]
     {

--- a/app/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/TreeModelItemCell.java
+++ b/app/pvtree/src/main/java/org/phoebus/applications/pvtree/ui/TreeModelItemCell.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ import java.awt.image.BufferedImage;
 
 import org.epics.vtype.AlarmSeverity;
 import org.phoebus.applications.pvtree.model.TreeModelItem;
+import org.phoebus.ui.Preferences;
 import org.phoebus.ui.pv.SeverityColors;
 
 import javafx.embed.swing.SwingFXUtils;
@@ -29,8 +30,16 @@ class TreeModelItemCell extends TreeCell<TreeModelItem>
     /** @param color Color of icon
      *  @return Icon
      */
-    private static Image createAlarmIcon(final java.awt.Color color)
+    private static Image createAlarmIcon(final int[] rgba)
     {
+        java.awt.Color color;
+        if (rgba.length == 3)
+            color = new java.awt.Color(rgba[0], rgba[1], rgba[2]);
+        else if (rgba.length == 4)
+            color = new java.awt.Color(rgba[0], rgba[1], rgba[2], rgba[3]);
+        else
+            throw new IllegalStateException("Color must provide RGB or RGBA");
+
         final BufferedImage buf = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
         final Graphics2D gc = buf.createGraphics();
         gc.setColor(new java.awt.Color(0, 0, 0, 0));
@@ -42,16 +51,16 @@ class TreeModelItemCell extends TreeCell<TreeModelItem>
     }
 
     /** Icon for null alarm */
-    private static final Image NO_ICON = createAlarmIcon(new java.awt.Color(0, 200, 0, 50));
+    private static final Image NO_ICON = createAlarmIcon(new int[] { 0, 200, 0, 50});
 
     /** Icons for alarm severity by ordinal */
     private static final Image[] ALARM_ICONS = new Image[]
     {
-        createAlarmIcon(java.awt.Color.GREEN),
-        createAlarmIcon(java.awt.Color.YELLOW),
-        createAlarmIcon(java.awt.Color.RED),
-        createAlarmIcon(java.awt.Color.MAGENTA),
-        createAlarmIcon(new java.awt.Color(139, 0, 139)) // DARKMAGENTA
+        createAlarmIcon(Preferences.ok_severity_text_color),
+        createAlarmIcon(Preferences.minor_severity_text_color),
+        createAlarmIcon(Preferences.major_severity_text_color),
+        createAlarmIcon(Preferences.invalid_severity_text_color),
+        createAlarmIcon(Preferences.undefined_severity_text_color)
     };
 
     static

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -70,16 +70,16 @@ layout_dir=
 print_landscape=true
 
 # Color for 'OK' alarm severity (R,G,B or R,G,B,A values in range 0..255)
-ok_severity_text_color=0,0,0
+ok_severity_text_color=0,255,0
 
 # Color for 'MINOR' alarm severity
-minor_severity_text_color=204,204,0
+minor_severity_text_color=255, 128, 0
 
 # Color for 'MAJOR' alarm severity
 major_severity_text_color=255,0,0
 
 # Color for 'INVALID' alarm severity
-invalid_severity_text_color=128,128,128
+invalid_severity_text_color=255, 0, 255
 
 # Color for 'UNDEFINED' alarm severity
-undefined_severity_text_color=139,0,139
+undefined_severity_text_color=200, 0, 200, 200

--- a/core/vtype/src/main/java/org/phoebus/core/vtypes/VTypeHelper.java
+++ b/core/vtype/src/main/java/org/phoebus/core/vtypes/VTypeHelper.java
@@ -1,11 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
 package org.phoebus.core.vtypes;
+
+import java.time.Instant;
+import java.util.List;
 
 import org.epics.util.array.ListBoolean;
 import org.epics.util.array.ListInteger;
@@ -37,9 +40,6 @@ import org.epics.vtype.VUByteArray;
 import org.epics.vtype.VUIntArray;
 import org.epics.vtype.VULongArray;
 import org.epics.vtype.VUShortArray;
-
-import java.time.Instant;
-import java.util.List;
 
 public class VTypeHelper {
     /**
@@ -372,7 +372,7 @@ public class VTypeHelper {
 
     public static AlarmSeverity getSeverity(final VType value) {
         final Alarm alarm = Alarm.alarmOf(value);
-        if (alarm == null)
+        if (isDisconnected(value))
             return AlarmSeverity.UNDEFINED;
         return alarm.getSeverity();
     }


### PR DESCRIPTION
This makes alarm colors configurable and changes the defaults to match the display builder.

Alarm colors for displays were always configurable via named colors, 
https://github.com/ControlSystemStudio/phoebus/blob/22bbdc3bb0b122cc0522b32e237ced5ffaeed539/app/display/model/src/main/resources/examples/color.def#L13-L18
but that was limited to displays. The PV Tree, PV Table, Probe, data browser sample inspector and other tools that used the https://github.com/ControlSystemStudio/phoebus/blob/master/core/ui/src/main/java/org/phoebus/ui/pv/SeverityColors.java had fixed colors. Commit  22bbdc3bb0b122cc0522b32e237ced5ffaeed539 made them configurable, but kept the original values 
https://github.com/ControlSystemStudio/phoebus/blob/22bbdc3bb0b122cc0522b32e237ced5ffaeed539/core/ui/src/main/resources/phoebus_ui_preferences.properties#L72-L85

 As a result, the alarm colors for displays and other tools still clearly differed:

![alarmcolors1](https://user-images.githubusercontent.com/1932421/186207246-eb22dfae-c1e1-4d63-82c2-36737865958d.png)

Historically, EPICS only supported OK, MINOR, MAJOR, INVALID alarm severities.
PV Access added UNDEFINED as a severity level, meant to be used with the 'disconnected' state.
For values read from Channel Access, the INVALID/disconnected was handled just like other INVALID states.
This PR displays INVALID/disconnected like an UNDEFINED severity:

![alarm_colors2](https://user-images.githubusercontent.com/1932421/186207277-10e612a6-fce9-49f8-a02c-8cd12bbff1ad.png)

Finally, the default SeverityColors settings are updated to match the display color.def settings, so alarms show up in the same colors for displays, PV table, PV tree, probe, ..:

![alarm_colors3](https://user-images.githubusercontent.com/1932421/186207299-29a8e377-3dc7-4be6-a7c4-cffa6d978ff6.png)
