### PR TITLE
Handle tracenames from legacy xygraph widget

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/StripchartWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/StripchartWidget.java
@@ -360,6 +360,12 @@ public class StripchartWidget extends VisibleWidget
 
                 if (! handleLegacyTraces(model_reader, strip, xml, pv_macro))
                     return false;
+		    
+		// If legend was turned off, clear the trace names since they would
+                // otherwise show on the Y axes
+                if (! strip.propLegend().getValue())
+                    for (TraceWidgetProperty trace : strip.propTraces().getValue())
+                        trace.traceName().setValue("");
                 
             }
             // Stripchart V2.1.0


### PR DESCRIPTION
The PR is to handle trace names for legacy XYGraph widget when converted to stripchart. This is already fixed for xyplot but was missing for stripchart.