### PR TITLE
Set Jackson version defined in top-level pom for alarm logger

### DIFF
--- a/services/alarm-logger/pom.xml
+++ b/services/alarm-logger/pom.xml
@@ -48,11 +48,6 @@
         </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
       <version>2.0.0</version>
@@ -75,12 +70,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.12.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.json</groupId>
@@ -90,12 +85,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.13.2</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.13.2</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>


### PR DESCRIPTION
Resolves Depenadabot alert.

No issues seen in smoke test.