### PR TITLE
In-memory credentials store: a few updates

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertiesEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogPropertiesEditorController.java
@@ -154,8 +154,10 @@ public class LogPropertiesEditorController {
                         treeItem.setExpanded(true);
                         return treeItem;
                     }).collect(Collectors.toSet()));
-            selectedPropertiesTree.setRoot(root);
-            selectedPropertiesTree.setShowRoot(false);
+            Platform.runLater(() -> {
+                selectedPropertiesTree.setRoot(root);
+                selectedPropertiesTree.setShowRoot(false);
+            });
         }
     }
 

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
@@ -196,7 +196,7 @@ public class LogEntryModel {
                 // Let anyone listening know that their credentials are now out of date.
                 updateCredentials.set(true);
             } catch (Exception ex) {
-                logger.log(Level.WARNING, "Secure Store file not found.", ex);
+                logger.log(Level.WARNING, "Unable to fetch credentials from secure store.", ex);
             }
         });
     }

--- a/core/security/src/main/java/org/phoebus/security/store/FileBasedStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/FileBasedStore.java
@@ -1,5 +1,10 @@
 package org.phoebus.security.store;
 
+import org.phoebus.framework.workbench.Locations;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -8,56 +13,56 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
-import org.phoebus.framework.workbench.Locations;
 
-/** Secure Store
+/**
+ * Secure Store
  *
- *  <p>Writes tag/value pairs into an encrypted file.
+ * <p>Writes tag/value pairs into an encrypted file.
  *
- *  <p>Does depend on a password to read and write the file.
+ * <p>Does depend on a password to read and write the file.
  *
- *  @author Kay Kasemir
+ * @author Kay Kasemir
  */
 public class FileBasedStore implements Store<String, String> {
 
     private final SecretKeyFactory kf = SecretKeyFactory.getInstance("PBE");
     private final KeyStore store;
     private final File secure_file;
+    private byte[] secureStoreByteArray;
     private final char[] store_pass;
     private final KeyStore.ProtectionParameter pp;
 
     private static final Logger LOGGER = Logger.getLogger(SecureStore.class.getName());
 
-    /** Create with default file in 'user' location
-     *  @throws Exception on error
+    /**
+     * Create with default file in 'user' location
+     *
+     * @throws Exception on error
      */
-    public FileBasedStore() throws Exception
-    {
+    public FileBasedStore() throws Exception {
         this(new File(Locations.user(), "secure_store.dat"));
     }
 
-    /** Create with default password.
+    /**
+     * Create with default password.
      *
-     *  <p>Knowledge of this code would allow reading the file
+     * <p>Knowledge of this code would allow reading the file
      *
-     *  @param secure_file File to read or write
-     *  @throws Exception on error
+     * @param secure_file File to read or write
+     * @throws Exception on error
      */
-    public FileBasedStore(final File secure_file) throws Exception
-    {
+    public FileBasedStore(final File secure_file) throws Exception {
         this(secure_file, Integer.toString(secure_file.getAbsolutePath().hashCode()).toCharArray());
     }
 
-    /** Create
-     *  @param secure_file File to read or write
-     *  @param store_pass Password for encoding/decoding entries
-     *  @throws Exception on error
+    /**
+     * Create
+     *
+     * @param secure_file File to read or write
+     * @param store_pass  Password for encoding/decoding entries
+     * @throws Exception on error
      */
-    public FileBasedStore(final File secure_file, final char[] store_pass) throws Exception
-    {
+    public FileBasedStore(final File secure_file, final char[] store_pass) throws Exception {
         this.secure_file = secure_file;
         this.store_pass = store_pass;
 
@@ -72,14 +77,19 @@ public class FileBasedStore implements Store<String, String> {
             store.load(null, store_pass);
     }
 
-    /** Read an entry from the store
-     *  @param tag Tag that identifies the entry
-     *  @return Stored text or <code>null</code>
-     *  @throws Exception on error
+    /**
+     * Read an entry from the store
+     *
+     * @param tag Tag that identifies the entry.
+     * @return Stored text or <code>null</code>, e.g. if tag is <code>null</code> or tag is not associated with
+     * a key in the secure store file.
+     * @throws Exception on error.
      */
     @Override
-    public String get(final String tag) throws Exception
-    {
+    public String get(final String tag) throws Exception {
+        if (tag == null) {
+            return null;
+        }
         final KeyStore.SecretKeyEntry entry = (KeyStore.SecretKeyEntry) store.getEntry(tag, pp);
         if (entry == null)
             return null;
@@ -88,14 +98,15 @@ public class FileBasedStore implements Store<String, String> {
         return new String(key.getPassword());
     }
 
-    /** Write an entry to the store. If the entry already exists, it will be overwritten.
-     *  @param tag Tag that identifies the entry
-     *  @param value Value of the entry
-     *  @throws Exception on error
+    /**
+     * Write an entry to the store. If the entry already exists, it will be overwritten.
+     *
+     * @param tag   Tag that identifies the entry
+     * @param value Value of the entry
+     * @throws Exception on error
      */
     @Override
-    public void set(final String tag, final String value) throws Exception
-    {
+    public void set(final String tag, final String value) throws Exception {
         final SecretKey skey = kf.generateSecret(new PBEKeySpec(value.toCharArray()));
         store.setEntry(tag, new KeyStore.SecretKeyEntry(skey), pp);
 
@@ -103,12 +114,17 @@ public class FileBasedStore implements Store<String, String> {
         store.store(new FileOutputStream(secure_file), store_pass);
     }
 
-    /** Deletes an entry in the secure store.
-     *  @param tag The tag to delete, must not be <code>null</code>.
-     *  @throws Exception on error
+    /**
+     * Deletes an entry in the secure store.
+     *
+     * @param tag The tag to delete. If <code>null</code> this method does not do anything.
+     * @throws Exception on error
      */
     @Override
-    public void delete(String tag) throws Exception{
+    public void delete(String tag) throws Exception {
+        if (tag == null) {
+            return;
+        }
         store.deleteEntry(tag);
         LOGGER.log(Level.INFO, "Deleting entry " + tag + " from secure store");
         // Write file whenever an entry is changed

--- a/core/security/src/main/java/org/phoebus/security/store/MemoryBasedStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/MemoryBasedStore.java
@@ -24,9 +24,6 @@ public class MemoryBasedStore implements Store<String, String> {
 
     @Override
     public String get(String key) {
-        if(!store.containsKey(key)){
-            throw new NullPointerException("Key " + key + " not found");
-        }
         return store.get(key);
     }
 
@@ -42,9 +39,6 @@ public class MemoryBasedStore implements Store<String, String> {
 
     @Override
     public void delete(String key) {
-        if(!store.containsKey(key)){
-            throw new NullPointerException("Key " + key + " not found");
-        }
         store.remove(key);
     }
 }

--- a/core/security/src/main/java/org/phoebus/security/store/MemoryBasedStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/MemoryBasedStore.java
@@ -1,5 +1,7 @@
 package org.phoebus.security.store;
 
+import org.phoebus.security.tokens.ScopedAuthenticationToken;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +24,9 @@ public class MemoryBasedStore implements Store<String, String> {
 
     @Override
     public String get(String key) {
+        if(!store.containsKey(key)){
+            throw new NullPointerException("Key " + key + " not found");
+        }
         return store.get(key);
     }
 
@@ -37,7 +42,9 @@ public class MemoryBasedStore implements Store<String, String> {
 
     @Override
     public void delete(String key) {
+        if(!store.containsKey(key)){
+            throw new NullPointerException("Key " + key + " not found");
+        }
         store.remove(key);
     }
-
 }

--- a/core/security/src/main/java/org/phoebus/security/store/SecureStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/SecureStore.java
@@ -44,14 +44,12 @@ public class SecureStore
     {
         switch(PhoebusSecurity.secure_store_target) {
             case FILE:
+            default:
                 store = new FileBasedStore();
                 break;
             case IN_MEMORY:
                 store = MemoryBasedStore.getInstance();
                 break;
-            default:
-                // default to FILE if not set explicitly
-                store = new FileBasedStore();
         }
     }
 
@@ -84,7 +82,7 @@ public class SecureStore
     }
 
     /** Deletes an entry in the secure store.
-     *  @param tag The tag to delete, must not be <code>null</code>.
+     *  @param tag The tag to delete.
      *  @throws Exception on error
      */
     public void delete(String tag) throws Exception{
@@ -159,7 +157,7 @@ public class SecureStore
             set(scope + "." + USERNAME_TAG, username);
             set(scope + "." + PASSWORD_TAG, password);
         }
-        LOGGER.log(Level.INFO, "Storing scoped authentication token " + scopedAuthenticationToken.toString());
+        LOGGER.log(Level.INFO, "Storing scoped authentication token " + scopedAuthenticationToken);
     }
 
     /**
@@ -183,7 +181,7 @@ public class SecureStore
      * {@link #PASSWORD_TAG} item can be found.
      * @param aliases All aliases in the secure store.
      * @return List of {@link ScopedAuthenticationToken}s.
-     * @throws Exception
+     * @throws Exception If interaction with the underlying store implementation fails.
      */
     private List<ScopedAuthenticationToken> matchEntries(List<String> aliases) throws Exception{
         List<ScopedAuthenticationToken> allScopedAuthenticationTokens

--- a/core/security/src/main/java/org/phoebus/security/store/SecureStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/SecureStore.java
@@ -92,7 +92,7 @@ public class SecureStore
         store.delete(tag);
     }
 
-    /** @param scope Scope
+    /** @param scope Scope identifier, will be converted to lower case, see {@link ScopedAuthenticationToken}
      *  @return Token for that scope
      *  @throws Exception on error
      */
@@ -104,6 +104,7 @@ public class SecureStore
             password = get(PASSWORD_TAG);
         }
         else{
+            scope = scope.toLowerCase();
             username = get(scope + "." + USERNAME_TAG);
             password = get(scope + "." + PASSWORD_TAG);
         }
@@ -113,7 +114,7 @@ public class SecureStore
         return new ScopedAuthenticationToken(scope, username, password);
     }
 
-    /** @param scope Scope
+    /** @param scope Scope identifier, will be converted to lower case, see {@link ScopedAuthenticationToken}
      *  @throws Exception on error
      */
     public void deleteScopedAuthenticationToken(String scope) throws Exception{

--- a/core/security/src/main/java/org/phoebus/security/tokens/ScopedAuthenticationToken.java
+++ b/core/security/src/main/java/org/phoebus/security/tokens/ScopedAuthenticationToken.java
@@ -19,30 +19,37 @@
 package org.phoebus.security.tokens;
 
 /**
- * Extension of  {@link SimpleAuthenticationToken}
+ * Extension of  {@link SimpleAuthenticationToken}.
+ *
+ * Note that the unique identity of a {@link ScopedAuthenticationToken} instance as defined in the
+ * <code>scope</code> field is maintained as a lower case string, effectively rendering the identity as
+ * case-insensitive. Reason is that if a Java native secure store file is used to maintain the tokens,
+ * the identity key is saved in lower case in the secure store.
  */
 public class ScopedAuthenticationToken extends SimpleAuthenticationToken{
 
     private String scope;
 
     /** @param username Username
-     *  @param password Passworf
+     *  @param password Password
      */
     public ScopedAuthenticationToken(String username, String password){
         super(username, password);
     }
 
-    /** @param scope Scope
+    /** @param scope Scope identity, will be converted to lower case.
      *  @param username Username
-     *  @param password Passworf
+     *  @param password Password
      */
     public ScopedAuthenticationToken(String scope, String username, String password){
         this(username, password);
-        if(scope != null && scope.trim().isEmpty()){
-            this.scope = null;
-        }
-        else{
-            this.scope = scope;
+        if(scope != null){
+            if(scope.trim().isEmpty()){
+                this.scope = null;
+            }
+            else{
+                this.scope = scope.toLowerCase();
+            }
         }
     }
 


### PR DESCRIPTION
- Need to handle that "scope" for credentials must be a case-insensitive (lower case) string as the Java native secure store implementation treats keys in lower case.
- Added some test cases for MemoryBasedStore
- Minor bug fix in log entry properties UI controller