### PR TITLE
moving the jdk8 compatibility bits to a stand alone profile

### DIFF
--- a/core/pva/pom.xml
+++ b/core/pva/pom.xml
@@ -38,15 +38,31 @@
           </archive>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.2</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <fork>false</fork>
-        </configuration>
-      </plugin>
+
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <maven.test.skip>true</maven.test.skip>
+      </properties>
+      <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <fork>false</fork>
+                </configuration>
+            </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
This fixes the build issues with IDE's

Also, this profile is automatically activated when the building with jdk8 so no explicit instructions or documentation needed 