### PR TITLE
Ignore drop when content of wrong type

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java
@@ -113,7 +113,7 @@ public class DockItem extends Tab
      *
      *  Custom format to prevent dropping a tab into e.g. a text editor
      */
-    private static final DataFormat DOCK_ITEM = new DataFormat("dock_item.custom");
+    protected static final DataFormat DOCK_ITEM = new DataFormat("dock_item.custom");
 
     /** Name of the tab */
     protected String name;
@@ -404,7 +404,7 @@ public class DockItem extends Tab
     /** Accept a dropped tab */
     private void handleDrop(final DragEvent event)
     {
-        if (getDockPane().isFixed())
+        if (getDockPane().isFixed() || !event.getDragboard().hasContent(DOCK_ITEM))
             return;
 
         final DockItem item = dragged_item.getAndSet(null);

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -523,6 +523,9 @@ public class DockPane extends TabPane
     /** Accept a dropped tab */
     private void handleDrop(final DragEvent event)
     {
+        if (!event.getDragboard().hasContent(DockItem.DOCK_ITEM)){
+            return;
+        }
         final DockItem item = DockItem.dragged_item.getAndSet(null);
         if (item == null)
             logger.log(Level.SEVERE, "Empty drop, " + event);


### PR DESCRIPTION
In upcoming updates to save-and-restore, user will be able to drag-n-drop objects inside the UI (from a TreeView to a TableView). The drop action will be intercepted by ``DockItem.handleDrop()``, which will log a SEVERE message stating that nothing was dropped.

This PR is to address this such that ``DockItem.handleDrop()`` checks if the dropped content is of the ``DataFormat`` associated with drag-n-drop of tabs/DockItems.