### PR TITLE
CSSTUDIO-1249 Changing Font size doesn't refresh in the editor

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverController.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverController.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import javafx.event.Event;
 import org.csstudio.display.builder.model.persist.NamedWidgetFonts;
 import org.csstudio.display.builder.model.persist.WidgetFontService;
 import org.csstudio.display.builder.model.properties.NamedWidgetFont;
@@ -280,6 +281,8 @@ public class WidgetFontPopOverController implements Initializable {
             }
         });
         sizes.valueProperty().addListener(( observable, oldValue, newValue ) -> sizesUpdater.accept(newValue));
+
+        sizes.setOnKeyPressed(Event::consume);
 
         // Get fonts on background thread
         ModelThreadPool.getExecutor().execute( ( ) -> {

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverController.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetFontPopOverController.java
@@ -284,6 +284,20 @@ public class WidgetFontPopOverController implements Initializable {
 
         sizes.setOnKeyPressed(Event::consume);
 
+        sizes.addEventHandler(KeyEvent.KEY_RELEASED, releasedKey -> {
+            releasedKey.consume();
+            if (releasedKey.getCode() == KeyCode.ENTER) {
+                if (!okButton.isDefaultButton()) {
+                    fontNames.refresh();
+                    families.refresh();
+                    okButton.setDefaultButton(true);
+                }
+            }
+            else {
+                okButton.setDefaultButton(false);
+            }
+        });
+
         // Get fonts on background thread
         ModelThreadPool.getExecutor().execute( ( ) -> {
 


### PR DESCRIPTION
There is an inconsistency (described in CSSTUDIO-1249) in the font-selection pop-over window across the platforms Linux, Windows, and Mac OS: if a number is entered (using the keyboard) into the font-size ComboBox, and the "enter" key is pressed, then the following behavior is observed on the different platforms:

- On Linux and Windows, the font-selection pop-over window closes, and the font size of the selected UI-element in the OPI is *not* updated.
- On Mac OS, the font selection pop-over window itself is updated with the entered font-size (i.e., the example text is rendered with the new font size), and if the font-size is different from the original font-size of the selected UI-element in the OPI, the "OK"-button is enabled.

This PR implements the following two changes in the font-selection pop-over controller:

1.  When the "enter" key is pressed and then released, the font-size selection window refreshes (and the example text is rendered using the entered font-size), and the "OK"-button is made the "Default Button" of the window, so that an immediate second "enter" key press submits the changes to the OPI. The intention of this change is firstly to harmonize the behavior of the UI across Linux, Windows, and Mac OS, and to improve the UI by facilitating the submission of the changed font to the OPI by pressing the "enter"-key twice in a row.
2. An event handler is added to the "sizes" ComboBox consuming any "key pressed"-events. This is to fix a bug where the "enter" key-pressed event is propagated to the underlying window, re-opening the font-selection pop-over controller quickly after it has been closed.