### PR TITLE
CSSTUDIO-1745: hitting enter after changing a value in the color picker doesn't commit it to the property

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOverController.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOverController.java
@@ -152,7 +152,6 @@ public class WidgetColorPopOverController implements Initializable {
         {
             if (event.getCode() == KeyCode.ENTER)
                 okPressed(null);
-                event.consume();
         });
 
         picker.valueProperty().addListener(( observable, oldColor, newColor ) -> {


### PR DESCRIPTION
When changing a value in the color picker popover for e.g. a color widget property such as Background, the popover closes without the value changing. 

This occurs because both the root node and the ok button itself are bound to these keyboard events (explicitly and implicitly), and the sanitization is triggered by leaving the field (such as clicking elsewhere, or tabbing to another field) e.g. closing the field's editor. By consuming the Enter key event explicitly, this sanitisation and editor commit/close is bypassed. 

Hence, the fix being one line; to not consume the event captured by the root node and to let it propagate.