### PR TITLE
CSSTUDIO-1826 Add description of the calculation of the statistical measures to the documentation

### DIFF
--- a/app/databrowser/doc/index.rst
+++ b/app/databrowser/doc/index.rst
@@ -443,6 +443,6 @@ indirectly for determining the subset of data-points to calculate the statistica
 individual data-points are part of the calculation.
 
 E.g., the statistical mean will be skewed towards more recent data-points if the sample frequency of recent data-points
-is higher than the sample frequency of less recent data-points. This may, e.g., occur when the Data Browser displays
-historic data-points obtained from the archiver together with more recent data-points obtained from the PV itself
-(broadcast at a higher sample frequency than the archiver archives at).
+is higher than the sample frequency of less recent data-points. For instance, in a plot based on both archived and live
+samples, the mean value will be skewed towards the live data portion if live data is sampled at a higher frequency than
+archived data.

--- a/app/databrowser/doc/index.rst
+++ b/app/databrowser/doc/index.rst
@@ -443,7 +443,6 @@ indirectly for determining the subset of data-points to calculate the statistica
 individual data-points are part of the calculation.
 
 E.g., the statistical mean will be skewed towards more recent data-points if the sample frequency of recent data-points
-is higher than the sample frequency of less recent data-points. This may, e.g., occur in the case where a PV broadcasts
-measurement values more frequently than the archiver archives them: if the Data Browser has obtained more recent
-data-points directly from the PV itself while less recent data-points have been obtained from the archiver, then the
-calculated statistical mean will be skewed towards the more recent values that were broadcast by the PV.
+is higher than the sample frequency of less recent data-points. This may, e.g., occur when the Data Browser displays
+historic data-points obtained from the archiver together with more recent data-points obtained from the PV itself
+(broadcast at a higher sample frequency than the archiver archives at).

--- a/app/databrowser/doc/index.rst
+++ b/app/databrowser/doc/index.rst
@@ -429,3 +429,21 @@ To see available options, run phoebus like this::
 
     File names ending in *.m or *.mat generate Matlab files.
     All other file name endings create tab-separated data files.
+
+
+
+The Statistics-tab
+------------------
+Under the Statistics-tab, some basic statistical measures of the plotted data-points can be viewed.
+
+It is important to note that the statistics are calculated only on the data values themselves *without taking into
+account the timestamps of data-points*: in the calculation of the statistical measures, only the value of data-points
+and the total number of data-points are taken into account, while neither the time interval under consideration (except
+indirectly for determining the subset of data-points to calculate the statistical measures for), nor the timestamps of
+individual data-points are part of the calculation.
+
+E.g., the statistical mean will be skewed towards more recent data-points if the sample frequency of recent data-points
+is higher than the sample frequency of less recent data-points. This may, e.g., occur in the case where a PV broadcasts
+measurement values more frequently than the archiver archives them: if the Data Browser has obtained more recent
+data-points directly from the PV itself while less recent data-points have been obtained from the archiver, then the
+calculated statistical mean will be skewed towards the more recent values that were broadcast by the PV.

--- a/app/databrowser/doc/index.rst
+++ b/app/databrowser/doc/index.rst
@@ -442,7 +442,5 @@ and the total number of data-points are taken into account, while neither the ti
 indirectly for determining the subset of data-points to calculate the statistical measures for), nor the timestamps of
 individual data-points are part of the calculation.
 
-E.g., the statistical mean will be skewed towards more recent data-points if the sample frequency of recent data-points
-is higher than the sample frequency of less recent data-points. For instance, in a plot based on both archived and live
-samples, the mean value will be skewed towards the live data portion if live data is sampled at a higher frequency than
-archived data.
+For instance, in a plot based on both archived and live samples, the mean value will be skewed towards the live data
+portion if live data is sampled at a higher frequency than archived data.


### PR DESCRIPTION
This PR adds a description of the calculation of the statistical measures under the Statistics-tab in the Data Browser to the documentation.

The intention is to clarify the meaning of the statistical measures that are shown in the UI. In particular, it is emphasized that the timestamps data-points are *not* taken into account in their calculation.