### PR TITLE
Legacy resize option 3 mapped to None

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -179,8 +179,10 @@ public class EmbeddedDisplayWidget extends MacroWidget
                             widget.setPropertyValue(propResize, Resize.ResizeContent);
                         else if (old_resize == 1)
                             widget.setPropertyValue(propResize, Resize.SizeToContent);
-                        else // 'scroll' or 'crop' -> crop
+                        else if (old_resize == 2) //'crop' -> crop
                             widget.setPropertyValue(propResize, Resize.Crop);
+			else
+			    widget.setPropertyValue(propResize, Resize.None);
                     }
                     catch (NumberFormatException ex)
                     {


### PR DESCRIPTION
This PR is to auto-convert legacy linking containers with resize option 3 i.e. don't resize anything but add a scrollbar to embedded display with Resize.None so as to get the scrollbars needed.