### PR TITLE
Load settings from URL

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/preferences/PropertyPreferenceLoader.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/PropertyPreferenceLoader.java
@@ -7,7 +7,14 @@
  *******************************************************************************/
 package org.phoebus.framework.preferences;
 
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Properties;
 import java.util.prefs.Preferences;
 
@@ -44,5 +51,35 @@ public class PropertyPreferenceLoader
             prefs.put(name, value);
             // System.out.println(pack + "/" + name + "=" + value);
         }
+    }
+
+    /**
+     * Loads settings from file or remote URL.
+     * @param location Location speciifying a file name or a remote http(s) URL.
+     * @throws Exception If settings cannot be loaded, e.g. file not found or invalid URL.
+     */
+    public static void load(String location) throws Exception{
+        if(location.substring(0, 4).equalsIgnoreCase("http")){
+            loadFromRemoteURL(location);
+        }
+        else{
+            load(new FileInputStream(location));
+        }
+    }
+
+    /**
+     * Load settings from remote URL.
+     * @param uri A remote URL.
+     * @throws Exception If settings cannot be loaded, e.g. invalid URL.
+     */
+    private static void loadFromRemoteURL(final String uri) throws Exception{
+
+        HttpClient httpClient = HttpClient.newHttpClient();
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .build();
+        HttpResponse<String> response =
+                httpClient.send(httpRequest, BodyHandlers.ofString());
+        load(new ByteArrayInputStream(response.body().getBytes()));
     }
 }

--- a/core/launcher/src/main/java/org/phoebus/product/Launcher.java
+++ b/core/launcher/src/main/java/org/phoebus/product/Launcher.java
@@ -99,14 +99,15 @@ public class Launcher
                     if (! iter.hasNext())
                         throw new Exception("Missing -settings file name");
                     iter.remove();
-                    final String filename = iter.next();
+                    final String location = iter.next();
                     iter.remove();
 
-                    logger.info("Loading settings from " + filename);
-                    if (filename.endsWith(".xml"))
-                        Preferences.importPreferences(new FileInputStream(filename));
+                    logger.info("Loading settings from " + location);
+                    if (location.endsWith(".xml"))
+                        Preferences.importPreferences(new FileInputStream(location));
                     else
-                        PropertyPreferenceLoader.load(new FileInputStream(filename));
+                        PropertyPreferenceLoader.load(location);
+                  
                 }
                 else if (cmd.equals("-export_settings"))
                 {

--- a/docs/source/preferences.rst
+++ b/docs/source/preferences.rst
@@ -51,6 +51,13 @@ Start Phoebus like this to import the settings from your file::
 
   phoebus.sh -settings /path/to/settings.ini
 
+Start Phoebus like this to import the settings from a remote URL::
+
+  phoebus.sh -settings http://mysite.com/settings.ini
+
+Loading from URL assumes remote service does not respond with a redirect. Moreover, if using https, the remote URL
+must be backed by a trusted certificate.
+
 At runtime, you can view the currently effective preference settings
 from the menu ``Help``, ``About``. The ``Details`` pane includes a tab
 that lists all preference settings in the same format that is used by the


### PR DESCRIPTION
As per user request: if settings file starts with http(s), load from remote location. The http client side of this implementation is very basic and will only be able to handle an OK response with settings contained in the body. 

Limitations:

- Redirects, basic authentication, and other non-200 responses will not work.
- https must be backed by trusted certificate