### PR TITLE
Fix Y axis autoscale for data that's all zero

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotProcessor.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -441,8 +441,16 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                     if (low == high)
                     {   // Center trace with constant value (empty range)
                         final double half = Math.abs(low/2);
-                        low -= half;
-                        high += half;
+                        if (half > 0)
+                        {
+                            low -= half;
+                            high += half;
+                        }
+                        else
+                        {   // low = high = half = 0, default to [-1, 1]
+                            low = -1.0;
+                            high = 1.0;
+                        }
                     }
                     if (axis.isLogarithmic())
                     {   // Perform adjustment in log space.


### PR DESCRIPTION
@ralphlange noted that data like `sim://const(1)` will auto-scale to 0.5 .. 1.5, while all zero data like `sim://const(0)` doesn't. This is annoying for binary PVs when you happen to look at an all "off" state.

When the data has a single value, so low == high, we need to come up with some arbitrary axis min and max.
It does that based on using +- half the value, to get an axis that represents the order-of-magnitude of the data.
.. but that failed for low == high == zero.
