### PR TITLE
Support automatic updates from gitlab package registry

### DIFF
--- a/app/update/pom.xml
+++ b/app/update/pom.xml
@@ -34,5 +34,16 @@
       <artifactId>core-ui</artifactId>
       <version>4.7.2-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>javax.jms</groupId>
+      <artifactId>javax.jms-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <version>1.1.4</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/app/update/src/main/java/org/phoebus/applications/update/DummyUpdate.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/DummyUpdate.java
@@ -1,0 +1,31 @@
+package org.phoebus.applications.update;
+
+import java.io.File;
+import java.time.Instant;
+
+import org.phoebus.framework.jobs.JobMonitor;
+
+/**
+ * Dummy class returned from the factory instead of null.
+ */
+public class DummyUpdate implements UpdateProvider
+{
+    @Override
+    public boolean isEnabled()
+    {
+        return false;
+    }
+
+    @Override
+    public Instant checkForUpdate(JobMonitor monitor) throws Exception
+    {
+        return null;
+    }
+
+    @Override
+    public void downloadAndUpdate(JobMonitor monitor, File install_location)
+            throws Exception
+    {
+    }
+
+}

--- a/app/update/src/main/java/org/phoebus/applications/update/GitlabUpdate.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/GitlabUpdate.java
@@ -1,0 +1,236 @@
+package org.phoebus.applications.update;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.logging.Logger;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import org.phoebus.framework.jobs.JobMonitor;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
+
+/**
+ * Pull updates from the gitlab package registry.
+ * 
+ * <p>
+ * The timestamp of the available update is determined from the timestamp of the
+ * commit that triggered the pipeline. The version information in the package
+ * repository is only used for display purposes.
+ *
+ * <p>
+ * To initialize the package version, use
+ * <code>echo org.phoebus.applications.update/current_version=$CI_COMMIT_TIMESTAMP >> phoebus-product/settings.ini</code>
+ * in the build pipeline, then package <code>settings.ini</code>.
+ * 
+ * @author Michael Ritzert
+ *
+ */
+public class GitlabUpdate extends Update implements UpdateProvider
+{
+    public static final Logger logger = Logger
+            .getLogger(GitlabUpdate.class.getPackageName());
+
+    /**
+     * The path to the "V4 API".
+     * 
+     * Typically https://HOST/api/v4
+     */
+    @Preference
+    public static String gitlab_api_url;
+    /** The numeric ID of the gitlab project. */
+    @Preference
+    public static int gitlab_project_id;
+    /**
+     * The package name used in the registry.
+     * 
+     * Defaults to "phoebus-$(arch)".
+     */
+    @Preference
+    public static String gitlab_package_name;
+    /**
+     * Access token for the project's API and registry. Required if access to
+     * the gitlab project is not public.
+     */
+    @Preference
+    public static String gitlab_token;
+
+    // filled step by step with the information of the latest update
+    private String latest_version;
+    private int latest_id;
+    private long file_size;
+    private String file_name;
+    private String latest_commit;
+
+    static
+    {
+        AnnotatedPreferences.initialize(GitlabUpdate.class,
+                "/update_preferences.properties");
+
+        gitlab_package_name = replace_arch(gitlab_package_name);
+    }
+
+    @Override
+    public boolean isEnabled()
+    {
+        return !gitlab_api_url.isEmpty() && (gitlab_project_id != 0)
+                && !gitlab_package_name.isEmpty();
+    }
+
+    @Override
+    protected Long getDownloadSize()
+    {
+        return file_size;
+    }
+
+    @Override
+    protected InputStream getDownloadStream() throws Exception
+    {
+        final var endpoint = String.format(
+                "projects/%d/packages/generic/%s/%s/%s", gitlab_project_id,
+                gitlab_package_name, latest_version, file_name);
+        return makeApiCall(endpoint);
+    }
+
+    /**
+     * Identify the latest commit for the package we want.
+     * 
+     * Fills in latest_commit, file_size, and file_name.
+     * 
+     * @throws Exception
+     */
+    private void getLatestCommit() throws Exception
+    {
+        monitor.updateTaskName("Finding latest commit.");
+        final var endpoint = String.format(
+                "projects/%d/packages/%d/package_files", gitlab_project_id,
+                latest_id);
+        try (final var body = makeApiCall(endpoint);
+                final var reader = Json
+                        .createReader(new InputStreamReader(body)))
+        {
+            final var files = reader.readArray();
+            // within the package, get the commit id for the last pipeline run.
+            final var latest_file = files.stream().map(v -> (JsonObject) v)
+                    .sorted((a, b) -> {
+                        return -a.getString("created_at")
+                                .compareTo(b.getString("created_at"));
+                    }).findFirst();
+            if (!latest_file.isPresent())
+            {
+                throw new RuntimeException("No commit found."); //$NON-NLS-1$
+            }
+            latest_commit = latest_file.get().getJsonArray("pipelines")
+                    .getJsonObject(0).getString("sha");
+            logger.fine("Latest commit ID: " + latest_commit);
+            file_size = latest_file.get().getInt("size");
+            file_name = latest_file.get().getString("file_name");
+            logger.finer(file_name + " / " + file_size);
+        }
+    }
+
+    /**
+     * Find the latest package with the configured name.
+     * 
+     * Fills in latest_version and latest_id.
+     * 
+     * @throws Exception
+     */
+    private void getLatestPackage() throws Exception
+    {
+        monitor.updateTaskName("Finding latest package.");
+        final var endpoint = String.format(
+                "projects/%d/packages?package_name=%s&order_by=version",
+                gitlab_project_id, gitlab_package_name);
+        try (final var body = makeApiCall(endpoint);
+                final var reader = Json
+                        .createReader(new InputStreamReader(body)))
+        {
+            final var packages = reader.readArray();
+            // we assume the first package in the list is the latest
+            final var latest_package = packages.getJsonObject(0);
+            latest_version = latest_package.getString("version");
+            logger.info("Latest version: " + latest_version);
+            latest_id = latest_package.getInt("id");
+        }
+    }
+
+    /**
+     * Get the timestamp of the given commit.
+     * 
+     * @param commit_id
+     *            The full SHA hash of the commit.
+     * @return The timestamp of the commit.
+     * @throws Exception
+     */
+    private Instant getTimestampOfCommit(final String commit_id)
+            throws Exception
+    {
+        monitor.updateTaskName("Getting commit details.");
+        final var endpoint = String.format("projects/%d/repository/commits/%s",
+                gitlab_project_id, commit_id);
+        try (final var body = makeApiCall(endpoint);
+                final var reader = Json
+                        .createReader(new InputStreamReader(body)))
+        {
+            final var info = reader.readObject();
+            final var timestamp = Instant.parse(info.getString("created_at"));
+            logger.fine("Latest release time: " + timestamp);
+            return timestamp;
+        }
+    }
+
+    @Override
+    protected Instant getVersion() throws Exception
+    {
+        getLatestPackage();
+        getLatestCommit();
+        update_version = getTimestampOfCommit(latest_commit);
+        return update_version;
+    }
+
+    /**
+     * Execute a GET call to the gitlab API.
+     * 
+     * @param endpoint
+     *            The URL to access. The part up to /v4/ is automatically
+     *            prepended.
+     * @return An InputStream to receive the result.
+     * @throws Exception
+     */
+    private InputStream makeApiCall(final String endpoint) throws Exception
+    {
+        final var uri = URI
+                .create(String.format("%s/%s", gitlab_api_url, endpoint));
+        final var c = HttpClient.newHttpClient();
+        // perform the HTTP request
+        var builder = HttpRequest.newBuilder().uri(uri).GET();
+        if (!gitlab_token.isEmpty())
+        {
+            builder = builder.header("PRIVATE-TOKEN", gitlab_token);
+        }
+        final var request = builder.build();
+        final var response = c.send(request, BodyHandlers.ofInputStream());
+        if (200 != response.statusCode())
+        {
+            try (final var body = response.body())
+            {
+                // on error, log the response body
+                new BufferedReader(
+                        new InputStreamReader(body, StandardCharsets.UTF_8))
+                                .lines().forEach(logger::warning);
+            }
+            throw new RuntimeException("API call failed."); //$NON-NLS-1$
+        }
+        return response.body();
+    }
+}

--- a/app/update/src/main/java/org/phoebus/applications/update/URLUpdate.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/URLUpdate.java
@@ -1,0 +1,94 @@
+package org.phoebus.applications.update;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Instant;
+
+import org.phoebus.framework.jobs.JobMonitor;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
+import org.phoebus.framework.util.ResourceParser;
+
+public class URLUpdate extends Update implements UpdateProvider
+{
+    @Override
+    public boolean isEnabled()
+    {
+        return !update_url.isEmpty();
+    }
+
+    /** Update URL, or empty if not set */
+    @Preference public static String update_url;
+
+    final URL distribution_url;
+
+    static {
+        AnnotatedPreferences.initialize(URLUpdate.class, "/update_preferences.properties");
+
+        update_url = replace_arch(update_url);
+    }
+
+    public URLUpdate()
+    {
+        URL tmp = null;
+        try
+        {
+            tmp = new URL(update_url);
+        }
+        catch (MalformedURLException e)
+        {
+           // handled later when distribution_url is null
+        }
+        distribution_url = tmp;
+    }
+
+    @Override
+    public Instant checkForUpdate(final JobMonitor monitor) throws Exception
+    {
+        // complain, if it update_url defined, but could not be parsed.
+        if (null == distribution_url)
+            throw new RuntimeException("Invalid distribution_url.");
+        return super.checkForUpdate(monitor);
+    }
+
+    @Override
+    public void downloadAndUpdate(final JobMonitor monitor, final File install_location) throws Exception
+    {
+        this.monitor = monitor;
+        // shortcut for file: URLs: No need to download first
+        if (update_url.startsWith("file:")) {
+            monitor.beginTask("Update", 100);
+            update(install_location, new File(update_url.substring(5)));
+            adjustCurrentVersion();
+        }
+        else
+        {
+            super.downloadAndUpdate(monitor, install_location);
+        }
+    }
+
+    @Override
+    protected Instant getVersion() throws Exception
+    {
+        logger.info("Checking " + update_url);
+        monitor.updateTaskName("Querying latest version.");
+        if (distribution_url.getProtocol().equals("https"))
+            ResourceParser.trustAnybody();
+        return Instant.ofEpochMilli(
+                distribution_url.openConnection().getLastModified());
+    }
+
+    @Override
+    protected Long getDownloadSize() throws Exception
+    {
+        return distribution_url.openConnection().getContentLengthLong();
+    }
+
+    @Override
+    protected InputStream getDownloadStream() throws Exception
+    {
+        return distribution_url.openStream();
+    }
+}

--- a/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
@@ -43,7 +43,7 @@ public class UpdateApplication implements AppDescriptor
     private static final String NAME = "Update";
     private Button start_update = null;
 
-    private Update updater = new Update();
+    private UpdateProvider updater;
 
     @Override
     public String getName()
@@ -60,6 +60,7 @@ public class UpdateApplication implements AppDescriptor
             TimeUnit.SECONDS.sleep(Update.delay);
             if (monitor.isCanceled())
                 return;
+            updater = Update.updaterFactory();
             final Instant new_version = updater.checkForUpdate(monitor);
             if (new_version != null)
                 installUpdateButton(new_version);
@@ -91,9 +92,7 @@ public class UpdateApplication implements AppDescriptor
            .append("\n\n")
            .append("The update will replace the installation in\n")
            .append(install_location)
-           .append("\n(").append(stage_area).append(")")
-           .append("\nwith the content of ")
-           .append(Update.update_url)
+           .append("\n(").append(stage_area).append(").")
            .append("\n\n")
            .append("Do you want to update?\n");
 

--- a/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/UpdateApplication.java
@@ -43,6 +43,8 @@ public class UpdateApplication implements AppDescriptor
     private static final String NAME = "Update";
     private Button start_update = null;
 
+    private Update updater = new Update();
+
     @Override
     public String getName()
     {
@@ -58,7 +60,7 @@ public class UpdateApplication implements AppDescriptor
             TimeUnit.SECONDS.sleep(Update.delay);
             if (monitor.isCanceled())
                 return;
-            final Instant new_version = Update.checkForUpdate(monitor);
+            final Instant new_version = updater.checkForUpdate(monitor);
             if (new_version != null)
                 installUpdateButton(new_version);
         });
@@ -120,8 +122,7 @@ public class UpdateApplication implements AppDescriptor
             // Perform update
             JobManager.schedule(NAME, monitor ->
             {
-                Update.downloadAndUpdate(monitor, stage_area);
-                Update.adjustCurrentVersion();
+                updater.downloadAndUpdate(monitor, stage_area);
                 if (! monitor.isCanceled())
                     Platform.runLater(() -> restart(parent));
             });

--- a/app/update/src/main/java/org/phoebus/applications/update/UpdateProvider.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/UpdateProvider.java
@@ -1,0 +1,31 @@
+package org.phoebus.applications.update;
+
+import java.io.File;
+import java.time.Instant;
+
+import org.phoebus.framework.jobs.JobMonitor;
+import org.phoebus.framework.workbench.Locations;
+
+public interface UpdateProvider
+{
+    /** Return true, if the required configuration is detected. */
+    boolean isEnabled();
+
+    /** Check for update
+    *
+    *  @param monitor {@link JobMonitor}
+    *  @return Time stamp of the new version, or <code>null</code> if there is no valid update
+    *  @throws Exception on error
+    */
+   Instant checkForUpdate(final JobMonitor monitor) throws Exception;
+
+   /** Perform update
+   *
+   *  <p>Get & unpack the update file into the current installation.
+   *
+   *  @param monitor {@link JobMonitor}
+   *  @param install_location Existing {@link Locations#install()}
+   *  @throws Exception on error
+   */
+   void downloadAndUpdate(final JobMonitor monitor, final File install_location) throws Exception;
+}

--- a/app/update/src/main/resources/META-INF/services/org.phoebus.applications.update.UpdateProvider
+++ b/app/update/src/main/resources/META-INF/services/org.phoebus.applications.update.UpdateProvider
@@ -1,0 +1,2 @@
+org.phoebus.applications.update.GitlabUpdate
+org.phoebus.applications.update.URLUpdate

--- a/app/update/src/main/resources/update_preferences.properties
+++ b/app/update/src/main/resources/update_preferences.properties
@@ -33,11 +33,13 @@ current_version=
 # Location may include system properties
 # and $(arch) will be replaced by "linux", "mac" or "win"
 # to allow locations specific to each architecture.
-#
-# Empty: Do not perform any update check
 update_url=
 # update_url=https://controlssoftware.sns.ornl.gov/css_phoebus/nightly/product-sns-$(arch).zip
 
+#gitlab_api_url=https://HOST/api/v4
+#gitlab_project_id=
+gitlab_package_name=phoebus-$(arch)
+#gitlab_token=
 
 # List of regular expressions, comma-separated, which will be
 # removed from the ZIP file entry.

--- a/app/update/src/test/java/org/phoebus/applications/update/UpdateDemo.java
+++ b/app/update/src/test/java/org/phoebus/applications/update/UpdateDemo.java
@@ -49,8 +49,9 @@ public class UpdateDemo
             }
         };
 
-        final Instant new_version = Update.checkForUpdate(monitor);
+        final var updater = new Update();
+        final Instant new_version = updater.checkForUpdate(monitor);
         if (new_version != null)
-            Update.downloadAndUpdate(monitor, install_location);
+            updater.downloadAndUpdate(monitor, install_location);
     }
 }

--- a/app/update/src/test/java/org/phoebus/applications/update/UpdateDemo.java
+++ b/app/update/src/test/java/org/phoebus/applications/update/UpdateDemo.java
@@ -49,7 +49,7 @@ public class UpdateDemo
             }
         };
 
-        final var updater = new Update();
+        final var updater = new URLUpdate();
         final Instant new_version = updater.checkForUpdate(monitor);
         if (new_version != null)
             updater.downloadAndUpdate(monitor, install_location);


### PR DESCRIPTION
With this code, automatic updates can be retrieved from gitlab CI builds.

The update mechanism are implemented as different plugins detected via the ServiceLoader. All detected plugins are checked to find one that has all configuration in the ini file. This plugin will be used.

The current code that updates from plain URLs has been refactored but is functionally unchanged.
