### PR TITLE
Use a longer timeout

### DIFF
--- a/core/pva/src/test/java/org/epics/pva/combined/ServerClientTest.java
+++ b/core/pva/src/test/java/org/epics/pva/combined/ServerClientTest.java
@@ -247,7 +247,7 @@ public class ServerClientTest {
 
         PVAChannel channel = client.getChannel(pvName);
         try {
-            channel.connect().get(5, TimeUnit.SECONDS);
+            channel.connect().get(10, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
             fail(e.getMessage());


### PR DESCRIPTION
Hopefully this will reduce chances of test failure due to slower running of tests on the github ci machine. 