### PR TITLE
CSSTUDIO-1795: Support for In Memory Credentials Caching

### DIFF
--- a/core/security/src/main/java/org/phoebus/security/PhoebusSecurity.java
+++ b/core/security/src/main/java/org/phoebus/security/PhoebusSecurity.java
@@ -11,6 +11,7 @@ import java.util.logging.Logger;
 
 import org.phoebus.framework.preferences.AnnotatedPreferences;
 import org.phoebus.framework.preferences.Preference;
+import org.phoebus.security.store.SecureStoreTarget;
 
 /** Phoebus security logger and Preference settings
  *  @author Kay Kasemir
@@ -23,6 +24,8 @@ public class PhoebusSecurity
 
     /** Preference setting */
     @Preference public static String authorization_file;
+
+    @Preference public static SecureStoreTarget secure_store_target;
 
     static
     {

--- a/core/security/src/main/java/org/phoebus/security/store/FileBasedStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/FileBasedStore.java
@@ -1,0 +1,123 @@
+package org.phoebus.security.store;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.security.KeyStore;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import org.phoebus.framework.workbench.Locations;
+
+/** Secure Store
+ *
+ *  <p>Writes tag/value pairs into an encrypted file.
+ *
+ *  <p>Does depend on a password to read and write the file.
+ *
+ *  @author Kay Kasemir
+ */
+public class FileBasedStore implements Store<String, String> {
+
+    private final SecretKeyFactory kf = SecretKeyFactory.getInstance("PBE");
+    private final KeyStore store;
+    private final File secure_file;
+    private final char[] store_pass;
+    private final KeyStore.ProtectionParameter pp;
+
+    private static final Logger LOGGER = Logger.getLogger(SecureStore.class.getName());
+
+    /** Create with default file in 'user' location
+     *  @throws Exception on error
+     */
+    public FileBasedStore() throws Exception
+    {
+        this(new File(Locations.user(), "secure_store.dat"));
+    }
+
+    /** Create with default password.
+     *
+     *  <p>Knowledge of this code would allow reading the file
+     *
+     *  @param secure_file File to read or write
+     *  @throws Exception on error
+     */
+    public FileBasedStore(final File secure_file) throws Exception
+    {
+        this(secure_file, Integer.toString(secure_file.getAbsolutePath().hashCode()).toCharArray());
+    }
+
+    /** Create
+     *  @param secure_file File to read or write
+     *  @param store_pass Password for encoding/decoding entries
+     *  @throws Exception on error
+     */
+    public FileBasedStore(final File secure_file, final char[] store_pass) throws Exception
+    {
+        this.secure_file = secure_file;
+        this.store_pass = store_pass;
+
+        store = KeyStore.getInstance(KeyStore.getDefaultType());
+
+        pp = new KeyStore.PasswordProtection(store_pass);
+
+        // Load existing file or initialize as empty
+        if (secure_file.canRead())
+            store.load(new FileInputStream(secure_file), store_pass);
+        else
+            store.load(null, store_pass);
+    }
+
+    /** Read an entry from the store
+     *  @param tag Tag that identifies the entry
+     *  @return Stored text or <code>null</code>
+     *  @throws Exception on error
+     */
+    @Override
+    public String get(final String tag) throws Exception
+    {
+        final KeyStore.SecretKeyEntry entry = (KeyStore.SecretKeyEntry) store.getEntry(tag, pp);
+        if (entry == null)
+            return null;
+
+        final PBEKeySpec key = (PBEKeySpec) kf.getKeySpec(entry.getSecretKey(), PBEKeySpec.class);
+        return new String(key.getPassword());
+    }
+
+    /** Write an entry to the store. If the entry already exists, it will be overwritten.
+     *  @param tag Tag that identifies the entry
+     *  @param value Value of the entry
+     *  @throws Exception on error
+     */
+    @Override
+    public void set(final String tag, final String value) throws Exception
+    {
+        final SecretKey skey = kf.generateSecret(new PBEKeySpec(value.toCharArray()));
+        store.setEntry(tag, new KeyStore.SecretKeyEntry(skey), pp);
+
+        // Write file whenever an entry is changed
+        store.store(new FileOutputStream(secure_file), store_pass);
+    }
+
+    /** Deletes an entry in the secure store.
+     *  @param tag The tag to delete, must not be <code>null</code>.
+     *  @throws Exception on error
+     */
+    @Override
+    public void delete(String tag) throws Exception{
+        store.deleteEntry(tag);
+        LOGGER.log(Level.INFO, "Deleting entry " + tag + " from secure store");
+        // Write file whenever an entry is changed
+        store.store(new FileOutputStream(secure_file), store_pass);
+    }
+
+    @Override
+    public List<String> getKeys() throws Exception {
+        return Collections.list(store.aliases());
+    }
+
+}

--- a/core/security/src/main/java/org/phoebus/security/store/MemoryBasedStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/MemoryBasedStore.java
@@ -1,0 +1,43 @@
+package org.phoebus.security.store;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Writes entries to an in-memory map that persists during the lifetime the application is running.
+ */
+public class MemoryBasedStore implements Store<String, String> {
+
+    private final Map<String, String> store = new HashMap<>();
+
+    private static MemoryBasedStore INSTANCE = new MemoryBasedStore();
+
+    private MemoryBasedStore() {}
+
+    public static MemoryBasedStore getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String get(String key) {
+        return store.get(key);
+    }
+
+    @Override
+    public List<String> getKeys() {
+        return new ArrayList<>(store.keySet());
+    }
+
+    @Override
+    public void set(String key, String value) {
+        store.put(key, value);
+    }
+
+    @Override
+    public void delete(String key) {
+        store.remove(key);
+    }
+
+}

--- a/core/security/src/main/java/org/phoebus/security/store/SecureStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/SecureStore.java
@@ -7,40 +7,23 @@
  *******************************************************************************/
 package org.phoebus.security.store;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.security.KeyStore;
-import java.security.KeyStore.ProtectionParameter;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
-
-import org.phoebus.framework.workbench.Locations;
+import org.phoebus.security.PhoebusSecurity;
 import org.phoebus.security.tokens.ScopedAuthenticationToken;
 
-/** Secure Store
- *
- *  <p>Writes tag/value pairs into an encrypted file.
- *
- *  <p>Does depend on a password to read and write the file.
- *
- *  @author Kay Kasemir
+/**
+ * Handles reading/writing username, passsword, and token data. Internally delegates to
+ * a Store implementation that handles storage of that data.
  */
 @SuppressWarnings("nls")
 public class SecureStore
 {
-    private final SecretKeyFactory kf = SecretKeyFactory.getInstance("PBE");
-    private final KeyStore store;
-    private final File secure_file;
-    private final char[] store_pass;
-    private final ProtectionParameter pp;
+
+    private final Store<String, String> store;
 
     /** Tags */
     public static final String USERNAME_TAG = "username",
@@ -48,46 +31,35 @@ public class SecureStore
 
     private static final Logger LOGGER = Logger.getLogger(SecureStore.class.getName());
 
-    /** Create with default file in 'user' location
-     *  @throws Exception on error
+    /**
+     * Default constructor, self-initializes underlying store based on
+     * security preferences.
+     *
+     * @see {@link org.phoebus.security.PhoebusSecurity}
+     *
+     * @throws Exception if underlying store isn't configured, configured incorrectly.
+     * See javadocs for underlying implementations for details.
      */
     public SecureStore() throws Exception
     {
-        this(new File(Locations.user(), "secure_store.dat"));
+        switch(PhoebusSecurity.secure_store_target) {
+            case FILE:
+                store = new FileBasedStore();
+                break;
+            case IN_MEMORY:
+                store = MemoryBasedStore.getInstance();
+                break;
+            default:
+                throw new IllegalStateException("secure_store_target is unset");
+        }
     }
 
-    /** Create with default password.
-     *
-     *  <p>Knowledge of this code would allow reading the file
-     *
-     *  @param secure_file File to read or write
-     *  @throws Exception on error
+    /**
+     * Initialize with specified store implementation.
+     * @param store Underlying store implementation.
      */
-    public SecureStore(final File secure_file) throws Exception
-    {
-        this(secure_file, Integer.toString(secure_file.getAbsolutePath().hashCode()).toCharArray());
-    }
-
-    /** Create
-     *  @param secure_file File to read or write
-     *  @param store_pass Password for encoding/decoding entries
-     *  @throws Exception on error
-     */
-    public SecureStore(final File secure_file, final char[] store_pass) throws Exception
-    {
-        this.secure_file = secure_file;
-        this.store_pass = store_pass;
-
-        store = KeyStore.getInstance(KeyStore.getDefaultType());
-
-        pp = new KeyStore.PasswordProtection(store_pass);
-
-
-        // Load existing file or initialize as empty
-        if (secure_file.canRead())
-            store.load(new FileInputStream(secure_file), store_pass);
-        else
-            store.load(null, store_pass);
+    SecureStore(Store<String, String> store) {
+        this.store = store;
     }
 
     /** Read an entry from the store
@@ -97,12 +69,7 @@ public class SecureStore
      */
     public String get(final String tag) throws Exception
     {
-        final KeyStore.SecretKeyEntry entry = (KeyStore.SecretKeyEntry) store.getEntry(tag, pp);
-        if (entry == null)
-            return null;
-
-        final PBEKeySpec key = (PBEKeySpec) kf.getKeySpec(entry.getSecretKey(), PBEKeySpec.class);
-        return new String(key.getPassword());
+        return store.get(tag);
     }
 
     /** Write an entry to the store. If the entry already exists, it will be overwritten.
@@ -112,11 +79,7 @@ public class SecureStore
      */
     public void set(final String tag, final String value) throws Exception
     {
-        final SecretKey skey = kf.generateSecret(new PBEKeySpec(value.toCharArray()));
-        store.setEntry(tag, new KeyStore.SecretKeyEntry(skey), pp);
-
-        // Write file whenever an entry is changed
-        store.store(new FileOutputStream(secure_file), store_pass);
+        store.set(tag, value);
     }
 
     /** Deletes an entry in the secure store.
@@ -124,10 +87,8 @@ public class SecureStore
      *  @throws Exception on error
      */
     public void delete(String tag) throws Exception{
-        store.deleteEntry(tag);
         LOGGER.log(Level.INFO, "Deleting entry " + tag + " from secure store");
-        // Write file whenever an entry is changed
-        store.store(new FileOutputStream(secure_file), store_pass);
+        store.delete(tag);
     }
 
     /** @param scope Scope
@@ -197,7 +158,6 @@ public class SecureStore
             set(scope + "." + PASSWORD_TAG, password);
         }
         LOGGER.log(Level.INFO, "Storing scoped authentication token " + scopedAuthenticationToken.toString());
-        store.store(new FileOutputStream(secure_file), store_pass);
     }
 
     /**
@@ -208,7 +168,7 @@ public class SecureStore
      * @throws Exception on error
      */
     public List<ScopedAuthenticationToken> getAuthenticationTokens() throws Exception{
-        List<String> allAliases = Collections.list(store.aliases());
+        List<String> allAliases = new ArrayList<>(store.getKeys());
         List<ScopedAuthenticationToken> allScopedAuthenticationTokens = matchEntries(allAliases);
 
         return allScopedAuthenticationTokens;

--- a/core/security/src/main/java/org/phoebus/security/store/SecureStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/SecureStore.java
@@ -50,7 +50,8 @@ public class SecureStore
                 store = MemoryBasedStore.getInstance();
                 break;
             default:
-                throw new IllegalStateException("secure_store_target is unset");
+                // default to FILE if not set explicitly
+                store = new FileBasedStore();
         }
     }
 

--- a/core/security/src/main/java/org/phoebus/security/store/SecureStoreTarget.java
+++ b/core/security/src/main/java/org/phoebus/security/store/SecureStoreTarget.java
@@ -1,0 +1,6 @@
+package org.phoebus.security.store;
+
+public enum SecureStoreTarget {
+    FILE,
+    IN_MEMORY;
+}

--- a/core/security/src/main/java/org/phoebus/security/store/Store.java
+++ b/core/security/src/main/java/org/phoebus/security/store/Store.java
@@ -1,0 +1,12 @@
+package org.phoebus.security.store;
+
+import java.util.List;
+
+public interface Store<K, V> {
+
+    V get(K key) throws Exception;
+    void set(K key, V value) throws Exception;
+    List<K> getKeys() throws Exception;
+    void delete(K key) throws Exception;
+
+}

--- a/core/security/src/main/resources/phoebus_security_preferences.properties
+++ b/core/security/src/main/resources/phoebus_security_preferences.properties
@@ -23,3 +23,7 @@ authorization_file=
 # Use authorization.conf in the install location
 #authorization_file=authorization.conf
 
+# Secure store underlying implementation.
+# Can be 'FILE' or 'IN_MEMORY'
+secure_store_target=FILE
+

--- a/core/security/src/test/java/org/phoebus/security/store/SecureStoreTest.java
+++ b/core/security/src/test/java/org/phoebus/security/store/SecureStoreTest.java
@@ -16,10 +16,11 @@
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-package org.phoebus.security;
+package org.phoebus.security.store;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.phoebus.security.store.FileBasedStore;
 import org.phoebus.security.store.SecureStore;
 import org.phoebus.security.tokens.ScopedAuthenticationToken;
 
@@ -32,6 +33,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Exercises the SecureStore via a FileBased underlying store implementation.
+ */
 public class SecureStoreTest {
 
     private static SecureStore secureStore;
@@ -43,7 +47,8 @@ public class SecureStoreTest {
         secureStoreFile.deleteOnExit();
 
         String password = "forTestPurposesOnly";
-        secureStore = new SecureStore(secureStoreFile, password.toCharArray());
+        FileBasedStore fileBasedStore = new FileBasedStore(secureStoreFile, password.toCharArray());
+        secureStore = new SecureStore(fileBasedStore);
     }
 
     @Test


### PR DESCRIPTION
refactor: provide in-memory backed SecureStore as an available security setting, configurable via the new 'secure_store_target' phoebus security preference. Available values are FILE or IN_MEMORY.

default is "FILE" for backwards-compatibility for now, however IN_MEMORY should be preferred over writing to a file.