### PR TITLE
Prepare timestamp userTag for 64 bit Long

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/Decoders.java
@@ -155,8 +155,10 @@ public class Decoders
                 timestamp = NO_TIME;
             else
                 timestamp = Instant.ofEpochSecond(sec.get(), nano.get());
-            final PVAInt user = time.get("userTag");
-            usertag = user == null ? NO_USERTAG : user.get();
+            // 2022-10 EPICS Developers meeting proposed 64 bit (Long) userTag
+            // Allow for that, but only use integer until VType is updated
+            final PVANumber user = time.get("userTag");
+            usertag = user == null ? NO_USERTAG : user.getNumber().intValue();
         }
         else
         {


### PR DESCRIPTION
EPICS developers meeting suggested update of userTag to 64 bit, and mentioned that phoebus won't handle it, since it expected a 32 bit value.

With this update,  we will handle a received 64 bit userTag without crashing. We still only use 32 bits from the userTag until the IOC and VType get updated, but are prepared for such an update
