### PR TITLE
CSSTUDIO-1747: hex field for color picker

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXUtil.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXUtil.java
@@ -65,10 +65,22 @@ public class JFXUtil extends org.phoebus.ui.javafx.JFXUtil
     }
 
     /** Convert model color into web-type RGB text
+     *  @param col {@link WidgetColor}
+     *  @return RGB text of the form "#FF8080"
+     */
+    public static String webHex(final WidgetColor col) {
+        if(col != null) {
+            return String.format((Locale) null, "#%02X%02X%02X", col.getRed(), col.getGreen(), col.getBlue());
+        } else {
+            return "";
+        }
+    }
+
+    /** Convert model color into web-type RGB text if transparent; otherwise converts to hex.
      *  @param color {@link WidgetColor}
      *  @return RGB text of the form "#FF8080"
      */
-    public static String webRGB(final WidgetColor color)
+    public static String webRgbOrHex(final WidgetColor color)
     {
         return webRGBCache.computeIfAbsent(color, col ->
         {
@@ -78,7 +90,7 @@ public class JFXUtil extends org.phoebus.ui.javafx.JFXUtil
                                  col.getBlue() + ',' +
                                  col.getAlpha()/255f + ')';
             else
-                return String.format((Locale) null, "#%02X%02X%02X", col.getRed(), col.getGreen(), col.getBlue());
+                return webHex(col);
         });
     }
 
@@ -89,7 +101,7 @@ public class JFXUtil extends org.phoebus.ui.javafx.JFXUtil
      */
     public static StringBuilder appendWebRGB(final StringBuilder buf, final WidgetColor color)
     {
-        return buf.append(webRGB(color));
+        return buf.append(webRgbOrHex(color));
     }
 
     /** Convert model color into CSS style string for shading tabs, buttons, etc
@@ -117,7 +129,7 @@ public class JFXUtil extends org.phoebus.ui.javafx.JFXUtil
             // The .button.armed state uses
             //   -fx-pressed-base: derive(-fx-base,-6%);
             // which we change into a more obvious variant.
-            final String bg = webRGB(col);
+            final String bg = webRgbOrHex(col);
             return "-fx-base: " + bg + "; " +
                    "-fx-pressed-base: derive(-fx-base,-25%);";
         });

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -230,7 +230,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
             label.setTextFill(color);
             label.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
 
-            led.setStyle("-fx-stroke: " + JFXUtil.webRGB(model_widget.propLineColor().getValue()));
+            led.setStyle("-fx-stroke: " + JFXUtil.webRgbOrHex(model_widget.propLineColor().getValue()));
 
             final int w = model_widget.propWidth().getValue();
             final int h = model_widget.propHeight().getValue();

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
@@ -269,8 +269,8 @@ public class ComboRepresentation extends RegionBaseRepresentation<ComboBox<Strin
                 "-fx-body-color: linear-gradient(to bottom,ladder({0}, derive({0},8%) 75%, derive({0},10%) 80%), derive({0},-8%)); "
               + "-fx-text-base-color: ladder(-fx-color, -fx-light-text-color 45%, -fx-dark-text-color 46%, -fx-dark-text-color 59%, {1}); "
               + "-fx-font: {2} {3}px \"{4}\";",
-                JFXUtil.webRGB(model_widget.propBackgroundColor().getValue()),
-                JFXUtil.webRGB(model_widget.propForegroundColor().getValue()),
+                JFXUtil.webRgbOrHex(model_widget.propBackgroundColor().getValue()),
+                JFXUtil.webRgbOrHex(model_widget.propForegroundColor().getValue()),
                 f.getStyle().toLowerCase().replace("regular", "normal"),
                 f.getSize(),
                 f.getFamily()

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
@@ -181,8 +181,8 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
             // Tweaking the color used by CSS keeps overall style.
             // See also http://stackoverflow.com/questions/13467259/javafx-how-to-change-progressbar-color-dynamically
             final StringBuilder style = new StringBuilder();
-            style.append("-fx-accent: ").append(JFXUtil.webRGB(model_widget.propFillColor().getValue())).append(';');
-            style.append("-fx-control-inner-background: ").append(JFXUtil.webRGB(model_widget.propBackgroundColor().getValue())).append(';');
+            style.append("-fx-accent: ").append(JFXUtil.webRgbOrHex(model_widget.propFillColor().getValue())).append(';');
+            style.append("-fx-control-inner-background: ").append(JFXUtil.webRgbOrHex(model_widget.propBackgroundColor().getValue())).append(';');
             jfx_node.setStyle(style.toString());
         }
         if (dirty_value.checkAndClear())

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
@@ -473,9 +473,9 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
             markers.setFont(font);
 
             final String style = // Text color (and border around the 'track')
-                                 "-fx-text-background-color: " + JFXUtil.webRGB(model_widget.propForegroundColor().getValue()) +
+                                 "-fx-text-background-color: " + JFXUtil.webRgbOrHex(model_widget.propForegroundColor().getValue()) +
                                  // Axis tick marks
-                                 "; -fx-background: " + JFXUtil.webRGB(model_widget.propForegroundColor().getValue()) +
+                                 "; -fx-background: " + JFXUtil.webRgbOrHex(model_widget.propForegroundColor().getValue()) +
                                  // Font; NOTE only the shorthand font style is supported for fx-tick-label-font;
                                  // e.g. fx-tick-label-font-size etc are not supported!
                                  "; " + JFXUtil.cssFontShorthand("-fx-tick-label-font", font);

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
@@ -286,7 +286,7 @@ public class SlideButtonRepresentation extends RegionBaseRepresentation<HBox, Sl
     private void styleChanged ( final WidgetProperty<?> property, final Object old_value, final Object new_value ) {
 
         foreground = JFXUtil.convert(model_widget.propForegroundColor().getValue());
-        state_colors = "-db-toggle-switch-off: " + JFXUtil.webRGB(model_widget.propOffColor().getValue()) + ";" + "-db-toggle-switch-on: " + JFXUtil.webRGB(model_widget.propOnColor().getValue()) + ";";
+        state_colors = "-db-toggle-switch-off: " + JFXUtil.webRgbOrHex(model_widget.propOffColor().getValue()) + ";" + "-db-toggle-switch-on: " + JFXUtil.webRgbOrHex(model_widget.propOnColor().getValue()) + ";";
 
         dirty_style.mark();
         toolkit.scheduleUpdate(this);

--- a/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/WidgetColorPopOver.fxml
+++ b/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/WidgetColorPopOver.fxml
@@ -20,6 +20,7 @@
 <?import javafx.scene.text.Font?>
 <?import org.phoebus.ui.javafx.ClearingTextField?>
 
+<?import javafx.scene.control.TextField?>
 <GridPane fx:id="root" hgap="12.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="455.0" prefWidth="637.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.csstudio.display.builder.representation.javafx.WidgetColorPopOverController">
   <columnConstraints>
     <ColumnConstraints hgrow="NEVER" percentWidth="50.0" />
@@ -87,6 +88,10 @@
                   <Label text="%WidgetColorPopOver_Alpha" GridPane.halignment="RIGHT" GridPane.rowIndex="6" />
                   <Slider fx:id="alphaSlider" max="255.0" GridPane.columnIndex="1" GridPane.rowIndex="6" />
                   <Spinner fx:id="alphaSpinner" editable="true" GridPane.columnIndex="2" GridPane.rowIndex="6" />
+
+                   <Label text="%WidgetColorPopOver_Hex" GridPane.halignment="RIGHT" GridPane.rowIndex="7" />
+                   <TextField promptText="000000" fx:id="hexField" GridPane.halignment="RIGHT" GridPane.columnIndex="1" GridPane.rowIndex="7" GridPane.hgrow="ALWAYS" />
+
                </children>
             </GridPane>
          </content>

--- a/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/messages.properties
+++ b/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/messages.properties
@@ -117,6 +117,7 @@ ShowConfirmationDialogTitle=Please Confirm
 ShowErrorDialogTitle=Error
 ShowMessageDialogTitle=Message
 ShowSaveAsDialogTitle=Save As
+WidgetColorPopOver_Hex=Hex Value:
 WidgetColorPopOver_Alpha=Alpha:
 WidgetColorPopOver_Blue=Blue:
 WidgetColorPopOver_Color=Color:

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/JFXUtilTest.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/JFXUtilTest.java
@@ -23,11 +23,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SuppressWarnings("nls")
 public class JFXUtilTest
 {
+
+    @Test
+    public void testHex() {
+        assertThat(JFXUtil.webHex(new WidgetColor(15, 255, 0)), equalTo("#0FFF00"));
+        assertThat(JFXUtil.webHex(new WidgetColor(0, 16, 255)), equalTo("#0010FF"));
+        assertThat(JFXUtil.webHex(new WidgetColor(0, 0, 0)), equalTo("#000000"));
+        assertThat(JFXUtil.webHex(new WidgetColor(255, 255, 255)), equalTo("#FFFFFF"));
+        assertThat(JFXUtil.webHex(null), equalTo(""));
+    }
+
     @Test
     public void testRGB()
     {
-        assertThat(JFXUtil.webRGB(new WidgetColor(15, 255, 0)), equalTo("#0FFF00"));
-        assertThat(JFXUtil.webRGB(new WidgetColor(0, 16, 255)), equalTo("#0010FF"));
+        assertThat(JFXUtil.webRgbOrHex(new WidgetColor(15, 255, 0)), equalTo("#0FFF00"));
+        assertThat(JFXUtil.webRgbOrHex(new WidgetColor(0, 16, 255)), equalTo("#0010FF"));
+        assertThat(JFXUtil.webRgbOrHex(new WidgetColor(0, 16, 255, 50)), equalTo("rgba(0,16,255,0.19607843)"));
     }
 
     @Test


### PR DESCRIPTION
feature: hex field in color picker popover. 
refactor: rename jfx util method to reflect what it better does

Field is locked to 6-digit hex format but will also accept 3-digit short format (e.g. '3ef' expands to '33eeff'). 
Debounce is to enable manual entry of values (as the formatter can prevent entry).