### PR TITLE
CSSTUDIO-1440 Remove saveFileDialog().

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/FileUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/FileUtil.java
@@ -175,14 +175,18 @@ public class FileUtil {
         return selected.getPath();
     }
 
-    /**Open a file save dialog.
-     * @param inWorkspace true if it is a workspace file dialog; Otherwise, it is a local
-     * file system file dialog.
-     * @return the full file path. Or null if it is cancelled.
+    /** Show file "Save As" dialog for selecting/entering a new file name
+     *
+     *  <p>Call blocks until the user closes the dialog
+     *  by either either entering/selecting a file name, or pressing "Cancel".
+     *
+     *  @param widget Widget, used to create and position the dialog
+     *  @param initial_value Initial path and file name
+     *  @return Path and file name or <code>null</code>
      */
-    public static String saveFileDialog(boolean inWorkspace)
+    public static String saveFileDialog(Widget widget, String initial_value)
     {
-	return ScriptUtil.showSaveAsDialog(null, null);
+	    return ScriptUtil.showSaveAsDialog(widget, initial_value);
     }
 
 

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/FileUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/FileUtil.java
@@ -175,17 +175,6 @@ public class FileUtil {
         return selected.getPath();
     }
 
-    /**Open a file save dialog.
-     * @param inWorkspace true if it is a workspace file dialog; Otherwise, it is a local
-     * file system file dialog.
-     * @return the full file path. Or null if it is cancelled.
-     */
-    public static String saveFileDialog(boolean inWorkspace)
-    {
-	return ScriptUtil.showSaveAsDialog(null, null);
-    }
-
-
     /**Convert a workspace path to system path.
      * If this resource is a project that does not exist in the workspace, or a file or folder below such a project, this method returns null.
      * @param workspacePath path in workspace.

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/FileUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/FileUtil.java
@@ -175,6 +175,17 @@ public class FileUtil {
         return selected.getPath();
     }
 
+    /**Open a file save dialog.
+     * @param inWorkspace true if it is a workspace file dialog; Otherwise, it is a local
+     * file system file dialog.
+     * @return the full file path. Or null if it is cancelled.
+     */
+    public static String saveFileDialog(boolean inWorkspace)
+    {
+	return ScriptUtil.showSaveAsDialog(null, null);
+    }
+
+
     /**Convert a workspace path to system path.
      * If this resource is a project that does not exist in the workspace, or a file or folder below such a project, this method returns null.
      * @param workspacePath path in workspace.

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/FileUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/FileUtil.java
@@ -186,7 +186,7 @@ public class FileUtil {
      */
     public static String saveFileDialog(Widget widget, String initial_value)
     {
-	    return ScriptUtil.showSaveAsDialog(widget, initial_value);
+        return ScriptUtil.showSaveAsDialog(widget, initial_value);
     }
 
 


### PR DESCRIPTION
This merge-request removes the function `FileUtil.saveFileDialog()`.

The motivation for removing the function is that a function call to `FileUtil.saveFileDialog()` cannot work: `FileUtil.saveFileDialog()` calls `ScriptUtil.showSaveAsDialog()` with the parameter `widget` set to `null`. The function `ScriptUtil.showSaveAsDialog()`, in turn, tries to invoke `widget.getDisplayModel()` which will necessarily result in an exception being thrown, the consequence of which is that an error is logged.

The user can use the function `ScriptUtil.showSaveAsDialog()` directly instead of calling `FileUtil.saveFileDialog()`.

There are no usages of `FileUtil.saveFileDialog()` in the Phoebus source code. It is possible that scripts reference it, but they are most likely buggy in that case, since the function call cannot succeed.