### PR TITLE
Add helper class for epics:nt/NTScalar:1.0

### DIFF
--- a/core/pva/README.md
+++ b/core/pva/README.md
@@ -46,6 +46,9 @@ Both Ant and Maven are supported:
     ant clean core-pva
     mvn clean install javadoc:javadoc
 
+To check JDK8 compatibility:
+
+    mvn clean install -P jdk8
 
 Configuration
 -------------

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStringArray.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStringArray.java
@@ -109,7 +109,7 @@ public class PVAStringArray extends PVAData implements PVAArray
     @Override
     protected int update(final int index, final PVAData new_value, final BitSet changes) throws Exception
     {
-        if (new_value instanceof PVALongArray)
+        if (new_value instanceof PVAStringArray)
         {
             final PVAStringArray other = (PVAStringArray) new_value;
             if (! Arrays.equals(other.value, value))

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStructures.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStructures.java
@@ -9,75 +9,59 @@ package org.epics.pva.data;
 
 import java.time.Instant;
 
+import org.epics.pva.data.nt.PVAAlarm;
+import org.epics.pva.data.nt.PVAEnum;
+import org.epics.pva.data.nt.PVATimeStamp;
+
 /** Helper to decode certain structures
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
 public class PVAStructures
 {
-    /** Type name for time stamp */
-    public static final String TIME_T = "time_t";
 
     /** @param structure Potential "time_t" structure
      *  @return Instant or <code>null</code>
      */
     public static Instant getTime(final PVAStructure structure)
     {
-        if (structure.getStructureName().equals(TIME_T))
+        var timeStamp = PVATimeStamp.fromStructure(structure);
+        if (timeStamp != null) 
         {
-            final PVALong secs = structure.get("secondsPastEpoch");
-            final PVAInt nano = structure.get("nanoseconds");
-            if (secs != null  && nano != null)
-                return Instant.ofEpochSecond(secs.get(), nano.get());
+            return timeStamp.instant();
         }
         return null;
     }
 
-
-    /** Type name for enum */
-    public static final String ENUM_T = "enum_t";
 
     /** @param structure Potential "enum_t" structure
      *  @return Selected option or <code>null</code>
      */
     public static String getEnum(final PVAStructure structure)
     {
-        if (structure.getStructureName().equals(ENUM_T))
+        var pvaEnum = PVAEnum.fromStructure(structure);
+        if (pvaEnum != null)
         {
-            final PVAInt index = structure.get("index");
-            final PVAStringArray choices = structure.get("choices");
-            if (index != null  && choices != null)
-            {
-                final int i = index.get();
-                final String[] labels = choices.get();
-                return i>=0 && i<labels.length ? labels[i] : "Invalid enum <" + i + ">";
-            }
+            return pvaEnum.enumString();
         }
         return null;
     }
 
-    /** Type name for alarm info */
-    public static final String ALARM_T = "alarm_t";
 
     /** @param structure Potential "alarm_t" structure
      *  @return Alarm info or <code>null</code>
      */
     public static String getAlarm(final PVAStructure structure)
     {
-        if (structure.getStructureName().equals(ALARM_T))
+        var alarm = PVAAlarm.fromStructure(structure);
+
+        if (alarm != null)
         {
-            final PVAInt index = structure.get("severity");
-            if (index != null)
-            {
-                switch (index.get())
-                {
-                case 0: return "NO_ALARM";
-                case 1: return "MINOR";
-                case 2: return "MAJOR";
-                case 3: return "INVALID";
-                case 4: return "UNDEFINED";
-                default: return "Invalid severity <" + index.get() + ">";
-                }
+            var severity = alarm.alarmSeverity();
+            if (severity != null) {
+                return severity.toString();
+            } else {
+                return "Invalid severity <" + alarm.get("severity") + ">";
             }
         }
         return null;

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStructures.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStructures.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import org.epics.pva.data.nt.PVAAlarm;
 import org.epics.pva.data.nt.PVAEnum;
 import org.epics.pva.data.nt.PVATimeStamp;
+import org.epics.pva.data.nt.PVAAlarm.AlarmSeverity;
 
 /** Helper to decode certain structures
  *  @author Kay Kasemir
@@ -25,7 +26,7 @@ public class PVAStructures
      */
     public static Instant getTime(final PVAStructure structure)
     {
-        var timeStamp = PVATimeStamp.fromStructure(structure);
+        PVATimeStamp timeStamp = PVATimeStamp.fromStructure(structure);
         if (timeStamp != null) 
         {
             return timeStamp.instant();
@@ -39,7 +40,7 @@ public class PVAStructures
      */
     public static String getEnum(final PVAStructure structure)
     {
-        var pvaEnum = PVAEnum.fromStructure(structure);
+        PVAEnum pvaEnum = PVAEnum.fromStructure(structure);
         if (pvaEnum != null)
         {
             return pvaEnum.enumString();
@@ -53,11 +54,11 @@ public class PVAStructures
      */
     public static String getAlarm(final PVAStructure structure)
     {
-        var alarm = PVAAlarm.fromStructure(structure);
+        PVAAlarm alarm = PVAAlarm.fromStructure(structure);
 
         if (alarm != null)
         {
-            var severity = alarm.alarmSeverity();
+            AlarmSeverity severity = alarm.alarmSeverity();
             if (severity != null) {
                 return severity.toString();
             } else {

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
@@ -24,6 +24,7 @@ import org.epics.pva.data.PVAStructure;
  * 
  */
 public class PVAAlarm extends PVAStructure {
+    public static final String ALARM_NAME_STRING = "alarm";
     private PVAString message;
     private PVAInt status;
     private PVAInt severity;
@@ -39,19 +40,18 @@ public class PVAAlarm extends PVAStructure {
      * @param message String message
      */
     public PVAAlarm(String message) {
-        this("alarm", 0, 0, message);
+        this(0, 0, message);
     }
 
     /**
      * Set all parameters in constructor
      * 
-     * @param name
      * @param severity
      * @param status
      * @param message
      */
-    public PVAAlarm(String name, int severity, int status, String message) {
-        super(name, "alarm_t",
+    public PVAAlarm(int severity, int status, String message) {
+        super(ALARM_NAME_STRING, "alarm_t",
                 new PVAInt("severity", severity),
                 new PVAInt("status", status),
                 new PVAString("message", message));
@@ -62,6 +62,7 @@ public class PVAAlarm extends PVAStructure {
 
     /**
      * Set the value of the alarm
+     * 
      * @param severity
      * @param status
      * @param message

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.epics.pva.data.nt;
+
+import org.epics.pva.data.PVAInt;
+import org.epics.pva.data.PVAString;
+import org.epics.pva.data.PVAStructure;
+
+/**
+ * Normative alarm type
+ * 
+ * An alarm_t describes a diagnostic of the value of a control system process
+ * variable.
+ * 
+ * structure
+ *   int severity
+ *   int status
+ *   string message
+ * 
+ */
+public class PVAAlarm extends PVAStructure {
+    private PVAString message;
+    private PVAInt status;
+    private PVAInt severity;
+
+    /** No alarm */
+    public PVAAlarm() {
+        this("");
+    }
+
+    /**
+     * Setting only the message, status and severity are set to 0.
+     * 
+     * @param message String message
+     */
+    public PVAAlarm(String message) {
+        this("alarm", 0, 0, message);
+    }
+
+    /**
+     * Set all parameters in constructor
+     * 
+     * @param name
+     * @param severity
+     * @param status
+     * @param message
+     */
+    public PVAAlarm(String name, int severity, int status, String message) {
+        super(name, "alarm_t",
+                new PVAInt("severity", severity),
+                new PVAInt("status", status),
+                new PVAString("message", message));
+        this.severity = get(1);
+        this.status = get(2);
+        this.message = get(3);
+    }
+
+    /**
+     * Set the value of the alarm
+     * @param severity
+     * @param status
+     * @param message
+     */
+    public void set(int severity, int status, String message) {
+        this.severity.set(severity);
+        this.status.set(status);
+        this.message.set(message);
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
@@ -34,22 +34,81 @@ import org.epics.pva.data.PVAStructure;
  * <li>int severity
  * <li>int status
  * <li>string message
+ * </ul>
+ * </ul>
  * 
  */
 public class PVAAlarm extends PVAStructure {
-    public static final String ALARM_NAME_STRING = "alarm";
+    private static final String ALARM_NAME_STRING = "alarm";
     /** Type name for alarm info */
-    public static final String ALARM_T = "alarm_t";
+    private static final String ALARM_T = "alarm_t";
     private PVAString message;
     private PVAInt status;
     private PVAInt severity;
 
+    /**
+     * Represents how severe an Alarm
+     */
     public enum AlarmSeverity {
+        /**
+         * No alarm
+         */
         NO_ALARM,
+        /**
+         * Minor alarm
+         */
         MINOR,
+        /**
+         * Major alarm
+         */
         MAJOR,
+        /**
+         * Invalid alarm
+         */
         INVALID,
+        /**
+         * Undefined alarm
+         */
         UNDEFINED,
+    }
+
+    /**
+     * Represents type of alarm.
+     */
+    // Defining the possible values for the status field of the alarm.
+    public enum AlarmStatus {
+        /**
+         * No Status
+         */
+        NO_STATUS,
+        /**
+         * Device Status
+         */
+        DEVICE,
+        /**
+         * Driver Status
+         */
+        DRIVER,
+        /**
+         * Record Status
+         */
+        RECORD,
+        /**
+         * Database Status
+         */
+        DB,
+        /**
+         * Configuration Status
+         */
+        CONF,
+        /**
+         * Undefined Status
+         */
+        UNDEFINED,
+        /**
+         * Client Status
+         */
+        CLIENT
     }
 
     /** Default no alarm */
@@ -63,28 +122,32 @@ public class PVAAlarm extends PVAStructure {
      * @param message String message
      */
     public PVAAlarm(String message) {
-        this(0, 0, message);
+        this(AlarmSeverity.NO_ALARM, AlarmStatus.NO_STATUS, message);
     }
 
     /**
      * Set all parameters in constructor
      * 
-     * @param severity
-     * @param status
-     * @param message
+     * @param severity severity of alarm
+     * @param status   what status is in alarm
+     * @param message  a message string
      */
-    public PVAAlarm(int severity, int status, String message) {
-        this(new PVAInt("severity", severity),
-                new PVAInt("status", status),
+    public PVAAlarm(AlarmSeverity severity, AlarmStatus status, String message) {
+        this(new PVAInt("severity", severity.ordinal()),
+                new PVAInt("status", status.ordinal()),
                 new PVAString("message", message));
     }
 
     /**
      * Set all parameters in constructor
      * 
-     * @param severity
-     * @param status
-     * @param message
+     * @param severity defined as an int (not an enum_t), but MUST be
+     *                 functionally interpreted as the enumeration
+     *                 {@link AlarmSeverity}
+     * @param status   defined as an int (not an enum_t), but MUST be
+     *                 functionally interpreted as the enumeration
+     *                 {@link AlarmStatus}
+     * @param message  a message string
      */
     public PVAAlarm(PVAInt severity, PVAInt status, PVAString message) {
         super(ALARM_NAME_STRING, ALARM_T,
@@ -99,20 +162,20 @@ public class PVAAlarm extends PVAStructure {
     /**
      * Set the value of the alarm
      * 
-     * @param severity
-     * @param status
-     * @param message
+     * @param severity severity of alarm
+     * @param status   what status is in alarm
+     * @param message  a message string
      */
-    public void set(int severity, int status, String message) {
-        this.severity.set(severity);
-        this.status.set(status);
+    public void set(AlarmSeverity severity, AlarmStatus status, String message) {
+        this.severity.set(severity.ordinal());
+        this.status.set(status.ordinal());
         this.message.set(message);
     }
 
     /**
      * Returns the enum representing the severity
      * 
-     * @return
+     * @return alarm severity
      */
     public AlarmSeverity alarmSeverity() {
         AlarmSeverity[] values = AlarmSeverity.values();

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
@@ -25,9 +25,19 @@ import org.epics.pva.data.PVAStructure;
  */
 public class PVAAlarm extends PVAStructure {
     public static final String ALARM_NAME_STRING = "alarm";
+    /** Type name for alarm info */
+    public static final String ALARM_T = "alarm_t";
     private PVAString message;
     private PVAInt status;
     private PVAInt severity;
+
+    public enum AlarmSeverity {
+        NO_ALARM,
+        MINOR,
+        MAJOR,
+        INVALID,
+        UNDEFINED,
+    }
 
     /** No alarm */
     public PVAAlarm() {
@@ -51,13 +61,26 @@ public class PVAAlarm extends PVAStructure {
      * @param message
      */
     public PVAAlarm(int severity, int status, String message) {
-        super(ALARM_NAME_STRING, "alarm_t",
-                new PVAInt("severity", severity),
+        this(new PVAInt("severity", severity),
                 new PVAInt("status", status),
                 new PVAString("message", message));
-        this.severity = get(1);
-        this.status = get(2);
-        this.message = get(3);
+    }
+
+    /**
+     * Set all parameters in constructor
+     * 
+     * @param severity
+     * @param status
+     * @param message
+     */
+    public PVAAlarm(PVAInt severity, PVAInt status, PVAString message) {
+        super(ALARM_NAME_STRING, ALARM_T,
+                severity,
+                status,
+                message);
+        this.severity = severity;
+        this.status = status;
+        this.message = message;
     }
 
     /**
@@ -71,5 +94,30 @@ public class PVAAlarm extends PVAStructure {
         this.severity.set(severity);
         this.status.set(status);
         this.message.set(message);
+    }
+
+    public AlarmSeverity alarmSeverity() {
+        var values = AlarmSeverity.values();
+        var index = this.severity.get();
+        if (index > values.length) {
+            return null;
+        }
+        return values[index];
+    }
+
+    /**
+     * Conversion from structure to PVATime
+     * 
+     * @param structure Potential "time_t" structure
+     * @return PVAAlarm or <code>null</code>
+     */
+    public static PVAAlarm fromStructure(PVAStructure structure) {
+        if (structure.getStructureName().equals(ALARM_T)) {
+            final PVAInt severity = structure.get("severity");
+            final PVAInt status = structure.get("status");
+            final PVAString message = structure.get("message");
+            return new PVAAlarm(severity, status, message);
+        }
+        return null;
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
@@ -115,8 +115,8 @@ public class PVAAlarm extends PVAStructure {
      * @return
      */
     public AlarmSeverity alarmSeverity() {
-        var values = AlarmSeverity.values();
-        var index = this.severity.get();
+        AlarmSeverity[] values = AlarmSeverity.values();
+        int index = this.severity.get();
         if (index > values.length) {
             return null;
         }
@@ -146,9 +146,9 @@ public class PVAAlarm extends PVAStructure {
      * @return PVAAlarm or <code>null</code>
      */
     public static PVAAlarm getAlarm(PVAStructure structure) {
-        var alarmStructure = structure.get(ALARM_NAME_STRING);
+        PVAStructure alarmStructure = structure.get(ALARM_NAME_STRING);
         if (alarmStructure != null) {
-            return fromStructure((PVAStructure) alarmStructure);
+            return fromStructure(alarmStructure);
         }
         return null;
     }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
@@ -1,10 +1,21 @@
-/*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- ******************************************************************************/
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 import org.epics.pva.data.PVAInt;
@@ -17,10 +28,12 @@ import org.epics.pva.data.PVAStructure;
  * An alarm_t describes a diagnostic of the value of a control system process
  * variable.
  * 
- * structure
- *   int severity
- *   int status
- *   string message
+ * <ul>
+ * <li>structure
+ * <ul>
+ * <li>int severity
+ * <li>int status
+ * <li>string message
  * 
  */
 public class PVAAlarm extends PVAStructure {
@@ -39,7 +52,7 @@ public class PVAAlarm extends PVAStructure {
         UNDEFINED,
     }
 
-    /** No alarm */
+    /** Default no alarm */
     public PVAAlarm() {
         this("");
     }
@@ -96,6 +109,11 @@ public class PVAAlarm extends PVAStructure {
         this.message.set(message);
     }
 
+    /**
+     * Returns the enum representing the severity
+     * 
+     * @return
+     */
     public AlarmSeverity alarmSeverity() {
         var values = AlarmSeverity.values();
         var index = this.severity.get();
@@ -120,4 +138,19 @@ public class PVAAlarm extends PVAStructure {
         }
         return null;
     }
+
+    /**
+     * Get Alarm from a PVAStructure
+     * 
+     * @param structure Structure containing alarm
+     * @return PVAAlarm or <code>null</code>
+     */
+    public static PVAAlarm getAlarm(PVAStructure structure) {
+        var alarmStructure = structure.get(ALARM_NAME_STRING);
+        if (alarmStructure != null) {
+            return fromStructure((PVAStructure) alarmStructure);
+        }
+        return null;
+    }
+
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java
@@ -106,9 +106,9 @@ public class PVAAlarm extends PVAStructure {
     }
 
     /**
-     * Conversion from structure to PVATime
+     * Conversion from structure to PVAAlarm
      * 
-     * @param structure Potential "time_t" structure
+     * @param structure Potential "alarm_t" structure
      * @return PVAAlarm or <code>null</code>
      */
     public static PVAAlarm fromStructure(PVAStructure structure) {

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
@@ -17,6 +17,7 @@ import org.epics.pva.data.PVAStructure;
  */
 public class PVAControl extends PVAStructure {
     public static final String CONTROL_NAME_STRING = "control";
+    public static final String CONTROL_T = "control_t";
 
     /**
      * Setting all parameters
@@ -26,10 +27,38 @@ public class PVAControl extends PVAStructure {
      * @param minStep
      */
     public PVAControl(double limitLow, double limitHigh, double minStep) {
-        super(CONTROL_NAME_STRING, "control_t",
-                new PVADouble("limitLow", limitLow),
+        this(new PVADouble("limitLow", limitLow),
                 new PVADouble("limitHigh", limitHigh),
                 new PVADouble("minStep", minStep));
     }
 
+    /**
+     * Setting all parameters
+     * 
+     * @param limitLow
+     * @param limitHigh
+     * @param minStep
+     */
+    public PVAControl(PVADouble limitLow, PVADouble limitHigh, PVADouble minStep) {
+        super(CONTROL_NAME_STRING, CONTROL_T,
+                limitLow,
+                limitHigh,
+                minStep);
+    }
+
+    /**
+     * Conversion from structure to PVAControl
+     * 
+     * @param structure Potential "control_t" structure
+     * @return PVAControl or <code>null</code>
+     */
+    public static PVAControl fromStructure(PVAStructure structure) {
+        if (structure.getStructureName().equals(CONTROL_T)) {
+            final PVADouble limitLow = structure.get("limitLow");
+            final PVADouble limitHigh = structure.get("limitHigh");
+            final PVADouble minStep = structure.get("minStep");
+            return new PVAControl(limitLow, limitHigh, minStep);
+        }
+        return null;
+    }
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
@@ -24,6 +24,11 @@ import org.epics.pva.data.PVAStructure;
 /**
  * Normative control type
  * 
+ * A control_t is a structure that describes a range, given by the interval
+ * (limitLow,limitHigh), within which it is expected some control software or
+ * hardware shall bind the control PV to which this Normative Type instance’s
+ * value field refers as well as a minimum step change of the control PV.
+ * 
  * control_t :=
  * <ul>
  * <li>structure
@@ -31,18 +36,20 @@ import org.epics.pva.data.PVAStructure;
  * <li>double limitLow
  * <li>double limitHigh
  * <li>double minStep
+ * </ul>
+ * </ul>
  * 
  */
 public class PVAControl extends PVAStructure {
-    public static final String CONTROL_NAME_STRING = "control";
-    public static final String CONTROL_T = "control_t";
+    private static final String CONTROL_NAME_STRING = "control";
+    private static final String CONTROL_T = "control_t";
 
     /**
      * Setting all parameters
      * 
-     * @param limitLow
-     * @param limitHigh
-     * @param minStep
+     * @param limitLow The control low limit for the value field.
+     * @param limitHigh The control high limit for the value field.
+     * @param minStep The minimum step change for the value field.
      */
     public PVAControl(double limitLow, double limitHigh, double minStep) {
         this(new PVADouble("limitLow", limitLow),
@@ -53,9 +60,9 @@ public class PVAControl extends PVAStructure {
     /**
      * Setting all parameters
      * 
-     * @param limitLow
-     * @param limitHigh
-     * @param minStep
+     * @param limitLow The control low limit for the value field.
+     * @param limitHigh The control high limit for the value field.
+     * @param minStep The minimum step change for the value field.
      */
     public PVAControl(PVADouble limitLow, PVADouble limitHigh, PVADouble minStep) {
         super(CONTROL_NAME_STRING, CONTROL_T,

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
@@ -1,0 +1,35 @@
+package org.epics.pva.data.nt;
+
+import org.epics.pva.data.PVADouble;
+import org.epics.pva.data.PVAStructure;
+
+/**
+ * Normative control type
+ * 
+ * control_t :=
+ * <ul>
+ * <li>structure
+ * <ul>
+ * <li>double limitLow
+ * <li>double limitHigh
+ * <li>double minStep
+ * 
+ */
+public class PVAControl extends PVAStructure {
+
+    /**
+     * Setting all parameters
+     * 
+     * @param name
+     * @param limitLow
+     * @param limitHigh
+     * @param minStep
+     */
+    public PVAControl(String name, double limitLow, double limitHigh, double minStep) {
+        super(name, "control_t",
+                new PVADouble("limitLow", limitLow),
+                new PVADouble("limitHigh", limitHigh),
+                new PVADouble("minStep", minStep));
+    }
+
+}

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
@@ -53,7 +53,7 @@ public class PVAControl extends PVAStructure {
      * @return PVAControl or <code>null</code>
      */
     public static PVAControl fromStructure(PVAStructure structure) {
-        if (structure.getStructureName().equals(CONTROL_T)) {
+        if (structure !=null && structure.getStructureName().equals(CONTROL_T)) {
             final PVADouble limitLow = structure.get("limitLow");
             final PVADouble limitHigh = structure.get("limitHigh");
             final PVADouble minStep = structure.get("minStep");

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
@@ -87,9 +87,9 @@ public class PVAControl extends PVAStructure {
      * @return PVAControl or <code>null</code>
      */
     public static PVAControl getControl(PVAStructure structure) {
-        var controlStructure = structure.get(CONTROL_NAME_STRING);
+        PVAStructure controlStructure = structure.get(CONTROL_NAME_STRING);
         if (controlStructure != null) {
-            return fromStructure((PVAStructure) controlStructure);
+            return fromStructure(controlStructure);
         }
         return null;
     }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 import org.epics.pva.data.PVADouble;
@@ -53,7 +71,7 @@ public class PVAControl extends PVAStructure {
      * @return PVAControl or <code>null</code>
      */
     public static PVAControl fromStructure(PVAStructure structure) {
-        if (structure !=null && structure.getStructureName().equals(CONTROL_T)) {
+        if (structure != null && structure.getStructureName().equals(CONTROL_T)) {
             final PVADouble limitLow = structure.get("limitLow");
             final PVADouble limitHigh = structure.get("limitHigh");
             final PVADouble minStep = structure.get("minStep");
@@ -61,4 +79,19 @@ public class PVAControl extends PVAStructure {
         }
         return null;
     }
+
+    /**
+     * Get Control from a PVAStructure
+     * 
+     * @param structure Structure containing Control
+     * @return PVAControl or <code>null</code>
+     */
+    public static PVAControl getControl(PVAStructure structure) {
+        var controlStructure = structure.get(CONTROL_NAME_STRING);
+        if (controlStructure != null) {
+            return fromStructure((PVAStructure) controlStructure);
+        }
+        return null;
+    }
+
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAControl.java
@@ -16,17 +16,17 @@ import org.epics.pva.data.PVAStructure;
  * 
  */
 public class PVAControl extends PVAStructure {
+    public static final String CONTROL_NAME_STRING = "control";
 
     /**
      * Setting all parameters
      * 
-     * @param name
      * @param limitLow
      * @param limitHigh
      * @param minStep
      */
-    public PVAControl(String name, double limitLow, double limitHigh, double minStep) {
-        super(name, "control_t",
+    public PVAControl(double limitLow, double limitHigh, double minStep) {
+        super(CONTROL_NAME_STRING, "control_t",
                 new PVADouble("limitLow", limitLow),
                 new PVADouble("limitHigh", limitHigh),
                 new PVADouble("minStep", minStep));

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
@@ -135,9 +135,9 @@ public class PVADisplay extends PVAStructure {
      * @return PVADisplay or <code>null</code>
      */
     public static PVADisplay getDisplay(PVAStructure structure) {
-        var displayStructure = structure.get(DISPLAY_NAME_STRING);
+        PVAStructure displayStructure = structure.get(DISPLAY_NAME_STRING);
         if (displayStructure != null) {
-            return fromStructure((PVAStructure) displayStructure);
+            return fromStructure(displayStructure);
         }
         return null;
     }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
@@ -26,6 +26,7 @@ import org.epics.pva.data.PVAStructure;
  * "Exponential", "Engineering"]
  */
 public class PVADisplay extends PVAStructure {
+    public static final String DISPLAY_NAME_STRING = "display";
 
     public enum Form {
         DEFAULT,
@@ -47,7 +48,6 @@ public class PVADisplay extends PVAStructure {
     /**
      * Construct a display_t normative type PVAStructure
      * 
-     * @param name
      * @param limitLow
      * @param limitHigh
      * @param description
@@ -55,9 +55,9 @@ public class PVADisplay extends PVAStructure {
      * @param precision
      * @param form
      */
-    public PVADisplay(String name, double limitLow, double limitHigh, String description, String units, int precision,
+    public PVADisplay(double limitLow, double limitHigh, String description, String units, int precision,
             Form form) {
-        super(name, "display_t",
+        super(DISPLAY_NAME_STRING, "display_t",
                 new PVADouble("limitLow", limitLow),
                 new PVADouble("limitHigh", limitHigh),
                 new PVAString("description", description),

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
@@ -27,6 +27,7 @@ import org.epics.pva.data.PVAStructure;
  */
 public class PVADisplay extends PVAStructure {
     public static final String DISPLAY_NAME_STRING = "display";
+    public static final String DISPLAY_T = "display_t";
 
     public enum Form {
         DEFAULT,
@@ -57,7 +58,7 @@ public class PVADisplay extends PVAStructure {
      */
     public PVADisplay(double limitLow, double limitHigh, String description, String units, int precision,
             Form form) {
-        super(DISPLAY_NAME_STRING, "display_t",
+        super(DISPLAY_NAME_STRING, DISPLAY_T,
                 new PVADouble("limitLow", limitLow),
                 new PVADouble("limitHigh", limitHigh),
                 new PVAString("description", description),
@@ -68,4 +69,44 @@ public class PVADisplay extends PVAStructure {
 
     }
 
+    /**
+     * Construct a display_t normative type PVAStructure
+     * 
+     * @param limitLow
+     * @param limitHigh
+     * @param description
+     * @param units
+     * @param precision
+     * @param form
+     */
+    public PVADisplay(PVADouble limitLow, PVADouble limitHigh, PVAString description, PVAString units, PVAInt precision,
+            PVAEnum form) {
+        super(DISPLAY_NAME_STRING, DISPLAY_T,
+                limitLow,
+                limitHigh,
+                description,
+                units,
+                precision,
+                form);
+
+    }
+
+    /**
+     * Conversion from structure to PVADisplay
+     * 
+     * @param structure Potential "display_t" structure
+     * @return PVADisplay or <code>null</code>
+     */
+    public static PVADisplay fromStructure(PVAStructure structure) {
+        if (structure.getStructureName().equals(DISPLAY_T)) {
+            return new PVADisplay(
+                    structure.get("limitLow"),
+                    structure.get("limitHigh"),
+                    structure.get("description"),
+                    structure.get("units"),
+                    structure.get("precision"),
+                    PVAEnum.fromStructure(structure.get("form")));
+        }
+        return null;
+    }
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
@@ -27,6 +27,11 @@ import org.epics.pva.data.PVAStructure;
 
 /**
  * Normative Display type
+ * 
+ * A display_t is a structure that describes some typical attributes of a
+ * numerical value that are of interest when displaying the value on a computer
+ * screen or similar medium.
+ * 
  * <p>
  * display_t :=
  * <ul>
@@ -42,22 +47,51 @@ import org.epics.pva.data.PVAStructure;
  * <li>int index
  * <li>string[] choices ["Default", "String", "Binary", "Decimal", "Hex",
  * "Exponential", "Engineering"]
+ * </ul>
+ * </ul>
+ * </ul>
  */
 public class PVADisplay extends PVAStructure {
-    public static final String DISPLAY_NAME_STRING = "display";
-    public static final String DISPLAY_T = "display_t";
+    private static final String DISPLAY_NAME_STRING = "display";
+    private static final String DISPLAY_T = "display_t";
 
+    /**
+     * An enumeration to specify formatting a value to be displayed. By default, a
+     * floating point number is formatted with the number of decimal points defined
+     * in the precision field.
+     */
     public enum Form {
+        /** 
+         * Default Formatting
+         */
         DEFAULT,
+        /** 
+         * String Format
+         */
         STRING,
+        /** 
+         * Binary Format
+         */
         BINARY,
+        /** 
+         * Decimal Format
+         */
         DECIMAL,
+        /** 
+         * Hex Format
+         */
         HEX,
+        /** 
+         * Exponential Format
+         */
         EXPONENTIAL,
+        /** 
+         * Engineering Format
+         */
         ENGINEERING
     }
 
-    public static String capitalizeFirstLetter(String original) {
+    private static String capitalizeFirstLetter(String original) {
         if (original == null || original.length() == 0) {
             return original;
         }
@@ -67,12 +101,17 @@ public class PVADisplay extends PVAStructure {
     /**
      * Construct a display_t normative type PVAStructure
      * 
-     * @param limitLow
-     * @param limitHigh
-     * @param description
-     * @param units
-     * @param precision
-     * @param form
+     * @param limitLow    The lower bound of range within which the value must be
+     *                    set, to be presented to a user.
+     * @param limitHigh   The upper bound of range within which the value must be
+     *                    set, to be presented to a user.
+     * @param description A textual summary of the variable that the value
+     *                    quantifies.
+     * @param units       The units for the value field.
+     * @param precision   Number of decimal points that are displayed when
+     *                    formatting a floating point number.
+     * @param form        An enumeration to specify formatting a value to be
+     *                    displayed.
      */
     public PVADisplay(double limitLow, double limitHigh, String description, String units, int precision,
             Form form) {
@@ -89,12 +128,17 @@ public class PVADisplay extends PVAStructure {
     /**
      * Construct a display_t normative type PVAStructure
      * 
-     * @param limitLow
-     * @param limitHigh
-     * @param description
-     * @param units
-     * @param precision
-     * @param form
+     * @param limitLow    The lower bound of range within which the value must be
+     *                    set, to be presented to a user.
+     * @param limitHigh   The upper bound of range within which the value must be
+     *                    set, to be presented to a user.
+     * @param description A textual summary of the variable that the value
+     *                    quantifies.
+     * @param units       The units for the value field.
+     * @param precision   Number of decimal points that are displayed when
+     *                    formatting a floating point number.
+     * @param form        An enumeration to specify formatting a value to be
+     *                    displayed.
      */
     public PVADisplay(PVADouble limitLow, PVADouble limitHigh, PVAString description, PVAString units, PVAInt precision,
             PVAEnum form) {

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 import java.util.stream.Stream;
@@ -100,12 +118,26 @@ public class PVADisplay extends PVAStructure {
         // Epics Iocs do not always use the DISPLAY_T type name
         if (structure != null && structure.getName().equals(DISPLAY_NAME_STRING)) {
             return new PVADisplay(
-                structure.get("limitLow"),
-                structure.get("limitHigh"),
-                structure.get("description"),
-                structure.get("units"),
-                structure.get("precision"),
-                PVAEnum.fromStructure(structure.get("form")));
+                    structure.get("limitLow"),
+                    structure.get("limitHigh"),
+                    structure.get("description"),
+                    structure.get("units"),
+                    structure.get("precision"),
+                    PVAEnum.fromStructure(structure.get("form")));
+        }
+        return null;
+    }
+
+    /**
+     * Get Display from a PVAStructure
+     * 
+     * @param structure Structure containing Display
+     * @return PVADisplay or <code>null</code>
+     */
+    public static PVADisplay getDisplay(PVAStructure structure) {
+        var displayStructure = structure.get(DISPLAY_NAME_STRING);
+        if (displayStructure != null) {
+            return fromStructure((PVAStructure) displayStructure);
         }
         return null;
     }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
@@ -1,0 +1,71 @@
+package org.epics.pva.data.nt;
+
+import java.util.stream.Stream;
+
+import org.epics.pva.data.PVADouble;
+import org.epics.pva.data.PVAInt;
+import org.epics.pva.data.PVAString;
+import org.epics.pva.data.PVAStructure;
+
+/**
+ * Normative Display type
+ * <p>
+ * display_t :=
+ * <ul>
+ * <li>structure
+ * <ul>
+ * <li>double limitLow
+ * <li>double limitHigh
+ * <li>string description
+ * <li>string units
+ * <li>int precision
+ * <li>enum_t form(3)
+ * <ul>
+ * <li>int index
+ * <li>string[] choices ["Default", "String", "Binary", "Decimal", "Hex",
+ * "Exponential", "Engineering"]
+ */
+public class PVADisplay extends PVAStructure {
+
+    public enum Form {
+        DEFAULT,
+        STRING,
+        BINARY,
+        DECIMAL,
+        HEX,
+        EXPONENTIAL,
+        ENGINEERING
+    }
+
+    public static String capitalizeFirstLetter(String original) {
+        if (original == null || original.length() == 0) {
+            return original;
+        }
+        return original.substring(0, 1).toUpperCase() + original.substring(1).toLowerCase();
+    }
+
+    /**
+     * Construct a display_t normative type PVAStructure
+     * 
+     * @param name
+     * @param limitLow
+     * @param limitHigh
+     * @param description
+     * @param units
+     * @param precision
+     * @param form
+     */
+    public PVADisplay(String name, double limitLow, double limitHigh, String description, String units, int precision,
+            Form form) {
+        super(name, "display_t",
+                new PVADouble("limitLow", limitLow),
+                new PVADouble("limitHigh", limitHigh),
+                new PVAString("description", description),
+                new PVAString("units", units),
+                new PVAInt("precision", precision),
+                new PVAEnum("form", form.ordinal(), Stream.of(Form.values()).map(Form::name)
+                        .map(PVADisplay::capitalizeFirstLetter).toArray(String[]::new)));
+
+    }
+
+}

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVADisplay.java
@@ -58,8 +58,7 @@ public class PVADisplay extends PVAStructure {
      */
     public PVADisplay(double limitLow, double limitHigh, String description, String units, int precision,
             Form form) {
-        super(DISPLAY_NAME_STRING, DISPLAY_T,
-                new PVADouble("limitLow", limitLow),
+        this(new PVADouble("limitLow", limitLow),
                 new PVADouble("limitHigh", limitHigh),
                 new PVAString("description", description),
                 new PVAString("units", units),
@@ -98,14 +97,15 @@ public class PVADisplay extends PVAStructure {
      * @return PVADisplay or <code>null</code>
      */
     public static PVADisplay fromStructure(PVAStructure structure) {
-        if (structure.getStructureName().equals(DISPLAY_T)) {
+        // Epics Iocs do not always use the DISPLAY_T type name
+        if (structure != null && structure.getName().equals(DISPLAY_NAME_STRING)) {
             return new PVADisplay(
-                    structure.get("limitLow"),
-                    structure.get("limitHigh"),
-                    structure.get("description"),
-                    structure.get("units"),
-                    structure.get("precision"),
-                    PVAEnum.fromStructure(structure.get("form")));
+                structure.get("limitLow"),
+                structure.get("limitHigh"),
+                structure.get("description"),
+                structure.get("units"),
+                structure.get("precision"),
+                PVAEnum.fromStructure(structure.get("form")));
         }
         return null;
     }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
@@ -16,8 +16,40 @@ import org.epics.pva.data.PVAStructure;
  * <li>string[] choices
  */
 public class PVAEnum extends PVAStructure {
+    /** Type name for enum */
+    public static final String ENUM_T = "enum_t";
+    private PVAInt index;
+    private PVAStringArray choices;
 
     public PVAEnum(String name, int index, String[] choices) {
-        super(name, "enum_t", new PVAInt("index", index), new PVAStringArray("choices", choices));
+        this(name, new PVAInt("index", index), new PVAStringArray("choices", choices));
+    }
+
+    public PVAEnum(String name, PVAInt index, PVAStringArray choices) {
+        super(name, ENUM_T, index, choices);
+        this.index = index;
+        this.choices = choices;
+    }
+
+    public String enumString() {
+
+        if (this.index != null  && this.choices != null)
+        {
+            final int i = this.index.get();
+            final String[] labels = this.choices.get();
+            return i>=0 && i<labels.length ? labels[i] : "Invalid enum <" + i + ">";
+        }
+        return null;
+    }
+
+    public static PVAEnum fromStructure(PVAStructure structure) {
+
+        if (structure.getStructureName().equals(ENUM_T))
+        {
+            final PVAInt index = structure.get("index");
+            final PVAStringArray choices = structure.get("choices");
+            return new PVAEnum(structure.getName(), index, choices);
+        }
+        return null;
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
@@ -25,6 +25,9 @@ import org.epics.pva.data.PVAStructure;
 /**
  * Normative enum type
  * 
+ * An enum_t describes an enumeration. The field is a structure describing a
+ * value drawn from a given set of valid values also given.
+ * 
  * enum_t :=
  * 
  * <ul>
@@ -32,17 +35,31 @@ import org.epics.pva.data.PVAStructure;
  * <ul>
  * <li>int index
  * <li>string[] choices
+ * </ul>
+ * </ul>
  */
 public class PVAEnum extends PVAStructure {
     /** Type name for enum */
-    public static final String ENUM_T = "enum_t";
+    private static final String ENUM_T = "enum_t";
     private PVAInt index;
     private PVAStringArray choices;
 
+    /**
+     * Constructor 
+     * @param name Name of the enum
+     * @param index The index of the current value of the enumeration in the array choices below.
+     * @param choices An array of strings specifying the set of labels for the valid values of the enumeration.
+     */
     public PVAEnum(String name, int index, String[] choices) {
         this(name, new PVAInt("index", index), new PVAStringArray("choices", choices));
     }
 
+    /**
+     * Constructor 
+     * @param name Name of the enum
+     * @param index The index of the current value of the enumeration in the array choices below.
+     * @param choices An array of strings specifying the set of labels for the valid values of the enumeration.
+     */
     public PVAEnum(String name, PVAInt index, PVAStringArray choices) {
         super(name, ENUM_T, index, choices);
         this.index = index;
@@ -52,7 +69,7 @@ public class PVAEnum extends PVAStructure {
     /**
      * String of the enum output
      * 
-     * @return
+     * @return The resulting string of the enum_t
      */
     public String enumString() {
 
@@ -67,8 +84,8 @@ public class PVAEnum extends PVAStructure {
     /**
      * Converts from a generic PVAStruture to PVAEnum
      * 
-     * @param structure
-     * @return
+     * @param structure Input structure
+     * @return Representative Enum
      */
     public static PVAEnum fromStructure(PVAStructure structure) {
         if (structure != null && structure.getStructureName().equals(ENUM_T)) {

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
@@ -1,0 +1,23 @@
+package org.epics.pva.data.nt;
+
+import org.epics.pva.data.PVAInt;
+import org.epics.pva.data.PVAStringArray;
+import org.epics.pva.data.PVAStructure;
+
+/**
+ * Normative enum type
+ * 
+ * enum_t :=
+ * 
+ * <ul>
+ * <li>structure
+ * <ul>
+ * <li>int index
+ * <li>string[] choices
+ */
+public class PVAEnum extends PVAStructure {
+
+    public PVAEnum(String name, int index, String[] choices) {
+        super(name, "enum_t", new PVAInt("index", index), new PVAStringArray("choices", choices));
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 import org.epics.pva.data.PVAInt;
@@ -31,6 +49,11 @@ public class PVAEnum extends PVAStructure {
         this.choices = choices;
     }
 
+    /**
+     * String of the enum output
+     * 
+     * @return
+     */
     public String enumString() {
 
         if (this.index != null && this.choices != null) {
@@ -41,6 +64,12 @@ public class PVAEnum extends PVAStructure {
         return null;
     }
 
+    /**
+     * Converts from a generic PVAStruture to PVAEnum
+     * 
+     * @param structure
+     * @return
+     */
     public static PVAEnum fromStructure(PVAStructure structure) {
         if (structure != null && structure.getStructureName().equals(ENUM_T)) {
             final PVAInt index = structure.get("index");
@@ -49,4 +78,5 @@ public class PVAEnum extends PVAStructure {
         }
         return null;
     }
+
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAEnum.java
@@ -33,19 +33,16 @@ public class PVAEnum extends PVAStructure {
 
     public String enumString() {
 
-        if (this.index != null  && this.choices != null)
-        {
+        if (this.index != null && this.choices != null) {
             final int i = this.index.get();
             final String[] labels = this.choices.get();
-            return i>=0 && i<labels.length ? labels[i] : "Invalid enum <" + i + ">";
+            return i >= 0 && i < labels.length ? labels[i] : "Invalid enum <" + i + ">";
         }
         return null;
     }
 
     public static PVAEnum fromStructure(PVAStructure structure) {
-
-        if (structure.getStructureName().equals(ENUM_T))
-        {
+        if (structure != null && structure.getStructureName().equals(ENUM_T)) {
             final PVAInt index = structure.get("index");
             final PVAStringArray choices = structure.get("choices");
             return new PVAEnum(structure.getName(), index, choices);

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
@@ -61,6 +61,7 @@ import org.epics.pva.data.PVAStructure;
 public class PVAScalar<S extends PVAData> extends PVAStructure {
     public static final String STRUCT_NAME_STRING = "epics:nt/NTScalar:1.0";
     public static final String VALUE_NAME_STRING = "value";
+    public static final String DESCRIPTION_NAME_STRING = "description";
 
     public static class Builder<S extends PVAData> {
 
@@ -121,7 +122,7 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
             return Builder.this;
         }
 
-        public PVAScalar<S> build() throws PVAScalarValueNameException {
+        public PVAScalar<S> build() throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
             if (this.name == null) {
                 throw new NullPointerException("The property \"name\" is null. "
                         + "Please set the value by \"name()\". "
@@ -134,6 +135,9 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
             }
             if (!value.getName().equals(VALUE_NAME_STRING)) {
                 throw new PVAScalarValueNameException(value.getName());
+            }
+            if (!description.getName().equals(DESCRIPTION_NAME_STRING)) {
+                throw new PVAScalarDescriptionNameException(description.getName());
             }
             return new PVAScalar<>(this);
         }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 import java.util.Arrays;
@@ -63,6 +81,14 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
     public static final String VALUE_NAME_STRING = "value";
     public static final String DESCRIPTION_NAME_STRING = "description";
 
+    /**
+     * Builder for the PVAScalar class
+     * 
+     * The description element must be named description
+     * otherwise a PVAScalarDescriptionNameException will be thrown
+     * The value element must be named value
+     * otherwise a PVAScalarValueNameException will be thrown
+     */
     public static class Builder<S extends PVAData> {
 
         private String name;
@@ -211,5 +237,25 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
 
     public static Builder<PVAStringArray> stringArrayScalarBuilder(String... value) {
         return new Builder<PVAStringArray>().value(new PVAStringArray(VALUE_NAME_STRING, value));
+    }
+
+    /**
+     * Converts from generic PVAStructure to PVAScalar
+     * 
+     * @param structure
+     * @return
+     * @throws PVAScalarValueNameException
+     * @throws PVAScalarDescriptionNameException
+     */
+    public static <S extends PVAData> PVAScalar<S> fromStructure(PVAStructure structure)
+            throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
+        var builder = new Builder<S>();
+        var value = (S) structure.get(VALUE_NAME_STRING);
+        return builder.name(structure.getName()).value(value)
+                .alarm(PVAAlarm.getAlarm(structure)).control(PVAControl.getControl(structure))
+                .description(structure.get(DESCRIPTION_NAME_STRING))
+                .timeStamp(PVATimeStamp.getTimeStamp(structure))
+                .display(PVADisplay.getDisplay(structure))
+                .build();
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
@@ -21,6 +21,7 @@ package org.epics.pva.data.nt;
 import java.util.Arrays;
 import java.util.Objects;
 
+import org.epics.pva.data.PVAArray;
 import org.epics.pva.data.PVABool;
 import org.epics.pva.data.PVABoolArray;
 import org.epics.pva.data.PVAByte;
@@ -82,7 +83,8 @@ import org.epics.pva.data.PVAStructure;
  *            </ul>
  */
 public class PVAScalar<S extends PVAData> extends PVAStructure {
-    public static final String STRUCT_NAME_STRING = "epics:nt/NTScalar:1.0";
+    public static final String SCALAR_STRUCT_NAME_STRING = "epics:nt/NTScalar:1.0";
+    public static final String ARRAY_STRUCT_NAME_STRING = "epics:nt/NTScalarArray:1.0";
     public static final String VALUE_NAME_STRING = "value";
     public static final String DESCRIPTION_NAME_STRING = "description";
 
@@ -105,8 +107,16 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
         private PVATimeStamp timeStamp;
         private PVADisplay display;
         private PVAControl control;
+        private String structName;
 
         public Builder() {
+        }
+
+        String determineStructName(S value) {
+            if (value instanceof PVAArray) {
+                return ARRAY_STRUCT_NAME_STRING;
+            }
+            return SCALAR_STRUCT_NAME_STRING;
         }
 
         Builder(String name, S value, PVAString description, PVAAlarm alarm, PVATimeStamp timeStamp, PVADisplay display,
@@ -118,6 +128,7 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
             this.timeStamp = timeStamp;
             this.display = display;
             this.control = control;
+            this.structName = determineStructName(value);
         }
 
         public Builder<S> name(String name) {
@@ -166,6 +177,7 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
                         + "Please set the value by \"value()\". "
                         + "The properties \"name\", \"value\" are required.");
             }
+            this.structName = determineStructName(value);
             if (!value.getName().equals(VALUE_NAME_STRING)) {
                 throw new PVAScalarValueNameException(value.getName());
             }
@@ -177,7 +189,7 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
     }
 
     private PVAScalar(Builder<S> builder) {
-        super(builder.name, STRUCT_NAME_STRING,
+        super(builder.name, builder.structName,
                 Arrays.stream(new PVAData[] { builder.value, builder.alarm, builder.control, builder.description,
                         builder.display, builder.timeStamp }).filter(Objects::nonNull).toArray(PVAData[]::new));
     }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
@@ -249,8 +249,8 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
      */
     public static <S extends PVAData> PVAScalar<S> fromStructure(PVAStructure structure)
             throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
-        var builder = new Builder<S>();
-        var value = (S) structure.get(VALUE_NAME_STRING);
+        Builder<S> builder = new Builder<>();
+        S value = structure.get(VALUE_NAME_STRING);
         return builder.name(structure.getName()).value(value)
                 .alarm(PVAAlarm.getAlarm(structure)).control(PVAControl.getControl(structure))
                 .description(structure.get(DESCRIPTION_NAME_STRING))

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
@@ -136,7 +136,7 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
             if (!value.getName().equals(VALUE_NAME_STRING)) {
                 throw new PVAScalarValueNameException(value.getName());
             }
-            if (!description.getName().equals(DESCRIPTION_NAME_STRING)) {
+            if (this.description != null && !description.getName().equals(DESCRIPTION_NAME_STRING)) {
                 throw new PVAScalarDescriptionNameException(description.getName());
             }
             return new PVAScalar<>(this);

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
@@ -53,28 +53,33 @@ import org.epics.pva.data.PVAStructure;
  * <li>time_t timeStamp :opt
  * <li>display_t display :opt
  * <li>control_t control :opt
+ * </ul>
+ * </ul>
  * 
- * where scalar_t can be:
- * <ul>
- * <li>{@link PVABool}
- * <li>{@link PVAByte}
- * <li>{@link PVAShort}
- * <li>{@link PVAInt}
- * <li>{@link PVALong}
- * <li>{@link PVAFloat}
- * <li>{@link PVADouble}
- * <li>{@link PVAString}
+ * @param <S> can be from scalar_t or scalar_t[] as specified by:
+ *            where scalar_t can be:
+ *            <ul>
+ *            <li>{@link PVABool}
+ *            <li>{@link PVAByte}
+ *            <li>{@link PVAShort}
+ *            <li>{@link PVAInt}
+ *            <li>{@link PVALong}
+ *            <li>{@link PVAFloat}
+ *            <li>{@link PVADouble}
+ *            <li>{@link PVAString}
+ *            </ul>
  * 
- * and scalar_t[] can be:
- * <ul>
- * <li>{@link PVABoolArray}
- * <li>{@link PVAByteArray}
- * <li>{@link PVAShortArray}
- * <li>{@link PVAIntArray}
- * <li>{@link PVALongArray}
- * <li>{@link PVAFloatArray}
- * <li>{@link PVADoubleArray}
- * <li>{@link PVAStringArray}
+ *            and scalar_t[] can be:
+ *            <ul>
+ *            <li>{@link PVABoolArray}
+ *            <li>{@link PVAByteArray}
+ *            <li>{@link PVAShortArray}
+ *            <li>{@link PVAIntArray}
+ *            <li>{@link PVALongArray}
+ *            <li>{@link PVAFloatArray}
+ *            <li>{@link PVADoubleArray}
+ *            <li>{@link PVAStringArray}
+ *            </ul>
  */
 public class PVAScalar<S extends PVAData> extends PVAStructure {
     public static final String STRUCT_NAME_STRING = "epics:nt/NTScalar:1.0";
@@ -84,10 +89,12 @@ public class PVAScalar<S extends PVAData> extends PVAStructure {
     /**
      * Builder for the PVAScalar class
      * 
-     * The description element must be named description
-     * otherwise a PVAScalarDescriptionNameException will be thrown
-     * The value element must be named value
-     * otherwise a PVAScalarValueNameException will be thrown
+     * @param <S> is in the {@link PVAScalar} list
+     * 
+     *            The description element must be named description
+     *            otherwise a PVAScalarDescriptionNameException will be thrown
+     *            The value element must be named value
+     *            otherwise a PVAScalarValueNameException will be thrown
      */
     public static class Builder<S extends PVAData> {
 

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalar.java
@@ -1,0 +1,211 @@
+package org.epics.pva.data.nt;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.epics.pva.data.PVABool;
+import org.epics.pva.data.PVABoolArray;
+import org.epics.pva.data.PVAByte;
+import org.epics.pva.data.PVAByteArray;
+import org.epics.pva.data.PVAData;
+import org.epics.pva.data.PVADouble;
+import org.epics.pva.data.PVADoubleArray;
+import org.epics.pva.data.PVAFloat;
+import org.epics.pva.data.PVAFloatArray;
+import org.epics.pva.data.PVAInt;
+import org.epics.pva.data.PVAIntArray;
+import org.epics.pva.data.PVALong;
+import org.epics.pva.data.PVALongArray;
+import org.epics.pva.data.PVAShort;
+import org.epics.pva.data.PVAShortArray;
+import org.epics.pva.data.PVAString;
+import org.epics.pva.data.PVAStringArray;
+import org.epics.pva.data.PVAStructure;
+
+/**
+ * Normative scalar and scaler[] type
+ * 
+ * NTScalar :=
+ * <ul>
+ * <li>structure
+ * <ul>
+ * <li>scalar_t value or scalar_t[] value
+ * <li>string descriptor :opt
+ * <li>alarm_t alarm :opt
+ * <li>time_t timeStamp :opt
+ * <li>display_t display :opt
+ * <li>control_t control :opt
+ * 
+ * where scalar_t can be:
+ * <ul>
+ * <li>{@link PVABool}
+ * <li>{@link PVAByte}
+ * <li>{@link PVAShort}
+ * <li>{@link PVAInt}
+ * <li>{@link PVALong}
+ * <li>{@link PVAFloat}
+ * <li>{@link PVADouble}
+ * <li>{@link PVAString}
+ * 
+ * and scalar_t[] can be:
+ * <ul>
+ * <li>{@link PVABoolArray}
+ * <li>{@link PVAByteArray}
+ * <li>{@link PVAShortArray}
+ * <li>{@link PVAIntArray}
+ * <li>{@link PVALongArray}
+ * <li>{@link PVAFloatArray}
+ * <li>{@link PVADoubleArray}
+ * <li>{@link PVAStringArray}
+ */
+public class PVAScalar<S extends PVAData> extends PVAStructure {
+    public static final String STRUCT_NAME_STRING = "epics:nt/NTScalar:1.0";
+    public static final String VALUE_NAME_STRING = "value";
+
+    public static class Builder<S extends PVAData> {
+
+        private String name;
+        private S value;
+        private PVAString description;
+        private PVAAlarm alarm;
+        private PVATimeStamp timeStamp;
+        private PVADisplay display;
+        private PVAControl control;
+
+        public Builder() {
+        }
+
+        Builder(String name, S value, PVAString description, PVAAlarm alarm, PVATimeStamp timeStamp, PVADisplay display,
+                PVAControl control) {
+            this.name = name;
+            this.value = value;
+            this.description = description;
+            this.alarm = alarm;
+            this.timeStamp = timeStamp;
+            this.display = display;
+            this.control = control;
+        }
+
+        public Builder<S> name(String name) {
+            this.name = name;
+            return Builder.this;
+        }
+
+        public Builder<S> value(S value) {
+            this.value = value;
+            return Builder.this;
+        }
+
+        public Builder<S> description(PVAString description) {
+            this.description = description;
+            return Builder.this;
+        }
+
+        public Builder<S> alarm(PVAAlarm alarm) {
+            this.alarm = alarm;
+            return Builder.this;
+        }
+
+        public Builder<S> timeStamp(PVATimeStamp timeStamp) {
+            this.timeStamp = timeStamp;
+            return Builder.this;
+        }
+
+        public Builder<S> display(PVADisplay display) {
+            this.display = display;
+            return Builder.this;
+        }
+
+        public Builder<S> control(PVAControl control) {
+            this.control = control;
+            return Builder.this;
+        }
+
+        public PVAScalar<S> build() throws PVAScalarValueNameException {
+            if (this.name == null) {
+                throw new NullPointerException("The property \"name\" is null. "
+                        + "Please set the value by \"name()\". "
+                        + "The properties \"name\", \"value\" are required.");
+            }
+            if (this.value == null) {
+                throw new NullPointerException("The property \"value\" is null. "
+                        + "Please set the value by \"value()\". "
+                        + "The properties \"name\", \"value\" are required.");
+            }
+            if (!value.getName().equals(VALUE_NAME_STRING)) {
+                throw new PVAScalarValueNameException(value.getName());
+            }
+            return new PVAScalar<>(this);
+        }
+    }
+
+    private PVAScalar(Builder<S> builder) {
+        super(builder.name, STRUCT_NAME_STRING,
+                Arrays.stream(new PVAData[] { builder.value, builder.alarm, builder.control, builder.description,
+                        builder.display, builder.timeStamp }).filter(Objects::nonNull).toArray(PVAData[]::new));
+    }
+
+    public static Builder<PVABool> boolScalarBuilder(boolean value) {
+        return new Builder<PVABool>().value(new PVABool(VALUE_NAME_STRING, value));
+    }
+
+    public static Builder<PVAByte> byteScalarBuilder(boolean unsigned, byte value) {
+        return new Builder<PVAByte>().value(new PVAByte(VALUE_NAME_STRING, unsigned, value));
+    }
+
+    public static Builder<PVAShort> shortScalarBuilder(final boolean unsigned, final short value) {
+        return new Builder<PVAShort>().value(new PVAShort(VALUE_NAME_STRING, unsigned, value));
+    }
+
+    public static Builder<PVAInt> intScalarBuilder(int value) {
+        return new Builder<PVAInt>().value(new PVAInt(VALUE_NAME_STRING, value));
+    }
+
+    public static Builder<PVALong> longScalarBuilder(final boolean unsigned, final long value) {
+        return new Builder<PVALong>().value(new PVALong(VALUE_NAME_STRING, unsigned, value));
+    }
+
+    public static Builder<PVAFloat> floatScalarBuilder(float value) {
+        return new Builder<PVAFloat>().value(new PVAFloat(VALUE_NAME_STRING, value));
+    }
+
+    public static Builder<PVADouble> doubleScalarBuilder(double value) {
+        return new Builder<PVADouble>().value(new PVADouble(VALUE_NAME_STRING, value));
+    }
+
+    public static Builder<PVAString> stringScalarBuilder(String value) {
+        return new Builder<PVAString>().value(new PVAString(VALUE_NAME_STRING, value));
+    }
+
+    public static Builder<PVABoolArray> boolScalarBuilder(boolean... value) {
+        return new Builder<PVABoolArray>().value(new PVABoolArray(VALUE_NAME_STRING, value));
+    }
+
+    public static Builder<PVAByteArray> byteArrayScalarBuilder(boolean unsigned, byte... value) {
+        return new Builder<PVAByteArray>().value(new PVAByteArray(VALUE_NAME_STRING, unsigned, value));
+    }
+
+    public static Builder<PVAShortArray> shortArrayScalarBuilder(final boolean unsigned, final short... value) {
+        return new Builder<PVAShortArray>().value(new PVAShortArray(VALUE_NAME_STRING, unsigned, value));
+    }
+
+    public static Builder<PVAIntArray> intArrayScalarBuilder(boolean unsigned, int... value) {
+        return new Builder<PVAIntArray>().value(new PVAIntArray(VALUE_NAME_STRING, unsigned, value));
+    }
+
+    public static Builder<PVALongArray> longArrayScalarBuilder(final boolean unsigned, final long... value) {
+        return new Builder<PVALongArray>().value(new PVALongArray(VALUE_NAME_STRING, unsigned, value));
+    }
+
+    public static Builder<PVAFloatArray> floatArrayScalarBuilder(float... value) {
+        return new Builder<PVAFloatArray>().value(new PVAFloatArray(VALUE_NAME_STRING, value));
+    }
+
+    public static Builder<PVADoubleArray> doubleArrayScalarBuilder(double... value) {
+        return new Builder<PVADoubleArray>().value(new PVADoubleArray(VALUE_NAME_STRING, value));
+    }
+
+    public static Builder<PVAStringArray> stringArrayScalarBuilder(String... value) {
+        return new Builder<PVAStringArray>().value(new PVAStringArray(VALUE_NAME_STRING, value));
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalarDescriptionNameException.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalarDescriptionNameException.java
@@ -1,0 +1,12 @@
+
+package org.epics.pva.data.nt;
+
+/**
+ * Exception when trying to construct a PVAScalar without using
+ * the name "description" for the description.
+ */
+public class PVAScalarDescriptionNameException extends Exception {
+    public PVAScalarDescriptionNameException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalarDescriptionNameException.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalarDescriptionNameException.java
@@ -1,4 +1,21 @@
-
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 /**

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalarValueNameException.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalarValueNameException.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 /**

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalarValueNameException.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVAScalarValueNameException.java
@@ -1,0 +1,11 @@
+package org.epics.pva.data.nt;
+
+/**
+ * Exception when trying to construct a PVAScalar without using
+ * the name "value" for the scalar.
+ */
+public class PVAScalarValueNameException extends Exception {
+    public PVAScalarValueNameException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
@@ -28,6 +28,10 @@ public class PVATimeStamp extends PVAStructure
 {
     public static final Instant NO_TIME = Instant.ofEpochSecond(0, 0);
     public static final String TIMESTAMP_NAME_STRING = "timeStamp";
+    public static final String SECONDS_PAST_EPOCH = "secondsPastEpoch";
+    public static final String NANOSECONDS = "nanoseconds";
+    /** Type name for time stamp */
+    public static final String TIME_T = "time_t";
 
     private final PVALong secs;
     private final PVAInt nano;
@@ -55,12 +59,24 @@ public class PVATimeStamp extends PVAStructure
      */
     public PVATimeStamp(final String name, final Instant time)
     {
-        super(name, "time_t",
-              new PVALong("secondsPastEpoch", false, time.getEpochSecond()),
-              new PVAInt("nanoseconds", false, time.getNano()),
+        this(name,
+             new PVALong(SECONDS_PAST_EPOCH, false, time.getEpochSecond()),
+             new PVAInt(NANOSECONDS, false, time.getNano()));
+    }
+
+    /** 
+     * Constructor with PVAData
+     * @param secs secondsPastEpoch
+     *  @param nanos nanoseconds
+     */
+    public PVATimeStamp(final String name, final PVALong secs, final PVAInt nanos)
+    {
+        super(name, TIME_T,
+              secs,
+              nanos,
               new PVAInt("userTag", 0));
-        secs = get(1);
-        nano = get(2);
+        this.secs = secs;
+        this.nano = nanos;
     }
 
     /** @param time Desired time (seconds, nanoseconds) */
@@ -91,5 +107,20 @@ public class PVATimeStamp extends PVAStructure
                 return NO_TIME;
         else
             return Instant.ofEpochSecond(secs.get(), nano.get());
+    }
+
+    /** 
+     * Conversion from structure to PVATime
+     * @param structure Potential "time_t" structure
+     *  @return PVATimeStamp or <code>null</code>
+     */
+    public static PVATimeStamp fromStructure(PVAStructure structure) {
+        if (structure.getStructureName().equals(TIME_T))
+        {
+            final PVALong secs = structure.get(SECONDS_PAST_EPOCH);
+            final PVAInt nano = structure.get(NANOSECONDS);
+            return new PVATimeStamp(TIMESTAMP_NAME_STRING, secs, nano);
+        }
+        return null;
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
@@ -134,9 +134,9 @@ public class PVATimeStamp extends PVAStructure
      * @return PVATimeStamp or <code>null</code>
      */
     public static PVATimeStamp getTimeStamp(PVAStructure structure) {
-        var timestampStructure = structure.get(TIMESTAMP_NAME_STRING);
+        PVAStructure timestampStructure = structure.get(TIMESTAMP_NAME_STRING);
         if (timestampStructure != null) {
-            return fromStructure((PVAStructure) timestampStructure);
+            return fromStructure(timestampStructure);
         }
         return null;
     }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
@@ -13,12 +13,21 @@ import org.epics.pva.data.PVAInt;
 import org.epics.pva.data.PVALong;
 import org.epics.pva.data.PVAStructure;
 
-/** Normative timestamp type
- *  @author Kay Kasemir
+/**
+ * Normative timestamp type
+ * 
+ * structure
+ *   long secondsPastEpoch
+ *   int nanoseconds
+ *   int userTag
+ * 
+ * @author Kay Kasemir
  */
 @SuppressWarnings("nls")
 public class PVATimeStamp extends PVAStructure
 {
+    public static final Instant NO_TIME = Instant.ofEpochSecond(0, 0);
+
     private final PVALong secs;
     private final PVAInt nano;
 
@@ -74,5 +83,12 @@ public class PVATimeStamp extends PVAStructure
         PVAInt nano = ts.get(2);
         secs.set(time.getEpochSecond());
         nano.set(time.getNano());
+    }
+
+    public Instant instant() {
+        if (secs == null || nano == null)
+                return NO_TIME;
+        else
+            return Instant.ofEpochSecond(secs.get(), nano.get());
     }
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
@@ -120,7 +120,9 @@ public class PVATimeStamp extends PVAStructure
         {
             final PVALong secs = structure.get(SECONDS_PAST_EPOCH);
             final PVAInt nano = structure.get(NANOSECONDS);
-            return new PVATimeStamp(TIMESTAMP_NAME_STRING, secs, nano);
+            if (secs != null && nano != null) {
+                return new PVATimeStamp(TIMESTAMP_NAME_STRING, secs, nano);
+            }
         }
         return null;
     }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
@@ -116,7 +116,7 @@ public class PVATimeStamp extends PVAStructure
      *  @return PVATimeStamp or <code>null</code>
      */
     public static PVATimeStamp fromStructure(PVAStructure structure) {
-        if (structure.getStructureName().equals(TIME_T))
+        if (structure != null && structure.getName().equals(TIMESTAMP_NAME_STRING))
         {
             final PVALong secs = structure.get(SECONDS_PAST_EPOCH);
             final PVAInt nano = structure.get(NANOSECONDS);

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
@@ -27,6 +27,7 @@ import org.epics.pva.data.PVAStructure;
 public class PVATimeStamp extends PVAStructure
 {
     public static final Instant NO_TIME = Instant.ofEpochSecond(0, 0);
+    public static final String TIMESTAMP_NAME_STRING = "timeStamp";
 
     private final PVALong secs;
     private final PVAInt nano;
@@ -40,7 +41,7 @@ public class PVATimeStamp extends PVAStructure
     /** @param time Instant */
     public PVATimeStamp(final Instant time)
     {
-        this("timeStamp", time);
+        this(TIMESTAMP_NAME_STRING, time);
     }
 
     /** @param name Name for 'now' */
@@ -75,7 +76,7 @@ public class PVATimeStamp extends PVAStructure
      */
     public static void set(final PVAStructure value, final Instant time)
     {
-        final PVAStructure ts = value.get("timeStamp");
+        final PVAStructure ts = value.get(TIMESTAMP_NAME_STRING);
         if (ts == null)
             throw new IllegalArgumentException("Cannot locate timeStamp in " + value);
         // Assume a structure "timeStamp" starts with seconds, nano

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
@@ -110,7 +110,8 @@ public class PVATimeStamp extends PVAStructure
     }
 
     /** 
-     * Conversion from structure to PVATime
+     * Conversion from structure to PVATimeStamp
+     * 
      * @param structure Potential "time_t" structure
      *  @return PVATimeStamp or <code>null</code>
      */

--- a/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/PVATimeStamp.java
@@ -124,4 +124,18 @@ public class PVATimeStamp extends PVAStructure
         }
         return null;
     }
+
+    /**
+     * Get TimeStamp from a PVAStructure
+     * 
+     * @param structure Structure containing TimeStamp
+     * @return PVATimeStamp or <code>null</code>
+     */
+    public static PVATimeStamp getTimeStamp(PVAStructure structure) {
+        var timestampStructure = structure.get(TIMESTAMP_NAME_STRING);
+        if (timestampStructure != null) {
+            return fromStructure((PVAStructure) timestampStructure);
+        }
+        return null;
+    }
 }

--- a/core/pva/src/main/java/org/epics/pva/data/nt/package-info.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/package-info.java
@@ -1,5 +1,6 @@
 /** PV Access Data API for normative types
  *
  *  <p>Helpers for dealing with commonly used {@link org.epics.pva.data.PVAStructure}s
+ *  Normative types documented at https://docs.epics-controls.org/en/latest/specs/Normative-Types-Specification.html# </p>
  */
 package org.epics.pva.data.nt;

--- a/core/pva/src/main/java/org/epics/pva/data/nt/package-info.java
+++ b/core/pva/src/main/java/org/epics/pva/data/nt/package-info.java
@@ -1,6 +1,6 @@
 /** PV Access Data API for normative types
  *
  *  <p>Helpers for dealing with commonly used {@link org.epics.pva.data.PVAStructure}s
- *  Normative types documented at https://docs.epics-controls.org/en/latest/specs/Normative-Types-Specification.html# </p>
+ *  * @see <a href="https://docs.epics-controls.org/en/latest/specs/Normative-Types-Specification.html">Normative types</a>
  */
 package org.epics.pva.data.nt;

--- a/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
@@ -448,5 +448,4 @@ public class ClientDemo
         channel.close();
         pva.close();
     }
-
 }

--- a/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
@@ -10,10 +10,6 @@ package org.epics.pva.client;
 import org.epics.pva.PVASettings;
 import org.epics.pva.data.PVAData;
 import org.epics.pva.data.PVAStructure;
-import org.epics.pva.data.nt.PVAAlarm;
-import org.epics.pva.data.nt.PVAControl;
-import org.epics.pva.data.nt.PVADisplay;
-import org.epics.pva.data.nt.PVATimeStamp;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
@@ -26,7 +22,6 @@ import java.util.logging.LogManager;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -454,28 +449,4 @@ public class ClientDemo
         pva.close();
     }
 
-    /**
-     * Tests if the ioc provides the expected formatting of PVATimeStamp,
-     * PVAAlarm, PVADisplay, PVAEnum, and PVAControl
-     * @throws Exception
-     */
-    @Test
-    public void testPVAScalarRead() throws Exception {
-        var client = new PVAClient();
-        var channel = client.getChannel("ramp");
-        channel.connect().get(5, TimeUnit.SECONDS);
-
-        channel.subscribe("", (ch, changes, overruns, data) ->
-        {
-            var timeStamp = PVATimeStamp.fromStructure(data.get(PVATimeStamp.TIMESTAMP_NAME_STRING));
-            assertNotNull(timeStamp);
-            var alarm = PVAAlarm.fromStructure(data.get(PVAAlarm.ALARM_NAME_STRING));
-            assertNotNull(alarm);
-            var display = PVADisplay.fromStructure(data.get(PVADisplay.DISPLAY_NAME_STRING));
-            assertNotNull(display);
-            var control = PVAControl.fromStructure(data.get(PVAControl.CONTROL_NAME_STRING));
-            assertNotNull(control);
-        });
-        client.close();
-    }
 }

--- a/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/client/ClientDemo.java
@@ -10,6 +10,10 @@ package org.epics.pva.client;
 import org.epics.pva.PVASettings;
 import org.epics.pva.data.PVAData;
 import org.epics.pva.data.PVAStructure;
+import org.epics.pva.data.nt.PVAAlarm;
+import org.epics.pva.data.nt.PVAControl;
+import org.epics.pva.data.nt.PVADisplay;
+import org.epics.pva.data.nt.PVATimeStamp;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
@@ -22,6 +26,7 @@ import java.util.logging.LogManager;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -447,5 +452,30 @@ public class ClientDemo
 
         channel.close();
         pva.close();
+    }
+
+    /**
+     * Tests if the ioc provides the expected formatting of PVATimeStamp,
+     * PVAAlarm, PVADisplay, PVAEnum, and PVAControl
+     * @throws Exception
+     */
+    @Test
+    public void testPVAScalarRead() throws Exception {
+        var client = new PVAClient();
+        var channel = client.getChannel("ramp");
+        channel.connect().get(5, TimeUnit.SECONDS);
+
+        channel.subscribe("", (ch, changes, overruns, data) ->
+        {
+            var timeStamp = PVATimeStamp.fromStructure(data.get(PVATimeStamp.TIMESTAMP_NAME_STRING));
+            assertNotNull(timeStamp);
+            var alarm = PVAAlarm.fromStructure(data.get(PVAAlarm.ALARM_NAME_STRING));
+            assertNotNull(alarm);
+            var display = PVADisplay.fromStructure(data.get(PVADisplay.DISPLAY_NAME_STRING));
+            assertNotNull(display);
+            var control = PVAControl.fromStructure(data.get(PVAControl.CONTROL_NAME_STRING));
+            assertNotNull(control);
+        });
+        client.close();
     }
 }

--- a/core/pva/src/test/java/org/epics/pva/combined/ServerClientTest.java
+++ b/core/pva/src/test/java/org/epics/pva/combined/ServerClientTest.java
@@ -1,0 +1,222 @@
+package org.epics.pva.combined;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.epics.pva.client.MonitorListener;
+import org.epics.pva.client.PVAClient;
+import org.epics.pva.data.PVAByte;
+import org.epics.pva.data.PVAByteArray;
+import org.epics.pva.data.PVAData;
+import org.epics.pva.data.PVADouble;
+import org.epics.pva.data.PVADoubleArray;
+import org.epics.pva.data.PVAFloat;
+import org.epics.pva.data.PVAFloatArray;
+import org.epics.pva.data.PVAInt;
+import org.epics.pva.data.PVAIntArray;
+import org.epics.pva.data.PVAShort;
+import org.epics.pva.data.PVAShortArray;
+import org.epics.pva.data.PVAString;
+import org.epics.pva.data.PVAStringArray;
+import org.epics.pva.data.PVAStructure;
+import org.epics.pva.data.PVAStructures;
+import org.epics.pva.data.nt.FakeDataUtil;
+import org.epics.pva.data.nt.PVAAlarm;
+import org.epics.pva.data.nt.PVAControl;
+import org.epics.pva.data.nt.PVADisplay;
+import org.epics.pva.data.nt.PVAScalar;
+import org.epics.pva.data.nt.PVAScalarDescriptionNameException;
+import org.epics.pva.data.nt.PVAScalarValueNameException;
+import org.epics.pva.data.nt.PVATimeStamp;
+import org.epics.pva.data.nt.PVADisplay.Form;
+import org.epics.pva.server.PVAServer;
+import org.epics.pva.server.ServerPV;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ServerClientTest {
+
+    private PVAServer server;
+    private PVAClient client;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        server = new PVAServer();
+        client = new PVAClient();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        server.close();
+        client.close();
+    }
+
+    /**
+     * Provides the input data for the test cases.
+     * 
+     * First goes over every scalar type, converting the first array of the
+     * generated fake data to the PVAccess type.
+     * Seconds goes over every waveform type, converting each array of the
+     * generated fake data to the PVAccess type.
+     * 
+     * @return input data
+     */
+    public static Collection<Object[]> data() {
+        List<List<Double>> fakeData = FakeDataUtil.fakeData(100, 1.1, 10);
+        return Arrays.asList(new Object[][] {
+                {
+                        fakeData.get(0).stream().map((d) -> new PVAString(PVAScalar.VALUE_NAME_STRING, d.toString()))
+                                .toList() },
+                {
+                        fakeData.get(0).stream().map(Double::shortValue)
+                                .map((s) -> new PVAShort(PVAScalar.VALUE_NAME_STRING, false, s)).toList() },
+                {
+                        fakeData.get(0).stream().map(Double::floatValue)
+                                .map((f) -> new PVAFloat(PVAScalar.VALUE_NAME_STRING, f)).toList() },
+                {
+                        fakeData.get(0).stream().map(Double::byteValue)
+                                .map((b) -> new PVAByte(PVAScalar.VALUE_NAME_STRING, false, b)).toList() },
+                {
+                        fakeData.get(0).stream().map(Double::intValue)
+                                .map((i) -> new PVAInt(PVAScalar.VALUE_NAME_STRING, false, i)).toList() },
+                {
+                        fakeData.get(0).stream().map(Double::doubleValue)
+                                .map((d) -> new PVADouble(PVAScalar.VALUE_NAME_STRING, d)).toList() },
+                {
+                        fakeData.stream()
+                                .map((dArray) -> new PVAStringArray(PVAScalar.VALUE_NAME_STRING,
+                                        dArray.stream().map((d) -> d.toString()).toArray(String[]::new)))
+                                .toList() },
+                {
+                        fakeData.stream()
+                                .map((dArray) -> {
+                                    short[] array = new short[dArray.size()];
+                                    int count = 0;
+                                    for (Double d : dArray) {
+                                        array[count] = d.shortValue();
+                                        count++;
+                                    }
+                                    return new PVAShortArray(PVAScalar.VALUE_NAME_STRING, false, array);
+                                }).toList() },
+                {
+                        fakeData.stream()
+                                .map((dArray) -> {
+                                    float[] array = new float[dArray.size()];
+                                    int count = 0;
+                                    for (Double d : dArray) {
+                                        array[count] = d.floatValue();
+                                        count++;
+                                    }
+                                    return new PVAFloatArray(PVAScalar.VALUE_NAME_STRING, array);
+                                }).toList() },
+                {
+                        fakeData.stream()
+                                .map((dArray) -> {
+                                    byte[] array = new byte[dArray.size()];
+                                    int count = 0;
+                                    for (Double d : dArray) {
+                                        array[count] = d.byteValue();
+                                        count++;
+                                    }
+                                    return new PVAByteArray(PVAScalar.VALUE_NAME_STRING, false, array);
+                                }).toList() },
+                {
+                        fakeData.stream()
+                                .map((dArray) -> new PVAIntArray(PVAScalar.VALUE_NAME_STRING, false,
+                                        dArray.stream().mapToInt((d) -> d.intValue()).toArray()))
+                                .toList() },
+                {
+                        fakeData.stream().map((dArray) -> new PVADoubleArray(PVAScalar.VALUE_NAME_STRING,
+                                dArray.stream().mapToDouble((d) -> d.doubleValue()).toArray()))
+                                .toList() },
+        });
+    }
+
+    static PVAStructure buildPVAStructure(String pvName, Instant instant, PVAData value, String pvDescription) {
+        PVAScalar.Builder<PVAData> builder = new PVAScalar.Builder<>();
+        builder.name(pvName);
+        builder.value(value);
+        builder.description(new PVAString("description",
+                pvDescription));
+        builder.alarm(new PVAAlarm(1, 2,
+                pvDescription + "alarm message"));
+        builder.timeStamp(new PVATimeStamp(instant));
+        builder.display(new PVADisplay(0, 1, pvDescription + "display", "units", 4, Form.STRING));
+        builder.control(new PVAControl(0, 1, 1));
+        try {
+            return builder.build();
+        } catch (PVAScalarValueNameException e) {
+            e.printStackTrace();
+            fail();
+        } catch (PVAScalarDescriptionNameException e) {
+            e.printStackTrace();
+            fail();
+        }
+        return null;
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public <S extends PVAData> void testSinglePV(List<S> inputData) {
+        String pvName = "PV:" + inputData.get(0).getClass().getSimpleName() + ":" + UUID.randomUUID().toString();
+
+        var fakeData = inputData.get(0);
+        String pvDescription = fakeData.getClass().getSimpleName() + ServerClientTest.class.getName() + " test on "
+                + pvName;
+        Instant instant = Instant.now();
+        var instants = new ArrayList<>();
+        instants.add(instant);
+        PVAStructure testPV = buildPVAStructure(pvName, Instant.now(), fakeData, pvDescription);
+        ServerPV serverPV = server.createPV(pvName, testPV);
+
+        try {
+            var ref = new AtomicReference<HashMap<Instant, PVAData>>();
+            ref.set(new HashMap<>());
+            MonitorListener listener = (ch, changes, overruns, data) -> {
+                System.out.println("Got data " + data.get(PVAScalar.VALUE_NAME_STRING));
+                ref.getAndUpdate((l) -> {
+                    Instant recInstant = PVAStructures.getTime(data.get(PVATimeStamp.TIMESTAMP_NAME_STRING));
+                    PVAData recData = data.get(PVAScalar.VALUE_NAME_STRING);
+                    l.put(recInstant, recData);
+                    return l;
+                });
+            };
+            var channel = client.getChannel(pvName);
+            channel.connect().get(5, TimeUnit.SECONDS);
+            channel.subscribe(pvDescription, listener);
+
+            var sentData = new HashMap<Instant, PVAData>();
+            for (S input : inputData) {
+                S newValue = testPV.get(PVAScalar.VALUE_NAME_STRING);
+                newValue.setValue(input);
+                PVATimeStamp timeStamp = testPV.get(PVATimeStamp.TIMESTAMP_NAME_STRING);
+                instant = Instant.now();
+                instants.add(instant);
+                timeStamp.set(instant);
+                sentData.put(instant, newValue);
+                serverPV.update(testPV);
+                TimeUnit.MILLISECONDS.sleep(10);
+                System.out.println("Sent data " + testPV.get(PVAScalar.VALUE_NAME_STRING));
+            }
+
+            assertEquals(inputData.size(), ref.get().size());
+            assertEquals(sentData, ref.get());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+}

--- a/core/pva/src/test/java/org/epics/pva/combined/ServerClientTest.java
+++ b/core/pva/src/test/java/org/epics/pva/combined/ServerClientTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.combined;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/pva/src/test/java/org/epics/pva/combined/ServerClientTest.java
+++ b/core/pva/src/test/java/org/epics/pva/combined/ServerClientTest.java
@@ -179,7 +179,7 @@ public class ServerClientTest {
         builder.value(value);
         builder.description(new PVAString("description",
                 pvDescription));
-        builder.alarm(new PVAAlarm(1, 2,
+        builder.alarm(new PVAAlarm(PVAAlarm.AlarmSeverity.MINOR, PVAAlarm.AlarmStatus.DEVICE,
                 pvDescription + "alarm message"));
         builder.timeStamp(new PVATimeStamp(instant));
         builder.display(new PVADisplay(0, 1, pvDescription + "display", "units", 4, Form.STRING));

--- a/core/pva/src/test/java/org/epics/pva/data/nt/FakeDataUtil.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/FakeDataUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 import java.util.List;

--- a/core/pva/src/test/java/org/epics/pva/data/nt/FakeDataUtil.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/FakeDataUtil.java
@@ -1,0 +1,30 @@
+package org.epics.pva.data.nt;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class FakeDataUtil {
+    
+    /**
+     * Generates a sequence of arrays of numbers up to maxInputNumber
+     * 
+     * For example with maxInputNumber: 10, multiplier: 2, nOfArrayGroups: 2
+     * returns {{2, 4, 6, 8, 10}, {12, 14, 16, 18, 20}}
+     * 
+     * @param maxInputNumber
+     * @param multiplier
+     * @param nOfArrayGroups
+     * @return List of list of fake data
+     */
+    public static List<List<Double>> fakeData(int maxInputNumber, double multiplier, int nOfArrayGroups) {
+        List<Double> listNumbers = IntStream.range(1, maxInputNumber).mapToDouble(i -> multiplier * i).boxed()
+                .collect(Collectors.toList());
+        int groupSize = maxInputNumber / nOfArrayGroups;
+        return IntStream.range(0, nOfArrayGroups - 1)
+                .mapToObj(i -> listNumbers.subList(i * groupSize, (i + 1) * groupSize))
+                .collect(Collectors.toList());
+
+    }
+
+}

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAAlarmTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAAlarmTest.java
@@ -1,0 +1,32 @@
+package org.epics.pva.data.nt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.epics.pva.data.PVAInt;
+import org.epics.pva.data.PVAString;
+import org.epics.pva.data.PVAStructure;
+import org.junit.jupiter.api.Test;
+
+public class PVAAlarmTest {
+
+    @Test
+    void testConstructor() {
+        PVAAlarm alarm = new PVAAlarm("alarm", 5, 1, "alarmMessage");
+        assertEquals(new PVAInt("severity", 5), alarm.get("severity"));
+        assertEquals(new PVAInt("status",  1), alarm.get("status"));
+        assertEquals(new PVAString("message", "alarmMessage"), alarm.get("message"));
+    }
+
+    @Test
+    public void testSet() {
+        PVAAlarm alarm = new PVAAlarm("testName", 1, 2, "test message");
+
+        PVAStructure clone = alarm.cloneData();
+
+        assertEquals(alarm, clone);
+
+        alarm.set(0, 0, "test message 2");
+        assertNotEquals(alarm, clone);
+    }
+}

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAAlarmTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAAlarmTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAAlarmTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAAlarmTest.java
@@ -30,21 +30,21 @@ public class PVAAlarmTest {
 
     @Test
     void testConstructor() {
-        PVAAlarm alarm = new PVAAlarm(5, 1, "alarmMessage");
-        assertEquals(new PVAInt("severity", 5), alarm.get("severity"));
-        assertEquals(new PVAInt("status",  1), alarm.get("status"));
+        PVAAlarm alarm = new PVAAlarm(PVAAlarm.AlarmSeverity.MAJOR, PVAAlarm.AlarmStatus.DRIVER, "alarmMessage");
+        assertEquals(new PVAInt("severity", 2), alarm.get("severity"));
+        assertEquals(new PVAInt("status", 2), alarm.get("status"));
         assertEquals(new PVAString("message", "alarmMessage"), alarm.get("message"));
     }
 
     @Test
     public void testSet() {
-        PVAAlarm alarm = new PVAAlarm(1, 2, "test message");
+        PVAAlarm alarm = new PVAAlarm(PVAAlarm.AlarmSeverity.MAJOR, PVAAlarm.AlarmStatus.DRIVER, "test message");
 
         PVAStructure clone = alarm.cloneData();
 
         assertEquals(alarm, clone);
 
-        alarm.set(0, 0, "test message 2");
+        alarm.set(PVAAlarm.AlarmSeverity.NO_ALARM, PVAAlarm.AlarmStatus.NO_STATUS, "test message 2");
         assertNotEquals(alarm, clone);
     }
 }

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAAlarmTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAAlarmTest.java
@@ -12,7 +12,7 @@ public class PVAAlarmTest {
 
     @Test
     void testConstructor() {
-        PVAAlarm alarm = new PVAAlarm("alarm", 5, 1, "alarmMessage");
+        PVAAlarm alarm = new PVAAlarm(5, 1, "alarmMessage");
         assertEquals(new PVAInt("severity", 5), alarm.get("severity"));
         assertEquals(new PVAInt("status",  1), alarm.get("status"));
         assertEquals(new PVAString("message", "alarmMessage"), alarm.get("message"));
@@ -20,7 +20,7 @@ public class PVAAlarmTest {
 
     @Test
     public void testSet() {
-        PVAAlarm alarm = new PVAAlarm("testName", 1, 2, "test message");
+        PVAAlarm alarm = new PVAAlarm(1, 2, "test message");
 
         PVAStructure clone = alarm.cloneData();
 

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarDemo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+package org.epics.pva.data.nt;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.TimeUnit;
+
+import org.epics.pva.client.PVAClient;
+import org.junit.jupiter.api.Test;
+
+
+/** Demo using demo.db from test resources:
+ *    softIocPVA -m N='' -d demo.db
+ */
+public class PVAScalarDemo {
+    
+    /**
+     * Tests if the ioc provides the expected formatting of PVATimeStamp,
+     * PVAAlarm, PVADisplay, PVAEnum, PVAControl and PVAScalar
+     * @throws Exception
+     */
+    @Test
+    public void testPVAScalarRead() throws Exception {
+        var client = new PVAClient();
+        var channel = client.getChannel("ramp");
+        channel.connect().get(5, TimeUnit.SECONDS);
+
+        channel.subscribe("", (ch, changes, overruns, data) ->
+        {
+            var timeStamp = PVATimeStamp.getTimeStamp(data);
+            assertNotNull(timeStamp);
+            var alarm = PVAAlarm.getAlarm(data);
+            assertNotNull(alarm);
+            var display = PVADisplay.getDisplay(data);
+            assertNotNull(display);
+            var control = PVAControl.getControl(data);
+            assertNotNull(control);
+            try {
+				var scalar = PVAScalar.fromStructure(data);
+			} catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+				e.printStackTrace();
+                fail();
+			}
+        });
+        client.close();
+    }
+}

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarDemo.java
@@ -23,7 +23,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.TimeUnit;
 
+import org.epics.pva.client.PVAChannel;
 import org.epics.pva.client.PVAClient;
+import org.epics.pva.data.PVAInt;
 import org.junit.jupiter.api.Test;
 
 
@@ -39,22 +41,23 @@ public class PVAScalarDemo {
      */
     @Test
     public void testPVAScalarRead() throws Exception {
-        var client = new PVAClient();
-        var channel = client.getChannel("ramp");
+        PVAClient client = new PVAClient();
+        PVAChannel channel = client.getChannel("ramp");
         channel.connect().get(5, TimeUnit.SECONDS);
 
         channel.subscribe("", (ch, changes, overruns, data) ->
         {
-            var timeStamp = PVATimeStamp.getTimeStamp(data);
+            PVATimeStamp timeStamp = PVATimeStamp.getTimeStamp(data);
             assertNotNull(timeStamp);
-            var alarm = PVAAlarm.getAlarm(data);
+            PVAAlarm alarm = PVAAlarm.getAlarm(data);
             assertNotNull(alarm);
-            var display = PVADisplay.getDisplay(data);
+            PVADisplay display = PVADisplay.getDisplay(data);
             assertNotNull(display);
-            var control = PVAControl.getControl(data);
+            PVAControl control = PVAControl.getControl(data);
             assertNotNull(control);
             try {
-				var scalar = PVAScalar.fromStructure(data);
+				PVAScalar<PVAInt> scalar = PVAScalar.fromStructure(data);
+                assertNotNull(scalar);
 			} catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
 				e.printStackTrace();
                 fail();

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
@@ -1,0 +1,33 @@
+package org.epics.pva.data.nt;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.epics.pva.data.PVADouble;
+import org.epics.pva.data.PVAString;
+import org.junit.Test;
+
+public class PVAScalarTest {
+    @Test
+    public void testDouble() throws PVAScalarValueNameException {
+        PVAScalar<PVADouble> doubleScalar = (new PVAScalar.Builder<PVADouble>()).name("pvDoubleName").value( new PVADouble("value", 1.1)).build();
+        assertEquals(new PVADouble("value", 1.1), doubleScalar.get("value"));
+    }
+
+    @Test
+    public void testString() throws PVAScalarValueNameException {
+        PVAScalar<PVAString> stringScalar = (new PVAScalar.Builder<PVAString>()).name("pvStringName").value( new PVAString("value", "1.1")).build();
+        assertEquals(new PVAString("value", "1.1"), stringScalar.get("value"));
+    }
+
+    @Test
+    public void testPVAScalarValueNameException() {
+        
+        PVAScalar.Builder<PVAString> builder = (new PVAScalar.Builder<PVAString>()).name("pvName").value(new PVAString("notvalue", "the value"));
+       
+        assertThrows(PVAScalarValueNameException.class, () -> {
+            builder.build();
+        });
+    }
+
+}

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
@@ -2,32 +2,208 @@ package org.epics.pva.data.nt;
 
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
 
 import org.epics.pva.data.PVADouble;
 import org.epics.pva.data.PVAString;
 import org.junit.Test;
 
 public class PVAScalarTest {
-    @Test
-    public void testDouble() throws PVAScalarValueNameException {
-        PVAScalar<PVADouble> doubleScalar = (new PVAScalar.Builder<PVADouble>()).name("pvDoubleName").value( new PVADouble("value", 1.1)).build();
-        assertEquals(new PVADouble("value", 1.1), doubleScalar.get("value"));
-    }
+        @Test
+        public void testDouble() throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
+                PVAScalar<PVADouble> doubleScalar = (new PVAScalar.Builder<PVADouble>()).name("pvDoubleName")
+                                .value(new PVADouble("value", 1.1)).build();
+                assertEquals(new PVADouble("value", 1.1), doubleScalar.get("value"));
+        }
 
-    @Test
-    public void testString() throws PVAScalarValueNameException {
-        PVAScalar<PVAString> stringScalar = (new PVAScalar.Builder<PVAString>()).name("pvStringName").value( new PVAString("value", "1.1")).build();
-        assertEquals(new PVAString("value", "1.1"), stringScalar.get("value"));
-    }
+        @Test
+        public void testString() throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
+                PVAScalar<PVAString> stringScalar = (new PVAScalar.Builder<PVAString>()).name("pvStringName")
+                                .value(new PVAString("value", "1.1")).build();
+                assertEquals(new PVAString("value", "1.1"), stringScalar.get("value"));
+        }
 
-    @Test
-    public void testPVAScalarValueNameException() {
-        
-        PVAScalar.Builder<PVAString> builder = (new PVAScalar.Builder<PVAString>()).name("pvName").value(new PVAString("notvalue", "the value"));
-       
-        assertThrows(PVAScalarValueNameException.class, () -> {
-            builder.build();
-        });
-    }
+        @Test
+        public void testPVAScalarValueNameException() {
+
+                PVAScalar.Builder<PVAString> builder = (new PVAScalar.Builder<PVAString>()).name("pvName")
+                                .value(new PVAString("notvalue", "the value"));
+
+                assertThrows(PVAScalarValueNameException.class, () -> {
+                        builder.build();
+                });
+        }
+
+        @Test
+        public void testPVAScalarDescriptionNameException() {
+
+                PVAScalar.Builder<PVAString> builder = (new PVAScalar.Builder<PVAString>()).name("pvName")
+                                .value(new PVAString("value", "the value"))
+                                .description(new PVAString("notdescription"));
+
+                assertThrows(PVAScalarDescriptionNameException.class, () -> {
+                        builder.build();
+                });
+        }
+
+        @Test
+        public void smokeTestBuilders() {
+                List<List<Double>> fakeData = FakeDataUtil.fakeData(100, 1.1, 10);
+                String pvName = "pvName";
+                fakeData.get(0).stream()
+                                .map((d) -> {
+                                        try {
+                                                return PVAScalar.stringScalarBuilder(d.toString()).name(pvName).build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                })
+                                .toList();
+                fakeData.get(0).stream().map(Double::shortValue)
+                                .map((s) -> {
+                                        try {
+                                                return PVAScalar.shortScalarBuilder(false, s).name(pvName).build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                })
+                                .toList();
+                fakeData.get(0).stream().map(Double::floatValue)
+                                .map((f) -> {
+                                        try {
+                                                return PVAScalar.floatScalarBuilder(f).name(pvName).build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                }).toList();
+                fakeData.get(0).stream().map(Double::byteValue)
+                                .map((b) -> {
+                                        try {
+                                                return PVAScalar.byteScalarBuilder(false, b).name(pvName).build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                })
+                                .toList();
+                fakeData.get(0).stream().map(Double::intValue)
+                                .map((i) -> {
+                                        try {
+                                                return PVAScalar.intScalarBuilder(i).name(pvName).build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                }).toList();
+                fakeData.get(0).stream().map(Double::doubleValue)
+                                .map((d) -> {
+                                        try {
+                                                return PVAScalar.doubleScalarBuilder(d).name(pvName).build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                }).toList();
+                fakeData.stream()
+                                .map((dArray) -> {
+                                        try {
+                                                return PVAScalar.stringArrayScalarBuilder(
+                                                                dArray.stream().map((d) -> d.toString()).toArray(String[]::new))
+                                                                .name(pvName).build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                })
+                                .toList();
+                fakeData.stream()
+                                .map((dArray) -> {
+                                        short[] array = new short[dArray.size()];
+                                        int count = 0;
+                                        for (Double d : dArray) {
+                                                array[count] = d.shortValue();
+                                                count++;
+                                        }
+                                        try {
+                                                return PVAScalar.shortArrayScalarBuilder(false, array).name(pvName)
+                                                                .build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                }).toList();
+                fakeData.stream()
+                                .map((dArray) -> {
+                                        float[] array = new float[dArray.size()];
+                                        int count = 0;
+                                        for (Double d : dArray) {
+                                                array[count] = d.floatValue();
+                                                count++;
+                                        }
+                                        try {
+                                                return PVAScalar.floatArrayScalarBuilder(array).name(pvName).build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                }).toList();
+                fakeData.stream()
+                                .map((dArray) -> {
+                                        byte[] array = new byte[dArray.size()];
+                                        int count = 0;
+                                        for (Double d : dArray) {
+                                                array[count] = d.byteValue();
+                                                count++;
+                                        }
+                                        try {
+                                                return PVAScalar.byteArrayScalarBuilder(false, array).name(pvName)
+                                                                .build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                }).toList();
+                fakeData.stream()
+                                .map((dArray) -> {
+                                        try {
+                                                return PVAScalar.intArrayScalarBuilder(false,
+                                                                dArray.stream().mapToInt((d) -> d.intValue()).toArray())
+                                                                .name(pvName).build();
+                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                                e.printStackTrace();
+                                                fail();
+                                        }
+                                        return null;
+                                })
+                                .toList();
+                fakeData.stream().map((dArray) -> {
+                        try {
+                                return PVAScalar.doubleArrayScalarBuilder(
+                                                dArray.stream().mapToDouble((d) -> d.doubleValue()).toArray()).name(pvName)
+                                                .build();
+                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                                e.printStackTrace();
+                                fail();
+                        }
+                        return null;
+                })
+                                .toList();
+
+        }
 
 }

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
@@ -27,202 +27,216 @@ import java.util.stream.Collectors;
 
 import org.epics.pva.data.PVADouble;
 import org.epics.pva.data.PVAString;
+import org.epics.pva.data.PVAStringArray;
 import org.junit.jupiter.api.Test;
 
 public class PVAScalarTest {
-        @Test
-        public void testDouble() throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
-                PVAScalar<PVADouble> doubleScalar = (new PVAScalar.Builder<PVADouble>()).name("pvDoubleName")
-                                .value(new PVADouble("value", 1.1)).build();
-                assertEquals(new PVADouble("value", 1.1), doubleScalar.get("value"));
-        }
+    @Test
+    public void testDouble() throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
+        PVAScalar<PVADouble> doubleScalar = (new PVAScalar.Builder<PVADouble>()).name("pvDoubleName")
+                .value(new PVADouble("value", 1.1)).build();
+        assertEquals(new PVADouble("value", 1.1), doubleScalar.get("value"));
+    }
 
-        @Test
-        public void testString() throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
-                PVAScalar<PVAString> stringScalar = (new PVAScalar.Builder<PVAString>()).name("pvStringName")
-                                .value(new PVAString("value", "1.1")).build();
-                assertEquals(new PVAString("value", "1.1"), stringScalar.get("value"));
-        }
+    @Test
+    public void testString() throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
+        PVAScalar<PVAString> stringScalar = (new PVAScalar.Builder<PVAString>()).name("pvStringName")
+                .value(new PVAString("value", "1.1")).build();
+        assertEquals(new PVAString("value", "1.1"), stringScalar.get("value"));
+    }
 
-        @Test
-        public void testPVAScalarValueNameException() {
+    @Test
+    public void testPVAScalarValueNameException() {
 
-                PVAScalar.Builder<PVAString> builder = (new PVAScalar.Builder<PVAString>()).name("pvName")
-                                .value(new PVAString("notvalue", "the value"));
+        PVAScalar.Builder<PVAString> builder = (new PVAScalar.Builder<PVAString>()).name("pvName")
+                .value(new PVAString("notvalue", "the value"));
 
-                assertThrows(PVAScalarValueNameException.class, () -> {
-                        builder.build();
-                });
-        }
+        assertThrows(PVAScalarValueNameException.class, () -> {
+            builder.build();
+        });
+    }
 
-        @Test
-        public void testPVAScalarDescriptionNameException() {
+    @Test
+    public void testPVAScalarDescriptionNameException() {
 
-                PVAScalar.Builder<PVAString> builder = (new PVAScalar.Builder<PVAString>()).name("pvName")
-                                .value(new PVAString("value", "the value"))
-                                .description(new PVAString("notdescription"));
+        PVAScalar.Builder<PVAString> builder = (new PVAScalar.Builder<PVAString>()).name("pvName")
+                .value(new PVAString("value", "the value"))
+                .description(new PVAString("notdescription"));
 
-                assertThrows(PVAScalarDescriptionNameException.class, () -> {
-                        builder.build();
-                });
-        }
+        assertThrows(PVAScalarDescriptionNameException.class, () -> {
+            builder.build();
+        });
+    }
 
-        @Test
-        public void smokeTestBuilders() {
-                List<List<Double>> fakeData = FakeDataUtil.fakeData(100, 1.1, 10);
-                String pvName = "pvName";
-                fakeData.get(0).stream()
-                                .map((d) -> {
-                                        try {
-                                                return PVAScalar.stringScalarBuilder(d.toString()).name(pvName).build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                })
-                                .collect(Collectors.toList());
-                fakeData.get(0).stream().map(Double::shortValue)
-                                .map((s) -> {
-                                        try {
-                                                return PVAScalar.shortScalarBuilder(false, s).name(pvName).build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                })
-                                .collect(Collectors.toList());
-                fakeData.get(0).stream().map(Double::floatValue)
-                                .map((f) -> {
-                                        try {
-                                                return PVAScalar.floatScalarBuilder(f).name(pvName).build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                }).collect(Collectors.toList());
-                fakeData.get(0).stream().map(Double::byteValue)
-                                .map((b) -> {
-                                        try {
-                                                return PVAScalar.byteScalarBuilder(false, b).name(pvName).build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                })
-                                .collect(Collectors.toList());
-                fakeData.get(0).stream().map(Double::intValue)
-                                .map((i) -> {
-                                        try {
-                                                return PVAScalar.intScalarBuilder(i).name(pvName).build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                }).collect(Collectors.toList());
-                fakeData.get(0).stream().map(Double::doubleValue)
-                                .map((d) -> {
-                                        try {
-                                                return PVAScalar.doubleScalarBuilder(d).name(pvName).build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                }).collect(Collectors.toList());
-                fakeData.stream()
-                                .map((dArray) -> {
-                                        try {
-                                                return PVAScalar.stringArrayScalarBuilder(
-                                                                dArray.stream().map((d) -> d.toString()).toArray(String[]::new))
-                                                                .name(pvName).build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                })
-                                .collect(Collectors.toList());
-                fakeData.stream()
-                                .map((dArray) -> {
-                                        short[] array = new short[dArray.size()];
-                                        int count = 0;
-                                        for (Double d : dArray) {
-                                                array[count] = d.shortValue();
-                                                count++;
-                                        }
-                                        try {
-                                                return PVAScalar.shortArrayScalarBuilder(false, array).name(pvName)
-                                                                .build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                }).collect(Collectors.toList());
-                fakeData.stream()
-                                .map((dArray) -> {
-                                        float[] array = new float[dArray.size()];
-                                        int count = 0;
-                                        for (Double d : dArray) {
-                                                array[count] = d.floatValue();
-                                                count++;
-                                        }
-                                        try {
-                                                return PVAScalar.floatArrayScalarBuilder(array).name(pvName).build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                }).collect(Collectors.toList());
-                fakeData.stream()
-                                .map((dArray) -> {
-                                        byte[] array = new byte[dArray.size()];
-                                        int count = 0;
-                                        for (Double d : dArray) {
-                                                array[count] = d.byteValue();
-                                                count++;
-                                        }
-                                        try {
-                                                return PVAScalar.byteArrayScalarBuilder(false, array).name(pvName)
-                                                                .build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                }).collect(Collectors.toList());
-                fakeData.stream()
-                                .map((dArray) -> {
-                                        try {
-                                                return PVAScalar.intArrayScalarBuilder(false,
-                                                                dArray.stream().mapToInt((d) -> d.intValue()).toArray())
-                                                                .name(pvName).build();
-                                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                                e.printStackTrace();
-                                                fail();
-                                        }
-                                        return null;
-                                })
-                                .collect(Collectors.toList());
-                fakeData.stream().map((dArray) -> {
-                        try {
-                                return PVAScalar.doubleArrayScalarBuilder(
-                                                dArray.stream().mapToDouble((d) -> d.doubleValue()).toArray()).name(pvName)
-                                                .build();
-                        } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
-                                e.printStackTrace();
-                                fail();
-                        }
-                        return null;
+    @Test
+    public void testStructName() throws PVAScalarValueNameException, PVAScalarDescriptionNameException {
+
+        PVAScalar<PVAString> scalar = (new PVAScalar.Builder<PVAString>()).name("pvName")
+                .value(new PVAString("value", "the value")).build();
+        assertEquals(PVAScalar.SCALAR_STRUCT_NAME_STRING, scalar.getStructureName());
+        PVAScalar<PVAStringArray> array = (new PVAScalar.Builder<PVAStringArray>()).name("pvName")
+                .value(new PVAStringArray("value", "the value", "another value")).build();
+        assertEquals(PVAScalar.ARRAY_STRUCT_NAME_STRING, array.getStructureName());
+    }
+
+    @Test
+    public void smokeTestBuilders() {
+        List<List<Double>> fakeData = FakeDataUtil.fakeData(100, 1.1, 10);
+        String pvName = "pvName";
+        fakeData.get(0).stream()
+                .map((d) -> {
+                    try {
+                        return PVAScalar.stringScalarBuilder(d.toString()).name(pvName).build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
                 })
-                                .collect(Collectors.toList());
+                .collect(Collectors.toList());
+        fakeData.get(0).stream().map(Double::shortValue)
+                .map((s) -> {
+                    try {
+                        return PVAScalar.shortScalarBuilder(false, s).name(pvName).build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                })
+                .collect(Collectors.toList());
+        fakeData.get(0).stream().map(Double::floatValue)
+                .map((f) -> {
+                    try {
+                        return PVAScalar.floatScalarBuilder(f).name(pvName).build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                }).collect(Collectors.toList());
+        fakeData.get(0).stream().map(Double::byteValue)
+                .map((b) -> {
+                    try {
+                        return PVAScalar.byteScalarBuilder(false, b).name(pvName).build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                })
+                .collect(Collectors.toList());
+        fakeData.get(0).stream().map(Double::intValue)
+                .map((i) -> {
+                    try {
+                        return PVAScalar.intScalarBuilder(i).name(pvName).build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                }).collect(Collectors.toList());
+        fakeData.get(0).stream().map(Double::doubleValue)
+                .map((d) -> {
+                    try {
+                        return PVAScalar.doubleScalarBuilder(d).name(pvName).build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                }).collect(Collectors.toList());
+        fakeData.stream()
+                .map((dArray) -> {
+                    try {
+                        return PVAScalar.stringArrayScalarBuilder(
+                                dArray.stream().map((d) -> d.toString())
+                                        .toArray(String[]::new))
+                                .name(pvName).build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                })
+                .collect(Collectors.toList());
+        fakeData.stream()
+                .map((dArray) -> {
+                    short[] array = new short[dArray.size()];
+                    int count = 0;
+                    for (Double d : dArray) {
+                        array[count] = d.shortValue();
+                        count++;
+                    }
+                    try {
+                        return PVAScalar.shortArrayScalarBuilder(false, array).name(pvName)
+                                .build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                }).collect(Collectors.toList());
+        fakeData.stream()
+                .map((dArray) -> {
+                    float[] array = new float[dArray.size()];
+                    int count = 0;
+                    for (Double d : dArray) {
+                        array[count] = d.floatValue();
+                        count++;
+                    }
+                    try {
+                        return PVAScalar.floatArrayScalarBuilder(array).name(pvName).build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                }).collect(Collectors.toList());
+        fakeData.stream()
+                .map((dArray) -> {
+                    byte[] array = new byte[dArray.size()];
+                    int count = 0;
+                    for (Double d : dArray) {
+                        array[count] = d.byteValue();
+                        count++;
+                    }
+                    try {
+                        return PVAScalar.byteArrayScalarBuilder(false, array).name(pvName)
+                                .build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                }).collect(Collectors.toList());
+        fakeData.stream()
+                .map((dArray) -> {
+                    try {
+                        return PVAScalar.intArrayScalarBuilder(false,
+                                dArray.stream().mapToInt((d) -> d.intValue()).toArray())
+                                .name(pvName).build();
+                    } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                        e.printStackTrace();
+                        fail();
+                    }
+                    return null;
+                })
+                .collect(Collectors.toList());
+        fakeData.stream().map((dArray) -> {
+            try {
+                return PVAScalar.doubleArrayScalarBuilder(
+                        dArray.stream().mapToDouble((d) -> d.doubleValue()).toArray())
+                        .name(pvName)
+                        .build();
+            } catch (PVAScalarValueNameException | PVAScalarDescriptionNameException e) {
+                e.printStackTrace();
+                fail();
+            }
+            return null;
+        })
+                .collect(Collectors.toList());
 
-        }
+    }
 
 }

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
@@ -1,14 +1,14 @@
 package org.epics.pva.data.nt;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
 import org.epics.pva.data.PVADouble;
 import org.epics.pva.data.PVAString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PVAScalarTest {
         @Test

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVAScalarTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.epics.pva.data.PVADouble;
 import org.epics.pva.data.PVAString;
@@ -80,7 +81,7 @@ public class PVAScalarTest {
                                         }
                                         return null;
                                 })
-                                .toList();
+                                .collect(Collectors.toList());
                 fakeData.get(0).stream().map(Double::shortValue)
                                 .map((s) -> {
                                         try {
@@ -91,7 +92,7 @@ public class PVAScalarTest {
                                         }
                                         return null;
                                 })
-                                .toList();
+                                .collect(Collectors.toList());
                 fakeData.get(0).stream().map(Double::floatValue)
                                 .map((f) -> {
                                         try {
@@ -101,7 +102,7 @@ public class PVAScalarTest {
                                                 fail();
                                         }
                                         return null;
-                                }).toList();
+                                }).collect(Collectors.toList());
                 fakeData.get(0).stream().map(Double::byteValue)
                                 .map((b) -> {
                                         try {
@@ -112,7 +113,7 @@ public class PVAScalarTest {
                                         }
                                         return null;
                                 })
-                                .toList();
+                                .collect(Collectors.toList());
                 fakeData.get(0).stream().map(Double::intValue)
                                 .map((i) -> {
                                         try {
@@ -122,7 +123,7 @@ public class PVAScalarTest {
                                                 fail();
                                         }
                                         return null;
-                                }).toList();
+                                }).collect(Collectors.toList());
                 fakeData.get(0).stream().map(Double::doubleValue)
                                 .map((d) -> {
                                         try {
@@ -132,7 +133,7 @@ public class PVAScalarTest {
                                                 fail();
                                         }
                                         return null;
-                                }).toList();
+                                }).collect(Collectors.toList());
                 fakeData.stream()
                                 .map((dArray) -> {
                                         try {
@@ -145,7 +146,7 @@ public class PVAScalarTest {
                                         }
                                         return null;
                                 })
-                                .toList();
+                                .collect(Collectors.toList());
                 fakeData.stream()
                                 .map((dArray) -> {
                                         short[] array = new short[dArray.size()];
@@ -162,7 +163,7 @@ public class PVAScalarTest {
                                                 fail();
                                         }
                                         return null;
-                                }).toList();
+                                }).collect(Collectors.toList());
                 fakeData.stream()
                                 .map((dArray) -> {
                                         float[] array = new float[dArray.size()];
@@ -178,7 +179,7 @@ public class PVAScalarTest {
                                                 fail();
                                         }
                                         return null;
-                                }).toList();
+                                }).collect(Collectors.toList());
                 fakeData.stream()
                                 .map((dArray) -> {
                                         byte[] array = new byte[dArray.size()];
@@ -195,7 +196,7 @@ public class PVAScalarTest {
                                                 fail();
                                         }
                                         return null;
-                                }).toList();
+                                }).collect(Collectors.toList());
                 fakeData.stream()
                                 .map((dArray) -> {
                                         try {
@@ -208,7 +209,7 @@ public class PVAScalarTest {
                                         }
                                         return null;
                                 })
-                                .toList();
+                                .collect(Collectors.toList());
                 fakeData.stream().map((dArray) -> {
                         try {
                                 return PVAScalar.doubleArrayScalarBuilder(
@@ -220,7 +221,7 @@ public class PVAScalarTest {
                         }
                         return null;
                 })
-                                .toList();
+                                .collect(Collectors.toList());
 
         }
 

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVATimeStampTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVATimeStampTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
 package org.epics.pva.data.nt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/pva/src/test/java/org/epics/pva/data/nt/PVATimeStampTest.java
+++ b/core/pva/src/test/java/org/epics/pva/data/nt/PVATimeStampTest.java
@@ -1,0 +1,22 @@
+package org.epics.pva.data.nt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+
+import org.epics.pva.data.PVAInt;
+import org.epics.pva.data.PVALong;
+import org.junit.jupiter.api.Test;
+
+public class PVATimeStampTest {
+    @Test
+    void testConstructor() {
+        Instant time = Instant.ofEpochSecond(2, 1);
+        PVATimeStamp timeStamp = new PVATimeStamp(time);
+        assertEquals(new PVALong("secondsPastEpoch", false, 2), timeStamp.get("secondsPastEpoch"));
+        assertEquals(new PVAInt("nanoseconds", false, 1), timeStamp.get("nanoseconds"));
+        assertEquals(new PVAInt("userTag", 0), timeStamp.get("userTag"));
+
+        assertEquals(time, timeStamp.instant());
+    }
+}

--- a/core/pva/src/test/java/org/epics/pva/server/ServerDemo.java
+++ b/core/pva/src/test/java/org/epics/pva/server/ServerDemo.java
@@ -94,7 +94,7 @@ public class ServerDemo
             catch (Exception ex)
             {
                 // Expected
-                if (! ex.getMessage().toLowerCase().contains("incompatibl"))
+                if (! ex.getMessage().toLowerCase().contains("incompatible"))
                     throw ex;
             }
         }

--- a/core/pva/src/test/resources/demo.db
+++ b/core/pva/src/test/resources/demo.db
@@ -11,6 +11,7 @@ record(calc, "ramp$(N)")
   field(LSV,  "MINOR")
   field(HSV,  "MINOR")
   field(FLNK, "waveform$(N)")
+  field(DESC, "ramp going up")
 }
 
 record(calc, "saw$(N)")


### PR DESCRIPTION
Adds helper classes for the [NTScalar type](https://docs.epics-controls.org/en/latest/specs/Normative-Types-Specification.html#ntscalar)

Includes helper classes for:
 Alarm
 Control
 Display
 Enum

With constructors and from PVStructure methods. 
Also refactors the PVATimeStamp class to match.

Tests added:

A few small smoke construction tests.

A Server client test
  Test sets up a server with a NTScalar pv and sends some fake data for all Scalar sub types (except enum)
  Test then checks that a client can recieve events and asserts they match.

An integration test for running with a local version of Epics. Checks that can parse a live ioc with the helper classes.