### PR TITLE
Edm converter: hidden buttons

### DIFF
--- a/app/display/convert-edm/.classpath
+++ b/app/display/convert-edm/.classpath
@@ -13,5 +13,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/core-formula"/>
         <classpathentry combineaccessrules="false" kind="src" path="/core-vtype"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/app-display-model"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/app-display-editor"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/app/display/convert-edm/build.xml
+++ b/app/display/convert-edm/build.xml
@@ -9,7 +9,7 @@
       <classpath>
         <path refid="app-classpath"/>
         <pathelement path="../model/${build}/app-display-model-${version}.jar"/>
-        <pathelement path="../model/${build}/app-display-editor-${version}.jar"/>
+        <pathelement path="../editor/${build}/app-display-editor-${version}.jar"/>
       </classpath>
     </javac>
   	

--- a/app/display/convert-edm/build.xml
+++ b/app/display/convert-edm/build.xml
@@ -9,6 +9,7 @@
       <classpath>
         <path refid="app-classpath"/>
         <pathelement path="../model/${build}/app-display-model-${version}.jar"/>
+        <pathelement path="../model/${build}/app-display-editor-${version}.jar"/>
       </classpath>
     </javac>
   	

--- a/app/display/convert-edm/pom.xml
+++ b/app/display/convert-edm/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
-      <artifactId>app-display-model</artifactId>
+      <artifactId>app-display-editor</artifactId>
       <version>4.7.2-SNAPSHOT</version>
     </dependency>
   </dependencies>

--- a/core/pva/.classpath
+++ b/core/pva/.classpath
@@ -5,6 +5,6 @@
 	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="src" path="src/test/resources"/>
-        <classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 
+
     <classpathentry exported="true" kind="lib" path="target/lib/FastInfoset-1.2.13.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/HikariCP-java7-2.4.13.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/JTangoClientLang-9.7.0.jar"/>
@@ -8,7 +9,7 @@
     <classpathentry exported="true" kind="lib" path="target/lib/JTangoServer-9.7.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/JavaEWAH-1.1.6.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/TangORB-9.7.0.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/accessors-smart-1.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/accessors-smart-2.4.7.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/activation-1.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/batik-anim-1.14.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/batik-awt-util-1.14.jar"/>
@@ -34,7 +35,6 @@
     <classpathentry exported="true" kind="lib" path="target/lib/cal10n-api-0.8.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/cglib-full-2.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/checker-qual-3.12.0.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/classmate-1.3.4.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commonj.sdo-2.1.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commonmark-0.15.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commonmark-ext-gfm-tables-0.15.2.jar"/>
@@ -65,10 +65,9 @@
     <classpathentry exported="true" kind="lib" path="target/lib/freetts-1.2.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/geronimo-spec-ejb-2.1-rc2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/guava-31.0.1-jre.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/hamcrest-2.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/hamcrest-all-1.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/hamcrest-core-1.3.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/hamcrest-library-1.3.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/hibernate-validator-6.0.16.Final.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/httpasyncclient-4.1.4.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/httpclient-4.5.10.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/httpcore-4.4.12.jar"/>
@@ -78,9 +77,9 @@
     <classpathentry exported="true" kind="lib" path="target/lib/jackson-annotations-2.12.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jackson-core-2.12.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jackson-databind-2.12.3.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jackson-datatype-jdk8-2.9.8.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jackson-datatype-jdk8-2.13.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jackson-datatype-jsr310-2.12.3.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jackson-module-parameter-names-2.9.8.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jackson-module-parameter-names-2.13.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jacorb-3.9.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jacorb-idl-compiler-3.8.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jacorb-omgapi-3.8.jar"/>
@@ -88,9 +87,8 @@
     <classpathentry exported="true" kind="lib" path="target/lib/jakarta.json-api-2.0.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/java_cup-0.9e.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.activation-1.2.0.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javax.annotation-api-1.3.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.json-1.0.4.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javax.json-api-1.0.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javax.json-api-1.1.4.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.mail-1.6.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.persistence-2.2.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.servlet-api-3.1.0.jar"/>
@@ -98,7 +96,6 @@
     <classpathentry exported="true" kind="lib" path="target/lib/jaxb-api-2.3.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jaxb-core-2.3.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jaxb-runtime-2.3.0.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jboss-logging-3.3.2.Final.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jca-2.4.7.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jeromq-0.5.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jersey-client-1.19.jar"/>
@@ -120,23 +117,32 @@
     <classpathentry exported="true" kind="lib" path="target/lib/jmock-cglib-1.0.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jnacl-1.0.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jsch-0.1.54.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/json-path-2.4.0.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/json-smart-2.3.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jsonassert-1.5.0.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/json-path-2.7.0.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/json-smart-2.4.7.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jsonassert-1.5.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jsr305-3.0.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jsr311-api-1.1.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/junit-4.13.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jython-standalone-2.7.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/junit-3.8.1.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/junit-jupiter-5.8.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/junit-jupiter-api-5.8.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/junit-jupiter-engine-5.8.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/junit-jupiter-params-5.8.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/junit-platform-commons-1.8.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/junit-platform-engine-1.8.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jython-standalone-2.7.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jzlib-1.1.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/kafka-clients-2.0.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/kafka-streams-2.0.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/log4j-api-2.17.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/log4j-to-slf4j-2.17.1.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/logback-classic-1.2.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/logback-core-1.2.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/lz4-java-1.4.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/mchange-commons-java-0.2.15.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/mimepull-1.9.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/mockito-core-2.23.4.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/mockito-junit-jupiter-4.5.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/mx4j-3.0.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/mx4j-impl-2.1.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/mx4j-jmx-2.1.1.jar"/>
@@ -144,13 +150,14 @@
     <classpathentry exported="true" kind="lib" path="target/lib/nanocontainer-remoting-1.0-RC-1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/objenesis-2.6.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/ojdbc8-12.2.0.1.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/opentest4j-1.2.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/org.eclipse.jgit-5.0.3.201809091024-r.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/org.eclipse.paho.client.mqttv3-1.2.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/parsson-1.0.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/pbrawclient-0.0.10.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/picocontainer-1.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/postgresql-42.2.9.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/protobuf-java-3.21.9.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/picocontainer-1.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/proxytoys-0.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/py4j-0.10.2.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/quartz-2.3.2.jar"/>
@@ -162,26 +169,26 @@
     <classpathentry exported="true" kind="lib" path="target/lib/slf4j-api-1.7.25.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/slf4j-ext-1.7.6.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/slf4j-jdk14-1.7.28.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/snakeyaml-1.23.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/snakeyaml-1.30.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/snappy-java-1.1.7.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-aop-5.1.7.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-beans-5.1.7.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-2.1.5.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-autoconfigure-2.1.5.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-2.1.5.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-json-2.1.5.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-test-2.1.5.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-tomcat-2.1.5.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-web-2.1.5.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-test-2.1.5.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-test-autoconfigure-2.1.5.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-context-5.1.7.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-core-5.1.7.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-expression-5.1.7.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-jcl-5.1.7.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-test-5.1.7.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-web-5.1.7.RELEASE.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/spring-webmvc-5.1.7.RELEASE.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-aop-5.3.22.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-beans-5.3.22.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-autoconfigure-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-json-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-test-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-tomcat-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-starter-web-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-test-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-boot-test-autoconfigure-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-context-5.3.22.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-core-5.3.22.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-expression-5.3.22.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-jcl-5.3.22.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-test-5.3.22.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-web-5.3.22.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/spring-webmvc-5.3.22.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/stax-ex-1.7.8.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/tango-idl-java-5.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/testfx-core-4.0.13-alpha.jar"/>
@@ -194,7 +201,7 @@
     <classpathentry exported="true" kind="lib" path="target/lib/wrapper-3.1.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/xalan-2.7.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/xmlgraphics-commons-2.4.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/xmlunit-core-2.6.2.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/xmlunit-core-2.9.0.jar"/>
 
 
     <!-- On Windows, need to add this:

--- a/phoebus-product/.classpath
+++ b/phoebus-product/.classpath
@@ -52,7 +52,9 @@
     <classpathentry combineaccessrules="false" kind="src" path="/app-perfmon"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-pace"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-diag"/>
+    <!-- These have incomplete eclipse build files
     <classpathentry combineaccessrules="false" kind="src" path="/app-credentials-management"/>
     <classpathentry combineaccessrules="false" kind="src" path="/app-eslog"/>
+    -->
     <classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
EDM display may have "transparent" buttons, which get replaced with similar invisible buttons.
In EDM, however, those could be placed behind other widgets.
In the display builder, that would render them inaccessible, so the converter moves them to the front.

.. but it only moved them to the front within their parent.
If the parent was a group, that group in turn could be covered by something else.
So now the converter moves "transparent" buttons to the front of the display, outside of "groups".

While at it, updated some eclipse build files that had gotten out of sync.