### PR TITLE
CSSTUDIO-1761 (Part 1/2) Add functionality to the menu of the main window for adding a layout to the current layout.

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
@@ -12,6 +12,7 @@ import org.phoebus.framework.nls.NLS;
 public class Messages
 {
     // Keep in alphabetical order and aligned with messages.properties
+    public static String AddLayout;
     public static String AllFiles;
     public static String AlwaysShowTabs;
     public static String Applications;

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -95,7 +95,7 @@ public class PhoebusApplication extends Application {
      * <p>Set on {@link #start(Stage)},
      * may be used to for example get HostServices
      */
-    public static Application INSTANCE;
+    public static PhoebusApplication INSTANCE;
 
     /**
      * Application parameters
@@ -181,7 +181,7 @@ public class PhoebusApplication extends Application {
      * without the ".memento" suffix and without the 'user'
      * location path.
      */
-    private final List<String> memento_files = new CopyOnWriteArrayList<>();
+    public final List<String> memento_files = new CopyOnWriteArrayList<>();
 
     /**
      * Toolbar button for top resources

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -172,7 +172,7 @@ public class PhoebusApplication extends Application {
     /**
      * Menu to add a layout to the current layout
      */
-    private final Menu add_layout = new Menu("Add Layout", ImageCache.getImageView(ImageCache.class, "/icons/layouts.png"));
+    private final Menu add_layout = new Menu(Messages.AddLayout, ImageCache.getImageView(ImageCache.class, "/icons/layouts.png"));
     
     /**
      * List of memento names

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -2,17 +2,10 @@ package org.phoebus.ui.application;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.lang.ref.WeakReference;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -176,6 +169,11 @@ public class PhoebusApplication extends Application {
      */
     private final Menu load_layout = new Menu(Messages.LoadLayout, ImageCache.getImageView(ImageCache.class, "/icons/layouts.png"));
 
+    /**
+     * Menu to add a layout to the current layout
+     */
+    private final Menu add_layout = new Menu("Add Layout", ImageCache.getImageView(ImageCache.class, "/icons/layouts.png"));
+    
     /**
      * List of memento names
      *
@@ -540,6 +538,7 @@ public class PhoebusApplication extends Application {
                 new SeparatorMenuItem(),
                 save_layout,
                 load_layout,
+                add_layout,
                 delete_layouts,
                 new SeparatorMenuItem(),
                 /* Full Screen placeholder */
@@ -592,6 +591,7 @@ public class PhoebusApplication extends Application {
 
             final List<MenuItem> menuItemList = new ArrayList<>();
             final List<MenuItem> toolbarMenuItemList = new ArrayList<>();
+            final List<MenuItem> addLayoutMenuItemList = new ArrayList<>();
 
             final Map<String, File> layoutFiles = new HashMap<String, File>();
 
@@ -646,6 +646,12 @@ public class PhoebusApplication extends Application {
                                 toolbarMenuItem.setMnemonicParsing(false);
                                 toolbarMenuItem.setOnAction(event -> startLayoutReplacement(file));
                                 toolbarMenuItemList.add(toolbarMenuItem);
+
+                                // Create menu for adding a layout:
+                                final MenuItem addLayoutMenuItem = new MenuItem(filename);
+                                addLayoutMenuItem.setMnemonicParsing(false);
+                                addLayoutMenuItem.setOnAction(event -> startAddingLayout(file));
+                                addLayoutMenuItemList.add(addLayoutMenuItem);
                             }
                         });
             }
@@ -654,6 +660,7 @@ public class PhoebusApplication extends Application {
             Platform.runLater(() ->
             {
                 load_layout.getItems().setAll(menuItemList);
+                add_layout.getItems().setAll(addLayoutMenuItemList);
                 layout_menu_button.getItems().setAll(toolbarMenuItemList);
                 delete_layouts.setDisable(memento_files.isEmpty());
             });
@@ -1012,6 +1019,28 @@ public class PhoebusApplication extends Application {
     }
 
     /**
+     * Initiate adding a layout to the current layout
+     *
+     * @param mementoFile Memento for the desired layout
+     */
+    private void startAddingLayout(File mementoFile) {
+        JobManager.schedule(mementoFile.getName(), monitor ->
+        {
+            MementoTree mementoTree;
+            try {
+                mementoTree = loadMemento(mementoFile);
+            } catch (FileNotFoundException fileNotFoundException) {
+                logger.log(Level.SEVERE, "Unable to add a layout to the existing layout due to an error when opening the file '" + mementoFile.getAbsolutePath() + "'.");
+                return;
+            } catch (Exception exception) {
+                logger.log(Level.SEVERE, "Unable to add a layout to the existing layout due to an error when parsing the file '" + mementoFile.getAbsolutePath() + "'.");
+                return;
+            }
+            Platform.runLater(() -> addLayoutToCurrentLayout(mementoTree));
+        });
+    }
+
+    /**
      * @param memento Memento for new layout that should replace current one
      */
     private void replaceLayout(final MementoTree memento) {
@@ -1094,6 +1123,41 @@ public class PhoebusApplication extends Application {
      */
     private MementoTree loadMemento(final File memfile) throws Exception {
         return XMLMementoTree.read(new FileInputStream(memfile));
+    }
+
+    /**
+     * Adds a layout from a MementoTree to the current layout.
+     */
+    private void addLayoutToCurrentLayout(MementoTree mementoTree) {
+
+        List<Runnable> restoreSelectedTabFunctions = new LinkedList<>();
+        for (Stage stage : DockStage.getDockStages()) {
+            for (DockPane pane : DockStage.getDockPanes(stage)) {
+                DockItem tab = (DockItem) pane.getSelectionModel().getSelectedItem();
+                restoreSelectedTabFunctions.add(() -> tab.select());
+            }
+        }
+
+        List<Runnable> focusNewlyCreatedStageFunctions = new LinkedList<>();
+        for (MementoTree childMementoTree : mementoTree.getChildren()) {
+            Stage stage = new Stage();
+            DockStage.configureStage(stage);
+            MementoHelper.restoreStage(childMementoTree, stage);
+
+            DockStage.deferUntilAllPanesOfStageHaveScenes(stage, () ->
+            {
+                long numberOfRestoredTabsInStage = DockStage.getDockPanes(stage).stream()
+                                                            .flatMap(pane -> pane.getTabs().stream())
+                                                            .count();
+                if (numberOfRestoredTabsInStage > 0) {
+                    focusNewlyCreatedStageFunctions.add(() -> stage.requestFocus());
+                } else {
+                    stage.close();
+                }
+                restoreSelectedTabFunctions.forEach(f -> f.run());
+                focusNewlyCreatedStageFunctions.forEach(f -> f.run());
+            });
+        }
     }
 
     /**

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -95,7 +95,7 @@ public class PhoebusApplication extends Application {
      * <p>Set on {@link #start(Stage)},
      * may be used to for example get HostServices
      */
-    public static PhoebusApplication INSTANCE;
+    public static Application INSTANCE;
 
     /**
      * Application parameters
@@ -181,7 +181,7 @@ public class PhoebusApplication extends Application {
      * without the ".memento" suffix and without the 'user'
      * location path.
      */
-    public final List<String> memento_files = new CopyOnWriteArrayList<>();
+    private final List<String> memento_files = new CopyOnWriteArrayList<>();
 
     /**
      * Toolbar button for top resources

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -394,8 +394,9 @@ public class DockPane extends TabPane
         return null;
     }
 
-    /** Somewhat hacky:
-     *  Need the scene of this dock pane to adjust the style sheet
+    private Deque<Consumer<Scene>> functionsDeferredUntilInScene = new LinkedList<>();
+    private boolean changeListenerAdded = false;
+    /** Need the scene of this dock pane to adjust the style sheet
      *  or to interact with the Window.
      *
      *  We _have_ added this DockPane to a scene graph, so getScene() should
@@ -405,10 +406,8 @@ public class DockPane extends TabPane
      *  The relative ordering in time of deferred function calls is preserved: if
      *  f1() is deferred before f2() is deferred, then f1() will be called before
      *  f2() is called.
-     *  @param user_of_scene Something that needs to run once there is a scene
+     *  @param function Something that needs to run once there is a scene
      */
-    private Deque<Consumer<Scene>> functionsDeferredUntilInScene = new LinkedList<>();
-    private boolean changeListenerAdded = false;
     public void deferUntilInScene(Consumer<Scene> function) {
         Scene scene = sceneProperty().get();
         if (scene != null) {

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -403,9 +403,22 @@ public class DockPane extends TabPane
      *  return the scene.
      *  But if this dock pane is nested inside a newly created {@link SplitDock},
      *  it will not have a scene until it is rendered.
-     *  The relative ordering in time of deferred function calls is preserved: if
-     *  f1() is deferred before f2() is deferred, then f1() will be called before
-     *  f2() is called.
+     *
+     *  If calls to deferUntilInScene() are not nested (i.e., there is no
+     *  call of the form deferUntilInScene(f) where f() in turn contains further
+     *  calls of the form deferUntilInScene(g) for some g), then the relative
+     *  ordering in time of deferred function calls is preserved: if f1() is
+     *  deferred before f2() is deferred, then f1() will be invoked before f2()
+     *  is invoked.
+     *
+     *  If, on the other hand, there *is* a call of the form deferUntilInScene(f)
+     *  where f() in turn contains a nested call of the form deferUntilInScene(g),
+     *  then the invocation of g() that is deferred by the call deferUntilInScene(g)
+     *  will occur as part of the (possibly deferred) invocation of f(). I.e.,  it
+     *  will *not* be deferred until after all other deferred function invocations
+     *  have completed, but will be invoked as part of the (possibly deferred)
+     *  invocation of f().
+     *
      *  @param function Something that needs to run once there is a scene
      */
     public void deferUntilInScene(Consumer<Scene> function) {

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -579,7 +579,7 @@ public class DockPane extends TabPane
     public SplitDock split(final boolean horizontally)
     {
         final SplitDock split;
-            if (dock_parent instanceof BorderPane)
+        if (dock_parent instanceof BorderPane)
         {
             final BorderPane parent = (BorderPane) dock_parent;
             // Remove this dock pane from BorderPane

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
@@ -417,4 +417,18 @@ public class DockStage
         else
             buf.append(node).append("\n");
     }
+
+    private static void deferUntilAllPanesOfStageHaveScenes(Runnable runnable, List<DockPane> remainingPanes) {
+        // This is a helper function for implementing deferUntilAllPanesOfStageHaveScenes(Stage stage, Runnable runnable).
+        if (remainingPanes.size() == 0) {
+            runnable.run();
+        } else {
+            var pane = remainingPanes.get(0);
+            pane.deferUntilInScene(scene -> deferUntilAllPanesOfStageHaveScenes(runnable, remainingPanes.subList(1, remainingPanes.size())));
+        }
+    }
+
+    public static void deferUntilAllPanesOfStageHaveScenes(Stage stage, Runnable runnable) {
+        deferUntilAllPanesOfStageHaveScenes(runnable, getDockPanes(stage));
+    }
 }

--- a/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
+++ b/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
@@ -1,3 +1,4 @@
+AddLayout=Add Layout
 AllFiles=All Files
 AlwaysShowTabs=Always Show Tabs
 Applications=Applications


### PR DESCRIPTION
`CSSTUDIO-1761` asks for implementation of:
1. The functionality to save the layout of individual windows.
2. The functionality to add windows that have been saved in this way to the current layout.

This merge-request implements point 2. Point 1. is implemented in merge-request https://github.com/ControlSystemStudio/phoebus/pull/2551.

This merge-request adds a sub-menu called "Add Layout" under the menu "Window" of the main window of the Phoebus application. In contrast to the sub-menu "Load Layout", "Add Layout" doesn't replace the current layout with the loaded layout, instead it _adds_ the loaded layout in by opening one or more new windows, leaving the currently opened layout intact.

The functionality implemented in this merge-request is more general than what is described under point 2.: not only individual windows can be added to the current layout, but any layout (with any number of windows) that has been saved.

The main part of the implementation of "Add Layout" is carried out in the function `addLayoutToCurrentLayout()` in the class `PhoebusApplication`. The implementation leverages the existing functionality of "restoring" stages from objects of type `MementoTree` by calling the function `MementoHelper.restoreStage()`.

`MementoHelper.restoreStage()` (re-)creates the individual applications of a stored layout by invoking the corresponding instances of `AppDescriptor.create()` for the applications in question. Many (but not all) applications implement functionality in `AppDescriptor.create()` that locates an already existing copy of the application in question, which, if such an instance is found, does _not_ create a new instance of the application, but instead puts the focus on the existing instance and possibly refreshes its content.

The functionality that `AppDescriptor.create()` often implements of selecting and possibly refreshing an already existing instance instead of creating a new instance leads to three complications for the implementation of the "Add Layout" sub-menu. If a new instance of an application is not created, but instead an existing instance is given focus, then:
1. the pane in the loaded layout that would contain the application is left empty. If all panes of a window in the loaded layout are empty, then the window in question should not be loaded (or, at the least, it should quickly be automatically closed again);
2. the focus of the tab containing the existing instance (that was focused by `AppDescriptor.create()`) will be opened, possibly changing which tab is opened in a window before "Add Layout" was invoked. This should not be the case, since the windows that were already open should be unchanged after invoking "Add Layout";
3. the existing instance may be refreshed by `AppDescriptor.create()`. This should not happen, since the windows that were already open should be unchanged after invoking "Add Layout".

Points 1. and 2. have been addressed, but I have not found a way to address point 3.

Point 1. is addressed by iterating through the newly created instances of `Stage`, checking whether they contain any tabs. If an instance doesn't contain any tabs, then no application was restored to the instance in question, and the stage in question is closed. The main difficulty in implementing this check is that it can only be performed once every created instance of `Pane` has an associated instance of `Scene`. To this end, the function `DockStage.deferUntilAllPanesOfStageHaveScenes()` was implemented. `DockStage.deferUntilAllPanesOfStageHaveScenes()` is implemented using `DockPane.deferUntilInScene()`, whose implementation was improved (also fixing #2544):
- It is now implemented using a `ChangeListener` instead of by trying to wait.
- The relative ordering in time of deferred function calls is preserved: if `f1()` is deferred before `f2()` is deferred, then `f1()` will be invoked before `f2()` is invoked. This is necessary in order to guarantee that the check for whether any tabs have been restored is run _after_ the code restoring instances is run.

Point 2. is addressed by iterating through the existing panes of the application before creating new stages, saving the selected item in each pane. After the new stages have been restored, the selected items of each original pane are restored. Finally, the newly created stages are given focus.

Point 3. is, as stated above, not addressed, and any suggestions on how to address point 3. are very welcome.