### PR TITLE
ByteMonitor: Unmanaged labels lacked 'layout'

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -442,6 +442,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
                         }
                         else
                             save_labels[i].setTextFill(text_color);
+                        save_labels[i].layout();
                     }
                 }
             }


### PR DESCRIPTION
More often than not, a screen with several byte monitor widgets that include labels expected to look like this ...

![Screenshot 2023-03-10 at 2 31 09 PM](https://user-images.githubusercontent.com/1932421/224423697-8b1d4ebf-396f-414d-910f-0786bbbccaca.png)

.. ended up looking like this with several labels missing:

![Screenshot 2023-03-10 at 2 30 48 PM](https://user-images.githubusercontent.com/1932421/224423700-22a2717b-6c51-43ff-9f7a-2648a98fb6f5.png)

Calling `layout()` after adjusting the label color seems to fix it.