### PR TITLE
Alarm server  -connect_secs and -stable_secs settings 

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/ResettableTimeout.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/ResettableTimeout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,26 +24,37 @@ import org.phoebus.framework.jobs.NamedThreadFactory;
  *  Eventually, if there are no more resets,
  *  it will time out.
  *
+ *  Timeout can be adjusted on each 'reset'
+ *
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
 public class ResettableTimeout
 {
-    private final long timeout_secs;
+    private long timeout_secs;
 
-	private final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("ResettableTimeout"));
+    private final ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("ResettableTimeout"));
     private final CountDownLatch no_more_messages = new CountDownLatch(1);
     private final Runnable signal_no_more_messages = () -> no_more_messages.countDown();
     private final AtomicReference<ScheduledFuture<?>> timeout = new AtomicReference<>();
 
     /** @param timeout_secs Seconds after which we time out */
     public ResettableTimeout(final long timeout_secs)
-	{
-	    this.timeout_secs = timeout_secs;
-		reset();
-	}
+    {
+        this.timeout_secs = timeout_secs;
+        reset();
+    }
 
-	/** Reset the timer. As long as this is called within the timeout, we keep running */
+    /** Reset the timer. As long as this is called within the timeout, we keep running
+     *  @param timeout_secs New timeout in seconds
+     */
+    public void reset(final long timeout_secs)
+    {
+        this.timeout_secs = timeout_secs;
+        reset();
+    }
+
+    /** Reset the timer. As long as this is called within the timeout, we keep running */
     public void reset()
     {
         final ScheduledFuture<?> previous = timeout.getAndSet(timer.schedule(signal_no_more_messages, timeout_secs, TimeUnit.SECONDS));

--- a/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelSnapshotDemo.java
+++ b/app/alarm/model/src/test/java/org/phoebus/applications/alarm/AlarmModelSnapshotDemo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,25 +20,25 @@ import org.phoebus.applications.alarm.model.xml.XmlModelWriter;
 @SuppressWarnings("nls")
 public class AlarmModelSnapshotDemo
 {
-	@Test
-	public void testAlarmModelWriter() throws Exception
-	{
-	    // Get alarm configuration
-	    final AlarmClient client = new AlarmClient(AlarmDemoSettings.SERVERS, AlarmDemoSettings.ROOT, AlarmDemoSettings.KAFKA_PROPERTIES_FILE);
+    @Test
+    public void testAlarmModelWriter() throws Exception
+    {
+        // Get alarm configuration
+        final AlarmClient client = new AlarmClient(AlarmDemoSettings.SERVERS, AlarmDemoSettings.ROOT, AlarmDemoSettings.KAFKA_PROPERTIES_FILE);
+        client.start();
+        
+        System.out.println("Wait 10 secs for connection, then for stable configuration, i.e. no changes for 4 seconds...");
+        final long start = System.currentTimeMillis();
 
-	    System.out.println("Wait for stable configuration, i.e. no changes for 4 seconds...");
+        final AlarmConfigMonitor monitor = new AlarmConfigMonitor(10, 4, client);
+        monitor.waitForPauseInUpdates(30);
+        final double secs = (System.currentTimeMillis() - start) / 1000.0;
+        System.out.format("Alarm configuration after %.3f seconds:\n\n", secs);
 
-	    // Wait until we have a snapshot, i.e. no more changes for 4 seconds
-	    final AlarmConfigMonitor monitor = new AlarmConfigMonitor(4, client);
-	    monitor.waitForPauseInUpdates(30);
-
-	    System.out.println("Alarm configuration:");
-
-
-		final ByteArrayOutputStream buf = new ByteArrayOutputStream();
-		final XmlModelWriter xmlWriter = new XmlModelWriter(buf);
-		xmlWriter.write(client.getRoot());
-		xmlWriter.close();
+        final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        final XmlModelWriter xmlWriter = new XmlModelWriter(buf);
+        xmlWriter.write(client.getRoot());
+        xmlWriter.close();
         final String xml = buf.toString();
         System.out.println(xml);
 
@@ -47,5 +47,5 @@ public class AlarmModelSnapshotDemo
             System.out.println("Bummer, there were " + changes + " updates to the configuration, might have to try this again...");
         monitor.dispose();
         client.shutdown();
-	}
+    }
 }

--- a/app/alarm/model/src/test/java/org/phoebus/applications/alarm/ResettableTimeoutTest.java
+++ b/app/alarm/model/src/test/java/org/phoebus/applications/alarm/ResettableTimeoutTest.java
@@ -61,4 +61,23 @@ public class ResettableTimeoutTest
         assertThat(timer.awaitTimeout(6), equalTo(true));
         timer.shutdown();
     }
+    
+    @Test
+    public void testChangingTimeout()
+    {
+        ResettableTimeout timer = new ResettableTimeout(4);
+        System.out.println("Should time out in 4 secs");
+        assertThat(timer.awaitTimeout(8), equalTo(true));
+        timer.shutdown();
+
+        
+        timer = new ResettableTimeout(4);
+        System.out.println("Now resetting after just 1 second to a 1 second timeout...");
+        assertThat(timer.awaitTimeout(1), equalTo(false));
+        timer.reset(1);
+
+        System.out.println(".. and expecting time out in 1 second...");
+        assertThat(timer.awaitTimeout(4), equalTo(true));
+        timer.shutdown();
+    }
 }

--- a/app/alarm/model/src/test/java/org/phoebus/applications/alarm/ResettableTimeoutTest.java
+++ b/app/alarm/model/src/test/java/org/phoebus/applications/alarm/ResettableTimeoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2012-2023 Oak Ridge National Laboratory.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmConfigTool.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmConfigTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,15 +28,16 @@ import org.phoebus.util.time.SecondsParser;
 @SuppressWarnings("nls")
 public class AlarmConfigTool
 {
+    /** Timeout for receiving the first config update, a quasi connection timeout. Default is 10 seconds. */
+    public static long CONNECTION_SECS = 10;
+
     /** Time the model must be stable for. Unit is seconds. Default is 4 seconds. */
-    private long STABILIZATION_SECS = 4;
+    public static long STABILIZATION_SECS = 4;
 
-    	// Export an alarm system model to an xml file.
-    public void exportModel(String filename, String server, String config, String kafka_properties_file, long wait) throws Exception
-	{
+        // Export an alarm system model to an xml file.
+    public void exportModel(String filename, String server, String config, String kafka_properties_file) throws Exception
+    {
         final XmlModelWriter xmlWriter;
-
-        if (wait > STABILIZATION_SECS) STABILIZATION_SECS = wait;
         
         // Write to stdout or to file.
         if (filename.equals("stdout"))
@@ -56,10 +57,11 @@ public class AlarmConfigTool
         final AlarmClient client = new AlarmClient(server, config, kafka_properties_file);
         client.start();
 
-        System.out.printf("Writing file after model is stable for %d seconds:\n", STABILIZATION_SECS);
+        System.out.printf("Writing file after %d second connection timeout, then waiting until model is stable for %d seconds:\n",
+                          CONNECTION_SECS, STABILIZATION_SECS);
         System.out.println("Monitoring changes...");
 
-        final AlarmConfigMonitor updateMonitor = new AlarmConfigMonitor(STABILIZATION_SECS, client);
+        final AlarmConfigMonitor updateMonitor = new AlarmConfigMonitor(CONNECTION_SECS, STABILIZATION_SECS, client);
         updateMonitor.waitForPauseInUpdates(30);
 
         System.out.printf("Received no more updates for %d seconds, I think I have a stable configuration\n", STABILIZATION_SECS);
@@ -77,18 +79,18 @@ public class AlarmConfigTool
         updateMonitor.dispose();
 
         client.shutdown();
-	}
+    }
 
-	// Import an alarm system model from an xml file.
-	public void importModel(final String filename, final String server, final String config, String kafka_properties_file) throws InterruptedException, Exception
-	{
-	    System.out.println("Reading new configuration from " + filename);
-	    final long start = System.currentTimeMillis();
-		final File file = new File(filename);
-		final FileInputStream fileInputStream = new FileInputStream(file);
+    // Import an alarm system model from an xml file.
+    public void importModel(final String filename, final String server, final String config, String kafka_properties_file) throws InterruptedException, Exception
+    {
+        System.out.println("Reading new configuration from " + filename);
+        final long start = System.currentTimeMillis();
+        final File file = new File(filename);
+        final FileInputStream fileInputStream = new FileInputStream(file);
 
-		final XmlModelReader xmlModelReader = new XmlModelReader();
-		xmlModelReader.load(fileInputStream);
+        final XmlModelReader xmlModelReader = new XmlModelReader();
+        xmlModelReader.load(fileInputStream);
 
         final AlarmClientNode new_root = xmlModelReader.getRoot();
         // Check that the configs match.
@@ -99,13 +101,14 @@ public class AlarmConfigTool
         }
         final long got_xml = System.currentTimeMillis();
 
-		// Connect to the server.
-		final AlarmClient client = new AlarmClient(server, config, kafka_properties_file);
+        // Connect to the server.
+        final AlarmClient client = new AlarmClient(server, config, kafka_properties_file);
         client.start();
         try
         {
-            System.out.println("Fetching existing alarm configuration for \"" + config + "\", then waiting for it to remain stable for " + STABILIZATION_SECS + " seconds...");
-            final AlarmConfigMonitor updateMonitor = new AlarmConfigMonitor(STABILIZATION_SECS, client);
+            System.out.println("Fetching existing alarm configuration for \"" + config + "\" with " + CONNECTION_SECS +
+                               " connection timeout, then waiting for it to remain stable for " + STABILIZATION_SECS + " seconds...");
+            final AlarmConfigMonitor updateMonitor = new AlarmConfigMonitor(CONNECTION_SECS, STABILIZATION_SECS, client);
             updateMonitor.waitForPauseInUpdates(30);
             updateMonitor.dispose();
             final long got_old_config = System.currentTimeMillis();
@@ -118,7 +121,7 @@ public class AlarmConfigTool
             // Delete the old model. Leave the root node.
             final List<AlarmTreeItem<?>> root_children = root.getChildren();
             for (final AlarmTreeItem<?> child : root_children)
-            	client.removeComponent(child);
+                client.removeComponent(child);
             final long deleted_old = System.currentTimeMillis();
 
             System.out.println("Loading new " + new_root.getName() + " ...");
@@ -126,7 +129,7 @@ public class AlarmConfigTool
             // For every child of the new root, add them and their descendants to the old root.
             final List<AlarmTreeItem<?>> new_root_children = new_root.getChildren();
             for (final AlarmTreeItem<?> child : new_root_children)
-				addNodes(client, root, child);
+                addNodes(client, root, child);
             final long loaded_new = System.currentTimeMillis();
 
             System.out.println("Time to read XML                     : " + SecondsParser.formatSeconds((got_xml - start) / 1000.0));
@@ -140,16 +143,16 @@ public class AlarmConfigTool
         {
             client.shutdown();
         }
-	}
+    }
 
-	private void addNodes(final AlarmClient client, final AlarmTreeItem<?> parent, final AlarmTreeItem<?> tree_item) throws Exception
-	{
-		// Send the configuration for the newly created node.
-		client.sendItemConfigurationUpdate(tree_item.getPathName(), tree_item);
+    private void addNodes(final AlarmClient client, final AlarmTreeItem<?> parent, final AlarmTreeItem<?> tree_item) throws Exception
+    {
+        // Send the configuration for the newly created node.
+        client.sendItemConfigurationUpdate(tree_item.getPathName(), tree_item);
 
-		// Recurse over children.
-		final List<AlarmTreeItem<?>> children = tree_item.getChildren();
-		for (final AlarmTreeItem<?> child : children)
-			addNodes(client, tree_item, child);
-	}
+        // Recurse over children.
+        final List<AlarmTreeItem<?>> children = tree_item.getChildren();
+        for (final AlarmTreeItem<?> child : children)
+            addNodes(client, tree_item, child);
+    }
 }

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -544,8 +544,8 @@ public class AlarmServerMain implements ServerModelListener
         System.out.println("-export             config.xml          - Export alarm configuration to file");
         System.out.println("-import             config.xml          - Import alarm configruation from file");
         System.out.println("-logging            logging.properties  - Load log settings");
-        System.out.println("-connect_secs       10                  - Time import/export waits for connection");
-        System.out.println("-stable_secs         4                  - Time import/export waits for stable configuration");
+        System.out.println("-connect_secs       10                  - Time alarm server and config import/export waits for connection");
+        System.out.println("-stable_secs         4                  - Time alarm server and config import/export waits for stable configuration");
         System.out.println("-kafka_properties   client.properties   - Load kafka client settings from file");
         System.out.println();
     }

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -87,7 +87,9 @@ public class AlarmServerMain implements ServerModelListener
             {
                 logger.info("Fetching past alarm states...");
                 final AlarmStateInitializer init = new AlarmStateInitializer(server, config, kafka_props_file);
-                if (! init.awaitCompleteStates())
+                if (init.awaitCompleteStates())
+                    logger.log(Level.INFO, "Alarm state stabilized");
+                else
                     logger.log(Level.WARNING, "Keep receiving state updates, may have incomplete initial set of alarm states");
                 final ConcurrentHashMap<String, ClientState> initial_states = init.shutdown();
 
@@ -542,6 +544,8 @@ public class AlarmServerMain implements ServerModelListener
         System.out.println("-export             config.xml          - Export alarm configuration to file");
         System.out.println("-import             config.xml          - Import alarm configruation from file");
         System.out.println("-logging            logging.properties  - Load log settings");
+        System.out.println("-connect_secs       10                  - Time import/export waits for connection");
+        System.out.println("-stable_secs         4                  - Time import/export waits for stable configuration");
         System.out.println("-kafka_properties   client.properties   - Load kafka client settings from file");
         System.out.println();
     }
@@ -571,9 +575,10 @@ public class AlarmServerMain implements ServerModelListener
             String settings_arg         = "-settings";
             String noshell_arg          = "-noshell";
             String export_arg           = "-export";
-            String export_wait_arg      = "-export_wait";
             String import_arg           = "-import";
             String logging_arg          = "-logging";
+            String connect_secs_arg     = "-connect_secs";
+            String stable_secs_arg      = "-stable_secs";
             String kafka_props_arg      = "-kafka_properties";
 
             Set<String> options = Set.of(
@@ -581,9 +586,10 @@ public class AlarmServerMain implements ServerModelListener
                 config_arg,
                 settings_arg,
                 export_arg,
-                export_wait_arg,
                 import_arg,
                 logging_arg,
+                connect_secs_arg,
+                stable_secs_arg,
                 kafka_props_arg);
 
             Set<String> flags = Set.of(
@@ -598,52 +604,52 @@ public class AlarmServerMain implements ServerModelListener
             Map<String, String> args_to_prefs = Map.ofEntries(
                 Map.entry(config_arg, "config_names"),
                 Map.entry(server_arg, "server"),
-                Map.entry(export_wait_arg, "export_wait"),
                 Map.entry(kafka_props_arg, "kafka_properties")
             );
 
             while (iter.hasNext())
             {
                 final String cmd = iter.next();
-                if (options.contains(cmd)) {
+                if (options.contains(cmd))
+                {
                     if (! iter.hasNext())
                         throw new Exception("Missing argument for " +  cmd);
                     final String arg = iter.next();
                     parsed_args.put(cmd, arg);
                 }
-                else if (flags.contains(cmd)) {
+                else if (flags.contains(cmd))
                     parsed_args.put(cmd, "");
-                }
-                else {
+                else
                     throw new Exception("Unknown option " + cmd);
-                }
             }
 
-            if (parsed_args.containsKey(help_arg) || parsed_args.containsKey(help_alt_arg)){
+            if (parsed_args.containsKey(help_arg) || parsed_args.containsKey(help_alt_arg))
+            {
                 help();
                 return;
             }
-            if (parsed_args.containsKey(logging_arg)) {
+            if (parsed_args.containsKey(logging_arg))
                 LogManager.getLogManager().readConfiguration(new FileInputStream(parsed_args.get(logging_arg)));
-            }
-            if (parsed_args.containsKey(settings_arg)){
+            if (parsed_args.containsKey(settings_arg))
+            {
                 final String filename = parsed_args.get(settings_arg);
                 logger.info("Loading settings from " + filename);
                 PropertyPreferenceLoader.load(new FileInputStream(filename));
-                Preferences userPrefs  = Preferences.userRoot().node("org/phoebus/applications/alarm");
+                final Preferences userPrefs  = Preferences.userRoot().node("org/phoebus/applications/alarm");
 
-                for (Map.Entry<String, String> entry: args_to_prefs.entrySet()) {
+                for (Map.Entry<String, String> entry: args_to_prefs.entrySet())
+                {
                     final String prefKey = entry.getValue();
                     final String arg = entry.getKey();
     
-                    if (parsed_args.containsKey(arg)){
+                    if (parsed_args.containsKey(arg))
+                    {
                         logger.log(Level.WARNING,"Potentially conflicting setting: -settings/"+prefKey+": " + userPrefs.get(prefKey, "") + " and " + arg + ":" + parsed_args.get(arg));
                         logger.log(Level.WARNING,"Using argument " + arg + " instead of -settings");
                         logger.log(Level.WARNING,prefKey + ": " + parsed_args.get(arg));
                     }
-                    else if (Set.of(userPrefs.keys()).contains(prefKey)){
+                    else if (Set.of(userPrefs.keys()).contains(prefKey))
                         parsed_args.put(arg, userPrefs.get(prefKey, ""));
-                    }
                 }
             }
 
@@ -651,30 +657,37 @@ public class AlarmServerMain implements ServerModelListener
             server = parsed_args.getOrDefault(server_arg, server);
             kafka_properties = parsed_args.getOrDefault(kafka_props_arg, kafka_properties);
             use_shell = !parsed_args.containsKey(noshell_arg);
+            
+            if (parsed_args.containsKey(connect_secs_arg))
+                AlarmStateInitializer.CONNECTION_SECS = AlarmConfigTool.CONNECTION_SECS
+                                                      = Long.parseLong(parsed_args.get(connect_secs_arg));
 
-            if (parsed_args.containsKey(create_topics_arg)){
+            if (parsed_args.containsKey(stable_secs_arg))
+                AlarmStateInitializer.STABILIZATION_SECS = AlarmConfigTool.STABILIZATION_SECS
+                                                         = Long.parseLong(parsed_args.get(stable_secs_arg));
+
+            if (parsed_args.containsKey(create_topics_arg))
+            {
                 logger.info("Discovering and creating any missing topics at " + server);
                 CreateTopics.discoverAndCreateTopics(server, true, List.of(config,
                                                      config + AlarmSystemConstants.COMMAND_TOPIC_SUFFIX,
                                                      config + AlarmSystemConstants.TALK_TOPIC_SUFFIX),
                                                      kafka_properties);
             }
-            if (parsed_args.containsKey(export_arg)){
+            if (parsed_args.containsKey(export_arg))
+            {
                 final String filename = parsed_args.get(export_arg);
-                final String waitArg = parsed_args.get(export_wait_arg);
-                final long wait = (waitArg != null && !waitArg.equals("")) ? Long.parseLong(waitArg) : 0;
                 logger.info("Exporting model to " + filename);
-                logger.info("wait " + wait);
-                new AlarmConfigTool().exportModel(filename, server, config, kafka_properties, wait);
+                new AlarmConfigTool().exportModel(filename, server, config, kafka_properties);
             }
-            if (parsed_args.containsKey(import_arg)){
+            if (parsed_args.containsKey(import_arg))
+            {
                 final String filename = parsed_args.get(import_arg);
                 logger.info("Import model from " + filename);
                 new AlarmConfigTool().importModel(filename, server, config, kafka_properties);
             }
-            if (parsed_args.containsKey(export_arg) || parsed_args.containsKey(import_arg)){
+            if (parsed_args.containsKey(export_arg) || parsed_args.containsKey(import_arg))
                 return;
-            }
         }
         catch (final Exception ex)
         {

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,7 +43,13 @@ import org.phoebus.applications.alarm.model.json.JsonModelReader;
 @SuppressWarnings("nls")
 public class AlarmStateInitializer
 {
-    private final ResettableTimeout timer = new ResettableTimeout(4);
+    /** Timeout for receiving the first update, a quasi connection timeout. Default is 10 seconds. */
+    public static long CONNECTION_SECS = 10;
+
+    /** Time the model must be stable for. Unit is seconds. Default is 4 seconds. */
+    public static long STABILIZATION_SECS = 4;
+    
+    private final ResettableTimeout timer = new ResettableTimeout(CONNECTION_SECS);
     private final AtomicBoolean running = new AtomicBoolean(true);
     private final Consumer<String, String> consumer;
     private final Thread thread;
@@ -105,7 +111,7 @@ public class AlarmStateInitializer
                     if (node_config == null)
                     {   // No config -> Delete node
                         inititial_severity.remove(path);
-                        timer.reset();
+                        timer.reset(STABILIZATION_SECS);
                     }
                     else
                     {
@@ -119,7 +125,7 @@ public class AlarmStateInitializer
                                 inititial_severity.remove(path);
                             else
                                 inititial_severity.put(path, state);
-                            timer.reset();
+                            timer.reset(STABILIZATION_SECS);
                         }
                     }
                 }


### PR DESCRIPTION
Follow-up to #2597

The config and status messages are a kafka stream.
To get the "current" configuration, we wait until there is a pause in config messages.
Similarly, the alarm server waits for a pause in state messages to assume it knows the initial alarm state.

This timeout was 4 seconds, and #2597 made it configurable.
The actual issue, however, was a slow connection which required about 10 seconds until receiving the first message.

This adds separate "`-connect_secs` and `-stable_secs` command line parameters.
`-connect_secs`, default 10, configures the wait for the initial message, while `-stable_secs` is then used to wait for a pause in messages.

These parameters apply to the `-import`, `-export` and also the alarm server startup.
