### PR TITLE
exclude logback dependency

### DIFF
--- a/core/pv/pom.xml
+++ b/core/pv/pom.xml
@@ -76,6 +76,12 @@
       <artifactId>JTango</artifactId>
       <version>9.7.0</version>
       <type>pom</type>
+      <exclusions>
+        <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The added JTango dependency in core/pv pulls in a logback dependency. This causes warnings like
```
SLF4J: Class path contains multiple SLF4J bindings.
```
Phoebus includes the slf4j-jdk14 as a binding to push all logging to java.util.logging. So, I believe logback should be removed here.