### PR TITLE
Save-and-restore : Add snapshot name automatically after a "Take Snapshot"

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/Preferences.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/Preferences.java
@@ -32,6 +32,16 @@ public class Preferences {
     public static int search_result_page_size;
     @Preference
     public static String default_search_query;
+    @Preference
+    public static String default_title_snapshot_configuration;
+    @Preference
+    public static String default_title_snapshot_format;
+    @Preference
+    public static String default_title_snapshot_date_format;
+    @Preference
+    public static String default_title_snapshot_pv1;
+    @Preference
+    public static String default_title_snapshot_pv2;
 
     static
     {

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/Preferences.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/Preferences.java
@@ -33,7 +33,7 @@ public class Preferences {
     @Preference
     public static String default_search_query;
     @Preference
-    public static String default_title_snapshot_date_format;
+    public static String default_snapshot_name_date_format;
 
     static
     {

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/Preferences.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/Preferences.java
@@ -33,15 +33,7 @@ public class Preferences {
     @Preference
     public static String default_search_query;
     @Preference
-    public static String default_title_snapshot_configuration;
-    @Preference
-    public static String default_title_snapshot_format;
-    @Preference
     public static String default_title_snapshot_date_format;
-    @Preference
-    public static String default_title_snapshot_pv1;
-    @Preference
-    public static String default_title_snapshot_pv2;
 
     static
     {

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -268,33 +268,6 @@ public class SnapshotController {
         });
     }
     
-    public String getValueVType(String pvEntry, List<SnapshotItem> entries){
-        String valueOutput ="";
-        for (SnapshotItem e : entries) {
-            if (e.getConfigPv().getPvName().equals(pvEntry)){
-                VType newValue=e.getValue();
-                if (newValue instanceof VNumber) {
-                Number newVType = ((VNumber) newValue).getValue();
-                valueOutput=newVType.toString();
-                return valueOutput;
-                } else if (newValue instanceof VString) {
-                String newVType = ((VString) newValue).getValue();
-                valueOutput=newVType.toString();
-                return valueOutput;
-                } else if (newValue instanceof VStringArray) {
-                    List<String> newVType =((VStringArray) newValue).getData();
-                    valueOutput=newVType.toString();
-                    return valueOutput;
-                } else if (newValue instanceof VEnum) {
-                    VEnum newVType = (VEnum) newValue;
-                    valueOutput=newVType.getValue().toString();
-                    return valueOutput;
-                }
-            }
-        }
-        return valueOutput;
-    }
-
     @FXML
     @SuppressWarnings("unused")
     private void takeSnapshot() {
@@ -320,31 +293,11 @@ public class SnapshotController {
                     Date now = new Date();
                     formater = new SimpleDateFormat("yy-MM-dd");
                     String defaultTitle="";
-                    if (!Preferences.default_title_snapshot_format.equals("")) {
-                        String[] formatTitle=Preferences.default_title_snapshot_format.split("_");
-                        for (int index = 0; index < formatTitle.length; index++) {
-                            switch (formatTitle[index]) {
-                                case "<date>":
-                                    if (!Preferences.default_title_snapshot_date_format.equals("")){
-                                        formater = new SimpleDateFormat(Preferences.default_title_snapshot_date_format);
-                                        defaultTitle+=defaultTitle+formater.format(now);
-                                    }
-                                    break;
-                                case "<pv1>": 
-                                    defaultTitle+=getValueVType(Preferences.default_title_snapshot_pv1,entries);
-                                    break;
-                                case "<pv2>":
-                                    defaultTitle+=getValueVType(Preferences.default_title_snapshot_pv2,entries);
-                                    break;
-                                default:
-                                    System.out.println("nothing");
-                                    break;
-                            }
-                            if (index<formatTitle.length-1)
-                                defaultTitle+="_";
-                        }            
+                    if (!Preferences.default_title_snapshot_date_format.equals("")) {
+                            formater = new SimpleDateFormat(Preferences.default_title_snapshot_date_format);
+                            defaultTitle+=defaultTitle+formater.format(now);
+                            snapshotNameProperty.set(defaultTitle);
                     }
-                    snapshotNameProperty.set(defaultTitle);
                 
                 })
         );

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -289,8 +289,8 @@ public class SnapshotController {
                     List<TableEntry> tableEntries = createTableEntries(snapshots.get(0));
                     snapshotTable.updateTable(tableEntries, snapshots, showLiveReadbackProperty.get(), false, showDeltaPercentage);
                 
-                    if (!Preferences.default_title_snapshot_date_format.equals("")) {
-                            SimpleDateFormat formater = new SimpleDateFormat(Preferences.default_title_snapshot_date_format);
+                    if (!Preferences.default_snapshot_name_date_format.equals("")) {
+                            SimpleDateFormat formater = new SimpleDateFormat(Preferences.default_snapshot_name_date_format);
                             snapshotNameProperty.set(formater.format(new Date()));
                     }
                 

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -271,7 +271,6 @@ public class SnapshotController {
     public String getValueVType(String pvEntry, List<SnapshotItem> entries){
         String valueOutput ="";
         for (SnapshotItem e : entries) {
-            System.out.println("name "+e.getConfigPv().getPvName());
             if (e.getConfigPv().getPvName().equals(pvEntry)){
                 VType newValue=e.getValue();
                 if (newValue instanceof VNumber) {

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -270,8 +270,6 @@ public class SnapshotController {
     
     public String getValueVType(String pvEntry, List<SnapshotItem> entries){
         String valueOutput ="";
-
-        System.out.println("length  "+entries.size());
         for (SnapshotItem e : entries) {
             System.out.println("name "+e.getConfigPv().getPvName());
             if (e.getConfigPv().getPvName().equals(pvEntry)){
@@ -279,22 +277,18 @@ public class SnapshotController {
                 if (newValue instanceof VNumber) {
                 Number newVType = ((VNumber) newValue).getValue();
                 valueOutput=newVType.toString();
-                System.out.println("VNumber "+valueOutput);
                 return valueOutput;
                 } else if (newValue instanceof VString) {
                 String newVType = ((VString) newValue).getValue();
                 valueOutput=newVType.toString();
-                System.out.println("VString "+valueOutput);
                 return valueOutput;
                 } else if (newValue instanceof VStringArray) {
                     List<String> newVType =((VStringArray) newValue).getData();
                     valueOutput=newVType.toString();
-                    System.out.println("VStringArray "+valueOutput);
                     return valueOutput;
                 } else if (newValue instanceof VEnum) {
                     VEnum newVType = (VEnum) newValue;
                     valueOutput=newVType.getValue().toString();
-                    System.out.println("VEnum "+valueOutput);
                     return valueOutput;
                 }
             }

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -289,14 +289,9 @@ public class SnapshotController {
                     List<TableEntry> tableEntries = createTableEntries(snapshots.get(0));
                     snapshotTable.updateTable(tableEntries, snapshots, showLiveReadbackProperty.get(), false, showDeltaPercentage);
                 
-                    SimpleDateFormat formater = null;
-                    Date now = new Date();
-                    formater = new SimpleDateFormat("yy-MM-dd");
-                    String defaultTitle="";
                     if (!Preferences.default_title_snapshot_date_format.equals("")) {
-                            formater = new SimpleDateFormat(Preferences.default_title_snapshot_date_format);
-                            defaultTitle+=defaultTitle+formater.format(now);
-                            snapshotNameProperty.set(defaultTitle);
+                            SimpleDateFormat formater = new SimpleDateFormat(Preferences.default_title_snapshot_date_format);
+                            snapshotNameProperty.set(formater.format(new Date()));
                     }
                 
                 })

--- a/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
+++ b/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
@@ -23,4 +23,4 @@ search_result_page_size=30
 default_search_query=tags=golden
 
 # If declared add a date automatically in the name of the snapshot "Take Snapshot"
-#default_title_snapshot_date_format=yyyy-MM-dd HH:mm:ss
+#default_snapshot_name_date_format=yyyy-MM-dd HH:mm:ss

--- a/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
+++ b/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
@@ -23,4 +23,4 @@ search_result_page_size=30
 default_search_query=tags=golden
 
 # If declared add a date automatically in the name of the snapshot "Take Snapshot"
-#default_title_snapshot_date_format=YYYYMMHH_hhmmss
+#default_title_snapshot_date_format=yyyy-MM-dd HH:mm:ss

--- a/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
+++ b/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
@@ -22,9 +22,5 @@ search_result_page_size=30
 # Default save-and-restore search query. Used unless a saved query is located.
 default_search_query=tags=golden
 
-# Configure the default snapshot name when "Take Snapshot"
-#default_title_snapshot_configuration=TuneList
-#default_title_snapshot_format=<date>_<pv1>_<pv2>
+# If declared add a date automatically in the name of the snapshot "Take Snapshot"
 #default_title_snapshot_date_format=YYYYMMHH_hhmmss
-#default_title_snapshot_pv1=SL-APP-MCS:BOM-CPU:IonSet
-#default_title_snapshot_pv2=SL-APP-MCS:BOM-CPU:BeamDestSet

--- a/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
+++ b/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
@@ -21,3 +21,10 @@ search_result_page_size=30
 
 # Default save-and-restore search query. Used unless a saved query is located.
 default_search_query=tags=golden
+
+# Configure the default snapshot name when "Take Snapshot"
+#default_title_snapshot_configuration=TuneList
+#default_title_snapshot_format=<date>_<pv1>_<pv2>
+#default_title_snapshot_date_format=YYYYMMHH_hhmmss
+#default_title_snapshot_pv1=SL-APP-MCS:BOM-CPU:IonSet
+#default_title_snapshot_pv2=SL-APP-MCS:BOM-CPU:BeamDestSet


### PR DESCRIPTION
Hi, 
I have modified save-and-restore phoebus app for my own need and add some properties to be able to format an automatic name to the snapshot when clicking "Take snapshot". 
I think the following properties are comprehensible by itself
```
# Configure the default snapshot name when "Take Snapshot"
#default_title_snapshot_configuration=TuneList
#default_title_snapshot_format=<date>_<pv1>_<pv2>
#default_title_snapshot_date_format=YYYYMMHH_hhmmss
#default_title_snapshot_pv1=SL-APP-MCS:BOM-CPU:IonSet
#default_title_snapshot_pv2=SL-APP-MCS:BOM-CPU:BeamDestSet
```

The `default_title_snapshot_configuration` is not used for now. The idea is to configure the format for configurations indicated here. At first implementation I don't find how to make it easily so for now it's a pending possibility.

Maybe the function `getValueVType` can be more efficient, I'm not completely comfortable with the code. But I propose this pull request more as an idea now because I see that @georgweiss made some modification on this part of the code quite recently so it could be deprecated/conflicted quickly if it's not integrated.

![image](https://user-images.githubusercontent.com/25428659/226337102-cfe5614e-0389-4e71-a50c-f434b29178b9.png)
