### PR TITLE
Csstudio 1414: Enable Grid Color for Plot widgets and Data Editor

### DIFF
--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_xyGraphClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_xyGraphClass.java
@@ -40,7 +40,9 @@ public class Convert_xyGraphClass extends ConverterBase<XYPlotWidget>
 
         convertColor(r.getBgColor(), widget.propBackground());
         convertColor(r.getFgColor(), widget.propForeground());
-        convertColor(r.getFgColor(), widget.propGridColor());
+        widget.propYAxes().getValue().forEach(propYAxis -> {
+            convertColor(r.getFgColor(), propYAxis.color());
+        });
 
         // X Axis
         if (r.getXLabel() == null)

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/PlotWidgetProperties.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/PlotWidgetProperties.java
@@ -20,6 +20,7 @@ import org.csstudio.display.builder.model.WidgetPropertyCategory;
 import org.csstudio.display.builder.model.WidgetPropertyDescriptor;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.NamedWidgetFonts;
+import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.persist.WidgetFontService;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.model.properties.EnumWidgetProperty;
@@ -144,6 +145,7 @@ public class PlotWidgetProperties
         public WidgetProperty<WidgetFont> scaleFont()   { return getElement(7); }
         /** @return Is axis visible? */
         public WidgetProperty<Boolean> visible()        { return getElement(8); }
+
     };
 
     /** 'on_right' property: Should axis be on the right? */
@@ -170,7 +172,10 @@ public class PlotWidgetProperties
                                 propTitleFont.createProperty(widget, WidgetFontService.get(NamedWidgetFonts.DEFAULT_BOLD)),
                                 propScaleFont.createProperty(widget, WidgetFontService.get(NamedWidgetFonts.DEFAULT)),
                                 propOnRight.createProperty(widget, false),
-                                CommonWidgetProperties.propVisible.createProperty(widget, true)));
+                                CommonWidgetProperties.propVisible.createProperty(widget, true),
+                                propGridColor.createProperty(widget, WidgetColorService.getColor(NamedWidgetColors.GRID))
+                  )
+            );
         }
 
         protected YAxisWidgetProperty(final StructuredWidgetProperty.Descriptor axis_descriptor,
@@ -185,6 +190,9 @@ public class PlotWidgetProperties
         // Element shifted from 8 in basic axis to 9 in Y axis
         @Override
         public WidgetProperty<Boolean> visible()        { return getElement(9); }
+
+        /** @return Grid color */
+        public WidgetProperty<WidgetColor> gridColor()  { return getElement(10); }
     };
 
 

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/PlotWidgetProperties.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/PlotWidgetProperties.java
@@ -89,7 +89,7 @@ public class PlotWidgetProperties
 
     /** 'grid_color' */
     public static final WidgetPropertyDescriptor<WidgetColor> propGridColor =
-        CommonWidgetProperties.newColorPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "grid_color", Messages.PlotWidget_GridColor);
+        CommonWidgetProperties.newColorPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "grid_color", Messages.PlotWidget_Color);
 
     /** 'x_axis' */
     public final static StructuredWidgetProperty.Descriptor propXAxis =
@@ -173,7 +173,7 @@ public class PlotWidgetProperties
                                 propScaleFont.createProperty(widget, WidgetFontService.get(NamedWidgetFonts.DEFAULT)),
                                 propOnRight.createProperty(widget, false),
                                 CommonWidgetProperties.propVisible.createProperty(widget, true),
-                                propGridColor.createProperty(widget, WidgetColorService.getColor(NamedWidgetColors.GRID))
+                                CommonWidgetProperties.propColor.createProperty(widget, WidgetColorService.getColor(NamedWidgetColors.TEXT))
                   )
             );
         }
@@ -191,8 +191,8 @@ public class PlotWidgetProperties
         @Override
         public WidgetProperty<Boolean> visible()        { return getElement(9); }
 
-        /** @return Grid color */
-        public WidgetProperty<WidgetColor> gridColor()  { return getElement(10); }
+        /** @return Axis/Grid color */
+        public WidgetProperty<WidgetColor> color()  { return getElement(10); }
     };
 
 

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/StripchartWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/StripchartWidget.java
@@ -148,11 +148,36 @@ public class StripchartWidget extends VisibleWidget
         public WidgetProperty<Boolean> visible()        { return getElement(6); }
     };
 
+    public static class YAxisWidgetProperty extends AxisWidgetProperty {
+
+        public static YAxisWidgetProperty create(final StructuredWidgetProperty.Descriptor descriptor, final Widget widget, final String title_text)
+        {
+            return new YAxisWidgetProperty(descriptor, widget,
+                    Arrays.asList(PlotWidgetProperties.propTitle.createProperty(widget, title_text),
+                            PlotWidgetProperties.propAutoscale.createProperty(widget, false),
+                            PlotWidgetProperties.propLogscale.createProperty(widget, false),
+                            CommonWidgetProperties.propMinimum.createProperty(widget, 0.0),
+                            CommonWidgetProperties.propMaximum.createProperty(widget, 100.0),
+                            PlotWidgetProperties.propGrid.createProperty(widget, false),
+                            CommonWidgetProperties.propVisible.createProperty(widget, true),
+                            CommonWidgetProperties.propColor.createProperty(widget, WidgetColorService.getColor(NamedWidgetColors.TEXT))
+                    ));
+        }
+
+        protected YAxisWidgetProperty(Descriptor axis_descriptor, Widget widget, List<WidgetProperty<?>> elements) {
+            super(axis_descriptor, widget, elements);
+        }
+
+        /** @return Axis/Grid color */
+        public WidgetProperty<WidgetColor> color()  { return getElement(7); }
+
+    }
+
     /** 'y_axes' array */
-    public static final ArrayWidgetProperty.Descriptor<AxisWidgetProperty> propYAxes =
+    public static final ArrayWidgetProperty.Descriptor<YAxisWidgetProperty> propYAxes =
         new ArrayWidgetProperty.Descriptor<>(WidgetPropertyCategory.BEHAVIOR, "y_axes", Messages.PlotWidget_YAxes,
                                              (widget, index) ->
-                                             AxisWidgetProperty.create(propYAxis, widget,
+                                             YAxisWidgetProperty.create(propYAxis, widget,
                                                                        index > 0
                                                                        ? Messages.PlotWidget_Y + " " + index
                                                                        : Messages.PlotWidget_Y));
@@ -358,10 +383,10 @@ public class StripchartWidget extends VisibleWidget
                 // Count actual Y axes, because legacy_axis includes skipped X axes
                 ++y_count;
 
-                final AxisWidgetProperty y_axis;
+                final YAxisWidgetProperty y_axis;
                 if (strip.y_axes.size() < y_count)
                 {
-                    y_axis = AxisWidgetProperty.create(propYAxis, strip, "");
+                    y_axis = YAxisWidgetProperty.create(propYAxis, strip, "");
                     strip.y_axes.addElement(y_axis);
                 }
                 else
@@ -452,7 +477,7 @@ public class StripchartWidget extends VisibleWidget
     private volatile WidgetProperty<Boolean> show_legend;
     private volatile WidgetProperty<String> start;
     private volatile WidgetProperty<String> end;
-    private volatile ArrayWidgetProperty<AxisWidgetProperty> y_axes;
+    private volatile ArrayWidgetProperty<YAxisWidgetProperty> y_axes;
     private volatile ArrayWidgetProperty<TraceWidgetProperty> traces;
     private volatile RuntimeEventProperty configure;
     private volatile RuntimeEventProperty open_full;
@@ -485,7 +510,7 @@ public class StripchartWidget extends VisibleWidget
         properties.add(show_legend = PlotWidgetProperties.propLegend.createProperty(this, false));
         properties.add(start = propStart.createProperty(this, "1 minute"));
         properties.add(end = propEnd.createProperty(this, ""));
-        properties.add(y_axes = propYAxes.createProperty(this, Arrays.asList(AxisWidgetProperty.create(propYAxis, this, Messages.PlotWidget_Y))));
+        properties.add(y_axes = propYAxes.createProperty(this, Arrays.asList(YAxisWidgetProperty.create(propYAxis, this, Messages.PlotWidget_Y))));
         properties.add(traces = propTraces.createProperty(this, Arrays.asList(new TraceWidgetProperty(this, 0))));
         properties.add(configure = (RuntimeEventProperty) runtimePropConfigure.createProperty(this, null));
         properties.add(open_full = (RuntimeEventProperty) DataBrowserWidget.runtimePropOpenFull.createProperty(this, null));
@@ -585,7 +610,7 @@ public class StripchartWidget extends VisibleWidget
     }
 
     /** @return 'y_axes' property */
-    public ArrayWidgetProperty<AxisWidgetProperty> propYAxes()
+    public ArrayWidgetProperty<YAxisWidgetProperty> propYAxes()
     {
         return y_axes;
     }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/XYPlotWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/XYPlotWidget.java
@@ -122,6 +122,18 @@ public class XYPlotWidget extends VisibleWidget
     /** Legacy properties that have already triggered a warning */
     private final CopyOnWriteArraySet<String> warnings_once = new CopyOnWriteArraySet<>();
 
+    /** Moving gridline color to individual Y-Axes was a backwards-incompatible change
+     *  So the major was incremented from 2.0.0 to 3.0.0
+     */
+    private static final Version VERSION = Version.parse("3.0.0");
+
+    /** @return Widget version number */
+    @Override
+    public Version getVersion()
+    {
+        return VERSION;
+    }
+
     /** Configurator that handles legacy properties */
     private static class Configurator extends WidgetConfigurator
     {
@@ -136,6 +148,7 @@ public class XYPlotWidget extends VisibleWidget
         {
             configureAllPropertiesFromMatchingXML(model_reader, widget, xml);
 
+            // Legacy widget
             if (xml_version.getMajor() < 2)
             {
                 if (StripchartWidget.isLegacyStripchart(xml))
@@ -175,6 +188,24 @@ public class XYPlotWidget extends VisibleWidget
                 if (! plot.propLegend().getValue())
                     for (TraceWidgetProperty trace : plot.propTraces().getValue())
                         trace.traceName().setValue("");
+            }
+
+            // Newer widgets with some high-level properties moved to individual axes
+            if (xml_version.getMajor() < 3) {
+
+                final XYPlotWidget plot = (XYPlotWidget) widget;
+
+                // If grid color was specified, then use it on each axis
+                Element gridColor = XMLUtil.getChildElement(xml, "grid_color");
+                if(gridColor != null) {
+                    plot.y_axes.getValue().forEach(axis -> {
+                        try {
+                            axis.color().readFromXML(model_reader, gridColor);
+                        } catch (Exception e) {
+                            logger.log(Level.WARNING, "Could not read widget color from grid_color of V2 X/Y Plot Widget");
+                        }
+                    });
+                }
             }
             return true;
         }
@@ -303,7 +334,6 @@ public class XYPlotWidget extends VisibleWidget
 
     private volatile WidgetProperty<WidgetColor> foreground;
     private volatile WidgetProperty<WidgetColor> background;
-    private volatile WidgetProperty<WidgetColor> grid;
     private volatile WidgetProperty<String> title;
     private volatile WidgetProperty<WidgetFont> title_font;
     private volatile WidgetProperty<Boolean> show_toolbar;
@@ -332,7 +362,6 @@ public class XYPlotWidget extends VisibleWidget
         super.defineProperties(properties);
         properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(background = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
-        properties.add(grid = propGridColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.GRID)));
         properties.add(title = PlotWidgetProperties.propTitle.createProperty(this, ""));
         properties.add(title_font = PlotWidgetProperties.propTitleFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.HEADER2)));
         properties.add(show_toolbar = propToolbar.createProperty(this,false));
@@ -397,12 +426,6 @@ public class XYPlotWidget extends VisibleWidget
     public WidgetProperty<WidgetColor> propForeground()
     {
         return foreground;
-    }
-
-    /** @return 'grid_color' property */
-    public WidgetProperty<WidgetColor> propGridColor()
-    {
-        return grid;
     }
 
     /** @return 'title' property */

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/StripchartRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/StripchartRepresentation.java
@@ -68,7 +68,7 @@ public class StripchartRepresentation extends RegionBaseRepresentation<Pane, Str
     private final WidgetPropertyListener<Integer> sizeChangedListener = this::sizeChanged;
     private final UntypedWidgetPropertyListener optsChangedListener = this::optsChanged;
     private final UntypedWidgetPropertyListener modelChangedListener = this::modelChanged;
-    private final WidgetPropertyListener<List<AxisWidgetProperty>> axes_listener = this::axesChanged;
+    private final WidgetPropertyListener<List<StripchartWidget.YAxisWidgetProperty>> axes_listener = this::axesChanged;
     private final WidgetPropertyListener<List<TraceWidgetProperty>> traces_listener = this::tracesChanged;
     private final WidgetPropertyListener<Instant> config_dialog_listener = (p, o, n) -> plot.getPlot().showConfigurationDialog();
     private final WidgetPropertyListener<Instant> open_databrowser_listener = (p, o, n) ->
@@ -164,22 +164,22 @@ public class StripchartRepresentation extends RegionBaseRepresentation<Pane, Str
         super.unregisterListeners();
     }
 
-    private void axesChanged(final WidgetProperty<List<AxisWidgetProperty>> prop, final List<AxisWidgetProperty> removed, final List<AxisWidgetProperty> added)
+    private void axesChanged(final WidgetProperty<List<StripchartWidget.YAxisWidgetProperty>> prop, final List<StripchartWidget.YAxisWidgetProperty> removed, final List<StripchartWidget.YAxisWidgetProperty> added)
     {
         // Track/ignore axes
         if (removed != null)
-            for (AxisWidgetProperty axis : removed)
+            for (StripchartWidget.YAxisWidgetProperty axis : removed)
                 ignoreAxisChanges(axis);
 
         if (added != null)
-            for (AxisWidgetProperty axis : added)
+            for (StripchartWidget.YAxisWidgetProperty axis : added)
                 trackAxisChanges(axis);
 
         // Anything changed -> Update complete model
         modelChanged(null, null, null);
     }
 
-    private void trackAxisChanges(final AxisWidgetProperty axis)
+    private void trackAxisChanges(final StripchartWidget.YAxisWidgetProperty axis)
     {
         axis.title().addUntypedPropertyListener(modelChangedListener);
         axis.autoscale().addUntypedPropertyListener(modelChangedListener);
@@ -188,9 +188,10 @@ public class StripchartRepresentation extends RegionBaseRepresentation<Pane, Str
         axis.maximum().addUntypedPropertyListener(modelChangedListener);
         axis.grid().addUntypedPropertyListener(modelChangedListener);
         axis.visible().addUntypedPropertyListener(modelChangedListener);
+        axis.color().addUntypedPropertyListener(modelChangedListener);
     }
 
-    private void ignoreAxisChanges(final AxisWidgetProperty axis)
+    private void ignoreAxisChanges(final StripchartWidget.YAxisWidgetProperty axis)
     {
         axis.title().removePropertyListener(modelChangedListener);
         axis.autoscale().removePropertyListener(modelChangedListener);
@@ -199,6 +200,8 @@ public class StripchartRepresentation extends RegionBaseRepresentation<Pane, Str
         axis.maximum().removePropertyListener(modelChangedListener);
         axis.grid().removePropertyListener(modelChangedListener);
         axis.visible().removePropertyListener(modelChangedListener);
+        axis.color().removePropertyListener(modelChangedListener);
+
     }
 
 
@@ -317,10 +320,10 @@ public class StripchartRepresentation extends RegionBaseRepresentation<Pane, Str
 
         // Value Axes
         int index = 0;
-        final List<AxisWidgetProperty> axes = model_widget.propYAxes().getValue();
+        final List<StripchartWidget.YAxisWidgetProperty> axes = model_widget.propYAxes().getValue();
         while (model.getAxisCount() > axes.size())
             model.removeAxis(model.getAxis(0));
-        for (AxisWidgetProperty axis : axes)
+        for (StripchartWidget.YAxisWidgetProperty axis : axes)
         {
             final AxisConfig config;
             if (index < model.getAxisCount())
@@ -336,6 +339,7 @@ public class StripchartRepresentation extends RegionBaseRepresentation<Pane, Str
             config.setLogScale(axis.logscale().getValue());
             config.setGridVisible(axis.grid().getValue());
             config.setVisible(axis.visible().getValue());
+            config.setColor(JFXUtil.convert(axis.color().getValue()));
             ++index;
         }
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -548,7 +548,7 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         axis.visible().addUntypedPropertyListener(config_listener);
         if (axis instanceof YAxisWidgetProperty) {
             ((YAxisWidgetProperty) axis).onRight().addUntypedPropertyListener(config_listener);
-            ((YAxisWidgetProperty) axis).gridColor().addUntypedPropertyListener(config_listener);
+            ((YAxisWidgetProperty) axis).color().addUntypedPropertyListener(config_listener);
         }
     }
 
@@ -568,7 +568,7 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         axis.visible().removePropertyListener(config_listener);
         if (axis instanceof YAxisWidgetProperty) {
             ((YAxisWidgetProperty) axis).onRight().removePropertyListener(config_listener);
-            ((YAxisWidgetProperty) axis).gridColor().removePropertyListener(config_listener);
+            ((YAxisWidgetProperty) axis).color().removePropertyListener(config_listener);
         }
     }
 
@@ -685,12 +685,12 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
             ((YAxisImpl)plot_axis).setGridColor(
                     GraphicsUtils.convert(
                             JFXUtil.convert(
-                                    ((YAxisWidgetProperty) model_axis).gridColor().getValue()
+                                    ((YAxisWidgetProperty) model_axis).color().getValue()
                             )
                     )
             );
             plot_axis.setColor(JFXUtil.convert(
-                    ((YAxisWidgetProperty) model_axis).gridColor().getValue()
+                    ((YAxisWidgetProperty) model_axis).color().getValue()
             ));
         }
     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -43,6 +43,8 @@ import org.csstudio.javafx.rtplot.Trace;
 import org.csstudio.javafx.rtplot.TraceType;
 import org.csstudio.javafx.rtplot.YAxis;
 import org.csstudio.javafx.rtplot.internal.NumericAxis;
+import org.csstudio.javafx.rtplot.internal.YAxisImpl;
+import org.csstudio.javafx.rtplot.internal.util.GraphicsUtils;
 import org.epics.util.array.ArrayDouble;
 import org.epics.util.array.ListNumber;
 import org.epics.vtype.Display;
@@ -544,8 +546,10 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         axis.titleFont().addUntypedPropertyListener(config_listener);
         axis.scaleFont().addUntypedPropertyListener(config_listener);
         axis.visible().addUntypedPropertyListener(config_listener);
-        if (axis instanceof YAxisWidgetProperty)
+        if (axis instanceof YAxisWidgetProperty) {
             ((YAxisWidgetProperty) axis).onRight().addUntypedPropertyListener(config_listener);
+            ((YAxisWidgetProperty) axis).gridColor().addUntypedPropertyListener(config_listener);
+        }
     }
 
     /** Ignore changed axis properties
@@ -562,8 +566,10 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         axis.titleFont().removePropertyListener(config_listener);
         axis.scaleFont().removePropertyListener(config_listener);
         axis.visible().removePropertyListener(config_listener);
-        if (axis instanceof YAxisWidgetProperty)
+        if (axis instanceof YAxisWidgetProperty) {
             ((YAxisWidgetProperty) axis).onRight().removePropertyListener(config_listener);
+            ((YAxisWidgetProperty) axis).gridColor().removePropertyListener(config_listener);
+        }
     }
 
     private void yAxesChanged(final WidgetProperty<List<YAxisWidgetProperty>> property,
@@ -632,7 +638,7 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         final Color foreground = JFXUtil.convert(model_widget.propForeground().getValue());
         plot.setForeground(foreground);
         plot.setBackground(JFXUtil.convert(model_widget.propBackground().getValue()));
-        plot.setGridColor(JFXUtil.convert(model_widget.propGridColor().getValue()));
+//        plot.setGridColor(JFXUtil.convert(model_widget.propGridColor().getValue()));
         plot.setTitleFont(JFXUtil.convert(model_widget.propTitleFont().getValue()));
         plot.setTitle(model_widget.propTitle().getValue());
 
@@ -675,6 +681,18 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         plot_axis.setLabelFont(JFXUtil.convert(model_axis.titleFont().getValue()));
         plot_axis.setScaleFont(JFXUtil.convert(model_axis.scaleFont().getValue()));
         plot_axis.setVisible(model_axis.visible().getValue());
+        if(plot_axis instanceof YAxisImpl) {
+            ((YAxisImpl)plot_axis).setGridColor(
+                    GraphicsUtils.convert(
+                            JFXUtil.convert(
+                                    ((YAxisWidgetProperty) model_axis).gridColor().getValue()
+                            )
+                    )
+            );
+            plot_axis.setColor(JFXUtil.convert(
+                    ((YAxisWidgetProperty) model_axis).gridColor().getValue()
+            ));
+        }
     }
 
     private void updateRanges()

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -475,7 +475,6 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
 
         model_widget.propBackground().addUntypedPropertyListener(config_listener);
         model_widget.propForeground().addUntypedPropertyListener(config_listener);
-        model_widget.propGridColor().addUntypedPropertyListener(config_listener);
         model_widget.propTitle().addUntypedPropertyListener(config_listener);
         model_widget.propTitleFont().addUntypedPropertyListener(config_listener);
         model_widget.propToolbar().addUntypedPropertyListener(config_listener);
@@ -508,7 +507,6 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
     {
         model_widget.propBackground().removePropertyListener(config_listener);
         model_widget.propForeground().removePropertyListener(config_listener);
-        model_widget.propGridColor().removePropertyListener(config_listener);
         model_widget.propTitle().removePropertyListener(config_listener);
         model_widget.propTitleFont().removePropertyListener(config_listener);
         model_widget.propToolbar().removePropertyListener(config_listener);
@@ -638,7 +636,6 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
         final Color foreground = JFXUtil.convert(model_widget.propForeground().getValue());
         plot.setForeground(foreground);
         plot.setBackground(JFXUtil.convert(model_widget.propBackground().getValue()));
-//        plot.setGridColor(JFXUtil.convert(model_widget.propGridColor().getValue()));
         plot.setTitleFont(JFXUtil.convert(model_widget.propTitleFont().getValue()));
         plot.setTitle(model_widget.propTitle().getValue());
 

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
@@ -666,7 +666,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends PlotCanvasBase
         final ScreenTransform<XTYPE> x_transform = x_axis.getScreenTransform();
         for (YAxisImpl<XTYPE> y_axis : y_axes)
         {
-            y_axis.setGridColor(grid);
+            y_axis.setGridColor(GraphicsUtils.convert(y_axis.getColor()));
             y_axis.paint(gc, plot_bounds);
         }
 


### PR DESCRIPTION
Enable grid+axis color for the Data editor (already has axis color, just make grid color match it)
Enable grid+axis colors on the X/Y Plot and Stripchart widgets