### PR TITLE
Add -v option to log inspected jars, detected properties files

### DIFF
--- a/phoebus-product/create_settings_template.py
+++ b/phoebus-product/create_settings_template.py
@@ -3,6 +3,7 @@ import glob
 import zipfile
 import os
 import shutil
+import sys
 
 
 def create_settings_template(product_location: str, include_comments: bool, verbose: bool) -> None:
@@ -15,6 +16,10 @@ def create_settings_template(product_location: str, include_comments: bool, verb
     """
     # find all jar files so we can unzip jar and find preference files
     jar_file_list = glob.glob(product_location + "/*.jar")
+    if len(jar_file_list) <= 0:
+        sys.stderr.write("No *.jar files found in '{}'\n".format(product_location))
+        sys.stderr.write("Need to build sources?\n")
+        sys.exit(-1)
 
     # temp directory to hold unzipped jar file contents (deleted at end of script)
     tmp_zip_dir = "./tmp-zip"

--- a/phoebus-product/create_settings_template.py
+++ b/phoebus-product/create_settings_template.py
@@ -5,12 +5,13 @@ import os
 import shutil
 
 
-def create_settings_template(product_location: str, include_comments: bool) -> None:
+def create_settings_template(product_location: str, include_comments: bool, verbose: bool) -> None:
     """
     Create complete list of settings for settings.ini file
 
     :param product_location: Location of the product jar files to check for *preferences.properties files
     :param include_comments: Option to include comments for each setting in output file
+    :param verbose: Verbose operation
     """
     # find all jar files so we can unzip jar and find preference files
     jar_file_list = glob.glob(product_location + "/*.jar")
@@ -25,6 +26,8 @@ def create_settings_template(product_location: str, include_comments: bool) -> N
     out_f.write("# Complete List of Available Preference Properties (Created by create_settings_template.py)\n")
 
     for jar_file in jar_file_list:
+        if verbose:
+            print("| {}".format(jar_file))
         if not os.path.isdir(tmp_zip_dir):
            os.makedirs(tmp_zip_dir)
         with zipfile.ZipFile(jar_file, 'r') as zip_ref:
@@ -34,6 +37,8 @@ def create_settings_template(product_location: str, include_comments: bool) -> N
 
         package_str = ""
         for prop_file in prop_files:
+            if verbose:
+                print("+ {}/{}".format(jar_file, prop_file).replace("/./tmp-zip/", "/"))
             with open(prop_file, 'r') as file:
                 lines = file.readlines()
             for line in lines:
@@ -45,6 +50,8 @@ def create_settings_template(product_location: str, include_comments: bool) -> N
                         out_f.write("\n{0}\n{1}\n{0}\n".format("#"*(len(line)), line))
                     else:
                         out_f.write("\n{0}\n{1}\n{0}\n\n".format("#"*(len(line)), line))
+                    if verbose:
+                        print("| {} ({})".format(" " * len(jar_file), package_str))
                 elif "--------" in line:
                     continue
                 # assume equal sign means this is a property
@@ -68,8 +75,9 @@ def create_settings_template(product_location: str, include_comments: bool) -> N
 
 parser = argparse.ArgumentParser(description="Create template of settings.ini with all available settings")
 parser.add_argument("product", type=str, nargs='?', default="./target/lib", help="Location of product jars. Defaults to ./target/lib")
-parser.add_argument("-c", "--comments", action="store_true", help="Include settting comments in file")
+parser.add_argument("-c", "--comments", action="store_true", help="Include setting comments in file")
+parser.add_argument("-v", "--verbose", action="store_true", help="Verbose operation")
 
 args = parser.parse_args()
 
-create_settings_template(args.product, args.comments)
+create_settings_template(args.product, args.comments, args.verbose)


### PR DESCRIPTION
... and packages.
Since tool from #2390  may run for 30 seconds, this option provides feedback on the progress of parsing the files.