### PR TITLE
Tank Widget: Mapping for legacy BOY property show_scale

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TankWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TankWidget.java
@@ -96,6 +96,10 @@ public class TankWidget extends PVWidget
                 if (element != null)
                     tank.font.readFromXML(model_reader, element);
 
+                element = XMLUtil.getChildElement(xml, "show_scale");
+                if (element != null)
+                    tank.scale_visible.readFromXML(model_reader, element);
+
                 if (XMLUtil.getChildBoolean(xml, "show_markers").orElse(true)  &&
                     (XMLUtil.getChildBoolean(xml, "show_hi").orElse(true)   ||
                      XMLUtil.getChildBoolean(xml, "show_hihi").orElse(true) ||


### PR DESCRIPTION
Conversion of BOY tank widget to Display Builder does not currently map the property show_scale to scale_visible. This PR addresses this.