### PR TITLE
CSSTUDIO-1725: Properties defined in Widget class files are ignored unless use_class=true

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetClassSupport.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetClassSupport.java
@@ -73,10 +73,12 @@ public class WidgetClassSupport
     {
         private final String specification;
         private final Object value;
+        private final boolean use_class;
 
         /** @param property Property with value to use for class */
         public PropertyValue(final WidgetProperty<?> property)
         {
+            use_class = property.isUsingWidgetClass();
             if (property instanceof MacroizedWidgetProperty)
             {
                 specification = ((MacroizedWidgetProperty<?>) property).getSpecification();
@@ -205,9 +207,12 @@ public class WidgetClassSupport
         else if (! DEFAULT.equals(widget_class))
             logger.log(Level.WARNING, "Widget type '" + type + "' class '" + widget_class + "' is defined more than once");
 
-        for (WidgetProperty<?> property : widget.getProperties())
-            if (property.isUsingWidgetClass())
+        for (WidgetProperty<?> property : widget.getProperties()) {
+            if (property.isValueReadFromFile()) {
+//            if (property.isUsingWidgetClass()) {
                 class_properties.put(property.getName(), new PropertyValue(property));
+            }
+        }
     }
 
     /** Get known widget classes
@@ -291,11 +296,16 @@ public class WidgetClassSupport
         }
 
         final PropertyValue class_setting = class_settings.get(property.getName());
-        if (class_setting == null)
+        if (class_setting == null) {
             property.useWidgetClass(false);
+        }
         else
         {
-            property.useWidgetClass(true);
+            if(class_setting.use_class) {
+                property.useWidgetClass(true);
+            } else {
+                property.useWidgetClass(false);
+            }
             class_setting.apply(property);
         }
     }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetConfigurator.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetConfigurator.java
@@ -134,6 +134,7 @@ public class WidgetConfigurator
             try
             {
                 property.readFromXML(model_reader, prop_xml);
+                property.setIsValueReadFromFile(true); // todo, integrate into readFromXml?
                 property.useWidgetClass(parseBoolean(prop_xml.getAttribute(XMLTags.USE_CLASS)));
             }
             catch (Exception ex)

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetProperty.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/WidgetProperty.java
@@ -48,6 +48,9 @@ public abstract class WidgetProperty<T extends Object> extends PropertyChangeHan
      */
     protected final T default_value;
 
+    /** Was this property's value set from xml, or just from the default value? **/
+    protected volatile boolean is_value_from_file = false;
+
     /** Does property follow the value suggested by class? */
     protected volatile boolean use_class = false;
 
@@ -307,6 +310,14 @@ public abstract class WidgetProperty<T extends Object> extends PropertyChangeHan
      *  @throws Exception on error
      */
     abstract public void readFromXML(final ModelReader model_reader, final Element property_xml) throws Exception;
+
+    public void setIsValueReadFromFile(boolean value) {
+        is_value_from_file = value;
+    }
+
+    public boolean isValueReadFromFile() {
+        return is_value_from_file;
+    }
 
     /** Notify listeners of property change.
      *


### PR DESCRIPTION
fix: properties defined in class/template files are ignored unless use_class is set true; now they are used if defined, and use_class can be optionally used to lock properties from editing

As a side effect of this, you can now override the DEFAULT class def by simply defining one with the same name for a given widget, for example:
```
<widget type="label" version="2.0.0">
    <name>DEFAULT</name>
    <text>I've been overridden!</text>
    <width use_class="true">600</width>
</widget>
```

NOTE: Will want to, as followup, cleanup the ess-phoebus-customization files as they set some properties (such as x and y position) that we may be wanting to ignore.