### PR TITLE
Add service URL to Olog log entry editor

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
@@ -142,6 +142,8 @@ public class LogEntryEditorController {
     private TextField logbooksSelection;
     @FXML
     private TextField tagsSelection;
+    @FXML
+    private Label serviceURL;
 
     private final ContextMenu logbookDropDown = new ContextMenu();
     private final ContextMenu tagDropDown = new ContextMenu();
@@ -212,6 +214,8 @@ public class LogEntryEditorController {
 
     @FXML
     public void initialize() {
+
+        serviceURL.textProperty().set(logFactory.getLogClient().getServiceUrl());
 
         // This could be configured in the fxml, but then these UI components would not be visible
         // in Scene Builder.

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/messages.properties
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/messages.properties
@@ -75,6 +75,7 @@ SelectFolder=Select Folder
 SelectFile=Select Image File
 SelectLevelTooltip=Select the log entry level.
 SelectLogEntry=Select Log Entry
+serviceURL=Service URL:
 ServiceConnectionError=Unable to connect to the logbook service
 ShowHelp=Show Help
 ShowHideDetails=Show/Hide Details

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/write/LogEntryEditor.fxml
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/write/LogEntryEditor.fxml
@@ -33,6 +33,12 @@
 
 
             <VBox fx:id="fields" alignment="CENTER" spacing="10.0" VBox.vgrow="ALWAYS">
+                <HBox alignment="CENTER_LEFT" spacing="5.0">
+                    <children>
+                        <Label prefWidth="80" text="%serviceURL" />
+                        <Label fx:id="serviceURL"  text="http://localhost:8080" HBox.hgrow="ALWAYS" />
+                    </children>
+                </HBox>
 
                 <HBox alignment="CENTER" spacing="5.0">
                     <children>
@@ -147,6 +153,7 @@
                         </Button>
                     </children>
                 </HBox>
+
                 <VBox.margin>
                     <Insets bottom="10.0" />
                 </VBox.margin>
@@ -219,8 +226,7 @@
                      <GridPane.margin>
                         <Insets bottom="5.0" />
                      </GridPane.margin></Label>
-                        <Button fx:id="errorCloseButton" mnemonicParsing="false"
-                                onAction="#cancel" text="%Close" GridPane.halignment="CENTER" GridPane.rowIndex="1" GridPane.valignment="TOP">
+                        <Button fx:id="errorCloseButton" mnemonicParsing="false" onAction="#cancel" text="%Close" GridPane.halignment="CENTER" GridPane.rowIndex="1" GridPane.valignment="TOP">
                      <GridPane.margin>
                         <Insets top="5.0" />
                      </GridPane.margin></Button>


### PR DESCRIPTION
As per user request: show the service URL to the Olog service in the log entry editor. This is useful in case multiple instances of the service are maintained.