### PR TITLE
BoolButton: Fix property listener

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
@@ -223,7 +223,7 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<Pane, Boo
         model_widget.propBit().removePropertyListener(bitChangedListener);
         model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
         model_widget.propMode().removePropertyListener(modeChangeListener);
-        model_widget.propMode().removePropertyListener(confirmDialogWidgetPropertyListener);
+        model_widget.propConfirmDialog().removePropertyListener(confirmDialogWidgetPropertyListener);
         super.unregisterListeners();
     }
 


### PR DESCRIPTION
The button registers `confirmDialogWidgetPropertyListener` for `propConfirmDialog` but then removes it from `propMode`, resulting in this stack trace:
```
SEVERE [org.csstudio.display.builder.model] Unknown listener org.csstudio.display.builder.representation.javafx.widgets.BoolButtonRepresentation$$Lambda$1503/0x000000080115b620@411bed6c
java.lang.Exception: Unknown listener
	at org.csstudio.display.builder.model.properties.PropertyChangeHandler.removePropertyListener(PropertyChangeHandler.java:119)
	at org.csstudio.display.builder.representation.javafx.widgets.BoolButtonRepresentation.unregisterListeners(BoolButtonRepresentation.java:226)
	at org.csstudio.display.builder.representation.javafx.widgets.JFXBaseRepresentation.dispose(JFXBaseRepresentation.java:247)
	at org.csstudio.display.builder.representation.WidgetRepresentation.destroy(WidgetRepresentation.java:88)
```