### PR TITLE
CSSTUDIO-1034 Add tooltips to UI-elements under "Properties" in the Display Builder

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -250,6 +250,10 @@ public class PropertyPanelSection extends GridPane
             final Button font_field = new Button();
             font_field.setMnemonicParsing(false);
             font_field.setMaxWidth(Double.MAX_VALUE);
+
+            Tooltip.install(font_field, new Tooltip(font_prop.getValue().toString()));
+            font_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(font_field, new Tooltip(new_value.toString())));
+
             final WidgetFontPropertyBinding binding = new WidgetFontPropertyBinding(undo, font_field, font_prop, other);
             bindings.add(binding);
             binding.bind();

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.function.Consumer;
 
@@ -30,20 +31,7 @@ import org.csstudio.display.builder.model.WidgetFactory;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyCategory;
 import org.csstudio.display.builder.model.persist.WidgetClassesService;
-import org.csstudio.display.builder.model.properties.ActionsWidgetProperty;
-import org.csstudio.display.builder.model.properties.BooleanWidgetProperty;
-import org.csstudio.display.builder.model.properties.ColorMapWidgetProperty;
-import org.csstudio.display.builder.model.properties.ColorWidgetProperty;
-import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
-import org.csstudio.display.builder.model.properties.EnumWidgetProperty;
-import org.csstudio.display.builder.model.properties.FilenameWidgetProperty;
-import org.csstudio.display.builder.model.properties.FontWidgetProperty;
-import org.csstudio.display.builder.model.properties.MacrosWidgetProperty;
-import org.csstudio.display.builder.model.properties.PVNameWidgetProperty;
-import org.csstudio.display.builder.model.properties.PointsWidgetProperty;
-import org.csstudio.display.builder.model.properties.RulesWidgetProperty;
-import org.csstudio.display.builder.model.properties.ScriptsWidgetProperty;
-import org.csstudio.display.builder.model.properties.WidgetClassProperty;
+import org.csstudio.display.builder.model.properties.*;
 import org.csstudio.display.builder.representation.javafx.FilenameSupport;
 import org.phoebus.framework.macros.MacroHandler;
 import org.phoebus.ui.autocomplete.PVAutocompleteMenu;
@@ -240,6 +228,25 @@ public class PropertyPanelSection extends GridPane
             final ColorWidgetProperty color_prop = (ColorWidgetProperty) property;
             final WidgetColorPropertyField color_field = new WidgetColorPropertyField();
             final WidgetColorPropertyBinding binding = new WidgetColorPropertyBinding(undo, color_field, color_prop, other);
+
+            Function<WidgetColor, Tooltip> widgetColorToTooltip = (widgetColor) ->
+            {
+                if (widgetColor instanceof NamedWidgetColor) {
+                    return new Tooltip(((NamedWidgetColor) widgetColor).getName());
+                }
+                else {
+                    if (widgetColor.getAlpha() == 255) {
+                        return new Tooltip("RGB(" + widgetColor.getRed() + "," + widgetColor.getGreen() + "," + widgetColor.getBlue() + ")");
+                    }
+                    else {
+                        return new Tooltip("RGB(" + widgetColor.getRed() + "," + widgetColor.getGreen() + "," + widgetColor.getBlue() + "," + widgetColor.getAlpha() + ")");
+                    }
+                }
+            };
+
+            Tooltip.install(color_field, widgetColorToTooltip.apply(color_prop.getValue()));
+            color_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(color_field, widgetColorToTooltip.apply(new_value)));
+
             bindings.add(binding);
             binding.bind();
             field = color_field;

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -569,6 +569,10 @@ public class PropertyPanelSection extends GridPane
             final PointsPropertyBinding binding = new PointsPropertyBinding(undo, points_field, points_prop, other);
             bindings.add(binding);
             binding.bind();
+
+            Tooltip.install(points_field, new Tooltip(points_prop.getValue().size() + " Points"));
+            points_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(points_field, new Tooltip(new_value.size() + " Points")));
+
             field = points_field;
         }
         return field;

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -521,13 +521,18 @@ public class PropertyPanelSection extends GridPane
             final MacroizedWidgetProperty<?> macro_prop = (MacroizedWidgetProperty<?>)property;
             final TextField text = new TextField();
             text.setPromptText(macro_prop.getDefaultValue().toString());
+            text.setOnKeyReleased((event) -> Tooltip.install(text, new Tooltip(text.getText())));
             final MacroizedWidgetPropertyBinding binding = new MacroizedWidgetPropertyBinding(undo, text, macro_prop, other);
             bindings.add(binding);
             binding.bind();
+
+            Tooltip.install(text, new Tooltip(text.getText()));
+
             if (CommonWidgetProperties.propText.getName().equals(property.getName())  ||
                 CommonWidgetProperties.propTooltip.getName().equals(property.getName()))
             {   // Allow editing multi-line text in dialog
                 final Button open_editor = new Button("...");
+                Tooltip.install(open_editor, new Tooltip("Open Editor"));
                 open_editor.setOnAction(event ->
                 {
                     final MultiLineInputDialog dialog = new MultiLineInputDialog(open_editor, macro_prop.getSpecification());
@@ -541,6 +546,8 @@ public class PropertyPanelSection extends GridPane
                         final MacroizedWidgetProperty<?> other_prop = (MacroizedWidgetProperty<?>) w.getProperty(macro_prop.getName());
                         undo.execute(new SetMacroizedWidgetPropertyAction(other_prop, result.get()));
                     }
+                    text.setText(result.get());
+                    Tooltip.install(text, new Tooltip(result.get()));
                 });
                 field = new HBox(text, open_editor);
                 HBox.setHgrow(text, Priority.ALWAYS);

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -769,6 +769,10 @@ public class PropertyPanelSection extends GridPane
             final TextField text = new TextField();
             text.setText(String.valueOf(property.getValue()));
             text.setEditable(false);
+
+            Tooltip.install(text, new Tooltip(text.getText()));
+            property.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(text, new Tooltip(text.getText())));
+
             field = text;
         }
 

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -196,7 +196,10 @@ public class PropertyPanelSection extends GridPane
             {
                 if (widget instanceof DisplayModel)
                 {   // DisplayModel is not registered as a Widget that users can add
-                    field = new Label(Messages.Display, ImageCache.getImageView(ModelPlugin.class, "/icons/display.png"));
+                    String text = Messages.Display;
+                    Label label = new Label(text, ImageCache.getImageView(ModelPlugin.class, "/icons/display.png"));
+                    Tooltip.install(label, new Tooltip(text));
+                    field = label;
                 }
                 else
                 {
@@ -205,13 +208,18 @@ public class PropertyPanelSection extends GridPane
                     {
                         final ImageView icon = new ImageView(WidgetIcons.getIcon(type));
                         final String name = WidgetFactory.getInstance().getWidgetDescriptor(type).getName();
-                        field = new Label(name, icon);
+                        Label label = new Label(name, icon);
+                        Tooltip.install(label, new Tooltip(name));
+                        field = label;
                     }
                     catch (Exception ex)
                     {
                         // Even 'unknown' widgets should have an icon,
                         // but fall back to just showing the type name
-                        field = new Label(String.valueOf(property.getValue()));
+                        String text = String.valueOf(property.getValue());
+                        Label label = new Label(text);
+                        Tooltip.install(label, new Tooltip(text));
+                        field = label;
                     }
                 }
             }
@@ -220,6 +228,7 @@ public class PropertyPanelSection extends GridPane
                 final TextField text = new TextField();
                 text.setText(String.valueOf(property.getValue()));
                 text.setDisable(true);
+                Tooltip.install(text, new Tooltip(text.getText()));
                 field = text;
             }
         }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -502,6 +502,11 @@ public class PropertyPanelSection extends GridPane
                 }
             });
 
+
+            Tooltip.install(open_editor, new Tooltip("Open Editor"));
+            Tooltip.install(text, new Tooltip(pv_prop.getValue()));
+            pv_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(text, new Tooltip(new_value)));
+
             field = new HBox(text, open_editor);
             HBox.setHgrow(text, Priority.ALWAYS);
             // For RulesDialog, see above

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -454,6 +454,11 @@ public class PropertyPanelSection extends GridPane
             final MacroizedWidgetPropertyBinding binding = new MacroizedWidgetPropertyBinding(undo, text, file_prop, other);
             bindings.add(binding);
             binding.bind();
+
+            Tooltip.install(select_file, new Tooltip("Select File"));
+            Tooltip.install(text, new Tooltip(file_prop.getValue()));
+            file_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(text, new Tooltip(new_value)));
+
             field = new HBox(text, select_file);
             HBox.setHgrow(text, Priority.ALWAYS);
             // For RulesDialog, see above

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -662,6 +662,10 @@ public class PropertyPanelSection extends GridPane
             final RulesPropertyBinding binding = new RulesPropertyBinding(undo, rules_field, rules_prop, other);
             bindings.add(binding);
             binding.bind();
+
+            Tooltip.install(rules_field, new Tooltip(rules_field.getText()));
+            rules_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(rules_field, new Tooltip(rules_field.getText())));
+
             field = rules_field;
         }
         else if (property instanceof StructuredWidgetProperty)

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -425,6 +425,10 @@ public class PropertyPanelSection extends GridPane
             final WidgetClassBinding binding = new WidgetClassBinding(undo, combo, widget_class_prop, other);
             bindings.add(binding);
             binding.bind();
+
+            Tooltip.install(combo, new Tooltip(widget_class_prop.getValue()));
+            widget_class_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(combo, new Tooltip(new_value)));
+
             field = combo;
         }
         else if (property instanceof FilenameWidgetProperty)

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -264,6 +264,9 @@ public class PropertyPanelSection extends GridPane
             combo.setMaxWidth(Double.MAX_VALUE);
             combo.setMaxHeight(Double.MAX_VALUE);
 
+            Tooltip.install(combo, new Tooltip(enum_prop.getValue().toString()));
+            enum_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(combo, new Tooltip(new_value.toString())));
+
             final ToggleButton macroButton = new ToggleButton("", ImageCache.getImageView(DisplayEditor.class, "/icons/macro-edit.png"));
             macroButton.getStyleClass().add("macro_button");
             macroButton.setTooltip(new Tooltip(Messages.MacroEditButton));

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -633,6 +633,10 @@ public class PropertyPanelSection extends GridPane
             final ActionsPropertyBinding binding = new ActionsPropertyBinding(undo, actions_field, actions_prop, other);
             bindings.add(binding);
             binding.bind();
+
+            Tooltip.install(actions_field, new Tooltip(actions_field.getText()));
+            actions_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(actions_field, new Tooltip(actions_field.getText())));
+
             field = actions_field;
         }
         else if (property instanceof ScriptsWidgetProperty)

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
+import java.util.function.Consumer;
 
 import org.csstudio.display.builder.editor.DisplayEditor;
 import org.csstudio.display.builder.editor.Messages;
@@ -321,6 +322,25 @@ public class PropertyPanelSection extends GridPane
             macroButton.setTooltip(new Tooltip(Messages.MacroEditButton));
             BorderPane.setMargin(macroButton, new Insets(0, 0, 0, 3));
             BorderPane.setAlignment(macroButton, Pos.CENTER);
+
+            {
+                Tooltip tooltipWhenSetToTrue = new Tooltip("True");
+                Tooltip tooltipWhenSetToFalse = new Tooltip("False");
+
+                Consumer<Boolean> setToolTip = (bool) -> {
+                    if (bool) {
+                        Tooltip.install(combo, tooltipWhenSetToTrue);
+                        Tooltip.install(check, tooltipWhenSetToTrue);
+                    }
+                    else {
+                        Tooltip.install(combo, tooltipWhenSetToTrue);
+                        Tooltip.install(check, tooltipWhenSetToFalse);
+                    }
+                };
+
+                setToolTip.accept(bool_prop.getValue());
+                bool_prop.addPropertyListener((listener, old_value, new_value) -> setToolTip.accept(new_value));
+            }
 
             final BooleanWidgetPropertyBinding binding = new BooleanWidgetPropertyBinding(undo, check, combo, macroButton, bool_prop, other);
             bindings.add(binding);

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -394,6 +394,21 @@ public class PropertyPanelSection extends GridPane
             final ColorMapPropertyBinding binding = new ColorMapPropertyBinding(undo, map_button, colormap_prop, other);
             bindings.add(binding);
             binding.bind();
+
+            Function<ColorMap, Tooltip> colorMapToTooltip = (colorMap) ->
+            {
+                if (colorMap instanceof PredefinedColorMaps.Predefined) {
+                    PredefinedColorMaps.Predefined predefinedColorMap = (PredefinedColorMaps.Predefined) colorMap;
+                    return new Tooltip(predefinedColorMap.getDescription());
+                }
+                else {
+                    return new Tooltip("Color Map");
+                }
+            };
+
+            Tooltip.install(map_button, colorMapToTooltip.apply(colormap_prop.getValue()));
+            colormap_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(map_button, colorMapToTooltip.apply(new_value)));
+
             field = map_button;
         }
         else if (property instanceof WidgetClassProperty)

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -648,6 +648,10 @@ public class PropertyPanelSection extends GridPane
             final ScriptsPropertyBinding binding = new ScriptsPropertyBinding(undo, scripts_field, scripts_prop, other);
             bindings.add(binding);
             binding.bind();
+
+            Tooltip.install(scripts_field, new Tooltip(scripts_field.getText()));
+            scripts_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(scripts_field, new Tooltip(scripts_field.getText())));
+
             field = scripts_field;
         }
         else if (property instanceof RulesWidgetProperty)

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -618,6 +618,10 @@ public class PropertyPanelSection extends GridPane
             final MacrosPropertyBinding binding = new MacrosPropertyBinding(undo, macros_field, macros_prop, other);
             bindings.add(binding);
             binding.bind();
+
+            Tooltip.install(macros_field, new Tooltip(macros_field.getText()));
+            macros_prop.addPropertyListener((listener, old_value, new_value) -> Tooltip.install(macros_field, new Tooltip(macros_field.getText())));
+
             field = macros_field;
         }
         else if (property instanceof ActionsWidgetProperty)


### PR DESCRIPTION
This merge-request adds tooltips to the UI elements under "Properties" in the Display Builder that are used to configure widgets.

Event handlers are installed to update the tooltip when the value represented by the underlying UI element is changed.

The following is a screenshot of the tooltip associated with "false" in a widget of type BooleanWidgetProperty. (The mouse disappeared from the screenshot; it is actually hovering over the clickable box on the right of "Highlight Active Region".)

![image](https://user-images.githubusercontent.com/122287276/229750146-7588c09d-73d7-4bbe-9f6b-7fae6de97f08.png)