### PR TITLE
Alarm tree cell refresh fix

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeView.java
@@ -486,8 +486,8 @@ public class AlarmTreeView extends BorderPane implements AlarmClientListener
         // but there are two problems:
         // Since we're currently using the alarm tree model item as a value,
         // the value as seen by the TreeView remains the same.
-        // We use a model item wrappers class as the cell value
-        // and replace it (still referencing the same model item!)
+        // We could use a model item wrapper class as the cell value
+        // and replace it (while still holding the same model item!)
         // for the TreeView to see a different wrapper value, but
         // as shown in org.phoebus.applications.alarm.TreeItemUpdateDemo,
         // replacing a tree cell value fails to trigger refreshes

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
@@ -38,7 +38,7 @@ class AlarmTreeViewCell extends TreeCell<AlarmTreeItem<?>>
     private final Label label = new Label();
     private final ImageView image = new ImageView();
     private final HBox content = new HBox(image, label);
-    
+
     // TreeCell optimizes redraws by suppressing updates
     // when old and new values match.
     // Since we use the model item as a value,
@@ -47,9 +47,13 @@ class AlarmTreeViewCell extends TreeCell<AlarmTreeItem<?>>
     // to present changing values to the TreeCell, but also note
     // the issue shown in org.phoebus.applications.alarm.TreeItemUpdateDemo
     //
-    // So for now we simply force redraws by always indicating a change
+    // So for now we simply force redraws by always pretending a change.
+    // This seems bad for performance, but profiling the alarm GUI for
+    // a large configuration like org.phoebus.applications.alarm.AlarmConfigProducerDemo
+    // with 1000 'sections' of 10 subsections of 10 PVs,
+    // the time spent in updateItem is negligible.
     @Override
-    protected boolean isItemChanged(AlarmTreeItem<?> before, AlarmTreeItem<?> after)
+    protected boolean isItemChanged(final AlarmTreeItem<?> before, final AlarmTreeItem<?> after)
     {
         return true;
     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
@@ -38,12 +38,27 @@ class AlarmTreeViewCell extends TreeCell<AlarmTreeItem<?>>
     private final Label label = new Label();
     private final ImageView image = new ImageView();
     private final HBox content = new HBox(image, label);
-            
+    
+    // TreeCell optimizes redraws by suppressing updates
+    // when old and new values match.
+    // Since we use the model item as a value,
+    // the cell sees no change, in fact an identical reference.
+    // In the fullness of time, a complete redesign might be useful
+    // to present changing values to the TreeCell, but also note
+    // the issue shown in org.phoebus.applications.alarm.TreeItemUpdateDemo
+    //
+    // So for now we simply force redraws by always indicating a change
+    @Override
+    protected boolean isItemChanged(AlarmTreeItem<?> before, AlarmTreeItem<?> after)
+    {
+        return true;
+    }
+
     @Override
     protected void updateItem(final AlarmTreeItem<?> item, final boolean empty)
     {
         super.updateItem(item, empty);
-        
+
         if (empty  ||  item == null)
             setGraphic(null);
         else

--- a/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/TreeItemUpdateDemo.java
+++ b/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/TreeItemUpdateDemo.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.phoebus.applications.alarm;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import org.phoebus.ui.javafx.ApplicationWrapper;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+/** Demo of alarm tree cell update
+ *
+ *  1) Start this program, click the "On" and "Off" buttons, and observe how item "Two" is updated
+ *  2) Click "Off", reduce the window height so that the items under "Top" are hidden,
+ *     click "On", increase window height to again show all items.
+ *     Would expect to see "On", but tree still shows "Off"
+ *     until the tree is collapsed and again expanded.
+ *  3) Click "On", reduce the window height so that the items under "Top" are hidden,
+ *     click "Off", increase window height to again show all items.
+ *     Tree should indeed show "Off".
+ *
+ *  Conclusion is that TreeItem.setValue() does not trigger updates of hidden items.
+ *  Basic google search suggests that the value must change, but "On" and "Off"
+ *  are different object references and they are not 'equal'.
+ *
+ *  When instead replacing the complete TreeItem, the tree is always updated.
+ *
+ *  @author Kay Kasemir
+ */
+public class TreeItemUpdateDemo extends ApplicationWrapper
+{
+    private TreeView<String> tree_view = new TreeView<>();
+
+    @Override
+    public void start(final Stage stage)
+    {
+        final Button on = new Button("On");
+        on.setOnAction(event ->
+        {   // Just updating the value of TreeItem is ignored for hidden items?
+            tree_view.getRoot().getChildren().get(1).setValue("On");
+        });
+        final Button off = new Button("Off");
+        off.setOnAction(event ->
+        {   // Replacing the TreeItem always "works"?
+            // (Note this would be more work for intermediate items
+            //  that have child nodes, since child nodes need to be moved/copied)
+            tree_view.getRoot().getChildren().set(1, new TreeItem<>("Off"));
+        });
+        final HBox bottom = new HBox(on, off);
+        HBox.setHgrow(on, Priority.ALWAYS);
+        HBox.setHgrow(off, Priority.ALWAYS);
+
+        final VBox root = new VBox(tree_view, bottom);
+        VBox.setVgrow(tree_view, Priority.ALWAYS);
+
+        TreeItem<String> top = new TreeItem<>("Top");
+        tree_view.setRoot(top);
+
+        top.getChildren().addAll(new TreeItem<>("One"), new TreeItem<>("Two"), new TreeItem<>("Three"));
+        top.setExpanded(true);
+
+        final Scene scene = new Scene(root, 300, 300);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(final String[] args)
+    {
+        launch(TreeItemUpdateDemo.class, args);
+    }
+}

--- a/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/TreeItemUpdateDemo.java
+++ b/app/alarm/ui/src/test/java/org/phoebus/applications/alarm/TreeItemUpdateDemo.java
@@ -7,12 +7,8 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm;
 
-import java.time.Instant;
-import java.util.concurrent.TimeUnit;
-
 import org.phoebus.ui.javafx.ApplicationWrapper;
 
-import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.TreeItem;
@@ -24,6 +20,11 @@ import javafx.stage.Stage;
 
 /** Demo of alarm tree cell update
  *
+ *  Demonstrates refresh issue for tree cells that are
+ *  not visible because they scrolled below the window bottom.
+ *
+ *  Only replacing the TreeItem results in reliable tree updates.
+ *
  *  1) Start this program, click the "On" and "Off" buttons, and observe how item "Two" is updated
  *  2) Click "Off", reduce the window height so that the items under "Top" are hidden,
  *     click "On", increase window height to again show all items.
@@ -33,11 +34,13 @@ import javafx.stage.Stage;
  *     click "Off", increase window height to again show all items.
  *     Tree should indeed show "Off".
  *
- *  Conclusion is that TreeItem.setValue() does not trigger updates of hidden items.
+ *  Conclusion is that TreeItem.setValue() does not trigger updates of certain hidden items.
  *  Basic google search suggests that the value must change, but "On" and "Off"
  *  are different object references and they are not 'equal'.
  *
  *  When instead replacing the complete TreeItem, the tree is always updated.
+ *
+ *  Tested with JavaFX 15, 19, 20
  *
  *  @author Kay Kasemir
  */
@@ -61,6 +64,8 @@ public class TreeItemUpdateDemo extends ApplicationWrapper
             tree_view.getRoot().getChildren().set(1, new TreeItem<>("Off"));
         });
         final HBox bottom = new HBox(on, off);
+        on.setMaxWidth(1000);
+        off.setMaxWidth(1000);
         HBox.setHgrow(on, Priority.ALWAYS);
         HBox.setHgrow(off, Priority.ALWAYS);
 
@@ -70,7 +75,9 @@ public class TreeItemUpdateDemo extends ApplicationWrapper
         TreeItem<String> top = new TreeItem<>("Top");
         tree_view.setRoot(top);
 
-        top.getChildren().addAll(new TreeItem<>("One"), new TreeItem<>("Two"), new TreeItem<>("Three"));
+        top.getChildren().add(new TreeItem<>("One"));
+        top.getChildren().add(new TreeItem<>("Two"));
+        top.getChildren().add(new TreeItem<>("Three"));
         top.setExpanded(true);
 
         final Scene scene = new Scene(root, 300, 300);


### PR DESCRIPTION
#2611 and TreeItemUpdateDemo show how cells obscured by being below the bottom of the window fail to update.

The TreeItemUpdateDemo suggests a fundamental issue in the JFX TreeView, at least for versions 15, 19 and 20.
Replacing the TreeItem seems to avoid the issue.
In addition, the TreeCell needs to be forced to perform updates since we use the alarm tree model items as values.
