### PR TITLE
PVA error handling

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
@@ -175,6 +175,16 @@ public class PVA_PV extends PV
         // in case some detail in the 'request' caused the PVA server
         // to perform a put-callback type of operation,
         // and a GUI calling write() expect an immediate return.
+
+        // Perform a disconnect check right now to alert caller
+        // of clearly disconnected channel
+        if (isDisconnected(read()))
+            throw new Exception("Channel '" + getName() + "' is not connected");
+
+        // The channel could still disconnect in the middle of the write,
+        // the channel may be read-only or experience other errors
+        // that we'll only see as log messages since we don't want to
+        // wait in 'get()' here...
         channel.write(name_helper.getWriteRequest(), new_value);
     }
 

--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
@@ -179,7 +179,7 @@ public class PVA_PV extends PV
         // Perform a disconnect check right now to alert caller
         // of clearly disconnected channel
         if (isDisconnected(read()))
-            throw new Exception("Channel '" + getName() + "' is not connected");
+            throw new IllegalStateException("Channel '" + getName() + "' is not connected");
 
         // The channel could still disconnect in the middle of the write,
         // the channel may be read-only or experience other errors

--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
@@ -164,6 +164,17 @@ public class PVA_PV extends PV
     @Override
     public void write(final Object new_value) throws Exception
     {
+        // With Channel Access, there are different protocol options
+        // for "put" vs. "put-callback".
+        // With PVA, it is currently unclear how to distinguish between
+        // these two. The PVA server might honor certain values in the
+        // "request", but that is not documented as part of the protocol.
+        // On one hand, we should 'get()' the result of the write to
+        // receive exceptions for read-only PVs.
+        // On the other hand, such a 'get()' could last a long time
+        // in case some detail in the 'request' caused the PVA server
+        // to perform a put-callback type of operation,
+        // and a GUI calling write() expect an immediate return.
         channel.write(name_helper.getWriteRequest(), new_value);
     }
 

--- a/core/pva/src/main/java/org/epics/pva/client/GetRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/GetRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -104,7 +104,7 @@ class GetRequest extends CompletableFuture<PVAStructure> implements RequestEncod
         final byte subcmd = buffer.get();
         PVAStatus status = PVAStatus.decode(buffer);
         if (! status.isSuccess())
-            throw new Exception(channel + " Get Response for " + request + ": " + status);
+            fail(new Exception(channel + " Get Response for " + request + ": " + status));
 
         if (subcmd == PVAHeader.CMD_SUB_INIT)
         {
@@ -147,6 +147,12 @@ class GetRequest extends CompletableFuture<PVAStructure> implements RequestEncod
         }
     }
 
+    /** Handle failure by both notifying whoever waits for this request to complete
+     *  and by throwing exception
+     *
+     *  @param ex Error description
+     *  @throws Exception
+     */
     private void fail(final Exception ex) throws Exception
     {
         completeExceptionally(ex);

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -86,8 +86,12 @@ public class PVAChannel extends SearchRequest.Channel implements AutoCloseable
     ClientTCPHandler getTCP() throws Exception
     {
         final ClientTCPHandler copy = tcp.get();
+
+        // Channel Access reacts to read/write access while disconnected
+        // via IllegalStateException("Channel not connected.")
+        // Use the same exception, but add channel name
         if (copy == null)
-            throw new Exception("Channel '" + name + "' is not connected");
+            throw new IllegalStateException("Channel '" + name + "' is not connected");
         return copy;
     }
 

--- a/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -153,7 +153,7 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
         final byte subcmd = buffer.get();
         PVAStatus status = PVAStatus.decode(buffer);
         if (! status.isSuccess())
-            throw new Exception(channel + " Put Response for " + request + ": " + status);
+            fail(new Exception(channel + " Put Response for " + request + ": " + status));
 
         if (subcmd == PVAHeader.CMD_SUB_INIT)
         {
@@ -186,9 +186,15 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
             complete(null);
         }
         else
-            throw new Exception("Cannot decode Put " + subcmd + " Reply #" + request_id);
+            fail(new Exception("Cannot decode Put " + subcmd + " Reply #" + request_id));
     }
 
+    /** Handle failure by both notifying whoever waits for this request to complete
+     *  and by throwing exception
+     *
+     *  @param ex Error description
+     *  @throws Exception
+     */
     private void fail(final Exception ex) throws Exception
     {
         completeExceptionally(ex);

--- a/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
@@ -94,12 +94,23 @@ public class ClientDemo
         final PVAChannel ch2 = pva.getChannel("saw", listener);
         CompletableFuture.allOf(ch1.connect(), ch2.connect()).get(5, TimeUnit.SECONDS);
 
-        // Get data
-        Future<PVAStructure> data = ch1.read("");
-        System.out.println(ch1.getName() + " = " + data.get());
+        System.out.println("Connected.. Stop IOC in next 10 seconds to test disconnect");
+        TimeUnit.SECONDS.sleep(10);
 
-        data = ch2.read("");
-        System.out.println(ch2.getName() + " = " + data.get());
+        // Get data
+        try
+        {
+            Future<PVAStructure> data = ch1.read("");
+            System.out.println(ch1.getName() + " = " + data.get());
+
+            data = ch2.read("");
+            System.out.println(ch2.getName() + " = " + data.get());
+        }
+        catch (Exception ex)
+        {
+            System.out.println("Read failed");
+            ex.printStackTrace();
+        }
 
         // Close channels
         ch2.close();
@@ -264,7 +275,7 @@ public class ClientDemo
     }
 
     /** Write ('put') test
-     * 
+     *
      *  Includes a pause to allow manual stopping of the server.
      *
      *  May be used with read-only access security on IOC

--- a/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -263,6 +263,13 @@ public class ClientDemo
         pva.close();
     }
 
+    /** Write ('put') test
+     * 
+     *  Includes a pause to allow manual stopping of the server.
+     *
+     *  May be used with read-only access security on IOC
+     *  to test failed write.
+     */
     @Test
     public void testPut() throws Exception
     {
@@ -270,11 +277,25 @@ public class ClientDemo
         final PVAClient pva = new PVAClient();
 
         // Connect to one or more channels
-        final PVAChannel channel = pva.getChannel("ramp");
+        final PVAChannel channel = pva.getChannel("saw");
         channel.connect().get(5, TimeUnit.SECONDS);
 
+
+        System.out.println("CONNECTED!");
+        System.out.println("Optionally stop the IOC within the next 10 seconds...");
+        TimeUnit.SECONDS.sleep(10);
+        System.out.println("Writing '2'...");
+
         // Write data
-        channel.write("value", 2.0).get(2, TimeUnit.SECONDS);
+        try
+        {
+            channel.write("value", 2.0).get(2, TimeUnit.SECONDS);
+        }
+        catch (Exception ex)
+        {
+            System.out.println("Write failed");
+            ex.printStackTrace();
+        }
 
         // Close channels
         channel.close();

--- a/core/pva/src/test/resources/demo.acf
+++ b/core/pva/src/test/resources/demo.acf
@@ -1,0 +1,8 @@
+# Test read-only PVs:
+#
+# softIocPVA -m N='' -d demo.db -a demo.acf
+
+ASG(DEFAULT)
+{
+   RULE(1, READ)
+}


### PR DESCRIPTION
The PVA library didn't generate exceptions when reading/writing, #2427 

Now it will, using the same types of exceptions as channel access: `IllegalStateException` when not connected, plain exception with message that mentions an access or permission problem.

@georgweiss note that to get the exception when writing, one must use the `PV#writeAsync` call:
```
pv.asyncWrite(the_value).get();
```
or
```
pv.asyncWrite(the_value).get(5, TimeUnit.SECONDS);
```
For save/restore that should be OK because it needs to confirm that the writes completed anyway.

When using the plain `pv.write(the_value)`, we do now throw an exception if the channel is disconnected right now, but the channel might disconnect in the middle of the call, or there might be errors on the server side. We'll see all such errors in log messages, but the `write` call would appear just fine except for a disconnect at the time of the call.

The issue here is that Channel Access had a `put` and a `put callback` type of operation, and always knows about the current write access permissions. With PVA, there is just one type of `put`, and write access information is only available via an error when writing. There might be some keywords in the "request" that can tell the server to perform a `put callback`, i.e., delay the response until some action has been completed on the server side, but this is not accessible via a designated type of `put` nor documented in the protocol.
When using a `pv.asyncWrite`, we do wait for the reply, we will detect errors in the server reply and report them as exceptions. With a plain `pv.write`, however, we cannot wait for the reply, because otherwise the GUI which calls the plain `write` would block.


To better support exceptions in the plain `write`, a few things need to happen in the PVA protocol, IOC, QSRV:

1) Document a way in which the protocol can select between a plain write-and-forget and a write-complete that waits for some action on the server to complete
2) Add a way for the client to get updates on read/write access, so a GUI can indicate write permissions, and a plain write can right away abort in case of a read-only channel instead of having to wait for the error returned from the server.