### PR TITLE
fix: DisplayRuntime window doesn't use width set by display properties

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -9,7 +9,8 @@ package org.csstudio.display.builder.runtime.app;
 
 import static org.csstudio.display.builder.runtime.WidgetRuntime.logger;
 
-import java.awt.*;
+
+import java.awt.geom.Rectangle2D;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Objects;
@@ -509,15 +510,21 @@ public class DisplayRuntimeInstance implements AppInstance
     }
 
     @Override
-    public Optional<Dimension> getDimensionHint() {
+    public Optional<Rectangle2D> getPositionAndSizeHint() {
         return Optional.ofNullable(active_model).flatMap(displayModel -> {
             Integer width = displayModel.propWidth().getValue();
             Integer height = displayModel.propHeight().getValue();
             if(width != null && width > 0 && height != null && height > 0) {
-                return Optional.of(new Dimension(width, height));
+                return Optional.of(new Rectangle2D.Double(
+                        displayModel.propX().getValue(),
+                        displayModel.propY().getValue(),
+                        width,
+                        height
+                ));
             } else {
                 return Optional.empty();
             }
         });
     }
+
 }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -9,6 +9,7 @@ package org.csstudio.display.builder.runtime.app;
 
 import static org.csstudio.display.builder.runtime.WidgetRuntime.logger;
 
+import java.awt.*;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Objects;
@@ -505,5 +506,18 @@ public class DisplayRuntimeInstance implements AppInstance
         representation.shutdown();
 
         navigation.dispose();
+    }
+
+    @Override
+    public Optional<Dimension> getDimensionHint() {
+        return Optional.ofNullable(active_model).flatMap(displayModel -> {
+            Integer width = displayModel.propWidth().getValue();
+            Integer height = displayModel.propHeight().getValue();
+            if(width != null && width > 0 && height != null && height > 0) {
+                return Optional.of(new Dimension(width, height));
+            } else {
+                return Optional.empty();
+            }
+        });
     }
 }

--- a/core/framework/src/main/java/org/phoebus/framework/spi/AppInstance.java
+++ b/core/framework/src/main/java/org/phoebus/framework/spi/AppInstance.java
@@ -1,5 +1,7 @@
 package org.phoebus.framework.spi;
 
+import java.awt.Dimension;
+import java.util.Optional;
 import org.phoebus.framework.persistence.Memento;
 
 public interface AppInstance {
@@ -38,4 +40,13 @@ public interface AppInstance {
     public default void save(Memento memento) {
         // Default does nothing
     }
+
+    /**
+     * Get possible window dimension for the application instance, if it defines one
+     * (for example, Display Runtime may want the window to be the size defined in the display)
+     *
+     * @return Empty optional if no dimension is specified by the application instance.
+     */
+    public default Optional<Dimension> getDimensionHint() { return Optional.empty(); }
+
 }

--- a/core/framework/src/main/java/org/phoebus/framework/spi/AppInstance.java
+++ b/core/framework/src/main/java/org/phoebus/framework/spi/AppInstance.java
@@ -1,6 +1,6 @@
 package org.phoebus.framework.spi;
 
-import java.awt.Dimension;
+import java.awt.geom.Rectangle2D;
 import java.util.Optional;
 import org.phoebus.framework.persistence.Memento;
 
@@ -42,11 +42,13 @@ public interface AppInstance {
     }
 
     /**
-     * Get possible window dimension for the application instance, if it defines one
+     * Get possible window size and position for the application instance, if defined
      * (for example, Display Runtime may want the window to be the size defined in the display)
+     *
+     * (Note: Use Rectangle2D to avoid loading AWT toolkit; we only need a data container)
      *
      * @return Empty optional if no dimension is specified by the application instance.
      */
-    public default Optional<Dimension> getDimensionHint() { return Optional.empty(); }
+    public default Optional<Rectangle2D> getPositionAndSizeHint() { return Optional.empty(); }
 
 }

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
-import javafx.application.Application;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
@@ -487,7 +486,7 @@ public class DockItem extends Tab
         // application (e.g. the width and height of the Display widget if
         // it's the display application). Otherwise, use the parent window dimensions.
         AppInstance application = this.getApplication();
-        application.getDimensionHint().ifPresentOrElse(dimension -> {
+        application.getPositionAndSizeHint().ifPresentOrElse(dimension -> {
             // use the dimension hints suggested by the application
             // such as possibly Display widget dimensions
             other.setWidth(dimension.getWidth() + extra_width);

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
+import javafx.application.Application;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
@@ -454,12 +455,14 @@ public class DockItem extends Tab
                 other.setX(loc.getX());
                 other.setY(loc.getY());
             }
+
         }
         event.consume();
     }
 
     private Stage detach()
     {
+
         // For size of new stage, approximate the
         // current size of the item, i.e. the size
         // of its DockPane, adding some extra space
@@ -479,8 +482,21 @@ public class DockItem extends Tab
         other.setTitle(UUID.randomUUID().toString());
 
         DockStage.configureStage(other, this);
-        other.setWidth(old_parent.getWidth() + extra_width);
-        other.setHeight(old_parent.getHeight() + extra_height);
+
+        // Set the dimensions of the stage using the dimension hint from the
+        // application (e.g. the width and height of the Display widget if
+        // it's the display application). Otherwise, use the parent window dimensions.
+        AppInstance application = this.getApplication();
+        application.getDimensionHint().ifPresentOrElse(dimension -> {
+            // use the dimension hints suggested by the application
+            // such as possibly Display widget dimensions
+            other.setWidth(dimension.getWidth() + extra_width);
+            other.setHeight(dimension.getHeight() + extra_height);
+        }, () -> {
+            // use the parent window dimensions if no dimension hints
+            other.setWidth(old_parent.getWidth() + extra_width);
+            other.setHeight(old_parent.getHeight() + extra_height);
+        });
 
         // Assert that styles used in old scene are still available
         for (String css : old_scene.getStylesheets())

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -447,16 +447,41 @@ public class DockItem extends Tab
             // but event.getX(), getSceneX(), getScreenX() are all 0.0.
             // --> Using MouseInfo, which is actually AWT code
             final Stage other = item.detach();
-            final PointerInfo pi = MouseInfo.getPointerInfo();
-            if (pi != null)
-            {
-                final Point loc = pi.getLocation();
-                other.setX(loc.getX());
-                other.setY(loc.getY());
-            }
+
+            // Try to use the x/y location of the stage using the dimension hint if it
+            // has been specified; Otherwise, use the pointer location
+            AppInstance application = this.getApplication();
+            application.getPositionAndSizeHint().ifPresentOrElse(dimension -> {
+                // If the x and y position are default values (zero) then
+                // use the cursor position
+                if (isDefaultPosition(dimension.getX()) && isDefaultPosition(dimension.getY())) {
+                    setLocationToMousePointer(other);
+                }
+                // Otherwise use the position hint
+                else {
+                    other.setX(dimension.getX());
+                    other.setY(dimension.getY());
+                }
+            }, () -> {
+                setLocationToMousePointer(other);
+            });
 
         }
         event.consume();
+    }
+
+    private void setLocationToMousePointer(Stage stage) {
+        final PointerInfo pi = MouseInfo.getPointerInfo();
+        if (pi != null)
+        {
+            final Point loc = pi.getLocation();
+            stage.setX(loc.getX());
+            stage.setY(loc.getY());
+        }
+    }
+
+    private boolean isDefaultPosition(double pos) {
+        return pos > -1.0 && pos < 1.0;
     }
 
     private Stage detach()


### PR DESCRIPTION
As discussed in #1926 

- does *not* introduce a compile-time dependency to the DisplayRuntime module
- introduces a dimension hint to the AppInstance interface. Since a lot of applications (most, probably?) just want to use the parent window dimensions, the default is to return an empty optional.
- implements the hint method on the DisplayRuntimeInstance impl, using the width and height properties if defined on the display