### PR TITLE
CA PV: Write any 32 bit long, signed or unsigned

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/ca/JCA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/ca/JCA_PV.java
@@ -529,9 +529,9 @@ public class JCA_PV extends PV implements ConnectionListener, MonitorListener, A
             // If value is small, write as int
             // 
             // Channel Access doesn't support unsigned, either.
-            // Will the number fits into 32 bits?
+            // Will the number fit into 32 bits?
             // As an unsigned long it may be beyond the largest int,
-            // but it fits into a signed int, write as such
+            // but if it fits into a signed int, write as such
             if (orig.longValue() == orig.intValue()  ||
                 Integer.toUnsignedLong(orig.intValue()) == orig.longValue())
             {

--- a/core/pv/src/main/java/org/phoebus/pv/ca/JCA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/ca/JCA_PV.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -525,10 +525,16 @@ public class JCA_PV extends PV implements ConnectionListener, MonitorListener, A
         else if (new_value instanceof Long)
         {
             final Long orig = (Long) new_value;
-            // ChannelAccess doesn't support long
-            if (orig.longValue() == orig.intValue())
+            // ChannelAccess doesn't support long.
+            // If value is small, write as int
+            // 
+            // Channel Access doesn't support unsigned, either.
+            // Will the number fits into 32 bits?
+            // As an unsigned long it may be beyond the largest int,
+            // but it fits into a signed int, write as such
+            if (orig.longValue() == orig.intValue()  ||
+                Integer.toUnsignedLong(orig.intValue()) == orig.longValue())
             {
-                // If value is small, write as int
                 final int val = orig.intValue();
                 if (put_listener != null)
                     channel.put(val, put_listener);


### PR DESCRIPTION
Channel Access doesn't have "long" (64 bit).
It only has 32 bit "int", and they're signed.

A value of 0x80000000, while a 32 bit value, exceeds the value range of a 32 bit signed integer. It was then written as a double, losing precision.
Now the JCA_PV detects if such a long value fits into 32 bits as a signed integer.

In the display builder or probe, when selecting Hex as the display format this now allows entering and displaying any values from 0x00000000 to 0xFFFFFFFF, whereas previously numbers beyond 0x7FFFFFFF could not be entered, had to enter negative values.