### PR TITLE
Missing mapping for plot_area_background_color for BOY XYGraph

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/StripchartWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/StripchartWidget.java
@@ -339,6 +339,13 @@ public class StripchartWidget extends VisibleWidget
 
                 handleLegacyAxes(model_reader, strip, xml, pv_macro);
 
+		// Map BOY 'plot_area_background_color' to 'background_color'
+		final Element plotAreaColor = XMLUtil.getChildElement(xml, "plot_area_background_color");
+		if (plotAreaColor != null)
+		    strip.propBackground().readFromXML(model_reader, plotAreaColor);
+		else
+                    strip.propBackground().setValue(WidgetColorService.getColor(NamedWidgetColors.BACKGROUND));
+
                 // Turn 'transparent' flag into transparent background color
                 if (XMLUtil.getChildBoolean(xml, "transparent").orElse(false))
                     strip.propBackground().setValue(NamedWidgetColors.TRANSPARENT);

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/XYPlotWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/XYPlotWidget.java
@@ -168,6 +168,13 @@ public class XYPlotWidget extends VisibleWidget
 
                 handleLegacyYAxes(model_reader, widget, xml, pv_macro);
 
+		// Map BOY 'plot_area_background_color' to 'background_color'
+		final Element plotAreaColor = XMLUtil.getChildElement(xml, "plot_area_background_color");
+		if (plotAreaColor != null)
+		    plot.propBackground().readFromXML(model_reader, plotAreaColor);
+		else
+                    plot.propBackground().setValue(WidgetColorService.getColor(NamedWidgetColors.BACKGROUND));
+
                 // Turn 'transparent' flag into transparent background color
                 if (XMLUtil.getChildBoolean(xml, "transparent").orElse(false))
                     plot.propBackground().setValue(NamedWidgetColors.TRANSPARENT);


### PR DESCRIPTION
When BOY XYGraph is converted to XYPlot or StripChart, BOY property "Plot Area Background Color" is not mapped correctly to the new widget's background color. This PR fixes the issue.