### PR TITLE
JavaFX 20

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -35,7 +35,6 @@
     <classpathentry exported="true" kind="lib" path="target/lib/cal10n-api-0.8.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/cglib-full-2.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/checker-qual-3.12.0.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/commonj.sdo-2.1.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commonmark-0.15.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commonmark-ext-gfm-tables-0.15.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/commonmark-ext-image-attributes-0.15.2.jar"/>
@@ -86,10 +85,8 @@
     <classpathentry exported="true" kind="lib" path="target/lib/jakarta.json-api-2.0.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/java_cup-0.9e.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.activation-1.2.0.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javax.json-1.0.4.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.json-api-1.1.4.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.mail-1.6.1.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javax.persistence-2.2.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.servlet-api-3.1.0.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/javax.ws.rs-api-2.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jaxb-api-2.3.0.jar"/>
@@ -204,53 +201,69 @@
 
 
     <!-- On Windows, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19-win.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-20-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-20-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-20-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-20-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-20-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-20-win.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-20-win.jar"/>
     -->
     <!-- On Linux, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19-linux.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-20-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-20-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-20-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-20-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-20-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-20-linux.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-20-linux.jar"/>
     -->
-    <!-- On Mac, need to add this:
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-19.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19-mac.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-19.jar"/>
+    <!-- On Intel Mac, need to add this:
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-20-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-20-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-20-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-20-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-20-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-20-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-20-mac.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-20.jar"/>
     -->
+    <!-- On Apple Silicon Mac, need to add this:
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-20-mac-aarch64.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-base-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-20-mac-aarch64.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-controls-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-20-mac-aarch64.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-fxml-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-20-mac-aarch64.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-graphics-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-20-mac-aarch64.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-media-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-20-mac-aarch64.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-swing-20.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-20-mac-aarch64.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/javafx-web-20.jar"/>
+     -->
 
     <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <project.build.outputTimestamp>2022-11-07T10:03:00Z</project.build.outputTimestamp>
     <epics.version>7.0.8</epics.version>
     <vtype.version>1.0.5</vtype.version>
-    <openjfx.version>19</openjfx.version>
+    <openjfx.version>20</openjfx.version>
     <jackson.version>2.12.3</jackson.version>
     <batik.version>1.14</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
Updates JavaFX version to 20, the current one, https://github.com/openjdk/jfx/blob/jfx20/doc-files/release-notes-20.md

On Mac OS, this fixes the menu icons, https://bugs.openjdk.org/browse/JDK-8181084. Icons provided in high-res variants used to render in a wrong size, note data browser, file browser, logbook entry items:

<img width="174" alt="Screenshot 2023-04-13 at 4 18 15 PM" src="https://user-images.githubusercontent.com/1932421/232043626-92ca2853-d062-422a-b006-e2c4c67bf01c.png">
<img width="161" alt="Screenshot 2023-04-13 at 4 18 38 PM" src="https://user-images.githubusercontent.com/1932421/232043630-ea781e05-2eb1-45a9-a007-880a8e8390ab.png">

With JavaFX 20, they render at the correct size:

<img width="155" alt="Screenshot 2023-04-13 at 4 25 47 PM" src="https://user-images.githubusercontent.com/1932421/232043633-3c582ffc-e77b-4a01-9e9e-a8ac5ffc8915.png">
<img width="149" alt="Screenshot 2023-04-13 at 4 26 00 PM" src="https://user-images.githubusercontent.com/1932421/232043635-e448d41b-6e87-4386-bbc1-14039fb57a4b.png">

On Mac OS, there is now also dedicated support for "Apple Silicon" aka "Arm", "M1", "M2", "aarch64", although as far as I can tell products built on/for the Intel x64 based version of OpenJDK for Mac OS will run fine on both Intel and Arm macs.


**An update to JFX 20 does require at least JDK 17!**
This requirement is shared with the apache derby lib as used by the scan server, #2465
So right now the github test builds which use JDK11 fail for the JFX 20 update.
JDK11 was released 2018. JDK 17 from Sept. 2021 is the current LTS release.
Might be time to overall require JDK 17 and then update JFX to 20.


