### PR TITLE
Alarm tree startup

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
@@ -95,6 +95,9 @@ public class AlarmSystem
     /** Limit for the number of context menu items */
     @Preference public static int alarm_menu_max_items;
 
+    /** Initial Alarm Tree UI update delay [ms] */
+    @Preference public static int alarm_tree_startup_ms;
+
     /** Alarm table columns */
     @Preference public static String[] alarm_table_columns;
 

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/ResettableTimeout.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/ResettableTimeout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ public class ResettableTimeout
 {
     private final long timeout_secs;
 
-	private final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("ResettableTimeout"));
+	public static final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("ResettableTimeout"));
     private final CountDownLatch no_more_messages = new CountDownLatch(1);
     private final Runnable signal_no_more_messages = () -> no_more_messages.countDown();
     private final AtomicReference<ScheduledFuture<?>> timeout = new AtomicReference<>();

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/ResettableTimeout.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/ResettableTimeout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ public class ResettableTimeout
 {
     private final long timeout_secs;
 
-	public static final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("ResettableTimeout"));
+	private final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("ResettableTimeout"));
     private final CountDownLatch no_more_messages = new CountDownLatch(1);
     private final Runnable signal_no_more_messages = () -> no_more_messages.countDown();
     private final AtomicReference<ScheduledFuture<?>> timeout = new AtomicReference<>();

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -90,7 +90,7 @@ public class AlarmClient
     private long last_state_update = 0;
 
     /** Timeout, not seen any messages from server? */
-    private boolean has_timed_out = false;
+    private volatile boolean has_timed_out = false;
 
     /** @param server Kafka Server host:port
      *  @param config_name Name of alarm tree root
@@ -569,6 +569,12 @@ public class AlarmClient
         {
             logger.log(Level.WARNING, "Cannot acknowledge component " + item, ex);
         }
+    }
+
+    /** @return <code>true</code> if connected to server, else updates have timed out */
+    public boolean isServerAlive()
+    {
+        return !has_timed_out;
     }
 
     /** Check if there have been any messages from server */

--- a/app/alarm/model/src/main/resources/alarm_preferences.properties
+++ b/app/alarm/model/src/main/resources/alarm_preferences.properties
@@ -45,6 +45,20 @@ alarm_area_font_size=15
 # 'display' and 'command' menu entries. 
 alarm_menu_max_items=10
 
+# Initial Alarm Tree UI update delay [ms]
+#
+# The initial flurry of alarm tree updates can be slow
+# to render. By allowing the alarm client to accumulate
+# alarm tree information for a little time and then
+# performing an initial bulk representation, the overall
+# alarm tree startup can be faster, especially when
+# the UI is viewed via a remote desktop
+#
+# Set to 0 for original implementation where
+# all alarm tree items are added to the model
+# as they are received in initial flurry of updates.
+alarm_tree_startup_ms=2000
+
 # Order of columns in alarm table
 # Allows re-ordering as well as omitting columns
 alarm_table_columns=Icon, PV, Description, Alarm Severity, Alarm Status, Alarm Time, Alarm Value, PV Severity, PV Status

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
@@ -23,7 +23,6 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import org.phoebus.applications.alarm.AlarmSystem;
-import org.phoebus.applications.alarm.ResettableTimeout;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.client.AlarmClientLeaf;
 import org.phoebus.applications.alarm.client.AlarmClientListener;
@@ -182,7 +181,7 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
             model.addListener(AlarmTreeView.this);
         }
         else
-            ResettableTimeout.timer.schedule(this::startup, AlarmSystem.alarm_tree_startup_ms, TimeUnit.MILLISECONDS);
+            UpdateThrottle.TIMER.schedule(this::startup, AlarmSystem.alarm_tree_startup_ms, TimeUnit.MILLISECONDS);
 
         // Caller will start the model once we return from constructor
     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import org.phoebus.applications.alarm.AlarmSystem;
+import org.phoebus.applications.alarm.ResettableTimeout;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.client.AlarmClientLeaf;
 import org.phoebus.applications.alarm.client.AlarmClientListener;
@@ -85,7 +87,27 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
     private final Label no_server = AlarmUI.createNoServerLabel();
     private final TreeView<AlarmTreeItem<?>> tree_view = new TreeView<>();
 
+    /** Model with current alarm tree, sends updates */
     private final AlarmClient model;
+
+    /** Latch for initially pausing model listeners
+     *
+     *  Imagine a large alarm tree that changes.
+     *  The alarm table can periodically display the current
+     *  alarms, it does not need to display every change right away.
+     *  The tree on the other hand must reflect every added or removed item,
+     *  because updates cannot be applied once the tree structure gets out of sync.
+     *  When the model is first started, there is a flurry of additions and removals,
+     *  which arrive in the order in which the tree was generated, not necessarily
+     *  in the order they're laid out in the hierarchy.
+     *  These can be slow to render, especially if displaying via a remote desktop (ssh-X).
+     *  The alarm tree view thus starts in stages:
+     *  1) Wait for model to receive the bulk of initial additions and removals
+     *  2) Add listeners to model changes, but block them via this latch
+     *  3) Represent the initial model
+     *  4) Release this latch to handle changes (blocked and those that arrive from now on)
+     */
+    private final CountDownLatch block_item_changes = new CountDownLatch(1);
 
     /** Map from alarm tree path to view's TreeItem */
     private final ConcurrentHashMap<String, TreeItem<AlarmTreeItem<?>>> path2view = new ConcurrentHashMap<>();
@@ -146,13 +168,49 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
         setTop(createToolbar());
         setCenter(tree_view);
 
-        tree_view.setRoot(createViewItem(model.getRoot()));
-
-        model.addListener(this);
-
         createContextMenu();
         addClickSupport();
         addDragSupport();
+
+        if (AlarmSystem.alarm_tree_startup_ms <= 0)
+        {
+            // Original implementation:
+            // Create initial (empty) representation,
+            // register listener, then model gets started
+            block_item_changes.countDown();
+            tree_view.setRoot(createViewItem(model.getRoot()));
+            model.addListener(AlarmTreeView.this);
+        }
+        else
+            ResettableTimeout.timer.schedule(this::startup, AlarmSystem.alarm_tree_startup_ms, TimeUnit.MILLISECONDS);
+
+        // Caller will start the model once we return from constructor
+    }
+
+    private void startup()
+    {
+        // Waited for model to receive the bulk of initial additions and removals...
+        Platform.runLater(() ->
+        {
+            if (! model.isRunning())
+            {
+                logger.log(Level.WARNING, model.getRoot().getName() + " was disposed while waiting for alarm tree startup");
+                return;
+            }
+            // Listen to model changes, but they're blocked,
+            // so this blocks model changes from now on
+            model.addListener(AlarmTreeView.this);
+
+            // Represent model that should by now be fairly complete
+            tree_view.setRoot(createViewItem(model.getRoot()));
+
+            // Set change indicator so that it clears when there are no more changes
+            indicateChange();
+            showServerState(model.isServerAlive());
+
+            // Un-block to handle changes from now on
+            block_item_changes.countDown();
+        });
     }
 
     private ToolBar createToolbar()
@@ -170,7 +228,8 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
                 ImageCache.getImageView(AlarmUI.class, "/icons/expand_alarms.png"));
         show_alarms.setTooltip(new Tooltip("Expand alarm tree to show active alarms"));
         show_alarms.setOnAction(event -> expandAlarms(tree_view.getRoot()));
-        return new ToolBar(no_server, ToolbarHelper.createSpring(), collapse, show_alarms);
+
+        return new ToolBar(no_server, changing, ToolbarHelper.createSpring(), collapse, show_alarms);
     }
 
     ToolBar getToolbar()
@@ -222,25 +281,29 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
             logger.log(Level.INFO, "Alarm tree changes start");
             setCursor(Cursor.WAIT);
             final ObservableList<Node> items = getToolbar().getItems();
-            items.add(1, changing);
+            if (! items.contains(changing))
+                items.add(1, changing);
         }
         else
             previous.cancel(false);
+    }
+
+    /** @param alive Have we seen server messages? */
+    private void showServerState(final boolean alive)
+    {
+        final ObservableList<Node> items = getToolbar().getItems();
+        items.remove(no_server);
+        if (! alive)
+            // Place left of spring, collapse, expand_alarms,
+            // i.e. right of potential AlarmConfigSelector
+            items.add(items.size()-3, no_server);
     }
 
     // AlarmClientModelListener
     @Override
     public void serverStateChanged(final boolean alive)
     {
-        Platform.runLater(() ->
-        {
-            final ObservableList<Node> items = getToolbar().getItems();
-            items.remove(no_server);
-            if (! alive)
-                // Place left of spring, collapse, expand_alarms,
-                // i.e. right of potential AlarmConfigSelector
-                items.add(items.size()-3, no_server);
-        });
+        Platform.runLater(() -> showServerState(alive));
     }
 
     // AlarmClientModelListener
@@ -257,11 +320,25 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
         // NOP
     }
 
+    /** Block until changes to items should be shown */
+    private void blockItemChanges()
+    {
+        try
+        {
+            block_item_changes.await();
+        }
+        catch (InterruptedException ex)
+        {
+            logger.log(Level.WARNING, "Blocker for item changes got interrupted", ex);
+        }
+    }
+
     // AlarmClientModelListener
     @Override
     public void itemAdded(final AlarmTreeItem<?> item)
     {
-        // System.out.println("Add " + item.getPathName());
+        blockItemChanges();
+        // System.out.println(Thread.currentThread() + " Add " + item.getPathName());
 
         // Parent must already exist
         final AlarmTreeItem<BasicState> model_parent = item.getParent();
@@ -311,7 +388,8 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
     @Override
     public void itemRemoved(final AlarmTreeItem<?> item)
     {
-        // System.out.println("Removed " + item.getPathName());
+        blockItemChanges();
+        // System.out.println(Thread.currentThread() + " Removed " + item.getPathName());
 
         // Remove item and all sub-items from model2ui
         final TreeItem<AlarmTreeItem<?>> view_item = removeViewItems(item);
@@ -365,7 +443,8 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
     @Override
     public void itemUpdated(final AlarmTreeItem<?> item)
     {
-        // System.out.println("Updated " + item.getPathName());
+        blockItemChanges();
+        // System.out.println(Thread.currentThread() + " Updated " + item.getPathName());
         final TreeItem<AlarmTreeItem<?>> view_item = path2view.get(item.getPathName());
         if (view_item == null)
         {


### PR DESCRIPTION
The initial flurry of alarm tree updates can be slow to render. By allowing the alarm client to accumulate alarm tree information for a little time and then performing an initial bulk representation, the overall alarm tree startup can be faster, especially when the UI is viewed via a remote desktop.

Local tests with CSS running on Linux accessed via "ThinLinc" reduced the alarm tree load time from about 20 seconds to 2 or 3 seconds.

The initial delay for accumulating the alarm model defaults to 2000ms. Setting it to 0 reverts to the original code.