### PR TITLE
CSSTUDIO-1174 Improve parsing: do not allow characters that are not spaces or tabs after a closing quote before the next space.

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/loc/ValueHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/loc/ValueHelper.java
@@ -129,7 +129,7 @@ public class ValueHelper
                         break;
                     }
                     else if (currentChar != ' ' && currentChar != '\t') {
-                        throw new Exception("A character that is not a space of a tab appeared after a closing quote");
+                        throw new Exception("A character that is not a space or a tab appeared after a closing quote");
                     }
                     else {
                         pos++;

--- a/core/pv/src/main/java/org/phoebus/pv/loc/ValueHelper.java
+++ b/core/pv/src/main/java/org/phoebus/pv/loc/ValueHelper.java
@@ -122,8 +122,19 @@ public class ValueHelper
                 items.add(text.substring(pos, end+1));
                 pos = end + 1;
                 // Advance to comma at end of string
-                while (pos < text.length() && text.charAt(pos) != ',')
-                    ++pos;
+                while (pos < text.length()) {
+                    char currentChar = text.charAt(pos);
+                    
+                    if (currentChar == ',') {
+                        break;
+                    }
+                    else if (currentChar != ' ' && currentChar != '\t') {
+                        throw new Exception("A character that is not a space of a tab appeared after a closing quote");
+                    }
+                    else {
+                        pos++;
+                    }
+                }
                 ++pos;
             }
 


### PR DESCRIPTION
This merge-request improves the parsing of lists of string literals when specifying local PVs using the `loc://`-syntax.

Previously, any non-comma character appearing after a closing quote `"` in a list of strings would be discarded until either the next comma `,` or the end of the input. E.g., the input `"a" "b", "c"` (note the missing comma after `"a"`) was parsed as `"a","c"`. 

This merge-requests makes the parsing of lists of strings more strict, and throws an exception if a non-space and non-tab character is encountered after a closing quote `"`. The input `"a" "b", "c"` now throws an exception. In the UI, the consequence is that a widget whose PV is specified as `loc://x("a" "b", "c")` receives a purple border signalling no connection, and the value is undefined.

This stricter parsing makes error detection and debugging easier.