### PR TITLE
Update derby

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -22,7 +22,9 @@
     <classpathentry exported="true" kind="lib" path="target/lib/commons-logging-1.1.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commons-compress-1.21.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/controlsfx-11.0.3.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/derby-10.14.1.0.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/derby-10.16.1.1.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/derbytools-10.16.1.1.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/derbyshared-10.16.1.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/eclipselink-2.7.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-6.8.4.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/elasticsearch-cli-6.8.4.jar"/>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -270,7 +270,17 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.14.1.0</version>
+      <version>${derby.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbytools</artifactId>
+      <version>${derby.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbyshared</artifactId>
+      <version>${derby.version}</version>
     </dependency>
 
     <!-- Kafka, used by alarm tools -->

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <skipITTests>true</skipITTests>
     <guava.version>31.0.1-jre</guava.version>
     <log4j-to-slf4j.version>2.17.1</log4j-to-slf4j.version>
+    <derby.version>10.16.1.1</derby.version>
   </properties>
   <build>
     <plugins>

--- a/services/scan-server/pom.xml
+++ b/services/scan-server/pom.xml
@@ -44,7 +44,17 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.14.1.0</version>
+      <version>${derby.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbytools</artifactId>
+      <version>${derby.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbyshared</artifactId>
+      <version>${derby.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
.. to latest version to silence https://github.com/ControlSystemStudio/phoebus/security/dependabot/22

Basic test that first created scan database with older code, then opened it with the updated Derby version ran fine.

Unfortunately, what used to be one Derby.jar now requires additional `derbytools` for `EmbeddedDriver`  and `derbyshared` for support.