### PR TITLE
Alarm table background

### DIFF
--- a/app/alarm/Readme.md
+++ b/app/alarm/Readme.md
@@ -25,9 +25,9 @@ kafka in `/opt/kafka`.
     cd examples
 
     # Use wget, 'curl -O', or web browser to fetch a recent version of kafka
-    wget https://dlcdn.apache.org/kafka/3.2.0/kafka_2.13-3.2.0.tgz
-    tar -vzxf kafka_2.13-3.2.0.tgz
-    ln -s kafka_2.13-3.2.0 kafka
+    wget https://downloads.apache.org/kafka/3.3.1/kafka_2.13-3.3.1.tgz
+    tar vzxf kafka_2.13-3.3.1.tgz
+    ln -s kafka_2.13-3.3.1 kafka
 
 Check `config/zookeeper.properties` and `config/server.properties`.
 By default these contain settings for keeping data in `/tmp/`, which works for initial tests,

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
@@ -101,8 +101,10 @@ public class AlarmSystem
     /** Alarm table columns */
     @Preference public static String[] alarm_table_columns;
 
-    /** Use background color to indicate alarm severity? Default: Text color */
-    @Preference public static boolean alarm_table_color_background;
+    /** Use text(!) color for background to indicate alarm severity,
+     *  instead of the common alarm severity text and background colors?
+     */
+    @Preference public static boolean alarm_table_color_legacy_background;
 
     /** Alarm table row limit */
     @Preference public static int alarm_table_max_rows;

--- a/app/alarm/model/src/main/resources/alarm_preferences.properties
+++ b/app/alarm/model/src/main/resources/alarm_preferences.properties
@@ -63,8 +63,14 @@ alarm_tree_startup_ms=2000
 # Allows re-ordering as well as omitting columns
 alarm_table_columns=Icon, PV, Description, Alarm Severity, Alarm Status, Alarm Time, Alarm Value, PV Severity, PV Status
 
-# Use background color to indicate alarm severity? Default: Text color
-alarm_table_color_background=false
+# By default, the alarm table uses the common alarm severity colors
+# for both the text color and the background of cells in the "Severity" column.
+#
+# Older implementations always used the background to indicate alarm severity,
+# and this options emulates that by using the alarm severity text(!) color
+# for the background, automatically using black or white for the text
+# based on brightness.
+alarm_table_color_legacy_background=true
 
 # Alarm table row limit
 # If there are more rows, they're suppressed

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -85,6 +85,20 @@ public class AlarmUI
         new Background(new BackgroundFill(createColor(Preferences.undefined_severity_background_color),                                  CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED
     };
 
+    private static final Background[] legacy_table_severity_backgrounds = new Background[]
+    {
+        new Background(new BackgroundFill(createColor(Preferences.ok_severity_text_color), CornerRadii.EMPTY, Insets.EMPTY)), // OK
+        new Background(new BackgroundFill(createColor(Preferences.minor_severity_text_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MINOR_ACK
+        new Background(new BackgroundFill(createColor(Preferences.major_severity_text_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR_ACK
+        new Background(new BackgroundFill(createColor(Preferences.invalid_severity_text_color)  .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // INVALID_ACK
+        new Background(new BackgroundFill(createColor(Preferences.undefined_severity_text_color).deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED_ACK
+        new Background(new BackgroundFill(createColor(Preferences.minor_severity_text_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MINOR
+        new Background(new BackgroundFill(createColor(Preferences.major_severity_text_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR
+        new Background(new BackgroundFill(createColor(Preferences.invalid_severity_text_color),                                    CornerRadii.EMPTY, Insets.EMPTY)), // INVALID
+        new Background(new BackgroundFill(createColor(Preferences.undefined_severity_text_color),                                  CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED
+    };
+
+
     /** Icon for disabled alarms */
     public static final Image disabled_icon = ImageCache.getImage(AlarmUI.class, "/icons/disabled.png");
 
@@ -111,6 +125,14 @@ public class AlarmUI
     public static Background getBackground(final SeverityLevel severity)
     {
         return severity_backgrounds[severity.ordinal()];
+    }
+
+    /** @param severity {@link SeverityLevel}
+     *  @return Background, may be <code>null</code>
+     */
+    public static Background getLegacyTableBackground(final SeverityLevel severity)
+    {
+        return legacy_table_severity_backgrounds[severity.ordinal()];
     }
 
     /** Verify authorization, qualified by model's current config

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import org.phoebus.framework.selection.Selection;
 import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.ui.application.ContextMenuService;
 import org.phoebus.ui.application.SaveSnapshotAction;
+import org.phoebus.ui.javafx.Brightness;
 import org.phoebus.ui.javafx.ClearingTextField;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.javafx.PrintAction;
@@ -67,10 +68,12 @@ import javafx.scene.image.ImageView;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.TransferMode;
+import javafx.scene.layout.Background;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 
 /** Alarm Table UI
  *
@@ -199,21 +202,31 @@ public class AlarmTableUI extends BorderPane
             if (empty  ||  item == null)
             {
                 setText("");
-                if (AlarmSystem.alarm_table_color_background)
+                if (AlarmSystem.alarm_table_color_legacy_background)
                     setBackground(null);
                 else
-                    setTextFill(Color.BLACK);
+                    setBackground(null);
+                setTextFill(Color.BLACK);
             }
             else
             {
                 setText(item.toString());
-                if (AlarmSystem.alarm_table_color_background)
+                if (AlarmSystem.alarm_table_color_legacy_background)
+                {
+                    final Background bg = AlarmUI.getLegacyTableBackground(item);
+                    setBackground(bg);
+                    final Paint p = bg.getFills().get(0).getFill();
+                    if (p instanceof Color &&
+                        Brightness.of((Color) p) < Brightness.BRIGHT_THRESHOLD)
+                        setTextFill(Color.WHITE);
+                    else
+                        setTextFill(Color.BLACK);
+                }
+                else
                 {
                     setBackground(AlarmUI.getBackground(item));
                     setTextFill(AlarmUI.getColor(item));
                 }
-                else
-                    setTextFill(AlarmUI.getColor(item));
             }
         }
     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -202,10 +202,7 @@ public class AlarmTableUI extends BorderPane
             if (empty  ||  item == null)
             {
                 setText("");
-                if (AlarmSystem.alarm_table_color_legacy_background)
-                    setBackground(null);
-                else
-                    setBackground(null);
+                setBackground(null);
                 setTextFill(Color.BLACK);
             }
             else

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import org.csstudio.display.builder.model.widgets.BaseLEDWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.VType;
+import org.phoebus.ui.javafx.Brightness;
 
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
@@ -272,12 +273,12 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
                 // Compare brightness of LED with text.
                 final Color color = (Color) value_color;
                 Color text_color = JFXUtil.convert(model_widget.propForegroundColor().getValue());
-                final double text_brightness = getBrightness(text_color),
-                             brightness      = getBrightness(color);
-                if (Math.abs(text_brightness - brightness) < SIMILARITY_THRESHOLD)
+                final double text_brightness = Brightness.of(text_color),
+                             brightness      = Brightness.of(color);
+                if (Math.abs(text_brightness - brightness) < Brightness.SIMILARITY_THRESHOLD)
                 {   // Colors of text and LED are very close in brightness.
                     // Make text visible by forcing black resp. white
-                    if (brightness > BRIGHT_THRESHOLD)
+                    if (brightness > Brightness.BRIGHT_THRESHOLD)
                         label.setTextFill(Color.BLACK);
                     else
                         label.setTextFill(Color.WHITE);
@@ -287,23 +288,5 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
             }
         }
         jfx_node.layout();
-    }
-
-    // Brightness weightings from BOY
-    // https://github.com/ControlSystemStudio/cs-studio/blob/master/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
-    // Original RGB was 0..255 with dark/bright threshold 105000
-    // JFX color uses RGB 0..1, so threshold becomes 105000/255 ~ 410
-    /** Threshold for considering a color 'bright', suggesting black for text */
-    public static final double BRIGHT_THRESHOLD = 410;
-
-    /** Brightness differences below this are considered 'similar brightness' */
-    public static final double SIMILARITY_THRESHOLD = 350;
-
-    /** @param color Color
-     *  @return Weighed brightness
-     */
-    public static double getBrightness(final Color color)
-    {
-        return color.getRed() * 299 + color.getGreen() * 587 + color.getBlue() * 114;
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.ByteMonitorWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.epics.vtype.VType;
+import org.phoebus.ui.javafx.Brightness;
 
 import javafx.application.Platform;
 import javafx.geometry.Pos;
@@ -423,18 +424,18 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
             else
             {
                 final Color text_color = JFXUtil.convert(model_widget.propForegroundColor().getValue());
-                final double text_brightness = BaseLEDRepresentation.getBrightness(text_color);
+                final double text_brightness = Brightness.of(text_color);
                 for (int i = 0; i < N; i++)
                 {
                     leds[i].setFill(save_values[i]);
                     if (save_labels[i] != null)
                     {
                         // Compare brightness of LED with text.
-                        final double brightness = BaseLEDRepresentation.getBrightness(save_values[i]);
-                        if (Math.abs(text_brightness - brightness) < BaseLEDRepresentation.SIMILARITY_THRESHOLD)
+                        final double brightness = Brightness.of(save_values[i]);
+                        if (Math.abs(text_brightness - brightness) < Brightness.SIMILARITY_THRESHOLD)
                         {   // Colors of text and LED are very close in brightness.
                             // Make text visible by forcing black resp. white
-                            if (brightness > BaseLEDRepresentation.BRIGHT_THRESHOLD)
+                            if (brightness > Brightness.BRIGHT_THRESHOLD)
                                 save_labels[i].setTextFill(Color.BLACK);
                             else
                                 save_labels[i].setTextFill(Color.WHITE);

--- a/core/ui/src/main/java/org/phoebus/ui/javafx/Brightness.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/Brightness.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.ui.javafx;
+
+import javafx.scene.paint.Color;
+
+/** Helper for dealing with brightness of a color
+ *
+ *  <p>Can be used to set color of a text to black or white
+ *  based on the brightness of the background.
+ *
+ *  @author Kay Kasemir
+ */
+public class Brightness
+{
+    // Brightness weightings from BOY
+    // https://github.com/ControlSystemStudio/cs-studio/blob/master/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
+    // Original RGB was 0..255 with dark/bright threshold 105000
+    // JFX color uses RGB 0..1, so threshold becomes 105000/255 ~ 410
+
+    /** Threshold for considering a color 'bright', suggesting black for text */
+    public static final double BRIGHT_THRESHOLD = 410;
+
+    /** Brightness differences below this are considered 'similar brightness' */
+    public static final double SIMILARITY_THRESHOLD = 350;
+
+    /** @param color Color
+     *  @return Weighed brightness of that color
+     */
+    public static double of(final Color color)
+    {
+        return color.getRed() * 299 + color.getGreen() * 587 + color.getBlue() * 114;
+    }
+}


### PR DESCRIPTION
The recent update towards common alarm severity colors #2449 misunderstood thus broke the `alarm_table_color_background` option.
That option was now _required_ to use the common alarm background color in the alarm table:
```
 if (AlarmSystem.alarm_table_color_background)
 {
     setBackground(AlarmUI.getBackground(item));
     setTextFill(AlarmUI.getColor(item));
 }
 else
     setTextFill(AlarmUI.getColor(item));
```

Instead, the alarm table should by default simply use the common alarm severity colors for both text and background.

That option, now renamed as `alarm_table_color_legacy_background`, makes the alarm table deviate from the rest by using the common alarm severity text(!) color for the background of the "Severity" cells. The text color is then simply white or black based on the brightness of that background.
This happened to be the original behavior in the Eclipse-based implementation to which local control room operators have become accustomed. The updated option name, and it being off by default, might discourage new sites from using it.

