### PR TITLE
phoebus.bat: Don't use server mode

### DIFF
--- a/phoebus-product/phoebus.bat
+++ b/phoebus-product/phoebus.bat
@@ -28,7 +28,7 @@ echo off
 FOR /F "tokens=* USEBACKQ" %%F IN (`dir /B product*.jar`) DO (SET JAR=%%F)
 echo on
 
-@REM Don't start CA repeater (#494)
-@REM To get one instance, use server mode
-@java -DCA_DISABLE_REPEATER=true -Dfile.encoding=UTF-8 -jar %JAR% -server 4918 %*
+@REM CA_DISABLE_REPEATER=true: Don't start CA repeater (#494)
+@REM To get one instance, use server mode by adding `-server 4918`
+@java -DCA_DISABLE_REPEATER=true -Dfile.encoding=UTF-8 -jar %JAR%  %*
 


### PR DESCRIPTION
Mention `-server 4918` in comment, but don't include it in the default parameters because it prevents opening multiple instances. In addition, that TCP port may be used by other tools, so leave addition of `-server...` settings to each site.

See also end user questions like https://epics.anl.gov/tech-talk/2023/msg00299.php