### PR TITLE
alarm server port

### DIFF
--- a/app/alarm/model/src/main/resources/alarm_preferences.properties
+++ b/app/alarm/model/src/main/resources/alarm_preferences.properties
@@ -3,7 +3,7 @@
 # --------------------------------------
 
 # Kafka Server host:port
-server=localhost:19092
+server=localhost:9092
 
 # A file to configure the properites of kafka clients
 kafka_properties=


### PR DESCRIPTION
In 45e662959b97f31c4e84c7ec2cc44db9dc68b042, the example server was changed from `server=localhost:9092`  to `server=localhost:19092`.
The default port for running kafka out of the box still seems to be 9092, though. That's also what's mentioned in the alarm/Readme.md
Ports 19092 or 29092 seem popular in examples where Kafka is configured to allow additional connections, or when re-configuring it to control access, and the preference of course allows setting the `server` to a specific operational host and port, but the default should probably be localhost:9092 to ease initial tests.