### PR TITLE
Fix settings without effect in alarm server

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAmount;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.phoebus.applications.alarm.client.IdentificationHelper;
 import org.phoebus.framework.macros.MacroOrSystemProvider;
@@ -27,39 +26,8 @@ import org.phoebus.util.time.TimeParser;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class AlarmSystem
+public class AlarmSystem extends AlarmSystemConstants
 {
-    /** Alarm system logger */
-    public static final Logger logger = Logger.getLogger(AlarmSystem.class.getPackageName());
-
-    /** Path prefix for config updates */
-    public static final String CONFIG_PREFIX = "config:";
-
-    /** Path prefix for state updates */
-    public static final String STATE_PREFIX = "state:";
-
-    /** Path prefix for commands */
-    public static final String COMMAND_PREFIX = "command:";
-
-    /** Path prefix for talk messages */
-    public static final String TALK_PREFIX = "talk:";
-
-    // In principle, all messages can be sent via the same topic,
-    // which also asserts that their order is preserved.
-    // The command and talk topics are sent via separate topics
-    // because they are one-directional and Kafka can be configured
-    // to delete older talk and command messages,
-    // while state and config need to be compacted (or kept forever).
-
-    /** Suffix for the topic that clients use to send commands to alarm server */
-    public static final String COMMAND_TOPIC_SUFFIX = "Command";
-
-    /** Suffix for the topic that server uses to send annunciations */
-    public static final String TALK_TOPIC_SUFFIX = "Talk";
-
-    /** Suffix for the topic that contains non compacted aggregate of other topics. */
-    public static final String LONG_TERM_TOPIC_SUFFIX = "LongTerm";
-
     /** Kafka Server host:port */
     @Preference public static String server;
 

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystemConstants.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystemConstants.java
@@ -1,0 +1,36 @@
+package org.phoebus.applications.alarm;
+
+import java.util.logging.Logger;
+
+public class AlarmSystemConstants {
+    /** Alarm system logger */
+    public static final Logger logger = Logger.getLogger(AlarmSystem.class.getPackageName());
+
+    /** Path prefix for config updates */
+    public static final String CONFIG_PREFIX = "config:";
+
+    /** Path prefix for state updates */
+    public static final String STATE_PREFIX = "state:";
+
+    /** Path prefix for commands */
+    public static final String COMMAND_PREFIX = "command:";
+
+    /** Path prefix for talk messages */
+    public static final String TALK_PREFIX = "talk:";
+
+    // In principle, all messages can be sent via the same topic,
+    // which also asserts that their order is preserved.
+    // The command and talk topics are sent via separate topics
+    // because they are one-directional and Kafka can be configured
+    // to delete older talk and command messages,
+    // while state and config need to be compacted (or kept forever).
+
+    /** Suffix for the topic that clients use to send commands to alarm server */
+    public static final String COMMAND_TOPIC_SUFFIX = "Command";
+
+    /** Suffix for the topic that server uses to send annunciations */
+    public static final String TALK_TOPIC_SUFFIX = "Talk";
+
+    /** Suffix for the topic that contains non compacted aggregate of other topics. */
+    public static final String LONG_TERM_TOPIC_SUFFIX = "LongTerm";
+}

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.server;
 
-import static org.phoebus.applications.alarm.AlarmSystem.logger;
+import static org.phoebus.applications.alarm.AlarmSystemConstants.logger;
 
 import java.io.FileInputStream;
 import java.util.ArrayList;
@@ -23,7 +23,7 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.prefs.Preferences;
 
-import org.phoebus.applications.alarm.AlarmSystem;
+import org.phoebus.applications.alarm.AlarmSystemConstants;
 import org.phoebus.applications.alarm.client.ClientState;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.applications.alarm.model.AlarmTreeLeaf;
@@ -652,8 +652,8 @@ public class AlarmServerMain implements ServerModelListener
             if (parsed_args.containsKey(create_topics_arg)){
                 logger.info("Discovering and creating any missing topics at " + server);
                 CreateTopics.discoverAndCreateTopics(server, true, List.of(config,
-                                                     config + AlarmSystem.COMMAND_TOPIC_SUFFIX,
-                                                     config + AlarmSystem.TALK_TOPIC_SUFFIX),
+                                                     config + AlarmSystemConstants.COMMAND_TOPIC_SUFFIX,
+                                                     config + AlarmSystemConstants.TALK_TOPIC_SUFFIX),
                                                      kafka_properties);
             }
             if (parsed_args.containsKey(export_arg)){


### PR DESCRIPTION
The alarm server includes in its main the AlarmSystem class. This causes all preferences in there to be initialized directly from defaults or previous values.
Passing other settings with `-settings my-settings.ini` has no effect, because they are added to the preferences only after the static variables are already initialized. A re-start of the alarm-server usually resolves this, because then the settings will already be in the user's perferences.
This affects the preferences under org.phoebus.applications.alarm such as the nag_period or the automated_email_sender.

The alarm server main only needs some constants from the AlarmSystem class. So, I introduced an AlarmSystemConstants class to hold the compile time constants. AlarmSystem inhererits these and the alarm server can include only the constants, thus deferring initializiation of the preferences until after the preferences have been updated with any passed settings.