### PR TITLE
Archive: Treat ca://, pva:// as equivalent

### DIFF
--- a/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/DisplayInfo.java
+++ b/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/DisplayInfo.java
@@ -7,7 +7,7 @@
  ******************************************************************************/
 package org.csstudio.archive.ts.reader;
 
-import static org.csstudio.archive.ts.reader.TSArchiveReaderFactory.logger;
+import static org.phoebus.archive.reader.ArchiveReaders.logger;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/TSArchiveReader.java
+++ b/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/TSArchiveReader.java
@@ -37,6 +37,7 @@ import org.phoebus.archive.reader.ArchiveReader;
 import org.phoebus.archive.reader.UnknownChannelException;
 import org.phoebus.archive.reader.ValueIterator;
 import org.phoebus.framework.rdb.RDBConnectionPool;
+import org.phoebus.pv.PVPool;
 import org.phoebus.util.time.TimestampFormats;
 
 /** Archive reader for TimestampDB
@@ -384,7 +385,7 @@ public class TSArchiveReader implements ArchiveReader
                 if (Preferences.timeout_secs > 0)
                     statement.setQueryTimeout(Preferences.timeout_secs);
                 // Loop over variants
-                for (String variant : getNameVariants(name))
+                for (String variant : PVPool.getNameVariants(name, org.csstudio.trends.databrowser3.preferences.Preferences.equivalent_pv_prefixes))
                 {
                     statement.setString(1, variant);
                     try (final ResultSet result = statement.executeQuery())

--- a/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/TSArchiveReader.java
+++ b/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/TSArchiveReader.java
@@ -7,7 +7,7 @@
  ******************************************************************************/
 package org.csstudio.archive.ts.reader;
 
-import static org.csstudio.archive.ts.reader.TSArchiveReaderFactory.logger;
+import static org.phoebus.archive.reader.ArchiveReaders.logger;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -368,7 +368,11 @@ public class TSArchiveReader implements ArchiveReader
         return new ArrayValueIterator(values);
     }
 
-
+    /** @param name Channel name
+     *  @return Numeric channel ID
+     *  @throws UnknownChannelException when channel not known
+     *  @throws Exception on error
+     */
     int getChannelID(final String name) throws UnknownChannelException, Exception
     {
         final Connection connection = pool.getConnection();
@@ -379,14 +383,22 @@ public class TSArchiveReader implements ArchiveReader
             {
                 if (Preferences.timeout_secs > 0)
                     statement.setQueryTimeout(Preferences.timeout_secs);
-                statement.setString(1, name);
-                try (final ResultSet result = statement.executeQuery())
+                // Loop over variants
+                for (String variant : getNameVariants(name))
                 {
-                    if (!result.next())
-                        throw new UnknownChannelException(name);
-                    final int channel_id = result.getInt(1);
-                    return channel_id;
+                    statement.setString(1, variant);
+                    try (final ResultSet result = statement.executeQuery())
+                    {
+                        if (result.next())
+                        {
+                            final int channel_id = result.getInt(1);
+                            logger.log(Level.FINE, () -> "Found '" + name + "' as '" + variant + "' (" + channel_id + ")");
+                            return channel_id;
+                        }
+                    }
                 }
+                // Nothing found
+                throw new UnknownChannelException(name);
             }
             finally
             {

--- a/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/TSArchiveReaderFactory.java
+++ b/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/TSArchiveReaderFactory.java
@@ -7,8 +7,6 @@
  ******************************************************************************/
 package org.csstudio.archive.ts.reader;
 
-import java.util.logging.Logger;
-
 import org.phoebus.archive.reader.ArchiveReader;
 import org.phoebus.archive.reader.spi.ArchiveReaderFactory;
 
@@ -26,9 +24,6 @@ import org.phoebus.archive.reader.spi.ArchiveReaderFactory;
 @SuppressWarnings("nls")
 public class TSArchiveReaderFactory implements ArchiveReaderFactory
 {
-    /** Common logger */
-    public static final Logger logger = Logger.getLogger(TSArchiveReaderFactory.class.getPackageName());
-
     /** Data source prefix */
     public static final String PREFIX = "ts:";
 

--- a/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/TSRawSampleIterator.java
+++ b/app/databrowser-timescale/src/main/java/org/csstudio/archive/ts/reader/TSRawSampleIterator.java
@@ -7,7 +7,7 @@
  ******************************************************************************/
 package org.csstudio.archive.ts.reader;
 
-import static org.csstudio.archive.ts.reader.TSArchiveReaderFactory.logger;
+import static org.phoebus.archive.reader.ArchiveReaders.logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -87,6 +87,8 @@ public class Preferences
     @Preference public static boolean use_default_archives;
     /** Setting */
     @Preference public static boolean drop_failed_archives;
+    /** Setting */
+    @Preference public static String[]  equivalent_pv_prefixes;
     /** Setting */
     @Preference public static boolean use_trace_names;
     /** Setting */

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/ArchiveReader.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/ArchiveReader.java
@@ -10,11 +10,6 @@ package org.phoebus.archive.reader;
 import java.io.Closeable;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
-import org.csstudio.trends.databrowser3.preferences.Preferences;
-import org.phoebus.pv.PVPool.TypedName;
 
 /** Interface to archive data retrieval.
  *
@@ -73,29 +68,6 @@ public interface ArchiveReader extends Closeable
      */
     public Collection<String> getNamesByPattern(String glob_pattern)
         throws Exception;
-
-    /** Create all name variants
-     *
-     *  See documentation of <code>equivalent_pv_prefixes</code>
-     *
-     *  @param name PV name as given
-     *  @return All name variants that should be considered for data retrieval
-     */
-    public default Set<String> getNameVariants(final String name)
-    {
-        // First, look for name as given
-        final Set<String> variants = new LinkedHashSet<>();
-        variants.add(name);
-        if (Preferences.equivalent_pv_prefixes.length > 0)
-        {   // Optionally, add equivalent prefixes
-            String base = TypedName.analyze(name).name;
-            for (String type : Preferences.equivalent_pv_prefixes)
-                variants.add(TypedName.format(type, base));
-            // and the base name without type
-            variants.add(base);
-        }
-        return variants;
-    }
 
     /** Read original, raw samples from the archive
      *  @param name Channel name

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/ArchiveReader.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/ArchiveReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,11 @@ package org.phoebus.archive.reader;
 import java.io.Closeable;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.csstudio.trends.databrowser3.preferences.Preferences;
+import org.phoebus.pv.PVPool.TypedName;
 
 /** Interface to archive data retrieval.
  *
@@ -68,6 +73,29 @@ public interface ArchiveReader extends Closeable
      */
     public Collection<String> getNamesByPattern(String glob_pattern)
         throws Exception;
+
+    /** Create all name variants
+     *
+     *  See documentation of <code>equivalent_pv_prefixes</code>
+     *
+     *  @param name PV name as given
+     *  @return All name variants that should be considered for data retrieval
+     */
+    public default Set<String> getNameVariants(final String name)
+    {
+        // First, look for name as given
+        final Set<String> variants = new LinkedHashSet<>();
+        variants.add(name);
+        if (Preferences.equivalent_pv_prefixes.length > 0)
+        {   // Optionally, add equivalent prefixes
+            String base = TypedName.analyze(name).name;
+            for (String type : Preferences.equivalent_pv_prefixes)
+                variants.add(TypedName.format(type, base));
+            // and the base name without type
+            variants.add(base);
+        }
+        return variants;
+    }
 
     /** Read original, raw samples from the archive
      *  @param name Channel name

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RDBArchiveReader.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/rdb/RDBArchiveReader.java
@@ -28,6 +28,7 @@ import org.phoebus.archive.reader.AveragedValueIterator;
 import org.phoebus.archive.reader.UnknownChannelException;
 import org.phoebus.archive.reader.ValueIterator;
 import org.phoebus.framework.rdb.RDBConnectionPool;
+import org.phoebus.pv.PVPool;
 import org.phoebus.util.time.TimeDuration;
 
 /** {@link ArchiveReader} for RDB
@@ -339,7 +340,7 @@ public class RDBArchiveReader implements ArchiveReader
                 if (RDBPreferences.timeout_secs > 0)
                     statement.setQueryTimeout(RDBPreferences.timeout_secs);
                 // Loop over variants
-                for (String variant : getNameVariants(name))
+                for (String variant : PVPool.getNameVariants(name, org.csstudio.trends.databrowser3.preferences.Preferences.equivalent_pv_prefixes))
                 {
                     statement.setString(1, variant);
                     try (final ResultSet result = statement.executeQuery())

--- a/app/databrowser/src/main/resources/databrowser_preferences.properties
+++ b/app/databrowser/src/main/resources/databrowser_preferences.properties
@@ -98,9 +98,16 @@ drop_failed_archives=true
 #
 # When the plot requests "pva://xxx", the archive might still
 # trace that channel as "ca://xxx" or "xxx".
+# Alternatively, the archive might already track the channel
+# as "pva://xxx" while data browser plots still use "ca://xxx"
+# or just "xxx".
 # This preference setting instructs the data browser
 # to try all equivalent variants. If any types are listed,
-# just "xxx" without any prefix will also be checked.
+# just "xxx" without any prefix will also be checked in addition
+# to the listed types.
+#
+# The default of setting of "ca, pva" supports the seamless
+# transition between the key protocols.
 #
 # When `equivalent_pv_prefixes` is empty,
 # the PV name is used as is without looking for any equivalent names.

--- a/app/databrowser/src/main/resources/databrowser_preferences.properties
+++ b/app/databrowser/src/main/resources/databrowser_preferences.properties
@@ -92,6 +92,20 @@ use_default_archives=false
 # return an error (cannot connect, ...) should be queried again for the given channel.
 drop_failed_archives=true
 
+# With EPICS IOCs from release 7 on, the PVs
+# "xxx", "ca://xxx" and "pva://xxx" all refer
+# to the same record "xxx" on the IOC.
+#
+# When the plot requests "pva://xxx", the archive might still
+# trace that channel as "ca://xxx" or "xxx".
+# This preference setting instructs the data browser
+# to try all equivalent variants. If any types are listed,
+# just "xxx" without any prefix will also be checked.
+#
+# When `equivalent_pv_prefixes` is empty,
+# the PV name is used as is without looking for any equivalent names.
+equivalent_pv_prefixes=ca, pva
+
 # Re-scale behavior when archived data arrives: NONE, STAGGER
 archive_rescale=STAGGER
 

--- a/core/pv/src/main/java/org/phoebus/pv/PVPool.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PVPool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,7 +61,7 @@ public class PVPool
     final private static Map<String, PVFactory> factories = new HashMap<>();
 
     /** Default PV name type prefix */
-    @Preference(name="default") private static String default_type;
+    @Preference(name="default") public static String default_type;
 
     static
     {
@@ -144,7 +144,7 @@ public class PVPool
      *  @param name PV Name, "base..." or  "prefix://base..."
      *  @return Array with type (or default) and base name
      */
-    private static String[] analyzeName(final String name)
+    public static String[] analyzeName(final String name)
     {
         final String type, base;
 

--- a/core/pv/src/main/java/org/phoebus/pv/PVPool.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PVPool.java
@@ -11,8 +11,10 @@ import static org.phoebus.pv.PV.logger;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.logging.Level;
 
 import org.phoebus.framework.preferences.AnnotatedPreferences;
@@ -143,6 +145,25 @@ public class PVPool
         {
             return format(type, name);
         }
+    }
+
+    /** @param name PV Name
+     *  @param equivalent_pv_prefixes List of equivalent PV prefixes (types)
+     *  @return Set of equivalent names
+     */
+    public static Set<String> getNameVariants(final String name, final String [] equivalent_pv_prefixes)
+    {
+        // First, look for name as given
+        final Set<String> variants = new LinkedHashSet<>();
+        variants.add(name);
+        if (equivalent_pv_prefixes != null  &&  equivalent_pv_prefixes.length > 0)
+        {   // Optionally, add equivalent prefixes, starting with base name
+            final String base = TypedName.analyze(name).name;
+            variants.add(base);
+            for (String type : equivalent_pv_prefixes)
+                variants.add(TypedName.format(type, base));
+        }
+        return variants;
     }
 
     /** PV Pool

--- a/core/pv/src/main/java/org/phoebus/pv/PVPool.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PVPool.java
@@ -147,9 +147,9 @@ public class PVPool
         }
     }
 
-    /** @param name PV Name
-     *  @param equivalent_pv_prefixes List of equivalent PV prefixes (types)
-     *  @return Set of equivalent names
+    /** @param name PV Name, may be "xxx" or "type://xxx"
+     *  @param equivalent_pv_prefixes List of equivalent PV prefixes (types), e.g. "ca", "pva"
+     *  @return Set of equivalent names, e.g. "xxx", "ca://xxx", "pva://xxx"
      */
     public static Set<String> getNameVariants(final String name, final String [] equivalent_pv_prefixes)
     {
@@ -157,11 +157,17 @@ public class PVPool
         final Set<String> variants = new LinkedHashSet<>();
         variants.add(name);
         if (equivalent_pv_prefixes != null  &&  equivalent_pv_prefixes.length > 0)
-        {   // Optionally, add equivalent prefixes, starting with base name
-            final String base = TypedName.analyze(name).name;
-            variants.add(base);
+        {   // Optionally, if the original name is one of the equivalent types ...
+            final TypedName typed = TypedName.analyze(name);
             for (String type : equivalent_pv_prefixes)
-                variants.add(TypedName.format(type, base));
+                if (type.equals(typed.type))
+                {
+                    // .. add equivalent prefixes, starting with base name
+                    variants.add(typed.name);
+                    for (String variant : equivalent_pv_prefixes)
+                        variants.add(TypedName.format(variant, typed.name));
+                    break;
+                }
         }
         return variants;
     }

--- a/core/pv/src/main/java/org/phoebus/pv/loc/LocalPVFactory.java
+++ b/core/pv/src/main/java/org/phoebus/pv/loc/LocalPVFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,7 +61,7 @@ public class LocalPVFactory implements PVFactory
         final String[] ntv = ValueHelper.parseName(base_name);
 
         // Actual name: loc://the_pv  without <type> or (initial value)
-        final String actual_name = LocalPVFactory.TYPE + PVPool.SEPARATOR + ntv[0];
+        final String actual_name = PVPool.TypedName.format(LocalPVFactory.TYPE, ntv[0]);
 
         // Info for initial value, null if nothing provided
         final List<String> initial_value = ValueHelper.splitInitialItems(ntv[2]);

--- a/core/pv/src/test/java/org/phoebus/pv/PVPoolTest.java
+++ b/core/pv/src/test/java/org/phoebus/pv/PVPoolTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.prefs.Preferences;
 
 import org.junit.Test;
@@ -44,6 +45,28 @@ public class PVPoolTest
         assertThat(type_name.name, equalTo("ramp"));
         assertThat(type_name.toString(), equalTo(PVPool.default_type + "://ramp"));
     }
+
+    @Test
+    public void equivalentPVs()
+    {
+        // Given "ramp" or "ca://ramp", all the other variants should be considered
+        final String[] equivalent_pv_prefixes = new String[] { "ca", "pva" };
+        Set<String> pvs = PVPool.getNameVariants("pva://ramp", equivalent_pv_prefixes);
+        assertThat(pvs.size(), equalTo(3));
+        assertThat(pvs, hasItem("ramp"));
+        assertThat(pvs, hasItem("ca://ramp"));
+        assertThat(pvs, hasItem("pva://ramp"));
+
+        // For loc or sim which are not in the equivalent list, pass name through
+        pvs = PVPool.getNameVariants("loc://ramp", equivalent_pv_prefixes);
+        assertThat(pvs.size(), equalTo(1));
+        assertThat(pvs, hasItem("loc://ramp"));
+
+        pvs = PVPool.getNameVariants("sim://ramp", equivalent_pv_prefixes);
+        assertThat(pvs.size(), equalTo(1));
+        assertThat(pvs, hasItem("sim://ramp"));
+    }
+
 
     @Test
     public void dumpPreferences() throws Exception

--- a/core/pv/src/test/java/org/phoebus/pv/PVPoolTest.java
+++ b/core/pv/src/test/java/org/phoebus/pv/PVPoolTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,8 +7,9 @@
  ******************************************************************************/
 package org.phoebus.pv;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collection;
 import java.util.prefs.Preferences;
@@ -27,6 +28,18 @@ public class PVPoolTest
         System.out.println("Prefixes: " + prefs);
         assertThat(prefs, hasItem("ca"));
         assertThat(prefs, hasItem("sim"));
+    }
+
+    @Test
+    public void analyzePVs()
+    {
+        String[] type_name = PVPool.analyzeName("pva://ramp");
+        assertThat(type_name[0], equalTo("pva"));
+        assertThat(type_name[1], equalTo("ramp"));
+
+        type_name = PVPool.analyzeName("ramp");
+        assertThat(type_name[0], equalTo(PVPool.default_type));
+        assertThat(type_name[1], equalTo("ramp"));
     }
 
     @Test

--- a/core/pv/src/test/java/org/phoebus/pv/PVPoolTest.java
+++ b/core/pv/src/test/java/org/phoebus/pv/PVPoolTest.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.prefs.Preferences;
 
 import org.junit.Test;
+import org.phoebus.pv.PVPool.TypedName;
 import org.phoebus.pv.ca.JCA_Preferences;
 
 /** @author Kay Kasemir */
@@ -33,13 +34,15 @@ public class PVPoolTest
     @Test
     public void analyzePVs()
     {
-        String[] type_name = PVPool.analyzeName("pva://ramp");
-        assertThat(type_name[0], equalTo("pva"));
-        assertThat(type_name[1], equalTo("ramp"));
+        TypedName type_name = TypedName.analyze("pva://ramp");
+        assertThat(type_name.type, equalTo("pva"));
+        assertThat(type_name.name, equalTo("ramp"));
+        assertThat(type_name.toString(), equalTo("pva://ramp"));
 
-        type_name = PVPool.analyzeName("ramp");
-        assertThat(type_name[0], equalTo(PVPool.default_type));
-        assertThat(type_name[1], equalTo("ramp"));
+        type_name = TypedName.analyze("ramp");
+        assertThat(type_name.type, equalTo(PVPool.default_type));
+        assertThat(type_name.name, equalTo("ramp"));
+        assertThat(type_name.toString(), equalTo(PVPool.default_type + "://ramp"));
     }
 
     @Test

--- a/services/archive-engine/doc/index.rst
+++ b/services/archive-engine/doc/index.rst
@@ -91,6 +91,30 @@ in this example replacing the original one::
     archive-engine.sh -engine Demo -import Demo.xml -port 4812 -replace_engine
 
 
+PV Name Details
+---------------
+
+The archive engine uses CS-Studio PV names.
+"ca://xxxx" will force a Channel Access connection,
+"pva://xxxx" will force a PV Access connection,
+and just "xxxx" will use the default PV type
+configurable via
+
+    org.phoebus.pv/default=ca
+
+Since EPICS 7, IOCs can support both protocols.
+"xxxx", "ca://xxxx" and "pva://xxxx" will thus
+refer to the same record on the IOC.
+
+The preference setting
+
+    org.csstudio.archive/equivalent_pv_prefixes=ca, pva
+
+causes the archive engine to treat them equivalent as well.
+For details, refer to the description of the
+`equivalent_pv_prefixes` preference setting.
+
+
 Run the Archive Engine
 ----------------------
 

--- a/services/archive-engine/src/main/java/org/csstudio/archive/Engine.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/Engine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@ package org.csstudio.archive;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -315,6 +316,7 @@ public class Engine
             logger.log(Level.INFO, "URL                 : " + url);
             logger.log(Level.INFO, "Replace engine      : " + replace_engine);
             logger.log(Level.INFO, "Duplicate channels  : " + duplicates);
+            logger.log(Level.INFO, "Equiv. PV prefixes  : " + Arrays.toString(Preferences.equivalent_pv_prefixes));
 
             try
             (

--- a/services/archive-engine/src/main/java/org/csstudio/archive/Preferences.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ public class Preferences
     @Preference public static String write_sample_table;
     @Preference public static int max_text_sample_length;
     @Preference public static boolean use_postgres_copy;
+    @Preference public static String[] equivalent_pv_prefixes;
     @Preference public static int log_trouble_samples;
     @Preference public static int log_overrun;
     @Preference public static int write_period;

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
@@ -198,11 +198,11 @@ public class RDBConfig implements AutoCloseable
 
     /** @param group_id Group where to add channel
      *  @param duplicates How to handle duplicate channels
-     *  @param name Name of channel
-     *  @param monitor
-     *  @param period
-     *  @param delta
-     *  @param enable
+     *  @param original_name Name of channel
+     *  @param monitor Monitor?
+     *  @param period Scan or estimated monitor period in seconds
+     *  @param delta Delta for engine-side deadband check
+     *  @param enable Does channel enable its group?
      *  @throws Exception on error, including existing channel
      */
     public void addChannel(final int group_id, final DuplicateMode duplicate_mode, final String original_name,

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
@@ -16,7 +16,6 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -28,7 +27,7 @@ import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.model.SampleMode;
 import org.csstudio.archive.writer.rdb.TimestampHelper;
 import org.phoebus.framework.rdb.RDBInfo;
-import org.phoebus.pv.PVPool.TypedName;
+import org.phoebus.pv.PVPool;
 
 @SuppressWarnings("nls")
 public class RDBConfig implements AutoCloseable
@@ -214,18 +213,7 @@ public class RDBConfig implements AutoCloseable
         try
         (   PreparedStatement statement = connection.prepareStatement(sql.channel_sel_by_name)  )
         {
-            // First, check name as given
-            final Set<String> variants = new LinkedHashSet<>();
-            variants.add(name);
-
-            if (Preferences.equivalent_pv_prefixes.length > 0)
-            {   // Also check base name..
-                TypedName type_name = TypedName.analyze(name);
-                variants.add(type_name.name);
-                // .. and all equivalent PVs
-                for (String type : Preferences.equivalent_pv_prefixes)
-                    variants.add(TypedName.format(type, type_name.name));
-            }
+            final Set<String> variants = PVPool.getNameVariants(name, Preferences.equivalent_pv_prefixes);
             for (String variant : variants)
             {
                 statement.setString(1, variant);

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
@@ -254,20 +254,21 @@ public class RDBConfig implements AutoCloseable
                     if (result.next())
                     {
                         // Channel is already used by another archive engine
-                        final String gn = result.getString(2);
                         final int gid = result.getInt(1);
+                        final String gn = result.getString(2);
+                        final String engine = result.getString(3);
+                        final String info = "Channel '" + original_name + "' is already in engine '" + engine + "' group '" + gn + "' (" + gid + ") as '" + name + "'";
                         switch (duplicate_mode)
                         {
                         case ABORT:
-                            throw new Exception("Channel '" + original_name + "' is already in group '" + gn + "' (" + gid + ") " + "as '" + name + "'");
+                            throw new Exception(info);
                         case SKIP:
-                            logger.log(Level.WARNING, "Channel '" + original_name + "' is already in group '" + gn + "' (" + gid + ") as '" + name + "' and not moved to this engine.");
+                            logger.log(Level.WARNING, info + " and will remain there.");
                             // Leave channel "as is" with other engine
                             return;
                         case STEAL:
                         default:
-                            logger.log(Level.WARNING, "Channel '" + original_name + "' will be stolen from group '" + gn + "' (" + gid + ") " +
-                                       " where it was as '" + name + "' and moved to this engine.");
+                            logger.log(Level.WARNING, info + " and will be moved to this engine.");
                             // Continue with moving channel to this engine's group
                         }
                     }

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/RDBConfig.java
@@ -28,7 +28,7 @@ import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.model.SampleMode;
 import org.csstudio.archive.writer.rdb.TimestampHelper;
 import org.phoebus.framework.rdb.RDBInfo;
-import org.phoebus.pv.PVPool;
+import org.phoebus.pv.PVPool.TypedName;
 
 @SuppressWarnings("nls")
 public class RDBConfig implements AutoCloseable
@@ -220,11 +220,11 @@ public class RDBConfig implements AutoCloseable
 
             if (Preferences.equivalent_pv_prefixes.length > 0)
             {   // Also check base name..
-                String[] type_name = PVPool.analyzeName(name);
-                variants.add(type_name[1]);
+                TypedName type_name = TypedName.analyze(name);
+                variants.add(type_name.name);
                 // .. and all equivalent PVs
                 for (String type : Preferences.equivalent_pv_prefixes)
-                    variants.add(type + PVPool.SEPARATOR + type_name[1]);
+                    variants.add(TypedName.format(type, type_name.name));
             }
             for (String variant : variants)
             {

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/SQL.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/config/SQL.java
@@ -70,9 +70,11 @@ public class SQL
         chan_grp_delete_by_engine_id = "DELETE FROM " + schema + "chan_grp WHERE eng_id=?";
         chan_grp_insert = "INSERT INTO " + schema + "chan_grp (grp_id, name, eng_id, enabling_chan_id) VALUES (?,?,?,null)";
         chan_grp_next_id = "SELECT MAX(grp_id) FROM " + schema + "chan_grp";
-        chan_grp_sel_by_channel = "SELECT g.grp_id, g.name FROM " + schema + "chan_grp g " +
+        chan_grp_sel_by_channel = "SELECT g.grp_id, g.name, e.name FROM " + schema + "chan_grp g " +
                                   "JOIN " + schema + "channel c ON g.grp_id = c.grp_id " +
+                                  "JOIN " + schema + "smpl_eng e ON g.eng_id = e.eng_id " +
                                   "WHERE c.name=?";
+
         chan_grp_set_enable_channel = "UPDATE " + schema + "chan_grp SET enabling_chan_id=? WHERE grp_id=?";
 
         // 'channel' table

--- a/services/archive-engine/src/main/resources/archive_preferences.properties
+++ b/services/archive-engine/src/main/resources/archive_preferences.properties
@@ -62,33 +62,50 @@ use_postgres_copy=false
 # determines the default type when no prefix is provided.
 #
 # With EPICS IOCs from release 7 on, the PVs
-# "xxx", "ca://xxx" and "pva://xxx" would all refer
+# "xxx", "ca://xxx" and "pva://xxx" all refer
 # to the same record "xxx" on the IOC.
 #
-# The archive configuration stores the PV name as given,
-# uses it as such when connecting to the live data source
-# and writes samples under that name to the archive.
-# This preference setting establishes one or more prefixes
-# as equal when importing the configuration.
+# The archive configuration stores the PV name as given.
+# It is used as such when connecting to the live data source,
+# resulting in "ca://.." or "pva://.." connections as requested.
+# Samples are written to the archive under that channel name.
+#
+# This archive engine preference setting establishes one or more prefixes
+# as equal when importing an engine configuration.
 # For example, assume
 #
 #  equivalent_pv_prefixes=ca, pva
 #
-# When adding a PV "ca://xxx" to the configuration,
+# When adding a PV "pva://xxx" to the configuration,
 # we check if the archive already contains a channel "xxx", "ca://xxx" or "pva://xxx".
-# If any of them are found, the `-import` will report "ca://xxx" as a duplicate
-# and not add it to the configuration.
+# If any of them are found, the `-import` will consider "pva://xxx" as a duplicate.
+#
+# When importing a PV "pva://xxx" into a sample engine configuration that already
+# contains the channel "ca://xxx" or "xxx", the channel will be renamed,
+# so that engine will from now on use "pva://xxx".
+#
+# When importing a PV "pva://xxx" into a configuration that already
+# contains a different engine setup with the channel "ca://xxx" or "xxx",
+# the channel will by default rename unchanged, so "ca://xxx" or "xxx"
+# will remain in their original engine setup, "pva://xxx" will be skipped.
+#
 # When using `-import` with the additional `-steal_channels` option,
-# the existing "...xxx" channel will be renamed to "ca://xxx" and moved
+# the existing "...xxx" channel will be renamed to "pva://xxx" and moved
 # to the imported engine configuration.
 #
-# When `equivalent_pv_prefixes` are empty,
+# When `equivalent_pv_prefixes` is empty,
 # any PV name is used as is without looking for equivalent names.
 # So "xxx", "ca://xxx" and "pva://xxx" can then all be imported
-# as separate channels, and the data for all of them will likely be the same
-# except for possible differences in sample modes.
+# as separate channels, which is likely wrong because it would simply
+# store data from the same underlying record more than once.
 #
-# This default should be the most practical setting.
+# This default should be the most practical setting when adding
+# EPICS 7 IOCs and starting to transition towards "pva://..".
+# Existing "xxx" or "ca://xxx" channels can thus be renamed
+# to "pva://xxx" while retaining their sample history.
+#
+# Note that the data browser has a similar `equivalent_pv_prefixes`
+# setting to search for a channel name in several variants.
 equivalent_pv_prefixes=ca, pva
 
 # Seconds between log messages for Not-a-Number, futuristic, back-in-time values, buffer overruns

--- a/services/archive-engine/src/main/resources/archive_preferences.properties
+++ b/services/archive-engine/src/main/resources/archive_preferences.properties
@@ -53,6 +53,44 @@ max_text_sample_length=80
 # Use postgres copy instead of insert
 use_postgres_copy=false
 
+# Channel names use a prefix ca://, pva://, loc://, ...
+# to select the type of PV or network protocol.
+# The preference setting
+#
+#  org.phoebus.pv/default=ca
+#
+# determines the default type when no prefix is provided.
+#
+# With EPICS IOCs from release 7 on, the PVs
+# "xxx", "ca://xxx" and "pva://xxx" would all refer
+# to the same record "xxx" on the IOC.
+#
+# The archive configuration stores the PV name as given,
+# uses it as such when connecting to the live data source
+# and writes samples under that name to the archive.
+# This preference setting establishes one or more prefixes
+# as equal when importing the configuration.
+# For example, assume
+#
+#  equivalent_pv_prefixes=ca, pva
+#
+# When adding a PV "ca://xxx" to the configuration,
+# we check if the archive already contains a channel "xxx", "ca://xxx" or "pva://xxx".
+# If any of them are found, the `-import` will report "ca://xxx" as a duplicate
+# and not add it to the configuration.
+# When using `-import` with the additional `-steal_channels` option,
+# the existing "...xxx" channel will be renamed to "ca://xxx" and moved
+# to the imported engine configuration.
+#
+# When `equivalent_pv_prefixes` are empty,
+# any PV name is used as is without looking for equivalent names.
+# So "xxx", "ca://xxx" and "pva://xxx" can then all be imported
+# as separate channels, and the data for all of them will likely be the same
+# except for possible differences in sample modes.
+#
+# This default should be the most practical setting.
+equivalent_pv_prefixes=ca, pva
+
 # Seconds between log messages for Not-a-Number, futuristic, back-in-time values, buffer overruns
 # 24h = 24*60*60 = 86400
 log_trouble_samples=86400


### PR DESCRIPTION
Channel names use a prefix ca://, pva://, loc://, ...  to select the type of PV or network protocol.
With EPICS IOCs from release 7 on, the PVs "xxx", "ca://xxx" and "pva://xxx" all refer to the same record "xxx" on the IOC.

This adds a preference setting
```
equivalent_pv_prefixes=ca, pva
```

to both the archive engine `-import` and the data browser data retrieval's RDB implementation.

The archive configuration stores the PV name as given.
It is used as such when connecting to the live data source,
resulting in "ca://.." or "pva://.." connections as requested.
Samples are written to the archive under that channel name.
When importing a new or updated archive configuration,
it will now treat ca://, pva:// or plain PV names as equivalent.

When importing a PV "pva://xxx" into a sample engine configuration that already
contains the channel "ca://xxx" or "xxx", the channel will be renamed,
so that engine will from now on use "pva://xxx".

When importing a PV "pva://xxx" into a configuration that already
contains a different engine setup with the channel "ca://xxx" or "xxx",
the channel will by default rename unchanged, so "ca://xxx" or "xxx"
will remain in their original engine setup, "pva://xxx" will be skipped.

When using `-import` with the additional `-steal_channels` option,
the existing "...xxx" channel will be renamed to "pva://xxx" and moved
to the imported engine configuration.

The data browser has a similar `equivalent_pv_prefixes`
setting to search for a channel name in several variants.
With the default setting of
```
equivalent_pv_prefixes=ca, pva
```
any lookup of "xxx", "ca://xxx" or "pva://xxx" will also look for the other variants.

Overall this will simplify moving for example one archive engine over to pva:// while the rest still uses ca://.
