### PR TITLE
Update JavaFX to 19.0.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
   <properties>
     <epics.version>7.0.8</epics.version>
     <vtype.version>1.0.5</vtype.version>
-    <openjfx.version>19</openjfx.version>
+    <openjfx.version>19.0.2.1</openjfx.version>
     <jackson.version>2.12.3</jackson.version>
     <batik.version>1.14</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
.. simply because that's the current one, while plain 19 is about 5 months old. Release notes under https://github.com/openjdk/jfx/tree/jfx19/doc-files mostly point to "not public" security fixes.