### PR TITLE
Update MySQL connector version

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -114,7 +114,7 @@
     <classpathentry exported="true" kind="lib" path="target/lib/lz4-java-1.4.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/mimepull-1.9.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/mockito-core-2.23.4.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/mysql-connector-java-5.1.45.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/mysql-connector-java-8.0.30.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/objenesis-2.6.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/ojdbc8-12.2.0.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/org.eclipse.jgit-5.0.3.201809091024-r.jar"/>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.45</version>
+      <version>${mysql.version}</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,8 @@
     <batik.version>1.14</batik.version>
     <mockito.version>2.23.4</mockito.version>
     <postgresql.driver.version>42.2.9</postgresql.driver.version>
+    <!-- When connections to older MySQL server fail because of CLIENT_PLUGIN_AUTH, downgrade to 5.1.45 -->
+    <mysql.version>8.0.30</mysql.version>
     <jetty.version>9.4.30.v20200611</jetty.version>
     <apache.commons.math.version>3.6.1</apache.commons.math.version>
     <junit.version>4.13.1</junit.version>

--- a/services/archive-engine/pom.xml
+++ b/services/archive-engine/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.45</version>
+      <version>${mysql.version}</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>


### PR DESCRIPTION
.. and define `mysql.version` property in parent pom so in case a local build needs to downgrade, it can be done there.

#1409
