### PR TITLE
CSSTUDIO-1335: Erratic movement of the OPI widget area on selec

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/Rubberband.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/Rubberband.java
@@ -83,9 +83,22 @@ public class Rubberband
     {
         if (! active)
             return;
+
+        // Get the current coords of the pointer, relative to the parent
         final Point2D in_parent = parent.sceneToLocal(event.getSceneX(), event.getSceneY());
         x1 = in_parent.getX();
         y1 = in_parent.getY();
+
+        // If outside the parent window,
+        // then set the coords to the parent window border (zero)
+        if(x1 <-1) {
+            x1 = 0;
+        }
+        if(y1 <-1) {
+            y1 = 0;
+        }
+
+        // Update the rectangle coords and dimensions
         rect.setX(Math.min(x0, x1));
         rect.setY(Math.min(y0, y1));
         rect.setWidth(Math.abs(x1 - x0));


### PR DESCRIPTION
fix: constrain rubberband selection in display editor to stay within parent window
This includes when scrolled e.g. to the center of the parent screen, but allows you to scroll over to the upper-left edge rather than off into the void at hyperspeed.

See #2393 for issue details
