### PR TITLE
EDM 'group' conversion: Handle content with line width > 1

### DIFF
--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeGroupClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeGroupClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,12 +34,38 @@ public class Convert_activeGroupClass extends ConverterBase<GroupWidget>
         widget.propStyle().setValue(Style.NONE);
         widget.propTransparent().setValue(true);
 
-        // Expand size by 1px to prevent cropping
-        widget.propWidth().setValue(widget.propWidth().getValue() + 1);
-        widget.propHeight().setValue(widget.propHeight().getValue() + 1);
+        // EDM group content uses absolute screen locations,
+        // while the display builder places it relative to the group,
+        // so content X,Y = 0,0 appears at the group's upper left corner.
+        // To correct the group member locations, including recursive sub-groups,
+        // a converter 'offset' is subtracted from group content.
+        //
+        // For some graphics like arcs, EDM will allow the line width to grow outside
+        // of the widget outline, while the display builder keeps the line inside
+        // the widget outline, basically moving the widget by half the line width.
+        //
+        // In combination, an EDM line element at the upper left edge of a group
+        // will then result in negative X, Y coordinates relative to the group,
+        // but negative X, Y is not permitted.
+        //
+        // We thus add a BUFFER to the EDM group outline to provide room for lines
+        // outside the original group outline.
+        // A BUFFER of 5 allows for line widths of up to 10.
+        // This does enlarge all groups, but since EDM groups are only used for
+        // widget organization without visual elements like border etc,
+        // a change in group size compared to EDM is accepted.
+        final int BUFFER = 5;
+        final int x = widget.propX().getValue() - BUFFER;
+        final int y = widget.propY().getValue() - BUFFER;
+        widget.propX().setValue(x);
+        widget.propY().setValue(y);
+
+        // Expand size by 1px to prevent cropping, by BUFFER to allow for wider line content
+        widget.propWidth().setValue(widget.propWidth().getValue() + 2*BUFFER);
+        widget.propHeight().setValue(widget.propHeight().getValue() + 2*BUFFER);
 
         // Add and later remove the container offset
-        converter.addPositionOffset(widget.propX().getValue(), widget.propY().getValue());
+        converter.addPositionOffset(x, y);
         try
         {
             for (EdmWidget c : g.getWidgets())
@@ -48,7 +74,7 @@ public class Convert_activeGroupClass extends ConverterBase<GroupWidget>
         }
         finally
         {
-            converter.addPositionOffset(-widget.propX().getValue(), -widget.propY().getValue());
+            converter.addPositionOffset(-x, -y);
         }
     }
 


### PR DESCRIPTION
EDM 'arc' and other elements with lines extend beyond the widget outline as their line width grows.
When imported, the converter adjusts the widget location accordingly.
For an arc with line width of 10 we basically subtract 5 from the X and Y position to have the widget appear the same as the EDM original.
This causes problems with line figures inside a group, since elements could end up at negative X, Y locations which then get truncated to zero.

This update extends the size of the converted group to allow for most line content in groups.

Example for the issue in converted EDM content:
![before](https://user-images.githubusercontent.com/1932421/190251080-fa6aa18b-1279-4451-a8e3-9ef00266d6c1.png)

Now:
![after](https://user-images.githubusercontent.com/1932421/190251107-8ac04a4a-dc08-4c24-a97f-c3f93d2b3e6b.png)
