### PR TITLE
Decode "boolean value" from NTScalar

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.epics.pva.data.PVAArray;
+import org.epics.pva.data.PVABool;
 import org.epics.pva.data.PVAByte;
 import org.epics.pva.data.PVAByteArray;
 import org.epics.pva.data.PVADouble;
@@ -50,6 +51,7 @@ import org.epics.vtype.AlarmStatus;
 import org.epics.vtype.Display;
 import org.epics.vtype.EnumDisplay;
 import org.epics.vtype.Time;
+import org.epics.vtype.VBoolean;
 import org.epics.vtype.VByte;
 import org.epics.vtype.VByteArray;
 import org.epics.vtype.VDouble;
@@ -319,6 +321,15 @@ public class Decoders
             alarm = warn = Range.undefined();
 
         return Display.of(display, alarm, warn, control, units, format, description);
+    }
+
+    /** @param struct Structure
+     *  @param field Field
+     *  @return Boolean for that field's value
+     */
+    public static VType decodeBool(PVAStructure struct, PVABool field)
+    {
+        return VBoolean.of(field.get(), decodeAlarm(struct), decodeTime(struct));
     }
 
     /** @param struct Structure

--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVAStructureHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVAStructureHelper.java
@@ -152,6 +152,8 @@ public class PVAStructureHelper
     {
         if (field instanceof PVANumber)
             return Decoders.decodeNumber(struct, (PVANumber) field);
+        if (field instanceof PVABool)
+            return Decoders.decodeBool(struct, (PVABool) field);
         if (field instanceof PVAString)
             return Decoders.decodeString(struct, (PVAString) field);
         return null;

--- a/core/pva/src/test/java/org/epics/pva/server/BoolDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/server/BoolDemo.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.epics.pva.server;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import org.epics.pva.data.PVABool;
+import org.epics.pva.data.PVAStructure;
+import org.epics.pva.data.nt.PVATimeStamp;
+
+/** PVA Server Demo for "bool" PV
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class BoolDemo
+{
+    public static void main(String[] args) throws Exception
+    {
+        try
+        (
+            // Create PVA Server (auto-closed)
+            final PVAServer server = new PVAServer();
+        )
+        {
+            // Create data structure to serve
+            final PVATimeStamp time = new PVATimeStamp();
+            final PVABool value = new PVABool("value", false);
+            final PVAStructure data = new PVAStructure("demo", "epics:nt/NTScalar:1.0",
+                                                       value,
+                                                       time);
+
+            // Create PV
+            final ServerPV pv = server.createPV("bool", data);
+            System.out.println("Check PV   '" + pv.getName() + "'");
+
+            // Update value and timestamp
+            while (true)
+            {
+                TimeUnit.SECONDS.sleep(1);
+                value.set(! value.get());
+                time.set(Instant.now());
+                pv.update(data);
+            }
+        }
+    }
+}


### PR DESCRIPTION
IOCs (qsrv) will represent boolean records as NTEnum, but custom PVA servers might create structures with a boolean value, and this allows displaying them as true/false in text updates or on/off in LED widgets.

Fixes #2410