### PR TITLE
JavaFX19

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -27,7 +27,7 @@
     <classpathentry exported="true" kind="lib" path="target/lib/commonmark-0.15.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commonmark-ext-gfm-tables-0.15.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commonmark-ext-image-attributes-0.15.2.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/commons-codec-1.11.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/commons-codec-1.14.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commons-compress-1.21.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commons-io-1.3.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commons-logging-1.1.3.jar"/>
@@ -37,9 +37,9 @@
     <classpathentry exported="true" kind="lib" path="target/lib/controlsfx-11.0.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/derby-10.14.1.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/eclipselink-2.7.0.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-java-7.17.3.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-rest-client-7.17.3.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-rest-client-sniffer-7.17.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-java-8.2.0.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-rest-client-8.2.0.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-rest-client-sniffer-8.2.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/epics-ntypes-0.3.7.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/epics-pvaccess-5.1.7.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/epics-pvdata-6.1.7.jar"/>
@@ -57,7 +57,6 @@
     <classpathentry exported="true" kind="lib" path="target/lib/httpclient-4.5.10.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/httpcore-4.4.12.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/httpcore-nio-4.4.12.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/install-jars-4.6.10-SNAPSHOT.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/istack-commons-runtime-3.0.5.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/j2objc-annotations-1.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jackson-annotations-2.12.3.jar"/>

--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -158,52 +158,52 @@
 
 
     <!-- On Windows, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-18-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-18-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-18-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-18-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-18-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-18-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-18-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19-win.jar"/>
     -->
     <!-- On Linux, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-18-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-18-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-18-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-18-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-18-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-18-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-18-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19-linux.jar"/>
     -->
     <!-- On Mac, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-18-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-18-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-18-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-18-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-18-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-18-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-18.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-18-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-18.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19.jar"/>
     -->
 
     <classpathentry kind="output" path="target/classes"/>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
   <properties>
     <epics.version>7.0.8</epics.version>
     <vtype.version>1.0.5</vtype.version>
-    <openjfx.version>18</openjfx.version>
+    <openjfx.version>19</openjfx.version>
     <jackson.version>2.12.3</jackson.version>
     <batik.version>1.14</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
Update JavaFX from 18 to the recently release version 19 just to stay current.

No change in JDK, still runs with JDK 11 and higher.
While release 18 already deprecated GTK 2 and issued warnings when running with `-Djdk.gtk.version=2`, that's still supported.
In the release notes, https://github.com/openjdk/jfx/blob/master/doc-files/release-notes-19.md, nothing stands out to me that we desperately need and no incompatible changes, either.