### PR TITLE
PVA write "value" vs. custom element

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
@@ -52,7 +52,7 @@ public class PVA_PV extends PV
         {   // When connected, subscribe to updates
             try
             {
-                channel.subscribe(name_helper.getReadRequest(), this::handleMonitor);
+                channel.subscribe(name_helper.getRequest(), this::handleMonitor);
             }
             catch (Exception ex)
             {
@@ -98,7 +98,7 @@ public class PVA_PV extends PV
     @Override
     public Future<VType> asyncRead() throws Exception
     {
-        final Future<PVAStructure> data = channel.read(name_helper.getReadRequest());
+        final Future<PVAStructure> data = channel.read(name_helper.getRequest());
         // Wrap into Future that converts PVAStructure into VType
         return new Future<>()
         {
@@ -174,7 +174,7 @@ public class PVA_PV extends PV
         // response checked below.
 
         // Perform a plain "put", not "put-callback"
-        final Future<Void> response = channel.write(false, name_helper.getWriteRequest(), new_value);
+        final Future<Void> response = channel.write(false, name_helper.getRequest(), new_value);
 
         // Compared to Channel Access, PVA currently offers no
         // information about writable vs. read-only channels.
@@ -196,7 +196,7 @@ public class PVA_PV extends PV
         // i.e., process target and block until processing completes,
         // akin to a Channel Access put-callback.
         // Return the Future that can be used to await completion
-        return channel.write(true, name_helper.getWriteRequest(), new_value);
+        return channel.write(true, name_helper.getRequest(), new_value);
     }
 
     @Override

--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVNameHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVNameHelper.java
@@ -33,7 +33,7 @@ public class PVNameHelper
     final private static Pattern ARRAY_PATTERN = Pattern.compile(".*(\\[\\S*\\])$");
     final private static Pattern ARRAY_INDEX_PATTERN = Pattern.compile("\\[(\\d*)\\]$");
 
-    final private String channel, field, read, write;
+    final private String channel, field, request;
     final private Optional<Integer> elementIndex;
 
     /** Create parser
@@ -71,41 +71,28 @@ public class PVNameHelper
         if (! matcher.matches())
             throw new Exception("Expect ?request=field(...) but got \"" + request + "\"");
         String field = matcher.group(1);
-        final Optional<Integer> elementIndex;
-        final String write;
         if (field.isEmpty())
+            return new PVNameHelper(channel, "value", Optional.empty(), "field()");
+
+        // Check if the channel name ends with "[index]", if present extract the array
+        // index part from the channel name and use it to populate the elementIndex optional
+        final Matcher arraySyntax = ARRAY_PATTERN.matcher(field);
+        final Optional<Integer> elementIndex;
+        if (arraySyntax.matches())
         {
-            field = "value";
-            write = "field(value)";
-            elementIndex = Optional.empty();
+            String arraySyntaxString = arraySyntax.group(1);
+            field = field.substring(0, arraySyntax.start(1));
+            final Matcher arrayIndex = ARRAY_INDEX_PATTERN.matcher(arraySyntaxString);
+            if (arrayIndex.matches())
+                elementIndex = Optional.of(Integer.valueOf(arrayIndex.group(1)));
+            else
+                // Error, the array index has not be correct defined, the index consist of non digit chars
+                throw new Exception("Expect [index], where the index is a valid int but got \"" + field + "\"");
         }
         else
-        {
-            // Check if the channel name ends with "[index]", if present extract the array
-            // index part from the channel name and use it to populate the elementIndex optional
-            final Matcher arraySyntax = ARRAY_PATTERN.matcher(field);
-            if(arraySyntax.matches())
-            {
-                String arraySyntaxString = arraySyntax.group(1);
-                field = field.substring(0, arraySyntax.start(1));
-                final Matcher arrayIndex = ARRAY_INDEX_PATTERN.matcher(arraySyntaxString);
-                if(arrayIndex.matches())
-                {
-                    elementIndex = Optional.of(Integer.valueOf(arrayIndex.group(1)));
-                }
-                else
-                {
-                    // Error, the array index has not be correct defined, the index consist of non digit chars
-                    throw new Exception("Expect [index], where the index is a valid int but got \"" + field + "\"");
-                }
-            }
-            else
-            {
-                elementIndex = Optional.empty();
-            }
-            write = "field(" + field + ")";
-        }
-        return new PVNameHelper(channel, field, elementIndex, request.substring(REQUEST_FIELD_START), write);
+            elementIndex = Optional.empty();
+
+        return new PVNameHelper(channel, field, elementIndex, request.substring(REQUEST_FIELD_START));
     }
 
     /** @param channel Channel name
@@ -116,13 +103,9 @@ public class PVNameHelper
     private static PVNameHelper forNameWithPath(final String channel, final String path) throws Exception
     {
         String field = path.replace('/', '.');
-        final String write;
         final Optional<Integer> elementIndex;
         if(field.isEmpty())
-        {
-            write = "field(value)";
             elementIndex = Optional.empty();
-        }
         else
         {
             final Matcher arraySyntax = ARRAY_PATTERN.matcher(field);
@@ -145,9 +128,8 @@ public class PVNameHelper
             {
                 elementIndex = Optional.empty();
             }
-            write = "field(" + field + ")";
         }
-        return new PVNameHelper(channel, field, elementIndex,"field(" + field + ")",  write);
+        return new PVNameHelper(channel, field, elementIndex, "field(" + field + ")");
     }
 
     /**
@@ -178,19 +160,18 @@ public class PVNameHelper
         {
             elementIndex = Optional.empty();
         }
-        return new PVNameHelper(channel, "value", elementIndex, "field()", "field()");
+        return new PVNameHelper(channel, "value", elementIndex, "field()");
     }
 
     /** Private to enforce use of <code>forName</code> */
-    private PVNameHelper(final String channel, final String field, final Optional<Integer> elementIndex, final String read, final String write) throws Exception
+    private PVNameHelper(final String channel, final String field, final Optional<Integer> elementIndex, final String request) throws Exception
     {
         if (channel.isEmpty())
             throw new Exception("Empty channel name");
         this.channel = channel;
         this.field = field;
         this.elementIndex = elementIndex;
-        this.read = read;
-        this.write = write;
+        this.request = request;
     }
 
     /** @return Channel name */
@@ -205,16 +186,10 @@ public class PVNameHelper
         return field;
     }
 
-    /** @return Request "field(..)" for reading */
-    public String getReadRequest()
+    /** @return Request "field(value)" or "field(struct.sub.value)" */
+    public String getRequest()
     {
-        return read;
-    }
-
-    /** @return Request "field(..)" for writing */
-    public String getWriteRequest()
-    {
-        return write;
+        return request;
     }
 
     /** @return The element index in the subscribed array*/
@@ -232,8 +207,7 @@ public class PVNameHelper
         sb.append(", field '").append(field).append("'");
         if(elementIndex.isPresent())
             sb.append(", element index '").append(String.valueOf(elementIndex.get())).append("'");
-        sb.append(", read request '").append(read).append("'");
-        sb.append(", write request '").append(write).append("'");
+        sb.append(", request '").append(request).append("'");
         return sb.toString();
     }
 }

--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVNameHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVNameHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ public class PVNameHelper
     // Regular expression for parsing out the array index value if present
     final private static Pattern ARRAY_PATTERN = Pattern.compile(".*(\\[\\S*\\])$");
     final private static Pattern ARRAY_INDEX_PATTERN = Pattern.compile("\\[(\\d*)\\]$");
-    
+
     final private String channel, field, read, write;
     final private Optional<Integer> elementIndex;
 
@@ -103,7 +103,7 @@ public class PVNameHelper
             {
                 elementIndex = Optional.empty();
             }
-            write = "field(" + field + ".value)";
+            write = "field(" + field + ")";
         }
         return new PVNameHelper(channel, field, elementIndex, request.substring(REQUEST_FIELD_START), write);
     }
@@ -145,7 +145,7 @@ public class PVNameHelper
             {
                 elementIndex = Optional.empty();
             }
-            write = "field(" + field + ".value)";
+            write = "field(" + field + ")";
         }
         return new PVNameHelper(channel, field, elementIndex,"field(" + field + ")",  write);
     }
@@ -178,7 +178,7 @@ public class PVNameHelper
         {
             elementIndex = Optional.empty();
         }
-        return new PVNameHelper(channel, "value", elementIndex, "field()", "field(value)");
+        return new PVNameHelper(channel, "value", elementIndex, "field()", "field()");
     }
 
     /** Private to enforce use of <code>forName</code> */

--- a/core/pv/src/test/java/org/phoebus/pv/PVACustomStructDemo.java
+++ b/core/pv/src/test/java/org/phoebus/pv/PVACustomStructDemo.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.pv;
+
+import java.util.concurrent.CountDownLatch;
+
+/** Write elements of data served by core-pva/src/test/java/org/epics/pva/server/BoolDemo.java
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class PVACustomStructDemo
+{
+    public static void main(String[] args) throws Exception
+    {
+        final PV pv = PVPool.getPV("pva://struct/flag2");
+
+        try
+        {
+            // Await connection
+            CountDownLatch connect = new CountDownLatch(1);
+            pv.onValueEvent().subscribe(value ->
+            {
+                System.out.println(pv.getName() + " = " + value);
+                if (!PV.isDisconnected(value))
+                    connect.countDown();
+            });
+            connect.await();
+
+            pv.asyncWrite(true).get();
+        }
+        finally
+        {
+            PVPool.releasePV(pv);
+        }
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
@@ -113,11 +113,24 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
             buffer.putInt(request_id);
             buffer.put(PVAHeader.CMD_SUB_DESTROY);
 
-            // Locate the 'value' field
+            // Locate the field to write
             PVAData field = null;
             try
-            {
-                field = data.locate(request_path);
+            {   // Default to "value"
+                if (request_path.isEmpty())
+                    field = data.locate("value");
+                else
+                {   // Start with the addressed element
+                    field = data.locate(request_path);
+                    // Check if there is a ".value" below
+                    if (field instanceof PVAStructure)
+                    {
+                        final PVAStructure struct = (PVAStructure) field;
+                        final PVAData value_sub = struct.get("value");
+                        if (value_sub != null)
+                            field = value_sub;
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/core/pva/src/main/java/org/epics/pva/server/ServerAuth.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerAuth.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -91,10 +91,10 @@ abstract class ServerAuth
         @Override
         public boolean hasWriteAccess(final String channel)
         {
-            // TODO Implement access security
-            if (channel.contains("demo"))
-                return true;
-            return false;
+            // TODO Implement access security based on `acf` type config file
+            // if (! channel.contains("demo"))
+            //     return false;
+            return true;
         }
 
         @Override

--- a/core/pva/src/test/java/org/epics/pva/server/BoolDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/server/BoolDemo.java
@@ -8,8 +8,12 @@
 package org.epics.pva.server;
 
 import java.time.Instant;
+import java.util.BitSet;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
 
+import org.epics.pva.PVASettings;
 import org.epics.pva.data.PVABool;
 import org.epics.pva.data.PVAStructure;
 import org.epics.pva.data.nt.PVATimeStamp;
@@ -22,6 +26,10 @@ public class BoolDemo
 {
     public static void main(String[] args) throws Exception
     {
+        // Log everything
+        LogManager.getLogManager().readConfiguration(PVASettings.class.getResourceAsStream("/pva_logging.properties"));
+        PVASettings.logger.setLevel(Level.FINE);
+
         try
         (
             // Create PVA Server (auto-closed)
@@ -45,8 +53,13 @@ public class BoolDemo
 
             // Create PVs
             final ServerPV pv1 = server.createPV("bool", data);
-            final ServerPV pv2 = server.createPV("struct", struct);
+            final ServerPV pv2 = server.createPV("struct", struct, (ServerPV pv, BitSet changes, PVAStructure written) ->
+            {
+                System.out.println("Somebody wrote this to '" + pv.getName() + "':\n" + written);
+                pv.update(written);
+            });
             System.out.println("Check PV   '" + pv1.getName() + "' or '" + pv2.getName() + "'");
+            System.out.println("May also try to write:   pvput struct 'flag2=true'");
 
             // Update value and timestamp
             while (true)


### PR DESCRIPTION
Write support always used the `.value` subfield. Now it can be used with `pva://custom_struct/some_field` and will then write just to `some_field`, not requiring `some_field.value`.

Still checking for `.value` to support the expected case of a "normative type".

Simplified the the PVNameHelper to just track one "request" since read and write requests are now the same.

Tested with plain `softIocPVA` type records (read and write), updated `BoolDemo` (read and write) and area detector image (read-only).

Fixes #2459