### PR TITLE
Ext. Command actions: Support property macros

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -270,7 +270,7 @@ public class ActionUtil
         try
         {
             // Path to resolve, after expanding macros
-            final Macros macros = source_widget.getEffectiveMacros();
+            final MacroValueProvider macros = source_widget.getMacrosOrProperties();
             final String command = MacroHandler.replace(macros, action.getCommand());
             logger.log(Level.FINER, "{0}, effective macros {1} ({2})", new Object[] { action, macros, command });
 


### PR DESCRIPTION
Create an action button, set name to "Fred" and action to the command `echo "Widget is named $(name)"`.

In the original implementation, macros got replaced but there was no fallback to widget properties like `$(name)`. Now this will work.

@tanviash  had reported this with an example that set widget names to "/tmp" and the action to "nautilus $(name)".