### PR TITLE
CSSTUDIO-1903 Use colors specified in the configuration file for alarm indications, and add separate color options for the application "Alarm Area Panel".

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -169,8 +169,8 @@ public class AlarmLogTableController {
 
                 if (empty  ||  item == null)
                 {
+                    setStyle("-fx-text-fill: black;  -fx-background-color: transparent");
                     setText("");
-                    setTextFill(Color.BLACK);
                 }
                 else
                 {
@@ -242,8 +242,8 @@ public class AlarmLogTableController {
 
                 if (empty  ||  item == null)
                 {
+                    setStyle("-fx-text-fill: black;  -fx-background-color: transparent");
                     setText("");
-                    setTextFill(Color.BLACK);
                 }
                 else
                 {

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -40,13 +40,13 @@ import org.phoebus.framework.jobs.Job;
 import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.ui.application.ContextMenuHelper;
 import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
+import org.phoebus.ui.javafx.JFXUtil;
 import org.phoebus.util.time.TimeParser;
 import org.phoebus.util.time.TimestampFormats;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -175,7 +175,8 @@ public class AlarmLogTableController {
                 else
                 {
                     setText(item);
-                    setTextFill(AlarmUI.getColor(parseSeverityLevel(item)));
+                    SeverityLevel severityLevel = parseSeverityLevel(item);
+                    setStyle("-fx-alignment: center; -fx-border-color: transparent; -fx-border-width: 2 0 2 0; -fx-background-insets: 2 0 2 0; -fx-text-fill: " + JFXUtil.webRGB(AlarmUI.getColor(severityLevel)) + ";  -fx-background-color: " + JFXUtil.webRGB(AlarmUI.getBackgroundColor(severityLevel)));
                 }
             }
         });
@@ -247,7 +248,8 @@ public class AlarmLogTableController {
                 else
                 {
                     setText(item);
-                    setTextFill(AlarmUI.getColor(parseSeverityLevel(item)));
+                    SeverityLevel severityLevel = parseSeverityLevel(item);
+                    setStyle("-fx-alignment: center; -fx-border-color: transparent; -fx-border-width: 2 0 2 0; -fx-background-insets: 2 0 2 0; -fx-text-fill: " + JFXUtil.webRGB(AlarmUI.getColor(severityLevel)) + ";  -fx-background-color: " + JFXUtil.webRGB(AlarmUI.getBackgroundColor(severityLevel)));
                 }
             }
         });

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -50,6 +50,19 @@ public class AlarmUI
         createColor(Preferences.undefined_severity_text_color)                                   // UNDEFINED
     };
 
+    private static final Color[] alarm_area_panel_severity_colors = new Color[]
+            {
+                    createColor(Preferences.alarm_area_panel_ok_severity_text_color),                                         // OK
+                    createColor(Preferences.alarm_area_panel_minor_severity_text_color)    .deriveColor(0, 1.0, ADJUST, 1.0), // MINOR_ACK
+                    createColor(Preferences.alarm_area_panel_major_severity_text_color)    .deriveColor(0, 1.0, ADJUST, 1.0), // MAJOR_ACK
+                    createColor(Preferences.alarm_area_panel_invalid_severity_text_color)  .deriveColor(0, 1.0, ADJUST, 1.0), // INVALID_ACK
+                    createColor(Preferences.alarm_area_panel_undefined_severity_text_color).deriveColor(0, 1.0, ADJUST, 1.0), // UNDEFINED_ACK
+                    createColor(Preferences.alarm_area_panel_minor_severity_text_color),                                      // MINOR
+                    createColor(Preferences.alarm_area_panel_major_severity_text_color),                                      // MAJOR
+                    createColor(Preferences.alarm_area_panel_invalid_severity_text_color),                                    // INVALID
+                    createColor(Preferences.alarm_area_panel_undefined_severity_text_color)                                   // UNDEFINED
+            };
+
     private static Color createColor(int[] rgb)
     {
         if (rgb.length == 3)
@@ -85,6 +98,19 @@ public class AlarmUI
         new Background(new BackgroundFill(createColor(Preferences.undefined_severity_background_color),                                  CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED
     };
 
+    private static final Background[] alarm_area_panel_severity_backgrounds = new Background[]
+            {
+                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_ok_severity_background_color), CornerRadii.EMPTY, Insets.EMPTY)), // OK
+                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_minor_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MINOR_ACK
+                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_major_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR_ACK
+                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_invalid_severity_background_color)  .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // INVALID_ACK
+                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_undefined_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED_ACK
+                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_minor_severity_background_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MINOR
+                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_major_severity_background_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR
+                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_invalid_severity_background_color),                                    CornerRadii.EMPTY, Insets.EMPTY)), // INVALID
+                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_undefined_severity_background_color),                                  CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED
+            };
+
     private static final Background[] legacy_table_severity_backgrounds = new Background[]
     {
         new Background(new BackgroundFill(createColor(Preferences.ok_severity_text_color), CornerRadii.EMPTY, Insets.EMPTY)), // OK
@@ -108,7 +134,14 @@ public class AlarmUI
     public static Color getColor(final SeverityLevel severity)
     {
         return severity_colors[severity.ordinal()];
+    }
 
+    /** @param severity {@link SeverityLevel}
+     *  @return Color
+     */
+    public static Color getAlarmAreaPanelColor(final SeverityLevel severity)
+    {
+        return alarm_area_panel_severity_colors[severity.ordinal()];
     }
 
     /** @param severity {@link SeverityLevel}
@@ -133,6 +166,14 @@ public class AlarmUI
     public static Background getLegacyTableBackground(final SeverityLevel severity)
     {
         return legacy_table_severity_backgrounds[severity.ordinal()];
+    }
+
+    /** @param severity {@link SeverityLevel}
+     *  @return Background, may be <code>null</code>
+     */
+    public static Background getAlarmAreaPanelBackground(final SeverityLevel severity)
+    {
+        return alarm_area_panel_severity_backgrounds[severity.ordinal()];
     }
 
     /** Verify authorization, qualified by model's current config

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -98,17 +98,17 @@ public class AlarmUI
         createColor(Preferences.undefined_severity_background_color)                                                                    , // UNDEFINED
     };
 
-    private static final Background[] alarm_area_panel_severity_backgrounds = new Background[]
+    private static final Color[] alarm_area_panel_severity_backgrounds = new Color[]
             {
-                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_ok_severity_background_color), CornerRadii.EMPTY, Insets.EMPTY)), // OK
-                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_minor_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MINOR_ACK
-                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_major_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR_ACK
-                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_invalid_severity_background_color)  .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // INVALID_ACK
-                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_undefined_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED_ACK
-                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_minor_severity_background_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MINOR
-                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_major_severity_background_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR
-                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_invalid_severity_background_color),                                    CornerRadii.EMPTY, Insets.EMPTY)), // INVALID
-                    new Background(new BackgroundFill(createColor(Preferences.alarm_area_panel_undefined_severity_background_color),                                  CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED
+                    createColor(Preferences.alarm_area_panel_ok_severity_background_color),                                                                            // OK
+                    createColor(Preferences.alarm_area_panel_minor_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), // MINOR_ACK
+                    createColor(Preferences.alarm_area_panel_major_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), // MAJOR_ACK
+                    createColor(Preferences.alarm_area_panel_invalid_severity_background_color)  .deriveColor(0, ADJUST, 1.0, 1.0), // INVALID_ACK
+                    createColor(Preferences.alarm_area_panel_undefined_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), // UNDEFINED_ACK
+                    createColor(Preferences.alarm_area_panel_minor_severity_background_color),                                                                         // MINOR
+                    createColor(Preferences.alarm_area_panel_major_severity_background_color),                                                                         // MAJOR
+                    createColor(Preferences.alarm_area_panel_invalid_severity_background_color),                                                                       // INVALID
+                    createColor(Preferences.alarm_area_panel_undefined_severity_background_color),                                                                     // UNDEFINED
             };
 
     private static final Background[] legacy_table_severity_backgrounds = new Background[]
@@ -171,7 +171,7 @@ public class AlarmUI
     /** @param severity {@link SeverityLevel}
      *  @return Background, may be <code>null</code>
      */
-    public static Background getAlarmAreaPanelBackground(final SeverityLevel severity)
+    public static Color getAlarmAreaPanelBackgroundColor(final SeverityLevel severity)
     {
         return alarm_area_panel_severity_backgrounds[severity.ordinal()];
     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -85,6 +85,19 @@ public class AlarmUI
         ImageCache.getImage(AlarmUI.class, "/icons/undefined.png")
     };
 
+    private static final Background[] severity_backgrounds = new Background[]
+    {
+        new Background(new BackgroundFill(createColor(Preferences.ok_severity_background_color), CornerRadii.EMPTY, Insets.EMPTY)), // OK
+        new Background(new BackgroundFill(createColor(Preferences.minor_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MINOR_ACK
+        new Background(new BackgroundFill(createColor(Preferences.major_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR_ACK
+        new Background(new BackgroundFill(createColor(Preferences.invalid_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // INVALID_ACK
+        new Background(new BackgroundFill(createColor(Preferences.undefined_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED_ACK
+        new Background(new BackgroundFill(createColor(Preferences.minor_severity_background_color), CornerRadii.EMPTY, Insets.EMPTY)), // MINOR
+        new Background(new BackgroundFill(createColor(Preferences.major_severity_background_color), CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR
+        new Background(new BackgroundFill(createColor(Preferences.invalid_severity_background_color), CornerRadii.EMPTY, Insets.EMPTY)), // INVALID
+        new Background(new BackgroundFill(createColor(Preferences.undefined_severity_background_color), CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED
+    };
+
     private static final Color[] severity_background_colors = new Color[]
     {
         createColor(Preferences.ok_severity_background_color),                                                                            // OK
@@ -159,6 +172,15 @@ public class AlarmUI
     {
         return severity_background_colors[severity.ordinal()];
     }
+
+    /** @param severity {@link SeverityLevel}
+     *  @return Background, may be <code>null</code>
+     */
+    public static Background getBackground(final SeverityLevel severity)
+    {
+        return severity_backgrounds[severity.ordinal()];
+    }
+
 
     /** @param severity {@link SeverityLevel}
      *  @return Background, may be <code>null</code>

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -99,17 +99,17 @@ public class AlarmUI
     };
 
     private static final Color[] alarm_area_panel_severity_backgrounds = new Color[]
-            {
-                    createColor(Preferences.alarm_area_panel_ok_severity_background_color),                                                                            // OK
-                    createColor(Preferences.alarm_area_panel_minor_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), // MINOR_ACK
-                    createColor(Preferences.alarm_area_panel_major_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), // MAJOR_ACK
-                    createColor(Preferences.alarm_area_panel_invalid_severity_background_color)  .deriveColor(0, ADJUST, 1.0, 1.0), // INVALID_ACK
-                    createColor(Preferences.alarm_area_panel_undefined_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), // UNDEFINED_ACK
-                    createColor(Preferences.alarm_area_panel_minor_severity_background_color),                                                                         // MINOR
-                    createColor(Preferences.alarm_area_panel_major_severity_background_color),                                                                         // MAJOR
-                    createColor(Preferences.alarm_area_panel_invalid_severity_background_color),                                                                       // INVALID
-                    createColor(Preferences.alarm_area_panel_undefined_severity_background_color),                                                                     // UNDEFINED
-            };
+    {
+        createColor(Preferences.alarm_area_panel_ok_severity_background_color),                                                                            // OK
+        createColor(Preferences.alarm_area_panel_minor_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), // MINOR_ACK
+        createColor(Preferences.alarm_area_panel_major_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), // MAJOR_ACK
+        createColor(Preferences.alarm_area_panel_invalid_severity_background_color)  .deriveColor(0, ADJUST, 1.0, 1.0), // INVALID_ACK
+        createColor(Preferences.alarm_area_panel_undefined_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), // UNDEFINED_ACK
+        createColor(Preferences.alarm_area_panel_minor_severity_background_color),                                                                         // MINOR
+        createColor(Preferences.alarm_area_panel_major_severity_background_color),                                                                         // MAJOR
+        createColor(Preferences.alarm_area_panel_invalid_severity_background_color),                                                                       // INVALID
+        createColor(Preferences.alarm_area_panel_undefined_severity_background_color),                                                                     // UNDEFINED
+    };
 
     private static final Background[] legacy_table_severity_backgrounds = new Background[]
     {

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -85,17 +85,17 @@ public class AlarmUI
         ImageCache.getImage(AlarmUI.class, "/icons/undefined.png")
     };
 
-    private static final Background[] severity_backgrounds = new Background[]
+    private static final Color[] severity_backgrounds = new Color[]
     {
-        new Background(new BackgroundFill(createColor(Preferences.ok_severity_background_color), CornerRadii.EMPTY, Insets.EMPTY)), // OK
-        new Background(new BackgroundFill(createColor(Preferences.minor_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MINOR_ACK
-        new Background(new BackgroundFill(createColor(Preferences.major_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR_ACK
-        new Background(new BackgroundFill(createColor(Preferences.invalid_severity_background_color)  .deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // INVALID_ACK
-        new Background(new BackgroundFill(createColor(Preferences.undefined_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED_ACK
-        new Background(new BackgroundFill(createColor(Preferences.minor_severity_background_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MINOR
-        new Background(new BackgroundFill(createColor(Preferences.major_severity_background_color),                                      CornerRadii.EMPTY, Insets.EMPTY)), // MAJOR
-        new Background(new BackgroundFill(createColor(Preferences.invalid_severity_background_color),                                    CornerRadii.EMPTY, Insets.EMPTY)), // INVALID
-        new Background(new BackgroundFill(createColor(Preferences.undefined_severity_background_color),                                  CornerRadii.EMPTY, Insets.EMPTY)), // UNDEFINED
+        createColor(Preferences.ok_severity_background_color),                                                                            // OK
+        createColor(Preferences.minor_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), // MINOR_ACK
+        createColor(Preferences.major_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), // MAJOR_ACK
+        createColor(Preferences.invalid_severity_background_color)  .deriveColor(0, ADJUST, 1.0, 1.0), // INVALID_ACK
+        createColor(Preferences.undefined_severity_background_color).deriveColor(0, ADJUST, 1.0, 1.0), // UNDEFINED_ACK
+        createColor(Preferences.minor_severity_background_color)                                                                        , // MINOR
+        createColor(Preferences.major_severity_background_color)                                                                        , // MAJOR
+        createColor(Preferences.invalid_severity_background_color)                                                                      , // INVALID
+        createColor(Preferences.undefined_severity_background_color)                                                                    , // UNDEFINED
     };
 
     private static final Background[] alarm_area_panel_severity_backgrounds = new Background[]
@@ -155,7 +155,7 @@ public class AlarmUI
     /** @param severity {@link SeverityLevel}
      *  @return Background, may be <code>null</code>
      */
-    public static Background getBackground(final SeverityLevel severity)
+    public static Color getBackgroundColor(final SeverityLevel severity)
     {
         return severity_backgrounds[severity.ordinal()];
     }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -153,7 +153,7 @@ public class AlarmUI
     }
 
     /** @param severity {@link SeverityLevel}
-     *  @return Background, may be <code>null</code>
+     *  @return Color, may be <code>null</code>
      */
     public static Color getBackgroundColor(final SeverityLevel severity)
     {

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmUI.java
@@ -85,7 +85,7 @@ public class AlarmUI
         ImageCache.getImage(AlarmUI.class, "/icons/undefined.png")
     };
 
-    private static final Color[] severity_backgrounds = new Color[]
+    private static final Color[] severity_background_colors = new Color[]
     {
         createColor(Preferences.ok_severity_background_color),                                                                            // OK
         createColor(Preferences.minor_severity_background_color)    .deriveColor(0, ADJUST, 1.0, 1.0), // MINOR_ACK
@@ -157,7 +157,7 @@ public class AlarmUI
      */
     public static Color getBackgroundColor(final SeverityLevel severity)
     {
-        return severity_backgrounds[severity.ordinal()];
+        return severity_background_colors[severity.ordinal()];
     }
 
     /** @param severity {@link SeverityLevel}

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/area/AlarmAreaView.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/area/AlarmAreaView.java
@@ -17,12 +17,21 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
+import javafx.scene.layout.Border;
+import javafx.scene.layout.BorderStroke;
+import javafx.scene.layout.BorderStrokeStyle;
+import javafx.scene.layout.BorderWidths;
+import javafx.scene.layout.CornerRadii;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.StackPane;
 import org.phoebus.applications.alarm.AlarmSystem;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.client.AlarmClientListener;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.applications.alarm.model.SeverityLevel;
 import org.phoebus.applications.alarm.ui.AlarmUI;
+import org.phoebus.ui.javafx.JFXUtil;
 import org.phoebus.ui.javafx.UpdateThrottle;
 
 import javafx.application.Platform;
@@ -32,16 +41,6 @@ import javafx.geometry.Pos;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
-import javafx.scene.layout.Background;
-import javafx.scene.layout.BackgroundFill;
-import javafx.scene.layout.Border;
-import javafx.scene.layout.BorderStroke;
-import javafx.scene.layout.BorderStrokeStyle;
-import javafx.scene.layout.BorderWidths;
-import javafx.scene.layout.CornerRadii;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.StrokeLineCap;
 import javafx.scene.shape.StrokeLineJoin;
@@ -234,11 +233,8 @@ public class AlarmAreaView extends StackPane implements AlarmClientListener
             logger.log(Level.WARNING, "Cannot update unknown alarm area item " + item_name);
             return;
         }
-        final SeverityLevel severity = areaFilter.getSeverity(item_name);
-        final Background background = AlarmUI.getAlarmAreaPanelBackground(severity);
-        view_item.setBackground(background);
-        Color foregroundColor = AlarmUI.getAlarmAreaPanelColor(severity);
-        view_item.setTextFill(foregroundColor);
+        SeverityLevel severityLevel = areaFilter.getSeverity(item_name);
+        view_item.setStyle("-fx-alignment: center; -fx-border-color: black; -fx-border-width: 2; -fx-border-radius: 10; -fx-background-insets: 1; -fx-background-radius: 10; -fx-text-fill: " + JFXUtil.webRGB(AlarmUI.getAlarmAreaPanelColor(severityLevel)) + ";  -fx-background-color: " + JFXUtil.webRGB(AlarmUI.getAlarmAreaPanelBackgroundColor(severityLevel)));
     }
 
     private void createContextMenu()

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/area/AlarmAreaView.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/area/AlarmAreaView.java
@@ -235,12 +235,10 @@ public class AlarmAreaView extends StackPane implements AlarmClientListener
             return;
         }
         final SeverityLevel severity = areaFilter.getSeverity(item_name);
-        final Color color = AlarmUI.getColor(severity);
-        view_item.setBackground(new Background(new BackgroundFill(color, radii, Insets.EMPTY)));
-        if (color.getBrightness() >= 0.5)
-            view_item.setTextFill(Color.BLACK);
-        else
-            view_item.setTextFill(Color.WHITE);
+        final Background background = AlarmUI.getAlarmAreaPanelBackground(severity);
+        view_item.setBackground(background);
+        Color foregroundColor = AlarmUI.getAlarmAreaPanelColor(severity);
+        view_item.setTextFill(foregroundColor);
     }
 
     private void createContextMenu()

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -17,6 +17,12 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.CornerRadii;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
 import org.phoebus.applications.alarm.AlarmSystem;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
@@ -68,10 +74,6 @@ import javafx.scene.image.ImageView;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.TransferMode;
-import javafx.scene.layout.Background;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 
@@ -221,7 +223,7 @@ public class AlarmTableUI extends BorderPane
                 }
                 else
                 {
-                    setBackground(AlarmUI.getBackground(item));
+                    setBackground(new Background(new BackgroundFill(AlarmUI.getBackgroundColor(item), CornerRadii.EMPTY, Insets.EMPTY)));
                     setTextFill(AlarmUI.getColor(item));
                 }
             }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -18,9 +18,7 @@ import java.util.logging.Level;
 import java.util.regex.Pattern;
 
 import javafx.scene.layout.Background;
-import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import org.phoebus.applications.alarm.AlarmSystem;
@@ -39,6 +37,7 @@ import org.phoebus.ui.application.SaveSnapshotAction;
 import org.phoebus.ui.javafx.Brightness;
 import org.phoebus.ui.javafx.ClearingTextField;
 import org.phoebus.ui.javafx.ImageCache;
+import org.phoebus.ui.javafx.JFXUtil;
 import org.phoebus.ui.javafx.PrintAction;
 import org.phoebus.ui.javafx.Screenshot;
 import org.phoebus.ui.javafx.ToolbarHelper;
@@ -197,11 +196,11 @@ public class AlarmTableUI extends BorderPane
         }
 
         @Override
-        protected void updateItem(final SeverityLevel item, final boolean empty)
+        protected void updateItem(final SeverityLevel severityLevel, final boolean empty)
         {
-            super.updateItem(item, empty);
+            super.updateItem(severityLevel, empty);
 
-            if (empty  ||  item == null)
+            if (empty  ||  severityLevel == null)
             {
                 setText("");
                 setBackground(null);
@@ -209,10 +208,10 @@ public class AlarmTableUI extends BorderPane
             }
             else
             {
-                setText(item.toString());
+                setText(severityLevel.toString());
                 if (AlarmSystem.alarm_table_color_legacy_background)
                 {
-                    final Background bg = AlarmUI.getLegacyTableBackground(item);
+                    final Background bg = AlarmUI.getLegacyTableBackground(severityLevel);
                     setBackground(bg);
                     final Paint p = bg.getFills().get(0).getFill();
                     if (p instanceof Color &&
@@ -223,8 +222,7 @@ public class AlarmTableUI extends BorderPane
                 }
                 else
                 {
-                    setBackground(new Background(new BackgroundFill(AlarmUI.getBackgroundColor(item), CornerRadii.EMPTY, Insets.EMPTY)));
-                    setTextFill(AlarmUI.getColor(item));
+                    setStyle("-fx-alignment: center; -fx-border-color: transparent; -fx-border-width: 2 0 2 0; -fx-background-insets: 2 0 2 0; -fx-text-fill: " + JFXUtil.webRGB(AlarmUI.getColor(severityLevel)) + ";  -fx-background-color: " + JFXUtil.webRGB(AlarmUI.getBackgroundColor(severityLevel)));
                 }
             }
         }

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -202,9 +202,8 @@ public class AlarmTableUI extends BorderPane
 
             if (empty  ||  severityLevel == null)
             {
+                setStyle("-fx-text-fill: black;  -fx-background-color: transparent");
                 setText("");
-                setBackground(null);
-                setTextFill(Color.BLACK);
             }
             else
             {

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
@@ -92,7 +92,7 @@ class AlarmTreeViewCell extends TreeCell<AlarmTreeItem<?>>
                                 .append(")");
                     }
                     label.setTextFill(AlarmUI.getColor(state.severity));
-                    label.setBackground(new Background(new BackgroundFill(AlarmUI.getBackgroundColor(state.severity), CornerRadii.EMPTY, Insets.EMPTY)));
+                    label.setBackground(AlarmUI.getBackground(state.severity));
                     image.setImage(AlarmUI.getIcon(state.severity));
                 }
                 else
@@ -111,7 +111,7 @@ class AlarmTreeViewCell extends TreeCell<AlarmTreeItem<?>>
 
                 severity = node.getState().severity;
                 label.setTextFill(AlarmUI.getColor(severity));
-                label.setBackground(new Background(new BackgroundFill(AlarmUI.getBackgroundColor(severity), CornerRadii.EMPTY, Insets.EMPTY)));
+                label.setBackground(AlarmUI.getBackground(severity));
                 image.setImage(AlarmUI.getIcon(severity));
             }
             // Profiler showed small advantage when skipping redundant 'setGraphic' call

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
@@ -7,10 +7,13 @@
  *******************************************************************************/
 package org.phoebus.applications.alarm.ui.tree;
 
+import javafx.geometry.Insets;
 import javafx.scene.control.Label;
 import javafx.scene.control.TreeCell;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 
@@ -89,7 +92,7 @@ class AlarmTreeViewCell extends TreeCell<AlarmTreeItem<?>>
                                 .append(")");
                     }
                     label.setTextFill(AlarmUI.getColor(state.severity));
-                    label.setBackground(AlarmUI.getBackground(state.severity));
+                    label.setBackground(new Background(new BackgroundFill(AlarmUI.getBackgroundColor(state.severity), CornerRadii.EMPTY, Insets.EMPTY)));
                     image.setImage(AlarmUI.getIcon(state.severity));
                 }
                 else
@@ -108,7 +111,7 @@ class AlarmTreeViewCell extends TreeCell<AlarmTreeItem<?>>
 
                 severity = node.getState().severity;
                 label.setTextFill(AlarmUI.getColor(severity));
-                label.setBackground(AlarmUI.getBackground(severity));
+                label.setBackground(new Background(new BackgroundFill(AlarmUI.getBackgroundColor(severity), CornerRadii.EMPTY, Insets.EMPTY)));
                 image.setImage(AlarmUI.getIcon(severity));
             }
             // Profiler showed small advantage when skipping redundant 'setGraphic' call

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetInfoDialog.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetInfoDialog.java
@@ -126,7 +126,7 @@ public class WidgetInfoDialog extends Dialog<Boolean>
             }
             else
                 severity = AlarmSeverity.NONE;
-            text.setStyle("-fx-text-fill: " + JFXUtil.webRGB(SeverityColors.getTextColor(severity)));
+            text.setStyle("-fx-text-fill: " + JFXUtil.webRGB(SeverityColors.getTextColor(severity)) + "; -fx-control-inner-background: " + JFXUtil.webRGB(SeverityColors.getBackgroundColor(severity)));
         }
     }
 

--- a/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
+++ b/app/probe/src/main/java/org/phoebus/applications/probe/view/ProbeController.java
@@ -8,10 +8,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
-import javafx.geometry.Insets;
-import javafx.scene.layout.Background;
-import javafx.scene.layout.BackgroundFill;
-import javafx.scene.layout.CornerRadii;
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.Display;
@@ -25,6 +21,7 @@ import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;
 import org.phoebus.ui.application.ContextMenuHelper;
+import org.phoebus.ui.javafx.JFXUtil;
 import org.phoebus.ui.pv.SeverityColors;
 import org.phoebus.ui.vtype.FormatOption;
 import org.phoebus.ui.vtype.FormatOptionHandler;
@@ -43,7 +40,6 @@ import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.TransferMode;
-import javafx.scene.paint.Color;
 
 @SuppressWarnings("nls")
 public class ProbeController {
@@ -323,34 +319,9 @@ public class ProbeController {
 
     private void setAlarm(final Alarm alarm)
     {
-        if (alarm == null  ||  alarm.getSeverity() == AlarmSeverity.NONE)
-        {
-            txtAlarm.setText("");
-            final Color bk_col = SeverityColors.getBackgroundColor(alarm.getSeverity());
-//            txtAlarm.setStyle("-fx-control-inner-background: rgba(" + (int)(bk_col.getRed()*255) + ',' +
-//                    (int)(bk_col.getGreen()*255) + ',' +
-//                    (int)(bk_col.getBlue()*255) + ',' +
-//                    bk_col.getOpacity()*255 + ");");
-        }
-        else
-        {
-            final Color col = SeverityColors.getTextColor(alarm.getSeverity());
-            txtAlarm.setStyle("-fx-text-fill: rgba(" + (int)(col.getRed()*255) + ',' +
-                                                       (int)(col.getGreen()*255) + ',' +
-                                                       (int)(col.getBlue()*255) + ',' +
-                                                             col.getOpacity()*255 + ");");
-            // TODO: Setting both the text and the background color using the css property fails.
-            //  Setting one seems to override the other with a derived value. Tried creating a custom css with little
-            //  luck so using only the text alarm color for the time being.
-            //  https://stackoverflow.com/questions/67820776/whats-the-difference-between-fx-text-fill-and-fx-text-inner-color-in-javafx-c
-
-//            final Color bk_col = SeverityColors.getBackgroundColor(alarm.getSeverity());
-//            txtAlarm.setStyle("-fx-control-inner-background: rgba(" + (int)(bk_col.getRed()*255) + ',' +
-//                    (int)(bk_col.getGreen()*255) + ',' +
-//                    (int)(bk_col.getBlue()*255) + ',' +
-//                    bk_col.getOpacity()*255 + ");");
-            txtAlarm.setText(alarm.getSeverity() + " - " + alarm.getName());
-        }
+        AlarmSeverity alarmSeverity = alarm.getSeverity();
+        txtAlarm.setStyle("-fx-text-fill: " + JFXUtil.webRGB(SeverityColors.getTextColor(alarmSeverity)) + "; -fx-control-inner-background: " + JFXUtil.webRGB(SeverityColors.getBackgroundColor(alarmSeverity)));
+        txtAlarm.setText(alarm.getSeverity() + " - " + alarm.getName());
     }
 
     private void setMetadata(final VType value)

--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -41,6 +41,17 @@ public class Preferences
     @Preference public static int[] major_severity_background_color;
     @Preference public static int[] invalid_severity_background_color;
     @Preference public static int[] undefined_severity_background_color;
+    // Alarm Area Panel Configuration:
+    @Preference public static int[] alarm_area_panel_ok_severity_text_color;
+    @Preference public static int[] alarm_area_panel_minor_severity_text_color;
+    @Preference public static int[] alarm_area_panel_major_severity_text_color;
+    @Preference public static int[] alarm_area_panel_invalid_severity_text_color;
+    @Preference public static int[] alarm_area_panel_undefined_severity_text_color;
+    @Preference public static int[] alarm_area_panel_ok_severity_background_color;
+    @Preference public static int[] alarm_area_panel_minor_severity_background_color;
+    @Preference public static int[] alarm_area_panel_major_severity_background_color;
+    @Preference public static int[] alarm_area_panel_invalid_severity_background_color;
+    @Preference public static int[] alarm_area_panel_undefined_severity_background_color;
 
     static
     {

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -88,3 +88,19 @@ invalid_severity_background_color=255,255,255
 # Color for text and the background for 'UNDEFINED' alarm severity
 undefined_severity_text_color=200,0,200,200
 undefined_severity_background_color=255,255,255
+
+# Color Configuration for the application "Alarm Area Panel" (R,G,B or R,G,B,A values in range 0..255):
+alarm_area_panel_ok_severity_text_color=255,255,255
+alarm_area_panel_ok_severity_background_color=0,255,0
+
+alarm_area_panel_minor_severity_text_color=255,255,255
+alarm_area_panel_minor_severity_background_color=255,128,0
+
+alarm_area_panel_major_severity_text_color=255,255,255
+alarm_area_panel_major_severity_background_color=255,0,0
+
+alarm_area_panel_invalid_severity_text_color=255,255,255
+alarm_area_panel_invalid_severity_background_color=255,0,255
+
+alarm_area_panel_undefined_severity_text_color=192,192,192
+alarm_area_panel_undefined_severity_background_color=200,0,200,200


### PR DESCRIPTION
This merge-requests improves the graphical representation of alarm indications by improving the use of the colors as specified in the Phoebus configuration file in the following applications/dialogs:

- The application "Alarm Area Panel"
- The application "Alarm Log Table"
- The information window "Widget Info" (Accessed through right-clicking on a widget in an OPI)
- The application "Probe"
- The application "Alarm Table"

In some cases, the text is also centered. (Previously, it was left-aligned.)

It also adds and implements separate configuration parameters for the application "Alarm Area Panel". The new parameters (whose names are self-descriptive), are (together with their default values):
 
> ```org.phoebus.ui/alarm_area_panel_ok_severity_text_color=255,255,255
> org.phoebus.ui/alarm_area_panel_ok_severity_background_color=0,255,0
> 
> org.phoebus.ui/alarm_area_panel_minor_severity_text_color=255,255,255
> org.phoebus.ui/alarm_area_panel_minor_severity_background_color=255,128,0
> 
> org.phoebus.ui/alarm_area_panel_major_severity_text_color=255,255,255
> org.phoebus.ui/alarm_area_panel_major_severity_background_color=255,0,0
> 
> org.phoebus.ui/alarm_area_panel_invalid_severity_text_color=255,255,255
> org.phoebus.ui/alarm_area_panel_invalid_severity_background_color=255,0,255
> 
> org.phoebus.ui/alarm_area_panel_undefined_severity_text_color=192,192,192
> org.phoebus.ui/alarm_area_panel_undefined_severity_background_color=200,0,200,200´´´

The motivation for having separate configuration options for the application "Alarm Area Panel" is that oftentimes the requirements are different, since this application is often running on a separate screen with the background of the individual items signalling the status of the corresponding sub-systems. In contrast, in other places where alarm statuses are indicated, the background color is not always used to signal the alarm-status. E.g., elsewhere in Phoebus, the status "OK" could be represented by black text on white background, while the "Alarm Area Panel" might represent the same status using a green background.