### PR TITLE
Save and restore force read

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/Preferences.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/Preferences.java
@@ -39,6 +39,8 @@ public class Preferences {
     public static String regex_hierarchy_parser_regex_list;
     @Preference
     public static boolean enableCSVIO;
+    @Preference
+    public static int readTimeout;
 
     static
     {

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -97,7 +97,10 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -190,7 +193,7 @@ public class SnapshotController implements NodeChangedListener {
 
     private final BooleanProperty showStoredReadbackProperty = new SimpleBooleanProperty(false);
 
-   // private final boolean showStoredReadbacks = false;
+    // private final boolean showStoredReadbacks = false;
 
     private boolean showDeltaPercentage = false;
     private boolean hideEqualItems;
@@ -590,7 +593,7 @@ public class SnapshotController implements NodeChangedListener {
                 boolean restorable = e.selectedProperty().get() && !e.readOnlyProperty().get();
 
                 if (restorable) {
-                    final PV pv = pvs.get(getPVKey(e.pvNameProperty().get(), e.readOnlyProperty().get() ^ e.readonlyOverrideProperty().get()));
+                    final PV pv = pvs.get(getPVKey(e.pvNameProperty().get(), e.readOnlyProperty().get()));
                     if (entry.getValue() != null) {
                         try {
                             pv.pv.write(Utilities.toRawValue(entry.getValue()));
@@ -628,62 +631,32 @@ public class SnapshotController implements NodeChangedListener {
     @FXML
     public void takeSnapshot() {
 
-        UI_EXECUTOR.execute(() -> {
-            snapshotNameProperty.set(null);
-            snapshotCommentProperty.set(null);
-            createdByTextProperty.set(null);
-            createdDateTextProperty.set(null);
-            lastModifiedDateTextProperty.set(null);
-            snapshotTab.setId(null);
-            snapshotTab.updateTabTitile(Messages.unnamedSnapshot, false);
-            nodeDataDirty.set(true);
-            snapshotDataDirty.set(true);
-        });
-        try {
-            List<SnapshotEntry> entries = new ArrayList<>(tableEntryItems.size());
-            PV pv;
-            String name, delta = null;
-            String readbackName;
-            VType value;
-            VType readbackValue;
-            for (TableEntry t : tableEntryItems.values()) {
-                name = t.pvNameProperty().get();
-                pv = pvs.get(getPVKey(t.pvNameProperty().get(), t.readOnlyProperty().get() ^ t.readonlyOverrideProperty().get()));
+        snapshotNameProperty.set(null);
+        snapshotCommentProperty.set(null);
+        createdByTextProperty.set(null);
+        createdDateTextProperty.set(null);
+        snapshotTab.setId(null);
+        snapshotTab.updateTabTitile(Messages.unnamedSnapshot, false);
+        nodeDataDirty.set(true);
+        snapshotDataDirty.set(true);
+        disabledUi.set(true);
 
-                // there is no issues with non atomic access to snapshotTreeTableEntryPvProxy.value or snapshotTreeTableEntryPvProxy.readbackValue because the PV is
-                // suspended and the value could not change while suspended
-                value = pv == null || pv.pvValue == null ? VDisconnectedData.INSTANCE : pv.pvValue;
-                String key = getPVKey(name, t.readOnlyProperty().get() ^ t.readonlyOverrideProperty().get());
-                readbackName = readbacks.get(key);
-                readbackValue = pv == null || pv.readbackValue == null ? VDisconnectedData.INSTANCE : pv.readbackValue;
-                for (VSnapshot s : getAllSnapshots()) {
-                    delta = s.getDelta(name);
-                    if (delta != null) {
-                        break;
-                    }
-                }
-
-                entries.add(new SnapshotEntry(t.getConfigPv(), value, t.selectedProperty().get(), readbackName, readbackValue,
-                        delta, t.readOnlyProperty().get() ^ t.readonlyOverrideProperty().get()));
-            }
-
+        List<SnapshotEntry> entries = new ArrayList<>();
+        readAll(list -> Platform.runLater(() -> {
+            disabledUi.set(false);
+            entries.addAll(list);
             Node snapshot = Node.builder().name(Messages.unnamedSnapshot).nodeType(NodeType.SNAPSHOT).build();
-
             multiplierSpinner.getEditor().setText("1.0");
             VSnapshot taken = new VSnapshot(snapshot, entries);
             snapshots.clear();
             snapshots.add(taken);
             List<TableEntry> tableEntries = loadSnapshotInternal(taken);
-            UI_EXECUTOR.execute(() -> {
-                snapshotTable.updateTable(tableEntries, snapshots, showLiveReadbackProperty.get(), false, showDeltaPercentage);
-                if (isTreeTableViewEnabled) {
-                    snapshotTreeTable.updateTable(tableEntries, snapshots, showLiveReadbackProperty.get(), false, showDeltaPercentage);
-                }
-                nodeDataDirty.set(true);
-            });
-        } catch (Exception e) {
-            LOGGER.log(Level.INFO, "Error taking snapshot", e);
-        }
+            snapshotTable.updateTable(tableEntries, snapshots, showLiveReadbackProperty.get(), false, showDeltaPercentage);
+            if (isTreeTableViewEnabled) {
+                snapshotTreeTable.updateTable(tableEntries, snapshots, showLiveReadbackProperty.get(), false, showDeltaPercentage);
+            }
+            nodeDataDirty.set(true);
+        }));
     }
 
     @FXML
@@ -719,8 +692,7 @@ public class SnapshotController implements NodeChangedListener {
                         DialogHelper.positionDialog(alert, snapshotTab.getTabPane(), -150, -150);
                         alert.showAndWait();
                     });
-                }
-                finally {
+                } finally {
                     disabledUi.set(false);
                 }
             });
@@ -929,11 +901,6 @@ public class SnapshotController implements NodeChangedListener {
         snapshots.forEach(snapshot -> snapshot.getEntries()
                 .forEach(item -> {
                     TableEntry tableEntry = tableEntryItems.get(getPVKey(item.getPVName(), item.isReadOnly()));
-
-                    if (item.isReadOnly() == !tableEntry.readonlyOverrideProperty().get()) {
-                        return;
-                    }
-
                     VType vtype = item.getStoredValue();
                     VType newVType;
 
@@ -1138,6 +1105,79 @@ public class SnapshotController implements NodeChangedListener {
             alert.setContentText(cause != null ? cause : Messages.loggingFailedCauseUnknown);
             DialogHelper.positionDialog(alert, snapshotTab.getTabPane(), -150, -150);
             alert.showAndWait();
+        });
+    }
+
+    /**
+     * Reads all PVs using a thread pool. All reads are asynchronous waiting at most the amount of time
+     * configured through a preference setting.
+     *
+     * @param completion Callback receiving a list of {@link SnapshotEntry}s where values for PVs that could
+     *                   not be read are set to {@link VDisconnectedData#INSTANCE}.
+     */
+    private void readAll(Consumer<List<SnapshotEntry>> completion) {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        List<SnapshotEntry> snapshotEntries = new ArrayList<>();
+
+        CountDownLatch countDownLatch = new CountDownLatch(tableEntryItems.values().size());
+
+        JobManager.schedule("Take snapshot", monitor -> {
+            try {
+                monitor.beginTask("Take snapshot", tableEntryItems.values().size());
+                int i = 0;
+                for (TableEntry t : tableEntryItems.values()) {
+                    executorService.submit(() -> {
+                        int index = i;
+                        String name = t.pvNameProperty().get();
+                        PV pv = pvs.get(getPVKey(t.pvNameProperty().get(), t.readOnlyProperty().get()));
+                        VType value = VDisconnectedData.INSTANCE;
+                        try {
+                            value = pv.pv.asyncRead().get(5, TimeUnit.SECONDS);
+                        } catch (Exception e) {
+                            LOGGER.log(Level.WARNING, "Failed to read PV " + pv.pvName);
+                        }
+                        String key = getPVKey(name, t.readOnlyProperty().get());
+                        String readbackName = readbacks.get(key);
+                        VType readbackValue = null;
+                        if (pv.readbackPv != null && !pv.readbackValue.equals(VDisconnectedData.INSTANCE)) {
+                            try {
+                                readbackValue = pv.readbackPv.asyncRead().get(5, TimeUnit.SECONDS);
+                            } catch (Exception e) {
+                                LOGGER.log(Level.WARNING, "Failed to read read-back PV " + pv.readbackPvName);
+                                readbackValue = VDisconnectedData.INSTANCE;
+                            }
+                        }
+                        String delta = "";
+                        for (VSnapshot s : getAllSnapshots()) {
+                            delta = s.getDelta(name);
+                            if (delta != null) {
+                                break;
+                            }
+                        }
+                        snapshotEntries.add(index, new SnapshotEntry(t.getConfigPv(), value, t.selectedProperty().get(), readbackName, readbackValue,
+                                delta, t.readOnlyProperty().get()));
+                        monitor.worked(1);
+                        countDownLatch.countDown();
+                        index++;
+                    });
+                }
+
+                countDownLatch.await();
+                monitor.done();
+                completion.accept(snapshotEntries);
+                executorService.shutdown();
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, "Take snapshot failed");
+                disabledUi.set(false);
+                Platform.runLater(() -> {
+                    Alert alert = new Alert(Alert.AlertType.ERROR);
+                    alert.setTitle(Messages.errorActionFailed);
+                    alert.setContentText(e.getMessage());
+                    alert.setHeaderText("Take snapshot failed");
+                    DialogHelper.positionDialog(alert, snapshotTab.getTabPane(), -150, -150);
+                    alert.showAndWait();
+                });
+            }
         });
     }
 }

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -610,7 +610,7 @@ public class SnapshotController implements NodeChangedListener {
             for (SnapshotEntry entry : entries) {
                 TableEntry e = tableEntryItems.get(getPVKey(entry.getPVName(), entry.isReadOnly()));
 
-                boolean restorable = e.selectedProperty().get() && !e.readOnlyProperty().get();
+                boolean restorable = e.selectedProperty().get() && !e.readOnlyProperty().get() && !entry.getValue().equals(VNoData.INSTANCE);
 
                 if (restorable) {
                     final PV pv = pvs.get(getPVKey(e.pvNameProperty().get(), e.readOnlyProperty().get()));
@@ -641,7 +641,7 @@ public class SnapshotController implements NodeChangedListener {
                 StringBuilder sb = new StringBuilder(restoreFailed.size() * 200);
                 restoreFailed.forEach(e -> sb.append(e).append('\n'));
                 LOGGER.log(Level.WARNING,
-                        "Not all PVs could be restored for {0}: {1}. The following errors occured:\n{2}",
+                        "Not all PVs could be restored for {0}: {1}. The following errors occurred:\n{2}",
                         new Object[]{s.getSnapshot().get().getName(), s.getSnapshot().get(), sb.toString()});
             }
             logSnapshotRestored(s.getSnapshot().get(), restoreFailed);
@@ -1145,7 +1145,7 @@ public class SnapshotController implements NodeChangedListener {
                 executorService.submit(() -> {
                     String name = t.pvNameProperty().get();
                     PV pv = pvs.get(getPVKey(t.pvNameProperty().get(), t.readOnlyProperty().get()));
-                    VType value = VDisconnectedData.INSTANCE;
+                    VType value = VNoData.INSTANCE;
                     try {
                         value = pv.pv.asyncRead().get(readTimeout, TimeUnit.MILLISECONDS);
                     } catch (Exception e) {
@@ -1153,13 +1153,12 @@ public class SnapshotController implements NodeChangedListener {
                     }
                     String key = getPVKey(name, t.readOnlyProperty().get());
                     String readbackName = readbacks.get(key);
-                    VType readbackValue = null;
+                    VType readbackValue = VNoData.INSTANCE;
                     if (pv.readbackPv != null && !pv.readbackValue.equals(VDisconnectedData.INSTANCE)) {
                         try {
                             readbackValue = pv.readbackPv.asyncRead().get(readTimeout, TimeUnit.MILLISECONDS);
                         } catch (Exception e) {
                             LOGGER.log(Level.WARNING, "Failed to read read-back PV " + pv.readbackPvName);
-                            readbackValue = VDisconnectedData.INSTANCE;
                         }
                     }
                     String delta = "";

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTable.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTable.java
@@ -443,6 +443,9 @@ class SnapshotTable extends TableView<TableEntry> {
                     if (item.readOnlyProperty().get()) {
                         cell.getStyleClass().add("check-box-table-cell-disabled");
                     }
+                    else if(item.valueProperty().get().value.equals(VNoData.INSTANCE)){
+                        item.selectedProperty().set(false);
+                    }
                 }
             }
         }

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTable.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTable.java
@@ -24,6 +24,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.Tooltip;
+import javafx.scene.control.TreeItem;
 import javafx.scene.control.cell.CheckBoxTableCell;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.image.Image;
@@ -61,6 +62,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Formatter;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -898,6 +900,7 @@ class SnapshotTable extends TableView<TableEntry> {
         final ObservableList<TableEntry> items = getItems();
         final boolean notHide = !controller.isHideEqualItems();
         items.clear();
+        entries.sort(Comparator.comparing(tableEntry -> tableEntry.getConfigPv().getPvName()));
         entries.forEach(e -> {
             // there is no harm if this is executed more than once, because only one line is allowed for these
             // two properties (see SingleListenerBooleanProperty for more details)

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTable.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTable.java
@@ -557,7 +557,6 @@ class SnapshotTable extends TableView<TableEntry> {
                         toggle.setOnAction(actionEvent -> {
                             item.readOnlyProperty().setValue(!item.readOnlyProperty().get());
                             item.selectedProperty().set(!item.readOnlyProperty().get());
-                            item.readonlyOverrideProperty().set(!item.readonlyOverrideProperty().get());
                         });
                         contextMenu.getItems().add(toggle);
                         contextMenu.show(this, event.getScreenX(), event.getScreenY());

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTable.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTable.java
@@ -903,7 +903,6 @@ class SnapshotTable extends TableView<TableEntry> {
         final ObservableList<TableEntry> items = getItems();
         final boolean notHide = !controller.isHideEqualItems();
         items.clear();
-        entries.sort(Comparator.comparing(tableEntry -> tableEntry.getConfigPv().getPvName()));
         entries.forEach(e -> {
             // there is no harm if this is executed more than once, because only one line is allowed for these
             // two properties (see SingleListenerBooleanProperty for more details)

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTreeTable.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTreeTable.java
@@ -602,7 +602,6 @@ class SnapshotTreeTable extends TreeTableView<TreeTableEntry> {
                             toggle.setOnAction(actionEvent -> {
                                 item.tableEntry.readOnlyProperty().set(!item.tableEntry.readOnlyProperty().get());
                                 item.tableEntry.selectedProperty().set(!item.tableEntry.readOnlyProperty().get());
-                                item.tableEntry.readonlyOverrideProperty().set(!item.tableEntry.readonlyOverrideProperty().get());
                             });
 
                             contextMenu.getItems().add(new SeparatorMenuItem());
@@ -652,7 +651,7 @@ class SnapshotTreeTable extends TreeTableView<TreeTableEntry> {
                     signal.initializeEqualPropertyChangeListener(controller);
                     signal.initializeChangeListenerForColumnHeaderCheckBox(selectAllCheckBox);
                     signal.initializeReadonlyChangeListenerForToggle();
-                    treeTableEntryItems.put(getPVKey(pvName, entry.readOnlyProperty().get() ^ entry.readonlyOverrideProperty().get()), signal);
+                    treeTableEntryItems.put(getPVKey(pvName, entry.readOnlyProperty().get()), signal);
                 }
             }
         }
@@ -1039,7 +1038,7 @@ class SnapshotTreeTable extends TreeTableView<TreeTableEntry> {
         final boolean notHide = !controller.isHideEqualItems();
 
         entries.forEach(tableEntry -> {
-            TreeTableEntry treeTableEntry = treeTableEntryItems.get(getPVKey(tableEntry.pvNameProperty().get(), tableEntry.readOnlyProperty().get() ^ tableEntry.readonlyOverrideProperty().get()));
+            TreeTableEntry treeTableEntry = treeTableEntryItems.get(getPVKey(tableEntry.pvNameProperty().get(), tableEntry.readOnlyProperty().get()));
             if (treeTableEntry != null) {
                 treeTableEntry.update(tableEntry);
                 if (notHide || !tableEntry.liveStoredEqualProperty().get()) {

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/TableEntry.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/TableEntry.java
@@ -76,9 +76,6 @@ public class TableEntry {
     private Optional<Threshold<?>> threshold = Optional.empty();
     private final BooleanProperty readOnly = new SimpleBooleanProperty(this, "readOnly", false);
 
-    private final BooleanProperty readonlyOverride = new SimpleBooleanProperty(false);
-
-    //private final ObjectProperty<ConfigPv> configPvObjectProperty = new SimpleObjectProperty<>(this, "configPv", null);
 
     private ConfigPv configPv;
 
@@ -212,13 +209,6 @@ public class TableEntry {
      */
     public BooleanProperty readOnlyProperty() {
         return readOnly;
-    }
-
-    /**
-     * @return the property indicating the the PV has read only setting overriden
-     */
-    public BooleanProperty readonlyOverrideProperty() {
-        return readonlyOverride;
     }
 
     /**

--- a/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
+++ b/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
@@ -9,7 +9,7 @@ sortSnapshotsTimeReversed=false
 # Hierarchy parser class should be in ui/snapshot/hierarchyparser
 # RegexHierarchyParser is provided for convenience. Use , as separator for each regex pattern.
 # First matched pattern is used to create its hierarchy.
-treeTableView.enable=false
+treeTableView.enable=true
 treeTableView.hierarchyParser=RegexHierarchyParser
 regexHierarchyParser.regexList=(\\w+)_(\\w+):(\\w+)_(\\w+):(.*),(\\w+)_(\\w+):(\\w+)_(.*),(\\w+)_(\\w+):(.*),(\\w+):(.*)
 

--- a/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
+++ b/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
@@ -15,3 +15,6 @@ regexHierarchyParser.regexList=(\\w+)_(\\w+):(\\w+)_(\\w+):(.*),(\\w+)_(\\w+):(\
 
 # Importing/exporting configuration/snapshot to/from CSV (Git SNP/BMS compatible)
 enableCSVIO=false
+
+# Read timeout (in ms) when taking snapshot
+readTimeout=5000

--- a/app/save-and-restore/model/src/main/java/org/phoebus/applications/saveandrestore/model/SnapshotItem.java
+++ b/app/save-and-restore/model/src/main/java/org/phoebus/applications/saveandrestore/model/SnapshotItem.java
@@ -84,10 +84,9 @@ public class SnapshotItem {
 	@Override
 	public String toString() {
 		return new StringBuffer()
-				.append("value=")
-				.append(value != null ? value.toString() : "READ FAILED")
 				.append(", config pv=").append(configPv.toString())
-				.append(readbackValue != null ? (", readback pv=" + readbackValue.toString()) : (", readback pv=READ_FAILED"))
+				.append("value=").append(value != null ? value.toString() : "null")
+				.append(readbackValue != null ? (", readback pv=" + readbackValue) : (", readback pv=null"))
 				.toString();
 	}
 


### PR DESCRIPTION
When user selects to take snapshot, a read request is used rather than relying on last monitor update.

Also changed UI representation: after snapshot has been taken, the snapshot value for disconnected values is shown as "---" (see screen shot) rather than DISCONNECTED. Reason for this UI change is that the value for DISCONNECTED PVs is persisted as null. When user selects a snapshot to do a restore operation, those PVs will then show "---" and will (of course) also be omitted when writing to PVs.

![Screenshot 2022-12-13 at 08 30 23](https://user-images.githubusercontent.com/35602960/207253346-34b15e2e-0d71-48f7-a385-b3de13222e1f.png)
