### PR TITLE
Bug fix alarm logger config search

### DIFF
--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/AlarmLogSearchUtil.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/AlarmLogSearchUtil.java
@@ -292,8 +292,9 @@ public class AlarmLogSearchUtil {
      */
     public static List<AlarmLogMessage> searchConfig(ElasticsearchClient client, Map<String, String> allRequestParams) {
         String configString = allRequestParams.get("config");
-        // Determine which alarm config to specify as Elasticsearch index
-        String alarmConfig = configString.split("/")[1];
+        // Determine which alarm config to specify as Elasticsearch index, convert to lower case as
+        // indices are created using lower case.
+        String alarmConfig = configString.split("/")[1].toLowerCase();
 
         String searchPattern = "*".concat(configString).concat("*");
         int size = 1;

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/SearchController.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/SearchController.java
@@ -7,12 +7,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.phoebus.alarm.logging.AlarmLoggingService;
 import org.phoebus.alarm.logging.ElasticClientHelper;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -84,6 +86,12 @@ public class SearchController {
 
     @RequestMapping(value = "/search/alarm/config", method = RequestMethod.GET)
     public List<AlarmLogMessage> searchConfig(@RequestParam Map<String, String> allRequestParams) {
+        if(allRequestParams == null ||
+                allRequestParams.isEmpty() ||
+                !allRequestParams.containsKey("config") ||
+                allRequestParams.get("config").isEmpty()){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+        }
         List<AlarmLogMessage> result = AlarmLogSearchUtil.searchConfig(ElasticClientHelper.getInstance().getClient(), allRequestParams);
         return result;
     }


### PR DESCRIPTION
Issue was that config identity was not converted to lower case (all Elastic indices are lower case).

Also added some checks on request params to avoid HTTP 500.