### PR TITLE
Reverting Elasticsearch mapping for PV names in save-and-restore

### DIFF
--- a/services/save-and-restore/src/main/resources/configuration_mapping.json
+++ b/services/save-and-restore/src/main/resources/configuration_mapping.json
@@ -8,10 +8,10 @@
         "type" : "nested",
         "properties": {
           "pvName": {
-            "type": "text"
+            "type": "keyword"
           },
           "readbackPvName": {
-            "type": "text"
+            "type": "keyword"
           },
           "readOnly": {
             "type": "boolean"

--- a/services/save-and-restore/src/main/resources/snapshot_mapping.json
+++ b/services/save-and-restore/src/main/resources/snapshot_mapping.json
@@ -10,7 +10,7 @@
           "configPv": {
             "properties": {
               "pvName" : {
-                "type": "text"
+                "type": "keyword"
               },
               "readOnly": {
                 "type" : "boolean"


### PR DESCRIPTION
PV names better not be tokenized by Elasticsearch.