### PR TITLE
Fix image zoom/pan with "limits from PV"

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTImagePlot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTImagePlot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -443,10 +443,10 @@ public class RTImagePlot extends BorderPane
     }
 
     /** Set axis range for 'full' image
-     *  @param min_x
-     *  @param max_x
-     *  @param min_y
-     *  @param max_y
+     *  @param min_x User coordinates
+     *  @param max_x ...
+     *  @param min_y ...
+     *  @param max_y ...
      */
     public void setAxisRange(final double min_x, final double max_x,
                              final double min_y, final double max_y)

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/ImagePlot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/ImagePlot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -237,18 +237,28 @@ public class ImagePlot extends PlotCanvasBase
     }
 
     /** Set axis range for 'full' image
-     *  @param min_x
-     *  @param max_x
-     *  @param min_y
-     *  @param max_y
+     *  @param min_x User coordinates
+     *  @param max_x ...
+     *  @param min_y ...
+     *  @param max_y ...
      */
     public void setAxisRange(final double min_x, final double max_x,
                              final double min_y, final double max_y)
     {
+        // Ignore if there are no changes, because otherwise
+        // each call would reset axes that had "zoomed" into the image
+        if (this.min_x == min_x  &&
+            this.max_x == max_x  &&
+            this.min_y == min_y  &&
+            this.max_y == max_y)
+            return;
+
+        // Update the full image size
         this.min_x = min_x;
         this.max_x = max_x;
         this.min_y = min_y;
         this.max_y = max_y;
+        // .. and set axes to show complete image
         x_axis.setValueRange(min_x, max_x);
         y_axis.setValueRange(min_y, max_y);
     }


### PR DESCRIPTION
Only update 'full' image size when it's actually changed.

Fixes #2438 where "limits from PV" would effectively prevent zoom/pan since each PV update resets not only the overall image size in user coordinates but also the axes.

Now "limits from PV" allows zoom/pan until the image is again resized.