### PR TITLE
 services-alarm-server : increase STABILIZATION_SECS when exporting #2596

### DIFF
--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmConfigTool.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmConfigTool.java
@@ -29,13 +29,15 @@ import org.phoebus.util.time.SecondsParser;
 public class AlarmConfigTool
 {
     /** Time the model must be stable for. Unit is seconds. Default is 4 seconds. */
-    private static final long STABILIZATION_SECS = 4;
+    private long STABILIZATION_SECS = 4;
 
     	// Export an alarm system model to an xml file.
-    public void exportModel(String filename, String server, String config, String kafka_properties_file) throws Exception
+    public void exportModel(String filename, String server, String config, String kafka_properties_file, long wait) throws Exception
 	{
         final XmlModelWriter xmlWriter;
 
+        if (wait > STABILIZATION_SECS) STABILIZATION_SECS = wait;
+        
         // Write to stdout or to file.
         if (filename.equals("stdout"))
             xmlWriter = new XmlModelWriter(System.out);

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -571,6 +571,7 @@ public class AlarmServerMain implements ServerModelListener
             String settings_arg         = "-settings";
             String noshell_arg          = "-noshell";
             String export_arg           = "-export";
+            String export_wait_arg      = "-export_wait";
             String import_arg           = "-import";
             String logging_arg          = "-logging";
             String kafka_props_arg      = "-kafka_properties";
@@ -580,6 +581,7 @@ public class AlarmServerMain implements ServerModelListener
                 config_arg,
                 settings_arg,
                 export_arg,
+                export_wait_arg,
                 import_arg,
                 logging_arg,
                 kafka_props_arg);
@@ -596,6 +598,7 @@ public class AlarmServerMain implements ServerModelListener
             Map<String, String> args_to_prefs = Map.ofEntries(
                 Map.entry(config_arg, "config_names"),
                 Map.entry(server_arg, "server"),
+                Map.entry(export_wait_arg, "export_wait"),
                 Map.entry(kafka_props_arg, "kafka_properties")
             );
 
@@ -658,8 +661,11 @@ public class AlarmServerMain implements ServerModelListener
             }
             if (parsed_args.containsKey(export_arg)){
                 final String filename = parsed_args.get(export_arg);
+                final String waitArg = parsed_args.get(export_wait_arg);
+                final long wait = (waitArg != null && !waitArg.equals("")) ? Long.parseLong(waitArg) : 0;
                 logger.info("Exporting model to " + filename);
-                new AlarmConfigTool().exportModel(filename, server, config, kafka_properties);
+                logger.info("wait " + wait);
+                new AlarmConfigTool().exportModel(filename, server, config, kafka_properties, wait);
             }
             if (parsed_args.containsKey(import_arg)){
                 final String filename = parsed_args.get(import_arg);


### PR DESCRIPTION
Added an argument export_wait to change the STABILIZATION_SECS default value of 4s.
My server is slow and 4s is too small to get a correct export.
Also added the possibility to set it in the settings.ini (org.phoebus.applications.alarm/export_wait)
Not sure the name I've chosen is the best, let you change it if necessary.