### PR TITLE
Alarm server XML doc fix

### DIFF
--- a/app/alarm/examples/alarm_configuration.xsd
+++ b/app/alarm/examples/alarm_configuration.xsd
@@ -56,7 +56,7 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="title" />
-                <xs:element ref="detail" />
+                <xs:element ref="details" />
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -64,7 +64,7 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="title" />
-                <xs:element ref="detail" />
+                <xs:element ref="details" />
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -72,7 +72,7 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="title" />
-                <xs:element ref="detail" />
+                <xs:element ref="details" />
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -80,7 +80,7 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="title" />
-                <xs:element ref="detail" />
+                <xs:element ref="details" />
                 <xs:element ref="delay" />
             </xs:sequence>
         </xs:complexType>

--- a/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelReaderTest.java
+++ b/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelReaderTest.java
@@ -64,6 +64,14 @@ public class AlarmModelReaderTest
 	+ "         <title>a1pv1 Command Title 1</title>\n"
 	+ "         <details>a1pv1 Command Detail 1</details>\n"
 	+ "       </command>\n"
+	+ "       <guidance>\n"
+	+ "         <title>a1pv1 Guidance Title 1</title>\n"
+	+ "         <details>a1pv1 Guidance Detail 1</details>\n"
+	+ "       </guidance>\n"
+	+ "       <display>\n"
+	+ "         <title>a1pv1 Display Title 1</title>\n"
+	+ "         <details>a1pv1 Display Detail 1</details>\n"
+	+ "       </display>\n"
 	+ "    </pv>"
 	+ "    <pv name=\"a1pv2\">\n"
 	+ "      <description>a1pv2 description</description>\n"
@@ -153,6 +161,20 @@ public class AlarmModelReaderTest
 
 		assertEquals("a1pv1 Command Title 1", a1pv1_commands.get(0).title);
 		assertEquals("a1pv1 Command Detail 1", a1pv1_commands.get(0).detail);
+
+		final List<TitleDetail> a1pv1_guidance = ((AlarmTreeItem<?>)a1pv1).getGuidance();
+
+		assertEquals(1, a1pv1_guidance.size());
+
+		assertEquals("a1pv1 Guidance Title 1", a1pv1_guidance.get(0).title);
+		assertEquals("a1pv1 Guidance Detail 1", a1pv1_guidance.get(0).detail);
+
+		final List<TitleDetail> a1pv1_displays = ((AlarmTreeItem<?>)a1pv1).getDisplays();
+
+		assertEquals(1, a1pv1_displays.size());
+
+		assertEquals("a1pv1 Display Title 1", a1pv1_displays.get(0).title);
+		assertEquals("a1pv1 Display Detail 1", a1pv1_displays.get(0).detail);
 
 		final AlarmTreeLeaf a1pv2 = (AlarmTreeLeaf) area1.getChild("a1pv2");
 


### PR DESCRIPTION
As far as I can tell, the alarm server XML schema doc is incorrect for the "detail" element for Guidance, Display, Automated Action, and Command. It should be `<details></details>`

This updates the XML schema doc and adds a test for Guidance and Display in AlarmModelReaderTest.java