### PR TITLE
Avoid archiver queries if no data is found

### DIFF
--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceArchiveReader.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/ApplianceArchiveReader.java
@@ -138,7 +138,11 @@ public class ApplianceArchiveReader implements ArchiveReader, IteratorListener {
         if (it == null) {
             try {
                 int points = getNumberOfPoints(name, start, end);
-                if (points <= count) {
+                // No points found, return "empty" iterator to suppress request for raw data
+                if(points == 0){
+                    it = new EmptyRawValueIterator(this, name, start, end, this);
+                }
+                else if (points <= count) {
                     it = new ApplianceRawValueIterator(this, name, start, end, this);
                 } else {
                     //only fetch if binning is "still" supported

--- a/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/EmptyRawValueIterator.java
+++ b/app/databrowser/src/main/java/org/phoebus/archive/reader/appliance/EmptyRawValueIterator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+package org.phoebus.archive.reader.appliance;
+
+import java.time.Instant;
+
+/**
+ * A {@link ApplianceValueIterator} used to indicate that no data was found.
+ */
+public class EmptyRawValueIterator extends ApplianceValueIterator{
+
+    public EmptyRawValueIterator(ApplianceArchiveReader reader,
+                                            String name, Instant start, Instant end, IteratorListener listener){
+        super(reader, name, start, end, listener);
+    }
+
+    @Override
+    public boolean hasNext(){
+        return false;
+    }
+}


### PR DESCRIPTION
In response to #2575.

In my simple test case in the ESS archiver setup this cuts number of archiver requests in half (20 -> 10).