### PR TITLE
Fix import of BOY files that carry no widget version=1.0.0

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/Widget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/Widget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,6 +79,9 @@ public class Widget
      *  which needs to be handled for each such widget.
      */
     public static final Version BASE_WIDGET_VERSION = new Version(2, 0, 0);
+
+    /** Typical version of legacy BOY display widgets */
+    public static final Version TYPICAL_LEGACY_WIDGET_VERSION = new Version(1, 0, 0);
 
     // These user data keys are reserved for internal use
     // of the framework.

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/persist/ModelReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -362,7 +362,18 @@ public class ModelReader
     {
         final String text = element.getAttribute(XMLTags.VERSION);
         if (text.isEmpty())
+        {
+            // Does widget look like a legacy widget without a type?
+            // Then assume 1.0.0
+            if (element.getAttribute(XMLTags.TYPE).isEmpty() &&
+                element.getAttribute("typeId") != null  &&
+                element.getAttribute("typeId").startsWith("org.csstudio.opibuilder.widgets."))
+                return Widget.TYPICAL_LEGACY_WIDGET_VERSION;
+
+            // Otherwise assume it's a new version but created by a script or manually
+            // so didn't bother to populate more than absolutely necessary
             return Widget.BASE_WIDGET_VERSION;
+        }
         return Version.parse(text);
     }
 }


### PR DESCRIPTION
Old BOY files that just contain `<widget typeId=...` without a `version="1.0.0"` attribute are assumed to have the current version, and patches for older files were then not applied, resulting in wrong displays.

One fix is to simply open the BOY files in the old editor and save them again to write in a BOY format that adds version info.
This patch checks for no "version" but "typeId=org.csstudio..." to assume they are old files.