### PR TITLE
Truncate log title but avoid ending in partial word

### DIFF
--- a/app/logbook/olog/client/src/main/java/org/phoebus/olog/api/OlogLog.java
+++ b/app/logbook/olog/client/src/main/java/org/phoebus/olog/api/OlogLog.java
@@ -134,7 +134,7 @@ public class OlogLog implements LogEntry {
 
     @Override
     public String getTitle() {
-        return getSource().substring(0, getSource().length() < 50 ? getSource().length() : getSource().substring(0, 50).lastIndexOf(" "));
+        return getSource().substring(0, getSource().length() < 50 ? getSource().length() : (getSource().substring(0, 50).contains(" ") ? getSource().substring(0, 50).lastIndexOf(" ") : 50));
     }
 
     /**

--- a/app/logbook/olog/client/src/main/java/org/phoebus/olog/api/OlogLog.java
+++ b/app/logbook/olog/client/src/main/java/org/phoebus/olog/api/OlogLog.java
@@ -134,7 +134,7 @@ public class OlogLog implements LogEntry {
 
     @Override
     public String getTitle() {
-        return getSource().substring(0, getSource().length() < 50 ? getSource().length() : 50);
+        return getSource().substring(0, getSource().length() < 50 ? getSource().length() : getSource().substring(0, 50).lastIndexOf(" "));
     }
 
     /**


### PR DESCRIPTION
This PR is for the old olog client to truncate its log's title but avoid ending in a partial word.