### PR TITLE
CSSTUDIO-1746: Color Picker Color Preview Shows Incorrect Current Color for Background field

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOverController.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetColorPopOverController.java
@@ -111,7 +111,12 @@ public class WidgetColorPopOverController implements Initializable {
     /*
      * ---- color property -----------------------------------------------------
      */
-    private final ObjectProperty<WidgetColor> color = new SimpleObjectProperty<>(this, "color", WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)) {
+    private final ObjectProperty<WidgetColor> color = new SimpleObjectProperty<>(this, "color",
+            // Initialize with an empty color, the initial color will be initialized from the widget
+            // default in #setInitialConditions (after color property listeners have been defined)
+            // where e.g. all the related fields in the widget will be subsequently updated/initialized
+            null
+    ) {
         @Override
         protected void invalidated() {
 


### PR DESCRIPTION
The cause is that the color picker popover was initialized with the 'Background' named color. Color initialization works, but only of course when the value (color property) has changed. Initializing the color with null is all that was needed.