### PR TITLE
Render one PV per line for Data Browser log entry

### DIFF
--- a/app/trends/rich-adapters/src/main/java/org/phoebus/apps/trends/rich/adapters/DatabrowserAdapterFactory.java
+++ b/app/trends/rich-adapters/src/main/java/org/phoebus/apps/trends/rich/adapters/DatabrowserAdapterFactory.java
@@ -91,13 +91,21 @@ public class DatabrowserAdapterFactory implements AdapterFactory {
         return Optional.ofNullable(null);
     }
 
+    /**
+     * Formats the body of the log entry.
+     *
+     * List of PVs is separated both by two blanks and a line separator. This is needed in order to get both the
+     * log entry editor and the Markdown text -> html conversion to render one PV per line.
+     * @param databrowserSelection The data selected from Data Browser
+     * @return The contents of the body text.
+     */
     private String getBody(DatabrowserSelection databrowserSelection)
     {
         StringBuffer body = new StringBuffer();
         databrowserSelection.getPlotTitle().ifPresent(body::append);
-        body.append("databrowser plot for the following pvs:" + System.lineSeparator());
-        body.append(databrowserSelection.getPlotPVs().stream().collect(Collectors.joining(System.lineSeparator())));
-        body.append(System.lineSeparator());
+        body.append("databrowser plot for the following pvs:  " + System.lineSeparator());
+        body.append(databrowserSelection.getPlotPVs().stream().collect(Collectors.joining("  " + System.lineSeparator())));
+        body.append("  " + System.lineSeparator());
         body.append("Over the time period: " +  databrowserSelection.getPlotTime().toAbsoluteInterval().toString());
         return body.toString();
     }


### PR DESCRIPTION
Since Markdown specifies line break as two blanks, the body text of a log entry created from a Data Browser selection must be formatted accordingly in order to render line breaks when log entry is viewed (as HTML in Olog or web client).

![Screenshot 2022-10-17 at 15 27 53](https://user-images.githubusercontent.com/35602960/196190712-96f19793-8250-482f-90eb-ea9230fc2109.png)
