### PR TITLE
CSSTUDIO-1827: (Data Browser) Fix the check for when exponential notation should be used for the labels of the ordinate

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
@@ -50,7 +50,7 @@ public class LinearTicks extends Ticks<Double>
     protected NumberFormat detailed_num_fmt = createDecimalFormat(2);
 
     /** Threshold for order-of-magnitude to use exponential notation */
-    private long exponential_threshold = 5;
+    private long exponential_threshold = 4;
 
     /** @param order_of_magnitude If value range exceeds this threshold, use exponential notation */
     public void setExponentialThreshold(long order_of_magnitude)

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
@@ -52,7 +52,7 @@ public class LinearTicks extends Ticks<Double>
     /** Threshold for order-of-magnitude to use exponential notation */
     private long exponential_threshold = 4;
 
-    /** @param order_of_magnitude If value range exceeds this threshold, use exponential notation */
+    /** @param order_of_magnitude determines when to use exponential notation */
     public void setExponentialThreshold(long order_of_magnitude)
     {
         exponential_threshold = order_of_magnitude;

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
@@ -125,9 +125,7 @@ public class LinearTicks extends Ticks<Double>
         double distance = selectNiceStep(min_distance);
         if (distance == 0.0)
             throw new Error("Broken tickmark computation");
-
-        // System.out.println("Range " + low + " - " + high + ", dist " + distance + ", prec. " + precision);
-
+        
         // Update num_fmt based on distance between major tick labels.
         // For example, an axis with range 0 .. 10 would ordinarily use precision 0
         // and axis markers like 0, 2, 4, 6, 8, 10.

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
@@ -91,12 +91,10 @@ public class LinearTicks extends Ticks<Double>
         final boolean normal = low < high;
         final double range = Math.abs(high-low);
 
-        final long order_of_magnitude = Math.abs(Math.round(Log10.log10(range)));
-
         // Determine initial precision for displaying numbers in this range.
         // Precision must be set to format test entries, which
         // are then used to compute ticks.
-        final boolean use_exp_notation = order_of_magnitude > exponential_threshold;
+        final boolean use_exp_notation = shouldUseExpNotation(low, high);
         int precision;
         if (use_exp_notation)
         {
@@ -203,6 +201,13 @@ public class LinearTicks extends Ticks<Double>
         }
         this.major_ticks = major_ticks;
         this.minor_ticks = minor_ticks;
+    }
+
+    protected boolean shouldUseExpNotation(Double low, Double high) {
+        boolean isLargeOrderOfMagnitude = Log10.log10(Math.abs(low)) >= exponential_threshold + 1 || Log10.log10(Math.abs(high)) >= exponential_threshold + 1;
+        boolean isSmallOrderOfMagnitude = Log10.log10(Math.abs(low)) < -exponential_threshold && Log10.log10(Math.abs(high)) < -exponential_threshold;
+
+        return isLargeOrderOfMagnitude || isSmallOrderOfMagnitude;
     }
 
     /** @param number A number

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TicksTestBase.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TicksTestBase.java
@@ -31,8 +31,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @SuppressWarnings("nls")
 public class TicksTestBase
 {
-    final static BufferedImage buf = new BufferedImage(400, 50, BufferedImage.TYPE_INT_ARGB);
-    final static Graphics2D gc = buf.createGraphics();
+    protected final static BufferedImage buf = new BufferedImage(400, 50, BufferedImage.TYPE_INT_ARGB);
+    protected final static Graphics2D gc = buf.createGraphics();
 
     @BeforeAll
     public static void setup()

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/internal/LinearTicksTest.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/internal/LinearTicksTest.java
@@ -85,4 +85,87 @@ public class LinearTicksTest extends TicksTestBase
         System.out.println(text);
         assertThat(text, equalTo("'10000' 9600 9200 8800 8400 '8000' 7600 7200 6800 6400 '6000' 5600 5200 4800 4400 '4000' 3600 3200 2800 2400 '2000' 1600 1200 800 400 "));
     }
+
+    @Test
+    public void testShouldUseExpNotation() {
+        final LinearTicks linearTicks = new LinearTicks();
+        linearTicks.setExponentialThreshold(3);
+
+        // Small orders of magnitude:
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 10.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 1.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 0.1), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 0.01), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 0.001), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 0.0001), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 0.00001), equalTo(true));
+
+        assertThat(linearTicks.shouldUseExpNotation(-10.0, 0.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-1.0, 0.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.1, 0.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.01, 0.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.001, 0.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.0001, 0.0), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(-0.00001, 0.0), equalTo(true));
+
+        assertThat(linearTicks.shouldUseExpNotation(-10.0, 10.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-1.0, 1.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.1, 0.1), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.01, 0.01), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.001, 0.001), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.0001, 0.0001), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(-0.00001, 0.00001), equalTo(true));
+
+        assertThat(linearTicks.shouldUseExpNotation(-9.0, 9.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.9, 0.9), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.09, 0.09), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.009, 0.009), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.0009, 0.0009), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(-0.00009, 0.00009), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(-0.000009, 0.000009), equalTo(true));
+
+        assertThat(linearTicks.shouldUseExpNotation(-9.999999999, 9.999999999), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.9999999999, 0.9999999999), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.09999999999, 0.09999999999), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.009999999999, 0.009999999999), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(-0.0009999999999, 0.0009999999999), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(-0.00009999999999, 0.00009999999999), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(-0.000009999999999, 0.000009999999999), equalTo(true));
+
+        // Large orders of magnitude:
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 1.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 10.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 100.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 1000.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 10000.0), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(0.0, 100000.0), equalTo(true));
+
+        assertThat(linearTicks.shouldUseExpNotation(1.0, 0.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(10.0, 0.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(100.0, 0.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(1000.0, 0.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(10000.0, 0.0), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(100000.0, 0.0), equalTo(true));
+
+        assertThat(linearTicks.shouldUseExpNotation(1.0, 1.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(10.0, 10.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(100.0, 100.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(1000.0, 1000.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(10000.0, 10000.0), equalTo(true));
+        assertThat(linearTicks.shouldUseExpNotation(100000.0, 100000.0), equalTo(true));
+
+        assertThat(linearTicks.shouldUseExpNotation(0.9, 0.9), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(9.0, 9.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(90.0, 90.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(900.0, 900.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(9000.0, 9000.0), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(90000.0, 90000.0), equalTo(true));
+
+        assertThat(linearTicks.shouldUseExpNotation(0.9999999999, 0.9999999999), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(9.999999999, 9.999999999), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(99.99999999, 99.99999999), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(999.9999999, 999.9999999), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(9999.999999, 9999.999999), equalTo(false));
+        assertThat(linearTicks.shouldUseExpNotation(99999.99999, 99999.99999), equalTo(true));
+    }
 }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/internal/LinearTicksTest.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/internal/LinearTicksTest.java
@@ -5,8 +5,9 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
-package org.csstudio.javafx.rtplot;
+package org.csstudio.javafx.rtplot.internal;
 
+import org.csstudio.javafx.rtplot.TicksTestBase;
 import org.csstudio.javafx.rtplot.internal.LinearTicks;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
This pull request fixes the check for when exponential notation should be used for the labels of the ordinate. Previously, the absolute difference of the parameters `low` and `high` was considered, and the check failed to account for the case where values are clustered relatively narrowly around large numbers (for example, around 1000000000).

This PR changes the check to check for two conditions:
1. If at least one of the parameters `low` or `high`is of large order of magnitude, then scientific notation is used.
2. If both `low` and `high` are of small orders of magnitude, then scientific notation is used.

If neither of these two conditions hold, then normal notation is used.

The initial value of `exponential_threshold` has been changed from `5` to `4`. In this implementation, `exponential_threshold == 4` means that numbers greater than 10^5-1 (i.e., with more than 4 "trailing decimals") and numbers less than 10^-4 (i.e., with more than 4 leading zeroes) are represented using scientific notation.

Tests have also been implemented for the check for whether scientific notation should be used or not. As part of this implementation, the class `LinearTicksTest` was moved from `org.csstudio.javafx.rtplot` to `org.csstudio.javafx.rtplot.internal`. The fields `buf` and `gc` of the class `TicksTestBase` had to be made `protected` to be accessible from `LinearTicksTest` after the move.