### PR TITLE
Reproducible builds

### DIFF
--- a/core/pva/pom.xml
+++ b/core/pva/pom.xml
@@ -28,7 +28,7 @@
         <!-- Build executable JAR -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>

--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -254,7 +254,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-		<version>3.1.0</version>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>

--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -269,7 +269,6 @@
       <!-- Above commands built the product.jar.
            Need to add the doc/ (if phoebus-doc is available)
            and the dependency jar files
-           and then list all lib/* jars in the manifest classpath
         -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
@@ -281,24 +280,6 @@
               <tasks>
                 <echo message="Copying doc/" />
                 <ant antfile="build.xml" target="copy-doc" />
-                <echo message="Adding dependencies to product" />
-                <manifestclasspath property="manifest-classpath" jarfile="${project.build.directory}/product-${project.version}.jar">
-                  <classpath>
-                    <path>
-                      <fileset dir="${project.build.directory}/lib">
-                        <include name="*.jar" />
-                      </fileset>
-                    </path>
-                  </classpath>
-                </manifestclasspath>
-
-                <!-- <echo message="Manifest classpath: ${manifest-classpath}" /> -->
-                <jar update="true" destfile="${project.build.directory}/product-${project.version}.jar">
-                  <manifest>
-                    <attribute name="Class-Path" value="${manifest-classpath}" />
-                  </manifest>
-                </jar>
-
               </tasks>
             </configuration>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,13 @@
           <releaseProfiles>releases</releaseProfiles>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <!-- Use a version > 3.2.0 by default for reproducible builds.
+          See: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
+        <version>3.3.0</version>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
   </distributionManagement>
 
   <properties>
+    <project.build.outputTimestamp>2022-11-07T10:03:00Z</project.build.outputTimestamp>
     <epics.version>7.0.8</epics.version>
     <vtype.version>1.0.5</vtype.version>
     <openjfx.version>19</openjfx.version>

--- a/services/alarm-config-logger/pom.xml
+++ b/services/alarm-config-logger/pom.xml
@@ -73,7 +73,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.1.6.RELEASE</version>
+        <version>2.7.9</version>
         <executions>
           <execution>
             <goals>

--- a/services/alarm-logger/pom.xml
+++ b/services/alarm-logger/pom.xml
@@ -147,7 +147,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.1.6.RELEASE</version>
+        <version>2.7.9</version>
         <executions>
           <execution>
             <goals>

--- a/services/alarm-server/pom.xml
+++ b/services/alarm-server/pom.xml
@@ -121,42 +121,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <configuration>
-              <failOnError>true</failOnError>
-              <tasks>
-                <echo message="Adding dependencies to product" />
-                <manifestclasspath property="manifest-classpath" jarfile="${project.build.directory}/service-alarm-server-${project.version}.jar">
-                  <classpath>
-                    <path>
-                      <fileset dir="${project.build.directory}/lib">
-                        <include name="*.jar" />
-                      </fileset>
-                    </path>
-                  </classpath>
-                </manifestclasspath>
-
-                <!--
-                 -->
-                 <echo message="Manifest classpath: ${manifest-classpath}" />
-
-                <jar update="true" destfile="${project.build.directory}/service-alarm-server-${project.version}.jar">
-                  <manifest>
-                    <attribute name="Class-Path" value="${manifest-classpath}" />
-                  </manifest>
-                </jar>
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <version>1.6.8</version>

--- a/services/alarm-server/pom.xml
+++ b/services/alarm-server/pom.xml
@@ -103,7 +103,7 @@
         -->
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.5.0</version>
         <configuration>
           <tarLongFileMode>posix</tarLongFileMode>
           <descriptors>

--- a/services/alarm-server/pom.xml
+++ b/services/alarm-server/pom.xml
@@ -83,7 +83,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-		<version>3.1.0</version>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>

--- a/services/archive-engine/pom.xml
+++ b/services/archive-engine/pom.xml
@@ -120,7 +120,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-		<version>3.1.0</version>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>

--- a/services/archive-engine/pom.xml
+++ b/services/archive-engine/pom.xml
@@ -131,43 +131,6 @@
           </archive>
         </configuration>
       </plugin>
-
-      <!-- Update jar, list all lib/* jars in the manifest classpath
-        -->
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <configuration>
-              <failOnError>true</failOnError>
-              <tasks>
-                <echo message="Adding dependencies to product" />
-                <manifestclasspath property="manifest-classpath" jarfile="${project.build.directory}/service-archive-engine-${project.version}.jar">
-                  <classpath>
-                    <path>
-                      <fileset dir="${project.build.directory}/lib">
-                        <include name="*.jar" />
-                      </fileset>
-                    </path>
-                  </classpath>
-                </manifestclasspath>
-
-                <!-- <echo message="Manifest classpath: ${manifest-classpath}" /> -->
-                <jar update="true" destfile="${project.build.directory}/service-archive-engine-${project.version}.jar">
-                  <manifest>
-                    <attribute name="Class-Path" value="${manifest-classpath}" />
-                  </manifest>
-                </jar>
-
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/services/save-and-restore/pom.xml
+++ b/services/save-and-restore/pom.xml
@@ -141,7 +141,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>2.7.0</version>
+				<version>2.7.9</version>
 				<executions>
 					<execution>
 						<goals>

--- a/services/scan-server/pom.xml
+++ b/services/scan-server/pom.xml
@@ -109,7 +109,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-		<version>3.1.0</version>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>

--- a/services/scan-server/pom.xml
+++ b/services/scan-server/pom.xml
@@ -120,49 +120,6 @@
           </archive>
         </configuration>
       </plugin>
-
-      <!-- Above commands built the product.jar.
-           Need to list all lib/* jars in the manifest classpath
-           (this adds for example the caj and pvaccess.jar
-            that's in lib/, but not added by maven-jar-plugin
-            to manifest because it's a system scope)
-        -->
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <configuration>
-              <failOnError>true</failOnError>
-              <tasks>
-                <echo message="Adding dependencies to product" />
-                <manifestclasspath property="manifest-classpath" jarfile="${project.build.directory}/service-scan-server-${project.version}.jar">
-                  <classpath>
-                    <path>
-                      <fileset dir="${project.build.directory}/lib">
-                        <include name="*.jar" />
-                      </fileset>
-                    </path>
-                  </classpath>
-                </manifestclasspath>
-
-                <!--
-                 <echo message="Manifest classpath: ${manifest-classpath}" />
-                 -->
-
-                <jar update="true" destfile="${project.build.directory}/service-scan-server-${project.version}.jar">
-                  <manifest>
-                    <attribute name="Class-Path" value="${manifest-classpath}" />
-                  </manifest>
-                </jar>
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>


### PR DESCRIPTION
This PR make it so that Phoebus products are reproducible, which is useful for checking that files were not tampered with.

To test that the build was reproducible, I ran:

```bash
mvn clean install -Dmaven.source.skip=true -DskipTests -Dmaven.javadoc.skip=true
mvn clean verify artifact:compare -Dmaven.source.skip=true -DskipTests -Dmaven.javadoc.skip=true
```

Which succeeds for all artifacts.

This was done with the help of @katysaintin and these resources:

- https://reproducible-builds.org/docs/jvm/
- https://maven.apache.org/guides/mini/guide-reproducible-builds.html
- https://maven.apache.org/plugins/maven-artifact-plugin/plugin-issues.html

This PR does 3 things:

- upgrade the versions of some specific Maven plugins so that they support producing reproducible outputs

- introduce the `project.build.outputTimestamp` property which sets the timestamp of produced files

From my understanding of the [Maven Guide for reproducible outputs](https://maven.apache.org/guides/mini/guide-reproducible-builds.html) this property will be automatically changed when running the `maven-release-plugin`.

- remove the modification of the jar manifest's classpath through the `maven-antrun-plugin`

The modification changed the timestamp of files inside jars, without taking into account `outputTimestamp`. From my checks, it seems the only difference it makes is that it adds jars from the test scope into the classpath.

Here's an example of what removing the antrun plugin does to the classpath (it was either `service-alarm`, or `scan-server`, I forgot which one):

<details>
  <summary>Classpath differences</summary>

```diff
--- a/with-antrun.txt
+++ b/without-antrun.txt
@@ -7,7 +7,6 @@ lib/activation-1.1.jar
 lib/ant-1.8.2.jar
 lib/ant-launcher-1.8.2.jar
 lib/antlr-2.7.2.jar
-lib/apiguardian-api-1.1.2.jar
 lib/app-alarm-model-4.7.2-SNAPSHOT.jar
 lib/bsh-2.0b5.jar
 lib/c3p0-0.9.5.4.jar
@@ -35,7 +34,6 @@ lib/error_prone_annotations-2.3.4.jar
 lib/failureaccess-1.0.1.jar
 lib/geronimo-spec-ejb-2.1-rc2.jar
 lib/guava-29.0-jre.jar
-lib/hamcrest-all-1.3.jar
 lib/j2objc-annotations-1.3.jar
 lib/jackson-annotations-2.12.3.jar
 lib/jackson-core-2.12.3.jar
@@ -56,12 +54,6 @@ lib/jmock-cglib-1.0.1.jar
 lib/jnacl-1.0.0.jar
 lib/jsr305-3.0.2.jar
 lib/junit-3.8.1.jar
-lib/junit-jupiter-5.8.2.jar
-lib/junit-jupiter-api-5.8.2.jar
-lib/junit-jupiter-engine-5.8.2.jar
-lib/junit-jupiter-params-5.8.2.jar
-lib/junit-platform-commons-1.8.2.jar
-lib/junit-platform-engine-1.8.2.jar
 lib/kafka-clients-2.0.0.jar
 lib/kafka-streams-2.0.0.jar
 lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
@@ -71,7 +63,6 @@ lib/mx4j-3.0.1.jar
 lib/mx4j-impl-2.1.1.jar
 lib/mx4j-jmx-2.1.1.jar
 lib/nanocontainer-remoting-1.0-RC-1.jar
-lib/opentest4j-1.2.0.jar
 lib/org.eclipse.paho.client.mqttv3-1.2.2.jar
 lib/picocontainer-1.2.jar
 lib/proxytoys-0.1.jar
```

</details>

I ran the affected jars, and they all can start without a ClassNotFound exception