### PR TITLE
update alarm severity comment and doc

### DIFF
--- a/app/display/editor/doc/rules.rst
+++ b/app/display/editor/doc/rules.rst
@@ -44,13 +44,15 @@ of the rule are accessible in the expression.
 
 - A PV severity value is referenced using the syntax pvSev{index}, e.g. pvSev0 == 1. Severity values are:
 
-    - -1 - Invalid
-
     - 0 - OK
 
     - 1 - Minor
 
     - 2 - Major
+
+    - 3 - Invalid
+
+    - 4 - Undefined
 
 Value as Expression
 -------------------

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
@@ -202,7 +202,7 @@ public class PVUtil
 
     /** Get alarm severity of the PV as an integer value.
      *  @param pv PV
-     *  @return 0: OK;  1: Major; 2:Minor, -1: Invalid or Undefined
+     *  @return 0: OK; 1: Major; 2:Minor; 3: Invalid; 4: Undefined
      */
     public final static int getSeverity(final RuntimePV pv)
     {

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/PVUtil.java
@@ -202,7 +202,7 @@ public class PVUtil
 
     /** Get alarm severity of the PV as an integer value.
      *  @param pv PV
-     *  @return 0: OK; 1: Major; 2:Minor; 3: Invalid; 4: Undefined
+     *  @return 0: OK; 1: Minor; 2: Major; 3: Invalid; 4: Undefined
      */
     public final static int getSeverity(final RuntimePV pv)
     {


### PR DESCRIPTION
I noticed the online docs had the incorrect index for the INVALID alarm state in pvSev. Probably was referring to the pvLegacySev instead

https://github.com/ControlSystemStudio/phoebus/blob/master/core/pva/src/main/java/org/epics/pva/data/nt/PVAAlarm.java#L54