### PR TITLE
Add create_settings_template.py - #2353

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,8 @@ buildNumber.properties
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
 
+# Exclude complete settings template file if it is created
+phoebus-product/settings_template.ini
 
 # End of https://www.gitignore.io/api/maven,eclipse
 /.gitignore

--- a/phoebus-product/create_settings_template.py
+++ b/phoebus-product/create_settings_template.py
@@ -1,0 +1,75 @@
+import argparse
+import glob
+import zipfile
+import os
+import shutil
+
+
+def create_settings_template(product_location: str, include_comments: bool) -> None:
+    """
+    Create complete list of settings for settings.ini file
+
+    :param product_location: Location of the product jar files to check for *preferences.properties files
+    :param include_comments: Option to include comments for each setting in output file
+    """
+    # find all jar files so we can unzip jar and find preference files
+    jar_file_list = glob.glob(product_location + "/*.jar")
+
+    # temp directory to hold unzipped jar file contents (deleted at end of script)
+    tmp_zip_dir = "./tmp-zip"
+
+    output_file = "settings_template.ini"
+    out_f = open(output_file, 'w')
+    print("Creating settings_template.ini file...")
+
+    out_f.write("# Complete List of Available Preference Properties (Created by create_settings_template.py)\n")
+
+    for jar_file in jar_file_list:
+        if not os.path.isdir(tmp_zip_dir):
+           os.makedirs(tmp_zip_dir)
+        with zipfile.ZipFile(jar_file, 'r') as zip_ref:
+            zip_ref.extractall(tmp_zip_dir)
+        # find all *preference.properties files
+        prop_files = glob.glob(tmp_zip_dir + "/*preferences.properties")
+
+        package_str = ""
+        for prop_file in prop_files:
+            with open(prop_file, 'r') as file:
+                lines = file.readlines()
+            for line in lines:
+                line = line.strip()
+                if line.startswith("# Package "):
+                    package_str = line[10:].strip()
+                    # print package name with number signs above and below
+                    if include_comments:
+                        out_f.write("\n{0}\n{1}\n{0}\n".format("#"*(len(line)), line))
+                    else:
+                        out_f.write("\n{0}\n{1}\n{0}\n\n".format("#"*(len(line)), line))
+                elif "--------" in line:
+                    continue
+                # assume equal sign means this is a property
+                elif "=" in line: 
+                    if line[0] == "#":
+                        if include_comments:
+                            out_f.write("# {}/{}\n".format(package_str, line[1:].strip()))
+                    else:
+                        out_f.write("# {}/{}\n".format(package_str, line))
+                # a few pva properties don't have equal sign so this covers those
+                elif line != "" and line[0] != "#":
+                    out_f.write("# {}/{}\n".format(package_str, line))
+                else:
+                    if include_comments:
+                        out_f.write(line + "\n")
+
+        # remove temp directory
+        shutil.rmtree(tmp_zip_dir)
+    print("Creation complete")
+
+
+parser = argparse.ArgumentParser(description="Create template of settings.ini with all available settings")
+parser.add_argument("product", type=str, nargs='?', default="./target/lib", help="Location of product jars. Defaults to ./target/lib")
+parser.add_argument("-c", "--comments", action="store_true", help="Include settting comments in file")
+
+args = parser.parse_args()
+
+create_settings_template(args.product, args.comments)


### PR DESCRIPTION
https://github.com/ControlSystemStudio/phoebus/issues/2353

Placed the script in phoebus-product but can move it if there is a better place. 

Writes to a settings_template.ini file and is run manually after the build. Unzips the jar files in <product> (defaults to ```./target/lib```) and checks for *preferences.properties files. Allows for including all the comments or not.

```
$ python create_settings_template.py -h
usage: create_settings_template.py [-h] [-c] [product]

Create template of settings.ini with all available settings

positional arguments:
  product         Location of product jars. Defaults to ./target/lib

options:
  -h, --help      show this help message and exit
  -c, --comments  Include settting comments in file
```

Example output files here:

[settings_template_comments.txt](https://github.com/ControlSystemStudio/phoebus/files/9579611/settings_template_comments.txt)
[settings_template_no_comments.txt](https://github.com/ControlSystemStudio/phoebus/files/9579612/settings_template_no_comments.txt)
