### PR TITLE
Fix wrong time stamp in alarm logger

### DIFF
--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/AlarmLogMessage.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/AlarmLogMessage.java
@@ -158,7 +158,7 @@ public class AlarmLogMessage {
 
     public static class AlarmInstantDeserializer extends JsonDeserializer<Instant> {
 
-        private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
+        private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.of("UTC"));
 
         public AlarmInstantDeserializer() {
         }


### PR DESCRIPTION
In the alarm log table, the time stamps were shown in UTC.