### PR TITLE
Show display name in data browser samples view

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/sampleview/SampleView.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/sampleview/SampleView.java
@@ -7,11 +7,26 @@
  ******************************************************************************/
 package org.csstudio.trends.databrowser3.ui.sampleview;
 
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
-
+import javafx.application.Platform;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.util.Callback;
 import org.csstudio.trends.databrowser3.Activator;
 import org.csstudio.trends.databrowser3.Messages;
 import org.csstudio.trends.databrowser3.model.Model;
@@ -24,59 +39,48 @@ import org.phoebus.archive.vtype.VTypeHelper;
 import org.phoebus.ui.pv.SeverityColors;
 import org.phoebus.util.time.TimestampFormats;
 
-import javafx.application.Platform;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.geometry.Insets;
-import javafx.geometry.Pos;
-import javafx.scene.control.Button;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.Label;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableRow;
-import javafx.scene.control.TableView;
-import javafx.scene.control.Tooltip;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.VBox;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
-/** Panel for inspecting samples of a trace
- *  @author Kay Kasemir
+/**
+ * Panel for inspecting samples of a trace
+ *
+ * @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class SampleView extends VBox
-{
+public class SampleView extends VBox {
     private final Model model;
-    private final ComboBox<String> items = new ComboBox<>();
+    private final ComboBox<ModelItem> items = new ComboBox<>();
     private final Label sample_count = new Label(Messages.SampleView_Count);
     private final TableView<PlotSample> sample_table = new TableView<>();
-    private volatile String item_name = null;
+    private volatile ModelItem modelItem = null;
 
-    private static class SeverityColoredTableCell extends TableCell<PlotSample, String>
-    {
+    private static class SeverityColoredTableCell extends TableCell<PlotSample, String> {
         @Override
-        protected void updateItem(final String item, final boolean empty)
-        {
+        protected void updateItem(final String item, final boolean empty) {
             super.updateItem(item, empty);
             final TableRow<PlotSample> row = getTableRow();
-            if (empty  ||  row == null  ||  row.getItem() == null)
+            if (empty || row == null || row.getItem() == null)
                 setText("");
-            else
-            {
+            else {
                 setText(item);
                 setTextFill(SeverityColors.getTextColor(org.phoebus.core.vtypes.VTypeHelper.getSeverity(row.getItem().getVType())));
             }
         }
     }
 
-    /** @param model Model */
-    public SampleView(final Model model)
-    {
+    /**
+     * @param model Model
+     */
+    public SampleView(final Model model) {
         this.model = model;
 
         items.setOnAction(event -> select(items.getSelectionModel().getSelectedItem()));
+
+        ModelItemListCellFactory factory = new ModelItemListCellFactory();
+        items.setCellFactory(factory);
+        items.setButtonCell(factory.call(null));
 
         final Button refresh = new Button(Messages.SampleView_Refresh);
         refresh.setTooltip(new Tooltip(Messages.SampleView_RefreshTT));
@@ -107,8 +111,8 @@ public class SampleView extends VBox
         update();
     }
 
-    private void createSampleTable()
-    {
+
+    private void createSampleTable() {
         TableColumn<PlotSample, String> col = new TableColumn<>(Messages.TimeColumn);
         final VTypeFormat format = DoubleVTypeFormat.get();
         col.setCellValueFactory(cell -> new SimpleStringProperty(TimestampFormats.FULL_FORMAT.format(org.phoebus.core.vtypes.VTypeHelper.getTimestamp(cell.getValue().getVType()))));
@@ -136,54 +140,65 @@ public class SampleView extends VBox
         sample_table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
     }
 
-    private void select(final String item_name)
-    {
-        this.item_name = item_name;
+    private void select(final ModelItem modelItem) {
+        this.modelItem = modelItem;
         Activator.thread_pool.submit(this::getSamples);
     }
 
-    private void update()
-    {
-        final List<String> model_items = model.getItems().stream().map(item -> item.getResolvedName()).collect(Collectors.toList());
-        if (! model_items.equals(items.getItems()))
-        {
-            items.getItems().setAll( model_items );
-            if (item_name != null)
-                items.getSelectionModel().select(item_name);
-        }
+    private void update() {
+        final List<ModelItem> model_items = model.getItems();
+        items.getItems().setAll(model_items);
+        if (modelItem != null)
+            items.getSelectionModel().select(modelItem);
         // Update samples off the UI thread
         Activator.thread_pool.submit(this::getSamples);
     }
 
-    private void getSamples()
-    {
-        final ModelItem item = model.getItem(item_name);
+    private void getSamples() {
+        //final ModelItem item = model.getItem(modelItem);
         final ObservableList<PlotSample> samples = FXCollections.observableArrayList();
-        if (item != null)
-        {
-                final PlotSamples item_samples = item.getSamples();
-                try
-                {
-                    if (item_samples.getLock().tryLock(2, TimeUnit.SECONDS))
-                    {
-                        final int N = item_samples.size();
-                        for (int i=0; i<N; ++i)
-                            samples.add(item_samples.get(i));
-                        item_samples.getLock().unlock();
-                    }
+        if (modelItem != null) {
+            final PlotSamples item_samples = modelItem.getSamples();
+            try {
+                if (item_samples.getLock().tryLock(2, TimeUnit.SECONDS)) {
+                    final int N = item_samples.size();
+                    for (int i = 0; i < N; ++i)
+                        samples.add(item_samples.get(i));
+                    item_samples.getLock().unlock();
                 }
-                catch (Exception ex)
-                {
-                    Activator.logger.log(Level.WARNING, "Cannot access samples for " + item.getResolvedName(), ex);
-                }
+            } catch (Exception ex) {
+                Activator.logger.log(Level.WARNING, "Cannot access samples for " + modelItem.getResolvedName(), ex);
+            }
         }
         // Update UI
         Platform.runLater(() -> updateSamples(samples));
     }
 
-    private void updateSamples(final ObservableList<PlotSample> samples)
-    {
+    private void updateSamples(final ObservableList<PlotSample> samples) {
         sample_count.setText(Messages.SampleView_Count + " " + samples.size());
         sample_table.setItems(samples);
+    }
+
+    /**
+     * Cell factory for the combo box. If user has set a non-empty display name, use it in the item
+     * list together with the resolved PV name. If not, use only resolved PV name.
+     */
+    private static class ModelItemListCellFactory implements Callback<ListView<ModelItem>, ListCell<ModelItem>> {
+        @Override
+        public ListCell<ModelItem> call(ListView<ModelItem> param) {
+            return new ListCell<>() {
+                @Override
+                protected void updateItem(ModelItem item, boolean empty) {
+                    super.updateItem(item, empty);
+                    if (item != null) {
+                        if (item.getResolvedName().equals(item.getDisplayName()) || item.getDisplayName().isEmpty()) {
+                            setText(item.getResolvedName());
+                        } else {
+                            setText(item.getDisplayName() + " (" + item.getResolvedName() + ")");
+                        }
+                    }
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
In the combo box of the data browser samples view items are shown by resolved PV name. But user may define a (more user friendly) display name, so it would make sense to use this in the combo box as well.

This PR adds display name if it is non-empty and different compared to the resolved PV name. In the attached screen shot "Temp" is the display name for PV "CrS-PHS:Cryo-D-0100:AmbientTemp"

Also: upon refresh the item list is always updated as user may have updated display name.

![Screenshot 2023-03-09 at 13 06 47](https://user-images.githubusercontent.com/35602960/224018422-a69e5ac8-eca9-43c7-85ab-2e2616df12fa.png)
