### PR TITLE
Legacy linking container transparent behavior

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -160,6 +160,9 @@ public class EmbeddedDisplayWidget extends MacroWidget
                         widget.setPropertyValue(propFile, opi_file.get());
                 }
 
+		// BOY linking containers are transparent by default
+		widget.setPropertyValue(propTransparent, true);
+
                 // Transition legacy "resize_behaviour"
                 Element element = XMLUtil.getChildElement(xml, "resize_behaviour");
                 if (element != null)


### PR DESCRIPTION
In BOY, the Linking Container behavior is always transparent, although there is no parameter for it.  During the conversion from OPI to BOB, the “Transparent” setting however is disabled. This PR fixes it. 