### PR TITLE
Detect EPICS epoch zero in PVA timestamp

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/ca/DBRHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/ca/DBRHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -69,6 +69,9 @@ import gov.aps.jca.dbr.TimeStamp;
 @SuppressWarnings("nls")
 public class DBRHelper
 {
+    /** 1990/01/01 00:00:00 epoch used by Channel Access and records on IOC */
+    public static final long EPICS_EPOCH = 631152000L;
+
     /** @param plain Get plain type of CTRL_... type?
      *  @param type Example data
      *  @return CTRL_... type for this channel.
@@ -155,7 +158,7 @@ public class DBRHelper
         if (epics_time == null)
             return Time.nowInvalid();
 
-        final Instant instant = Instant.ofEpochSecond(epics_time.secPastEpoch() + 631152000L,  (int) epics_time.nsec());
+        final Instant instant = Instant.ofEpochSecond(epics_time.secPastEpoch() + EPICS_EPOCH,  (int) epics_time.nsec());
         if (epics_time.secPastEpoch() <= 0)
             return Time.of(instant, 0, false);
 

--- a/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -160,7 +160,14 @@ public class Decoders
             timestamp = NO_TIME;
             usertag = NO_USERTAG;
         }
-        return Time.of(timestamp, usertag, timestamp.getEpochSecond() > 0);
+
+        // A time stamp of all zeroes is not valid.
+        // In addition, a time stamp of 1990/01/02 00:00:00
+        // as used for the Channel Access and IOC time stamp epoch
+        // is considered invalid because IOCs send it for never processed records
+        final boolean valid = timestamp.getNano() != 0  &&
+                              (timestamp.getEpochSecond() > 0 &&  timestamp.getEpochSecond() != 631152000L);
+        return Time.of(timestamp, usertag, valid);
     }
 
     /** @param printfFormat Format from NTScalar display.format

--- a/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
@@ -74,6 +74,7 @@ import org.epics.vtype.VULong;
 import org.epics.vtype.VULongArray;
 import org.epics.vtype.VUShort;
 import org.epics.vtype.VUShortArray;
+import org.phoebus.pv.ca.DBRHelper;
 
 /** Decodes {@link Time}, {@link Alarm}, {@link Display}, ...
  *  @author Kay Kasemir
@@ -166,7 +167,7 @@ public class Decoders
         // as used for the Channel Access and IOC time stamp epoch
         // is considered invalid because IOCs send it for never processed records
         final boolean valid = timestamp.getNano() != 0  &&
-                              (timestamp.getEpochSecond() > 0 &&  timestamp.getEpochSecond() != 631152000L);
+                              (timestamp.getEpochSecond() > 0 &&  timestamp.getEpochSecond() != DBRHelper.EPICS_EPOCH);
         return Time.of(timestamp, usertag, valid);
     }
 


### PR DESCRIPTION
A time stamp of 1990/01/02 00:00:00 as used for the Channel Access and IOC time stamp epoch should be considered invalid because IOCs send it for never processed records

#2415 