### PR TITLE
Provide visual feed-back if alarm actions fail

### DIFF
--- a/app/alarm/datasource/src/main/java/org/phoebus/pv/alarm/AlarmContext.java
+++ b/app/alarm/datasource/src/main/java/org/phoebus/pv/alarm/AlarmContext.java
@@ -116,7 +116,11 @@ public class AlarmContext
                     }
                     if (node != null)
                     {
-                        alarmModels.get(alarmPV.getInfo().getRoot()).acknowledge(node, ack);
+                        try {
+                            alarmModels.get(alarmPV.getInfo().getRoot()).acknowledge(node, ack);
+                        } catch (Exception e) {
+                            logger.log(Level.WARNING, "Failed to acknowledge alarm", e);
+                        }
                     }
                 }
             }

--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
@@ -470,7 +470,7 @@ public class AlarmClient
      *  @param path_name to parent Root or parent component under which to add the component
      *  @param new_name Name of the new component
      */
-    public void addComponent(final String path_name, final String new_name)
+    public void addComponent(final String path_name, final String new_name) throws Exception
     {
         try
         {
@@ -556,7 +556,7 @@ public class AlarmClient
     /** @param item Item for which to acknowledge alarm
      *  @param acknowledge <code>true</code> to acknowledge, else un-acknowledge
      */
-    public void acknowledge(final AlarmTreeItem<?> item, final boolean acknowledge)
+    public void acknowledge(final AlarmTreeItem<?> item, final boolean acknowledge) throws Exception
     {
         try
         {
@@ -568,6 +568,7 @@ public class AlarmClient
         catch (final Exception ex)
         {
             logger.log(Level.WARNING, "Cannot acknowledge component " + item, ex);
+            throw ex;
         }
     }
 

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AcknowledgeAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AcknowledgeAction.java
@@ -33,9 +33,9 @@ class AcknowledgeAction extends MenuItem
                     try {
                         model.acknowledge(item, true);
                     } catch (Exception e) {
-                        Platform.runLater(() -> ExceptionDetailsErrorDialog.openError(Messages.error,
+                        ExceptionDetailsErrorDialog.openError(Messages.error,
                                 Messages.acknowledgeFailed,
-                                e));
+                                e);
                         // Breaking under the assumption that if one acknowledge fails, all will fail.
                         break;
                     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AcknowledgeAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AcknowledgeAction.java
@@ -7,14 +7,15 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.ui;
 
-import java.util.List;
-
+import javafx.application.Platform;
+import javafx.scene.control.MenuItem;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.framework.jobs.JobManager;
+import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 
-import javafx.scene.control.MenuItem;
+import java.util.List;
 
 /** Action to acknowledge alarm
  *  @author Kay Kasemir
@@ -27,8 +28,19 @@ class AcknowledgeAction extends MenuItem
         super("Acknowledge", ImageCache.getImageView(AlarmUI.class, "/icons/acknowledge.png"));
         setOnAction(event ->
         {
-            JobManager.schedule(getText(), monitor ->
-                active.forEach(item -> model.acknowledge(item, true)));
+            JobManager.schedule(getText(), monitor -> {
+                for(AlarmTreeItem item : active){
+                    try {
+                        model.acknowledge(item, true);
+                    } catch (Exception e) {
+                        Platform.runLater(() -> ExceptionDetailsErrorDialog.openError(Messages.error,
+                                Messages.acknowledgeFailed,
+                                e));
+                        // Breaking under the assumption that if one acknowledge fails, all will fail.
+                        break;
+                    }
+                }
+            });
         });
     }
 }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/Messages.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/Messages.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.applications.alarm.ui;
+
+import org.phoebus.framework.nls.NLS;
+
+public class Messages
+{
+    public static String error;
+
+    public static String acknowledgeFailed;
+    public static String addComponentFailed;
+    public static String moveItemFailed;
+    public static String removeComponentFailed;
+    public static String renameItemFailed;
+    public static String unacknowledgeFailed;
+
+    static
+    {
+        // initialize resource bundle
+        NLS.initializeMessages(Messages.class);
+    }
+
+    private Messages() 
+    {
+        // prevent instantiation
+    }
+}

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/UnAcknowledgeAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/UnAcknowledgeAction.java
@@ -7,14 +7,15 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.ui;
 
-import java.util.List;
-
+import javafx.application.Platform;
+import javafx.scene.control.MenuItem;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.framework.jobs.JobManager;
+import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 
-import javafx.scene.control.MenuItem;
+import java.util.List;
 
 /** Action to acknowledge alarm
  *  @author Kay Kasemir
@@ -25,11 +26,21 @@ class UnAcknowledgeAction extends MenuItem
     public UnAcknowledgeAction(final AlarmClient model, final List<AlarmTreeItem<?>> active)
     {
         super("Un-Acknowledge", ImageCache.getImageView(AlarmUI.class, "/icons/unacknowledge.png"));
-        
-        JobManager.schedule(getText(), monitor ->
+        setOnAction(event ->
         {
-            setOnAction(event ->
-                active.forEach(item -> model.acknowledge(item, false)));
+            JobManager.schedule(getText(), monitor -> {
+                for (AlarmTreeItem item : active) {
+                    try {
+                        model.acknowledge(item, false);
+                    } catch (Exception e) {
+                        Platform.runLater(() -> ExceptionDetailsErrorDialog.openError(Messages.error,
+                                Messages.unacknowledgeFailed,
+                                e));
+                        // Breaking under the assumption that if one unacknowledge fails, all will fail.
+                        break;
+                    }
+                }
+            });
         });
     }
 }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/UnAcknowledgeAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/UnAcknowledgeAction.java
@@ -33,9 +33,9 @@ class UnAcknowledgeAction extends MenuItem
                     try {
                         model.acknowledge(item, false);
                     } catch (Exception e) {
-                        Platform.runLater(() -> ExceptionDetailsErrorDialog.openError(Messages.error,
+                        ExceptionDetailsErrorDialog.openError(Messages.error,
                                 Messages.unacknowledgeFailed,
-                                e));
+                                e);
                         // Breaking under the assumption that if one unacknowledge fails, all will fail.
                         break;
                     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AddComponentAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AddComponentAction.java
@@ -12,9 +12,11 @@ import java.util.List;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.applications.alarm.model.AlarmTreeLeaf;
+import org.phoebus.applications.alarm.ui.Messages;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.ui.autocomplete.PVAutocompleteMenu;
 import org.phoebus.ui.dialog.DialogHelper;
+import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javafx.application.Platform;
@@ -198,8 +200,15 @@ class AddComponentAction extends MenuItem
                                                      .replace('\n', ' ')
                                                      .replaceAll(" +", " ")
                                                      .trim();
-                    if (! haveExistingItem(node, parent, comp_name))
-                        model.addComponent(parent.getPathName(), comp_name);
+                    if (! haveExistingItem(node, parent, comp_name)) {
+                        try {
+                            model.addComponent(parent.getPathName(), comp_name);
+                        } catch (Exception e) {
+                            Platform.runLater(() -> ExceptionDetailsErrorDialog.openError(Messages.error,
+                                    Messages.addComponentFailed,
+                                    e));
+                        }
+                    }
                 }
             });
         });

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AddComponentAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AddComponentAction.java
@@ -204,9 +204,9 @@ class AddComponentAction extends MenuItem
                         try {
                             model.addComponent(parent.getPathName(), comp_name);
                         } catch (Exception e) {
-                            Platform.runLater(() -> ExceptionDetailsErrorDialog.openError(Messages.error,
+                            ExceptionDetailsErrorDialog.openError(Messages.error,
                                     Messages.addComponentFailed,
-                                    e));
+                                    e);
                         }
                     }
                 }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/MoveTreeItemAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/MoveTreeItemAction.java
@@ -10,7 +10,9 @@ package org.phoebus.applications.alarm.ui.tree;
 import org.phoebus.applications.alarm.AlarmSystem;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
+import org.phoebus.applications.alarm.ui.Messages;
 import org.phoebus.framework.jobs.JobManager;
+import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javafx.scene.control.MenuItem;
@@ -61,13 +63,19 @@ public class MoveTreeItemAction extends MenuItem
 			// On a background thread, send the item configuration updates for the item to be moved and all its children.
             JobManager.schedule(getText(), monitor ->
             {
-                // Move the item.
-                model.sendItemConfigurationUpdate(new_path, item);
-                // Move the item's children.
-                AlarmTreeHelper.rebuildTree(model, item, new_path);
-                // Delete the old item. This deletes the old item's children as well.
-                model.removeComponent(item);
-            });
+				try {
+					// Move the item.
+					model.sendItemConfigurationUpdate(new_path, item);
+					// Move the item's children.
+					AlarmTreeHelper.rebuildTree(model, item, new_path);
+					// Delete the old item. This deletes the old item's children as well.
+					model.removeComponent(item);
+				} catch (Exception e) {
+					ExceptionDetailsErrorDialog.openError(Messages.error,
+							Messages.moveItemFailed,
+							e);
+				}
+			});
 
     	});
 	}

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/RemoveComponentAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/RemoveComponentAction.java
@@ -9,10 +9,13 @@ package org.phoebus.applications.alarm.ui.tree;
 
 import java.util.List;
 
+import javafx.application.Platform;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
+import org.phoebus.applications.alarm.ui.Messages;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.ui.dialog.DialogHelper;
+import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javafx.scene.Node;
@@ -68,8 +71,18 @@ class RemoveComponentAction extends MenuItem
 
             JobManager.schedule(getText(), monitor ->
             {
-                for (AlarmTreeItem<?> item : items)
-                    model.removeComponent(item);
+                for (AlarmTreeItem<?> item : items){
+                    try {
+                        model.removeComponent(item);
+                    } catch (Exception e) {
+                        Platform.runLater(() -> ExceptionDetailsErrorDialog.openError(Messages.error,
+                                Messages.removeComponentFailed,
+                                e));
+                        // Breaking under the assumption that if one fails, all will fail
+                        break;
+                    }
+                }
+
             });
         });
     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/RemoveComponentAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/RemoveComponentAction.java
@@ -75,9 +75,9 @@ class RemoveComponentAction extends MenuItem
                     try {
                         model.removeComponent(item);
                     } catch (Exception e) {
-                        Platform.runLater(() -> ExceptionDetailsErrorDialog.openError(Messages.error,
+                        ExceptionDetailsErrorDialog.openError(Messages.error,
                                 Messages.removeComponentFailed,
-                                e));
+                                e);
                         // Breaking under the assumption that if one fails, all will fail
                         break;
                     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/RenameTreeItemAction.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/RenameTreeItemAction.java
@@ -13,7 +13,9 @@ import org.phoebus.applications.alarm.client.AlarmClientNode;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.applications.alarm.model.AlarmTreePath;
 import org.phoebus.applications.alarm.model.BasicState;
+import org.phoebus.applications.alarm.ui.Messages;
 import org.phoebus.framework.jobs.JobManager;
+import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javafx.scene.control.MenuItem;
@@ -56,10 +58,16 @@ class RenameTreeItemAction extends MenuItem
 	                // Remove the item and all its children.
 	                // Add the new item, and then rebuild all its children.
 	                final String new_path = AlarmTreePath.makePath(parent.getPathName(), new_name);
-					model.sendItemConfigurationUpdate(new_path, item);
-	                AlarmTreeHelper.rebuildTree(model, item, new_path);
-	                model.removeComponent(item);
-	            });
+					try {
+						model.sendItemConfigurationUpdate(new_path, item);
+						AlarmTreeHelper.rebuildTree(model, item, new_path);
+						model.removeComponent(item);
+					} catch (Exception e) {
+						ExceptionDetailsErrorDialog.openError(Messages.error,
+								Messages.renameItemFailed,
+								e);
+					}
+				});
         	});
         }
         else
@@ -80,12 +88,16 @@ class RenameTreeItemAction extends MenuItem
 	            {
 	                final AlarmTreeItem<BasicState> parent = item.getParent();
 	                final String new_path = AlarmTreePath.makePath(parent.getPathName(), new_name);
-	                model.sendItemConfigurationUpdate(new_path, item);
-	                model.removeComponent(item);
-	            });
+					try {
+						model.sendItemConfigurationUpdate(new_path, item);
+						model.removeComponent(item);
+					} catch (Exception e) {
+						ExceptionDetailsErrorDialog.openError(Messages.error,
+								Messages.renameItemFailed,
+								e);
+					}
+				});
 	        });
         }
     }
-
-
 }

--- a/app/alarm/ui/src/main/resources/org/phoebus/applications/alarm/ui/messages.properties
+++ b/app/alarm/ui/src/main/resources/org/phoebus/applications/alarm/ui/messages.properties
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2020 European Spallation Source ERIC.
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#
+#
+
+error=Error
+acknowledgeFailed=Failed to acknowledge alarm(s)
+addComponentFailed=Failed to add component
+moveItemFailed=Failed to move item
+removeComponentFailed=Failed to remove component
+renameItemFailed=Failed to rename item
+unacknowledgeFailed=Failed to unacknowledge alarm(s)


### PR DESCRIPTION
A site may configure the Kafka alarm service to allow producer messages only from certain IP addresses. This can be useful if alarm information is of interest to a wide audience, but actions should be allowed only from a limited context.

As this the current setup at ESS we discovered that blocked producer messages failed as expected, but left the user confused as nothing changed in the UI. This PR adds some code to display an error dialog in such cases.