### PR TITLE
Update Elastic mapping to allow sort on name

### DIFF
--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchTreeRepository.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchTreeRepository.java
@@ -72,8 +72,8 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
 
     private static final Logger logger = Logger.getLogger(ElasticsearchTreeRepository.class.getName());
 
-    @Value("${elasticsearch.tree_node.index:saveandrestore_tree}")
-    public String ES_TREE_INDEX;
+    @Value("${elasticsearch.tree_node.index_v2:saveandrestore_tree_v2}")
+    public String ES_TREE_INDEX_V2;
 
     /**
      * Used to determine if the {@link ESTreeNode} is saved or updated in connection to a migration
@@ -128,7 +128,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
 
             IndexRequest<ESTreeNode> indexRequest =
                     IndexRequest.of(i ->
-                            i.index(ES_TREE_INDEX)
+                            i.index(ES_TREE_INDEX_V2)
                                     .id(elasticTreeNode.getNode().getUniqueId())
                                     .document(elasticTreeNode)
                                     .refresh(Refresh.True));
@@ -137,7 +137,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
             if (response.result().equals(Result.Created) || response.result().equals(Result.Updated)) {
                 GetRequest getRequest =
                         GetRequest.of(g ->
-                                g.index(ES_TREE_INDEX).id(response.id()));
+                                g.index(ES_TREE_INDEX_V2).id(response.id()));
                 GetResponse<ESTreeNode> resp =
                         client.get(getRequest, ESTreeNode.class);
                 return (S) resp.source();
@@ -159,7 +159,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
         try {
             GetRequest getRequest =
                     GetRequest.of(g ->
-                            g.index(ES_TREE_INDEX).id(id));
+                            g.index(ES_TREE_INDEX_V2).id(id));
             GetResponse<ESTreeNode> resp =
                     client.get(getRequest, ESTreeNode.class);
 
@@ -177,7 +177,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
     public boolean existsById(String s) {
 
         try {
-            ExistsRequest existsRequest = ExistsRequest.of(e -> e.index(ES_TREE_INDEX).id(s));
+            ExistsRequest existsRequest = ExistsRequest.of(e -> e.index(ES_TREE_INDEX_V2).id(s));
             BooleanResponse existsResponse = client.exists(existsRequest);
             return existsResponse.value();
         } catch (IOException e) {
@@ -209,7 +209,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
         }
         List<String> ids = new ArrayList<>();
         uniqueIds.forEach(ids::add);
-        MgetRequest mgetRequest = MgetRequest.of(m -> m.index(ES_TREE_INDEX).ids(ids));
+        MgetRequest mgetRequest = MgetRequest.of(m -> m.index(ES_TREE_INDEX_V2).ids(ids));
         try {
             List<ESTreeNode> treeNodes = new ArrayList<>();
             MgetResponse<ESTreeNode> resp = client.mget(mgetRequest, ESTreeNode.class);
@@ -234,7 +234,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
     public void deleteById(String s) {
         try {
             DeleteRequest deleteRequest = DeleteRequest.of(d ->
-                    d.index(ES_TREE_INDEX).id(s).refresh(Refresh.True));
+                    d.index(ES_TREE_INDEX_V2).id(s).refresh(Refresh.True));
             DeleteResponse deleteResponse = client.delete(deleteRequest);
             if (deleteResponse.result().equals(Result.Deleted)) {
                 logger.log(Level.WARNING, "Node with id " + s + " deleted.");
@@ -266,7 +266,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
     public void deleteAll() {
         try {
             DeleteByQueryRequest deleteRequest = DeleteByQueryRequest.of(d ->
-                    d.index(ES_TREE_INDEX).query(new MatchAllQuery.Builder().build()._toQuery()).refresh(true));
+                    d.index(ES_TREE_INDEX_V2).query(new MatchAllQuery.Builder().build()._toQuery()).refresh(true));
             DeleteByQueryResponse deleteResponse = client.deleteByQuery(deleteRequest);
             logger.log(Level.INFO, "Deleted " + deleteResponse.deleted() + " ESTreeNode objects");
         } catch (IOException e) {
@@ -287,7 +287,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
     public ESTreeNode getParentNode(String uniqueId) {
         Builder bqb = new Builder();
         bqb.must(TermQuery.of(w -> w.field("childNodes").value(uniqueId))._toQuery());
-        SearchRequest searchRequest = SearchRequest.of(s -> s.index(ES_TREE_INDEX)
+        SearchRequest searchRequest = SearchRequest.of(s -> s.index(ES_TREE_INDEX_V2)
                 .query(bqb.build()._toQuery())
                 .timeout("60s"));
         try {
@@ -326,7 +326,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
         }
         NestedQuery outerNestedQuery = NestedQuery.of(n2 -> n2.path("node").query(innerNestedQuery._toQuery()));
         boolQueryBuilder.must(outerNestedQuery._toQuery());
-        SearchRequest searchRequest = SearchRequest.of(s -> s.index(ES_TREE_INDEX)
+        SearchRequest searchRequest = SearchRequest.of(s -> s.index(ES_TREE_INDEX_V2)
                 .query(boolQueryBuilder.build()._toQuery())
                 .timeout("60s")
                 .size(1000));
@@ -347,7 +347,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
             searchResult.setHitCount((int) searchResponse.hits().total().value());
             searchResult.setNodes(searchResponse.hits().hits().stream().map(e -> e.source().getNode()).collect(Collectors.toList()));
             return searchResult;
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -358,7 +358,7 @@ public class ElasticsearchTreeRepository implements CrudRepository<ESTreeNode, S
         MatchQuery matchQuery = MatchQuery.of(m -> m.field("node.name").query(nodeName));
         innerNestedQuery = NestedQuery.of(n1 -> n1.path("node").query(matchQuery._toQuery()));
         boolQueryBuilder.must(innerNestedQuery._toQuery());
-        SearchRequest searchRequest = SearchRequest.of(s -> s.index(ES_TREE_INDEX)
+        SearchRequest searchRequest = SearchRequest.of(s -> s.index(ES_TREE_INDEX_V2)
                 .query(boolQueryBuilder.build()._toQuery())
                 .timeout("60s")
                 .size(1000));

--- a/services/save-and-restore/src/main/resources/tree_node_mapping_v2.json
+++ b/services/save-and-restore/src/main/resources/tree_node_mapping_v2.json
@@ -1,0 +1,60 @@
+{
+  "mappings": {
+    "properties": {
+      "node": {
+        "type" : "nested",
+        "properties": {
+          "uniqueId": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "text",
+            "fields": {
+              "raw": {
+                "type": "keyword"
+              }
+            }
+          },
+          "userName": {
+            "type": "text"
+          },
+          "description" : {
+            "type": "text"
+          },
+          "created" : {
+            "type": "date",
+            "format": "epoch_millis||yyyy-MM-dd HH:mm:ss.SSS"
+          },
+          "lastUpdated": {
+            "type": "date",
+            "format": "epoch_millis||yyyy-MM-dd HH:mm:ss.SSS"
+          },
+          "nodeType": {
+            "type": "keyword"
+          },
+          "tags" : {
+            "type" : "nested",
+            "properties": {
+              "name": {
+                "type": "text"
+              },
+              "comment": {
+                "type": "text"
+              },
+              "userName": {
+                "type": "text"
+              },
+              "created" : {
+                "type": "date",
+                "format": "epoch_millis||yyyy-MM-dd HH:mm:ss.SSS"
+              }
+            }
+          }
+        }
+      },
+      "childNodes": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/persistence/dao/impl/DAOTestIT.java
+++ b/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/persistence/dao/impl/DAOTestIT.java
@@ -103,8 +103,8 @@ public class DAOTestIT {
     @Value("${elasticsearch.tree_node.index:test_saveandrestore_configuration}")
     private String ES_CONFIGURATION_INDEX;
 
-    @Value("${elasticsearch.tree_node.index:test_saveandrestore_tree}")
-    private String ES_TREE_INDEX;
+    @Value("${elasticsearch.tree_node.index_v2:test_saveandrestore_tree_v2}")
+    private String ES_TREE_INDEX_V2;
 
     @Value("${elasticsearch.filter.index:test_saveandrestore_filter}")
     private String ES_FILTER_INDEX;
@@ -1897,7 +1897,7 @@ public class DAOTestIT {
         snapshotData.setSnasphotItems(List.of(item1));
         snapshot.setSnapshotData(snapshotData);
 
-        nodeDAO.saveSnapshot(configuration.getConfigurationNode().getUniqueId(), snapshot);
+        Snapshot savedSnapshot = nodeDAO.saveSnapshot(configuration.getConfigurationNode().getUniqueId(), snapshot);
 
         List<Node> snapshotNodes = nodeDAO.getAllSnapshots();
         assertEquals(1, snapshotNodes.size());
@@ -1948,11 +1948,11 @@ public class DAOTestIT {
         }
 
         try {
-            BooleanResponse exists = client.indices().exists(ExistsRequest.of(e -> e.index(ES_TREE_INDEX)));
+            BooleanResponse exists = client.indices().exists(ExistsRequest.of(e -> e.index(ES_TREE_INDEX_V2)));
             if (exists.value()) {
                 client.indices().delete(
                         DeleteIndexRequest.of(
-                                c -> c.index(ES_TREE_INDEX)));
+                                c -> c.index(ES_TREE_INDEX_V2)));
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchTreeRepositoryTestIT.java
+++ b/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchTreeRepositoryTestIT.java
@@ -38,7 +38,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -71,8 +70,8 @@ public class ElasticsearchTreeRepositoryTestIT {
     @Autowired
     private ElasticsearchClient client;
 
-    @Value("${elasticsearch.tree_node.index:test_saveandrestore_tree}")
-    private String ES_TREE_INDEX;
+    @Value("${elasticsearch.tree_node.index_v2:test_saveandrestore_tree_v2}")
+    private String ES_TREE_INDEX_V2;
 
     @Autowired
     private ElasticsearchTreeRepository elasticsearchTreeRepository;
@@ -235,11 +234,11 @@ public class ElasticsearchTreeRepositoryTestIT {
     @AfterAll
     public void dropIndex() {
         try {
-            BooleanResponse exists = client.indices().exists(ExistsRequest.of(e -> e.index(ES_TREE_INDEX)));
+            BooleanResponse exists = client.indices().exists(ExistsRequest.of(e -> e.index(ES_TREE_INDEX_V2)));
             if (exists.value()) {
                 client.indices().delete(
                         DeleteIndexRequest.of(
-                                c -> c.index(ES_TREE_INDEX)));
+                                c -> c.index(ES_TREE_INDEX_V2)));
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/services/save-and-restore/src/test/resources/test_application.properties
+++ b/services/save-and-restore/src/test/resources/test_application.properties
@@ -10,8 +10,10 @@ elasticsearch.http.port=9200
 spring.jackson.serialization.write-dates-as-timestamps=false
 
 # The names of the index to use for save&restore
-elasticsearch.tree_node.index=test_saveandrestore_tree
+elasticsearch.tree_node.index_v2=test_saveandrestore_tree_v2
 elasticsearch.configuration_node.index=test_saveandrestore_configuration
 elasticsearch.snapshot_node.index:test_saveandrestore_snapshot
 elasticsearch.composite_snapshot_node.index=test_saveandrestore_composite_snapshot
 elasticsearch.filter.index:test_saveandrestore_filter
+
+performReindex=false


### PR DESCRIPTION
This is needed in order to be able to sort on node name in save&restore. 

Search util is updated to sort on node name.