### PR TITLE
PVA write (put) vs. writeAsync (put-callback or put-completion)

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -191,7 +191,7 @@ public class PVA_PV extends PV
     @Override
     public Future<?> asyncWrite(final Object new_value) throws Exception
     {
-        return channel.write(name_helper.getWriteRequest(), new_value);
+        return channel.write(true, name_helper.getWriteRequest(), new_value);
     }
 
     @Override

--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVA_Preferences.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVA_Preferences.java
@@ -43,6 +43,8 @@ public class PVA_Preferences
 {
     private static final PVA_Preferences instance = new PVA_Preferences();
 
+    public static int epics_pva_write_reply_timeout_ms;
+
     /** Prevent direct instantiation */
     private PVA_Preferences()
     {
@@ -76,6 +78,8 @@ public class PVA_Preferences
                            new Object[] { propname, PVA_PVFactory.class.getPackageName(), setting, value });
             }
         }
+
+        epics_pva_write_reply_timeout_ms = prefs.getInt("epics_pva_write_reply_timeout_ms");
     }
 
     /** @return Singleton instance */

--- a/core/pv/src/main/resources/pv_pva_preferences.properties
+++ b/core/pv/src/main/resources/pv_pva_preferences.properties
@@ -42,3 +42,11 @@ epics_pva_max_array_formatting
 
 # TCP buffer size for sending data
 epics_pva_send_buffer_size
+
+# Timeout used by plain "put" type of write
+# when checking success or failure.
+# Note this is not used with asyncWrite,
+# the "put-callback" which returns a Future
+# for awaiting the completion,
+# but only with the plain "put" that returns ASAP
+epics_pva_write_reply_timeout_ms=1000

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -241,7 +241,7 @@ public class PVAChannel extends SearchRequest.Channel implements AutoCloseable
      *  @param request Request for element to write, e.g. "field(value)"
      *  @param new_value New value: Number, String
      *  @throws Exception on error
-     *  @return {@link Future} for awaiting completion
+     *  @return {@link Future} for awaiting completion and getting Exception in case of error
      *  @deprecated Use {@link #write(boolean, String, Object)}
      */
     @Deprecated
@@ -271,7 +271,7 @@ public class PVAChannel extends SearchRequest.Channel implements AutoCloseable
     *  @param request Request for element to write, e.g. "field(value)"
     *  @param new_value New value: Number, String
     *  @throws Exception on error
-    *  @return {@link Future} for awaiting completion
+    *  @return {@link Future} for awaiting completion and getting Exception in case of error
     */
     public Future<Void> write(final boolean completion, final String request, final Object new_value) throws Exception
     {

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -242,10 +242,40 @@ public class PVAChannel extends SearchRequest.Channel implements AutoCloseable
      *  @param new_value New value: Number, String
      *  @throws Exception on error
      *  @return {@link Future} for awaiting completion
+     *  @deprecated Use {@link #write(boolean, String, Object)}
      */
+    @Deprecated
     public Future<Void> write(final String request, final Object new_value) throws Exception
     {
-        return new PutRequest(this, request, new_value);
+        return write(false, request, new_value);
+    }
+
+    /** Write (put) an element of the channel's value on server
+    *
+    *  <p>The request needs to address one field of the channel,
+    *  and the value to write must be accepted by that field.
+    *
+    *  <p>For example, when "field(value)" addresses a double field,
+    *  {@link PVADouble#setValue(Object)} will be called, so <code>new_value</code>
+    *  may be a {@link Number}.
+    *
+    *  <p>When "field(value)" addresses a text field,
+    *  {@link PVAString#setValue(Object)} will be called,
+    *  which accepts any object by converting it to a string.
+    *
+    *  <p>When writing an enumerated field, its <code>int index</code>
+    *  will be written, requiring a {@link Number} that's then
+    *  used as an integer.
+    *
+    *  @param completion Perform a processing "put" that blocks until completion, or write-and-forget?
+    *  @param request Request for element to write, e.g. "field(value)"
+    *  @param new_value New value: Number, String
+    *  @throws Exception on error
+    *  @return {@link Future} for awaiting completion
+    */
+    public Future<Void> write(final boolean completion, final String request, final Object new_value) throws Exception
+    {
+        return new PutRequest(this, completion, request, new_value);
     }
 
     /** Start a subscription

--- a/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
@@ -26,6 +26,9 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
 {
     private final PVAChannel channel;
 
+    /** Perform a processing/blocking "put"? */
+    private final boolean completion;
+
     /** Request "field(value)" or "field(struct.sub.value)" */
     private final String request;
 
@@ -43,14 +46,16 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
 
     /** Request to write channel's value
      *  @param channel {@link PVAChannel}
+     *  @param completion Perform a write that triggers processing and only returns on completion?
      *  @param request Request for element to write, e.g. "field(value)"
      *  @param new_value Value to write.
      *                   Must be accepted by {@link PVAData#setValue(Object)}
      *                   for the requested field.
      */
-    public PutRequest(final PVAChannel channel, final String request, final Object new_value)
+    public PutRequest(final PVAChannel channel, final boolean completion, final String request, final Object new_value)
     {
         this.channel = channel;
+        this.completion = completion;
         this.request = request;
         if (request.startsWith("field(")  &&  request.endsWith(")"))
             request_path = request.substring(6, request.length()-1);
@@ -89,7 +94,7 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_INIT);
 
-            final FieldRequest field_request = new FieldRequest(request);
+            final FieldRequest field_request = new FieldRequest(completion, request);
             field_request.encodeType(buffer);
             field_request.encode(buffer);
             buffer.putInt(size_offset, buffer.position() - payload_start);

--- a/core/pva/src/test/java/org/epics/pva/client/TestFieldRequest.java
+++ b/core/pva/src/test/java/org/epics/pva/client/TestFieldRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -124,6 +124,15 @@ public class TestFieldRequest
     public void testPipeline() throws Exception
     {
         FieldRequest request = new FieldRequest(10, "field(value)");
+        System.out.println(request);
+        ByteBuffer buffer = encode(request);
+        System.out.println(Hexdump.toHexdump(buffer));
+    }
+
+    @Test
+    public void testCompletion() throws Exception
+    {
+        FieldRequest request = new FieldRequest(true, "field(value)");
         System.out.println(request);
         ByteBuffer buffer = encode(request);
         System.out.println(Hexdump.toHexdump(buffer));

--- a/core/pva/src/test/java/org/epics/pva/combined/WriteDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/combined/WriteDemo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -96,11 +96,11 @@ public class WriteDemo
         for (double v=5.0; v>=-1.0; --v)
         {
             TimeUnit.MILLISECONDS.sleep(100);
-            ch1.write("", v);
+            ch1.write(false, "", v);
             TimeUnit.MILLISECONDS.sleep(100);
-            ch2.write("", v);
+            ch2.write(false, "", v);
             TimeUnit.MILLISECONDS.sleep(100);
-            ch3.write("", v);
+            ch3.write(false, "", v);
         }
         System.out.println("Closing PVs");
         ch3.close();


### PR DESCRIPTION
core-pva now supports "completion" for the put/write request.

Similar to a Channel Access put-callback aka put-with-completion this will cause QSRV on the IOC to process the target record and only return from the call once the record processing completes.
Compared to Channel Access, this is not handled via a designated protocol element but by adding `record._options.process="passive"` and `block=true` to the put request.

For the higher level core-pv library, `PV.write` performs a plain `put` while `PV.asyncWrite` will perform the `put` with completion, again just as with Channel Access.
In contrast to Channel Access, however, PVA can for the time being only detect a read-only channel by writing and then checking the reply from the PVA server. The `PV.write` can thus not be fully send-and-forget, it needs to wait for the reply from the PVA server to see if write access is possible at all. This could add short delays to GUI code that sends the write from the UI thread, but is for now unavoidable. The timeout is configurable via a new `org.phoebus.pv.pva/epics_pva_write_reply_timeout_ms=1000`

Has been tested with the generic GUI (calling plain `PV.write`) as well as with the scan server and the command line `pvaclient` (calling either the plain `PV.write` or the `PV.asyncWrite`) against a blocking "busy" record.

For progress on read-only vs. writable channel info see https://github.com/epics-base/pvAccessCPP/issues/186

Fixes  #2434 
