### PR TITLE
Fix for saving snapshot without data

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -273,11 +273,16 @@ public class SnapshotController implements NodeChangedListener {
             });
         }
 
-        saveSnapshotButton.disableProperty().bind(Bindings.createBooleanBinding(() -> (nodeDataDirty.not().get() &&
+        saveSnapshotButton.disableProperty().bind(Bindings.createBooleanBinding(() -> (nodeDataDirty.not().get() ||
                         snapshotDataDirty.not().get()) ||
                         snapshotNameProperty.isEmpty().get() ||
                         snapshotCommentProperty.isEmpty().get(),
                 nodeDataDirty, snapshotDataDirty, snapshotNameProperty, snapshotCommentProperty));
+
+        System.out.println(snapshotDataDirty.get());
+        snapshotDataDirty.addListener((a, b, c) -> {
+            System.out.println(b + " "+ c);
+        });
 
         showLiveReadbackButton.setGraphic(new ImageView(new Image(getClass().getResourceAsStream("/icons/show_live_readback_column.png"))));
         showLiveReadbackButton.setTooltip(new Tooltip(Messages.toolTipShowLiveReadback));

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -279,11 +279,6 @@ public class SnapshotController implements NodeChangedListener {
                         snapshotCommentProperty.isEmpty().get(),
                 nodeDataDirty, snapshotDataDirty, snapshotNameProperty, snapshotCommentProperty));
 
-        System.out.println(snapshotDataDirty.get());
-        snapshotDataDirty.addListener((a, b, c) -> {
-            System.out.println(b + " "+ c);
-        });
-
         showLiveReadbackButton.setGraphic(new ImageView(new Image(getClass().getResourceAsStream("/icons/show_live_readback_column.png"))));
         showLiveReadbackButton.setTooltip(new Tooltip(Messages.toolTipShowLiveReadback));
         showLiveReadbackProperty.bind(showLiveReadbackButton.selectedProperty());
@@ -638,6 +633,7 @@ public class SnapshotController implements NodeChangedListener {
             snapshotCommentProperty.set(null);
             createdByTextProperty.set(null);
             createdDateTextProperty.set(null);
+            lastModifiedDateTextProperty.set(null);
             snapshotTab.setId(null);
             snapshotTab.updateTabTitile(Messages.unnamedSnapshot, false);
             nodeDataDirty.set(true);


### PR DESCRIPTION
Snapshot could be saved as soon as name and description was set, but not snapshot data.

This is a fix.

Also contains a fix for resetting the last modified date if user selects to take a new snapshot from the snapshot view.