### PR TITLE
CSSTUDIO-1812: Fix width of columns in the "Statistics"-tab

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/StatisticsTabController.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/StatisticsTabController.java
@@ -37,6 +37,8 @@ import javafx.application.Platform;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleLongProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -68,19 +70,19 @@ public class StatisticsTabController implements ModelListener{
     @FXML
     private TableColumn<ModelItemStatistics, String> displayNameColumn;
     @FXML
-    private TableColumn<ModelItemStatistics, String> countColumn;
+    private TableColumn<ModelItemStatistics, Long> countColumn;
     @FXML
-    private TableColumn<ModelItemStatistics, String> meanColumn;
+    private TableColumn<ModelItemStatistics, Double> meanColumn;
     @FXML
-    private TableColumn<ModelItemStatistics, String> medianColumn;
+    private TableColumn<ModelItemStatistics, Double> medianColumn;
     @FXML
-    private TableColumn<ModelItemStatistics, String> stdDevColumn;
+    private TableColumn<ModelItemStatistics, Double> stdDevColumn;
     @FXML
-    private TableColumn<ModelItemStatistics, String> minColumn;
+    private TableColumn<ModelItemStatistics, Double> minColumn;
     @FXML
-    private TableColumn<ModelItemStatistics, String> maxColumn;
+    private TableColumn<ModelItemStatistics, Double> maxColumn;
     @FXML
-    private TableColumn<ModelItemStatistics, String> sumColumn;
+    private TableColumn<ModelItemStatistics, Double> sumColumn;
 
     /** @param model Model */
     public StatisticsTabController(Model model){
@@ -163,19 +165,19 @@ public class StatisticsTabController implements ModelListener{
         });
 
         countColumn.setText(Messages.StatisticsSampleCount);
-        countColumn.setCellValueFactory(cell -> cell.getValue().getCount());
+        countColumn.setCellValueFactory(cell -> cell.getValue().getCount().asObject());
         meanColumn.setText(Messages.StatisticsMean);
-        meanColumn.setCellValueFactory(cell -> cell.getValue().getMean());
+        meanColumn.setCellValueFactory(cell -> cell.getValue().getMean().asObject());
         medianColumn.setText(Messages.StatisticsMedian);
-        medianColumn.setCellValueFactory(cell -> cell.getValue().getMedian());
+        medianColumn.setCellValueFactory(cell -> cell.getValue().getMedian().asObject());
         stdDevColumn.setText(Messages.StatisticsStdDev);
-        stdDevColumn.setCellValueFactory(cell -> cell.getValue().getStdDev());
+        stdDevColumn.setCellValueFactory(cell -> cell.getValue().getStdDev().asObject());
         minColumn.setText(Messages.StatisticsMin);
-        minColumn.setCellValueFactory(cell -> cell.getValue().getMin());
+        minColumn.setCellValueFactory(cell -> cell.getValue().getMin().asObject());
         maxColumn.setText(Messages.StatisticsMax);
-        maxColumn.setCellValueFactory(cell -> cell.getValue().getMax());
+        maxColumn.setCellValueFactory(cell -> cell.getValue().getMax().asObject());
         sumColumn.setText(Messages.StatisticsSum);
-        sumColumn.setCellValueFactory(cell -> cell.getValue().getSum());
+        sumColumn.setCellValueFactory(cell -> cell.getValue().getSum().asObject());
     }
 
     /** Remove listener */
@@ -203,13 +205,13 @@ public class StatisticsTabController implements ModelListener{
      * the data model for the table.
      */
     private class ModelItemStatistics {
-        private SimpleStringProperty count = new SimpleStringProperty();
-        private SimpleStringProperty mean = new SimpleStringProperty();
-        private SimpleStringProperty median = new SimpleStringProperty();
-        private SimpleStringProperty stdDev = new SimpleStringProperty();
-        private SimpleStringProperty min = new SimpleStringProperty();
-        private SimpleStringProperty max = new SimpleStringProperty();
-        private SimpleStringProperty sum = new SimpleStringProperty();
+        private SimpleLongProperty count = new SimpleLongProperty();
+        private SimpleDoubleProperty mean = new SimpleDoubleProperty();
+        private SimpleDoubleProperty median = new SimpleDoubleProperty();
+        private SimpleDoubleProperty stdDev = new SimpleDoubleProperty();
+        private SimpleDoubleProperty min = new SimpleDoubleProperty();
+        private SimpleDoubleProperty max = new SimpleDoubleProperty();
+        private SimpleDoubleProperty sum = new SimpleDoubleProperty();
         private SimpleObjectProperty colorIndicator = new SimpleObjectProperty();
         private SimpleStringProperty traceName = new SimpleStringProperty();
 
@@ -227,25 +229,25 @@ public class StatisticsTabController implements ModelListener{
          */
         private void clear(){
             Platform.runLater(() -> {
-                count.set(null);
-                mean.set(null);
-                median.set(null);
-                stdDev.set(null);
-                min.set(null);
-                max.set(null);
-                sum.set(null);
+                count.set(0);
+                mean.set(0.0);
+                median.set(0.0);
+                stdDev.set(0.0);
+                min.set(0.0);
+                max.set(0.0);
+                sum.set(0.0);
             });
         }
 
         private void set(DescriptiveStatistics statistics){
             Platform.runLater(() -> {
-                count.set(String.valueOf(statistics.getN()));
-                mean.set(String.valueOf(statistics.getMean()));
-                median.set(String.valueOf(statistics.getPercentile(50)));
-                stdDev.set(String.valueOf(statistics.getStandardDeviation()));
-                min.set(String.valueOf(statistics.getMin()));
-                max.set(String.valueOf(statistics.getMax()));
-                sum.set(String.valueOf(statistics.getSum()));
+                count.set(statistics.getN());
+                mean.set(statistics.getMean());
+                median.set(statistics.getPercentile(50));
+                stdDev.set(statistics.getStandardDeviation());
+                min.set(statistics.getMin());
+                max.set(statistics.getMax());
+                sum.set(statistics.getSum());
             });
         }
 
@@ -296,31 +298,31 @@ public class StatisticsTabController implements ModelListener{
             colorIndicator.set(new ColorIndicator(color));
         }
 
-        public SimpleStringProperty getCount() {
+        public SimpleLongProperty getCount() {
             return count;
         }
 
-        public SimpleStringProperty getStdDev() {
+        public SimpleDoubleProperty getStdDev() {
             return stdDev;
         }
 
-        public SimpleStringProperty getMean() {
+        public SimpleDoubleProperty getMean() {
             return mean;
         }
 
-        public SimpleStringProperty getMedian() {
+        public SimpleDoubleProperty getMedian() {
             return median;
         }
 
-        public SimpleStringProperty getMin() {
+        public SimpleDoubleProperty getMin() {
             return min;
         }
 
-        public SimpleStringProperty getMax() {
+        public SimpleDoubleProperty getMax() {
             return max;
         }
 
-        public SimpleStringProperty getSum() {
+        public SimpleDoubleProperty getSum() {
             return sum;
         }
 

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/StatisticsTabController.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/StatisticsTabController.java
@@ -206,12 +206,12 @@ public class StatisticsTabController implements ModelListener{
      */
     private class ModelItemStatistics {
         private SimpleLongProperty count = new SimpleLongProperty();
-        private SimpleDoubleProperty mean = new SimpleDoubleProperty();
-        private SimpleDoubleProperty median = new SimpleDoubleProperty();
-        private SimpleDoubleProperty stdDev = new SimpleDoubleProperty();
-        private SimpleDoubleProperty min = new SimpleDoubleProperty();
-        private SimpleDoubleProperty max = new SimpleDoubleProperty();
-        private SimpleDoubleProperty sum = new SimpleDoubleProperty();
+        private SimpleDoubleProperty mean = new SimpleDoubleProperty(Double.NaN);
+        private SimpleDoubleProperty median = new SimpleDoubleProperty(Double.NaN);
+        private SimpleDoubleProperty stdDev = new SimpleDoubleProperty(Double.NaN);
+        private SimpleDoubleProperty min = new SimpleDoubleProperty(Double.NaN);
+        private SimpleDoubleProperty max = new SimpleDoubleProperty(Double.NaN);
+        private SimpleDoubleProperty sum = new SimpleDoubleProperty(Double.NaN);
         private SimpleObjectProperty colorIndicator = new SimpleObjectProperty();
         private SimpleStringProperty traceName = new SimpleStringProperty();
 
@@ -230,12 +230,12 @@ public class StatisticsTabController implements ModelListener{
         private void clear(){
             Platform.runLater(() -> {
                 count.set(0);
-                mean.set(0.0);
-                median.set(0.0);
-                stdDev.set(0.0);
-                min.set(0.0);
-                max.set(0.0);
-                sum.set(0.0);
+                mean.set(Double.NaN);
+                median.set(Double.NaN);
+                stdDev.set(Double.NaN);
+                min.set(Double.NaN);
+                max.set(Double.NaN);
+                sum.set(Double.NaN);
             });
         }
 

--- a/app/databrowser/src/main/resources/org/csstudio/trends/databrowser3/ui/properties/StatisticsTab.fxml
+++ b/app/databrowser/src/main/resources/org/csstudio/trends/databrowser3/ui/properties/StatisticsTab.fxml
@@ -31,15 +31,15 @@
     </ToolBar>
     <TableView fx:id="tracesTable" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" VBox.vgrow="ALWAYS">
       <columns>
-        <TableColumn fx:id="indicatorColumn" prefWidth="22.0" />
-        <TableColumn fx:id="displayNameColumn" prefWidth="130.0" text="Display Name"/>
-        <TableColumn fx:id="countColumn" prefWidth="100.0" text="Sample Count" />
-        <TableColumn fx:id="meanColumn" prefWidth="100.0" text="Mean" />
-        <TableColumn fx:id="medianColumn" prefWidth="100.0" text="Median" />
-        <TableColumn fx:id="stdDevColumn" prefWidth="100.0" text="Standard Deviation" />
-        <TableColumn fx:id="minColumn" prefWidth="100.0" text="Min Value" />
-        <TableColumn fx:id="maxColumn" prefWidth="100.0" text="Max Value" />
-        <TableColumn fx:id="sumColumn" prefWidth="100.0" text="Sum" />
+        <TableColumn fx:id="indicatorColumn" minWidth="22.0" maxWidth="22.0" prefWidth="22.0" />
+        <TableColumn fx:id="displayNameColumn" minWidth="130.0" prefWidth="260.0" text="Display Name"/>
+        <TableColumn fx:id="countColumn" minWidth="130" prefWidth="130.0" text="Sample Count" />
+        <TableColumn fx:id="meanColumn" minWidth="200.0" prefWidth="200.0" text="Mean" />
+        <TableColumn fx:id="medianColumn" minWidth="200.0" prefWidth="200.0" text="Median" />
+        <TableColumn fx:id="stdDevColumn" minWidth="200.0" prefWidth="200.0" text="Standard Deviation" />
+        <TableColumn fx:id="minColumn" minWidth="200.0" prefWidth="200.0" text="Min Value" />
+        <TableColumn fx:id="maxColumn" minWidth="200.0" prefWidth="200.0" text="Max Value" />
+        <TableColumn fx:id="sumColumn" minWidth="200.0" prefWidth="200.0" text="Sum" />
       </columns>
     </TableView>
    </children>

--- a/app/databrowser/src/main/resources/org/csstudio/trends/databrowser3/ui/properties/StatisticsTab.fxml
+++ b/app/databrowser/src/main/resources/org/csstudio/trends/databrowser3/ui/properties/StatisticsTab.fxml
@@ -21,33 +21,28 @@
   ~  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
   -->
 
-<GridPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.csstudio.trends.databrowser3.ui.properties.StatisticsTabController">
-   <children>
-
-    <ToolBar minHeight="-Infinity" minWidth="-Infinity" prefHeight="40.0" prefWidth="600.0" VBox.vgrow="NEVER">
-      <items>
-        <Button fx:id="refreshAll" mnemonicParsing="false" onAction="#refreshAll" text="Refresh All" />
-      </items>
-    </ToolBar>
-    <TableView fx:id="tracesTable" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" VBox.vgrow="ALWAYS">
-      <columns>
-        <TableColumn fx:id="indicatorColumn" minWidth="22.0" maxWidth="22.0" prefWidth="22.0" />
-        <TableColumn fx:id="displayNameColumn" minWidth="130.0" prefWidth="260.0" text="Display Name"/>
-        <TableColumn fx:id="countColumn" minWidth="130" prefWidth="130.0" text="Sample Count" />
-        <TableColumn fx:id="meanColumn" minWidth="200.0" prefWidth="200.0" text="Mean" />
-        <TableColumn fx:id="medianColumn" minWidth="200.0" prefWidth="200.0" text="Median" />
-        <TableColumn fx:id="stdDevColumn" minWidth="200.0" prefWidth="200.0" text="Standard Deviation" />
-        <TableColumn fx:id="minColumn" minWidth="200.0" prefWidth="200.0" text="Min Value" />
-        <TableColumn fx:id="maxColumn" minWidth="200.0" prefWidth="200.0" text="Max Value" />
-        <TableColumn fx:id="sumColumn" minWidth="200.0" prefWidth="200.0" text="Sum" />
-      </columns>
-    </TableView>
-   </children>
-   <columnConstraints>
-      <ColumnConstraints />
-   </columnConstraints>
-   <rowConstraints>
-      <RowConstraints />
-      <RowConstraints />
-   </rowConstraints>
-</GridPane>
+<VBox xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1"
+      fx:controller="org.csstudio.trends.databrowser3.ui.properties.StatisticsTabController">
+    <children>
+        <ToolBar prefHeight="40.0" VBox.vgrow="NEVER">
+            <items>
+                <Button fx:id="refreshAll" mnemonicParsing="false" onAction="#refreshAll" text="Refresh All"/>
+            </items>
+        </ToolBar>
+        <ScrollPane fitToHeight="true" fitToWidth="true" VBox.vgrow="ALWAYS">
+            <TableView fx:id="tracesTable">
+                <columns>
+                    <TableColumn fx:id="indicatorColumn" minWidth="22.0" maxWidth="22.0" prefWidth="22.0"/>
+                    <TableColumn fx:id="displayNameColumn" minWidth="130.0" prefWidth="260.0" text="Display Name"/>
+                    <TableColumn fx:id="countColumn" minWidth="130" prefWidth="130.0" text="Sample Count"/>
+                    <TableColumn fx:id="meanColumn" minWidth="200.0" prefWidth="200.0" text="Mean"/>
+                    <TableColumn fx:id="medianColumn" minWidth="200.0" prefWidth="200.0" text="Median"/>
+                    <TableColumn fx:id="stdDevColumn" minWidth="200.0" prefWidth="200.0" text="Standard Deviation"/>
+                    <TableColumn fx:id="minColumn" minWidth="200.0" prefWidth="200.0" text="Min Value"/>
+                    <TableColumn fx:id="maxColumn" minWidth="200.0" prefWidth="200.0" text="Max Value"/>
+                    <TableColumn fx:id="sumColumn" minWidth="200.0" prefWidth="200.0" text="Sum"/>
+                </columns>
+            </TableView>
+        </ScrollPane>
+    </children>
+</VBox>


### PR DESCRIPTION
The primary purpose of this merge-request is to increase the width of the columns containing `double`s in the "Statistics"-tab so that the full value is shown. The intent is to prevent the user from mistakenly reading the wrong order of magnitude since the exponent is shown using a postfix-notation at the end of the printable representation of the `double` in question. E.g., if the number to be shown is `1.234E8`, then, if this output is truncated, the user may only be shown `1.23...`, and mistakenly think that the order of magnitude is eight powers of ten less than it actually is.

To prevent this, this merge-request increase the `minWidth`- and `prefWidth`-properties of the columns containing `double`s to high enough values so that any double should be printable.

Other changes that are introduced in this merge-request are:

 - The width-fields of the columns "indicatorColumn", "displayNameColumnn", and "countColumn" are also updated in this merge-request, to improve the user-experience.
 - In "StatisticsTab.fxml", the "GridPane" was changed to "VBox" and a "ScrollPane" was added around the "TableView". This is to enable scrolling in the TableView when the window is too small to show the entire TableView.
 - The types in the view model of the "TableView" in "StatisticsTab.fxml" (i.e., the variables of type `TableColumn<S, T>` in the class `StatisticsTabController`) were changed so that the content of the cells in the table (i.e., the `T` in `TableColumn<S, T>`) is typed according to the data that it represents.
 - The types in the data model of the "TableView" in "StatisticsTab.fxml" (i.e., the class `ModelItemStatistics`) were updated so that the types of the elements reflect the types of the data that they hold. (In other words, the `S` in `TableColumn<S, T>` was also updated.)