### PR TITLE
 Alarm server sevrpv: remove outdated PVs

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/AlarmSystem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,9 @@ public class AlarmSystem extends AlarmSystemConstants
 
     /** Timeout in seconds for initial PV connection */
     @Preference public static int connection_timeout;
+
+    /** Timeout in seconds for "sevrpv:" updates */
+    @Preference public static int severity_pv_timeout;
 
     /** Item level of alarm area. A level of 2 would show all the root levels children. */
     @Preference public static int alarm_area_level;

--- a/app/alarm/model/src/main/resources/alarm_preferences.properties
+++ b/app/alarm/model/src/main/resources/alarm_preferences.properties
@@ -22,6 +22,8 @@ config_names=Accelerator, Demo
 # Timeout in seconds for initial PV connection
 connection_timeout=30
 
+# Timeout in seconds for "sevrpv:" updates
+severity_pv_timeout=5
 
 ## Area Panel 
 

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/TitleDetailDelayTable.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/TitleDetailDelayTable.java
@@ -92,7 +92,7 @@ public class TitleDetailDelayTable extends BorderPane
     class DelayTableCell extends TableCell<TitleDetailDelay, Integer>
     {
         private final Spinner<Integer> spinner;
-        
+
         public DelayTableCell()
         {
             this.spinner = new Spinner<>(0, 10000, 1);
@@ -124,7 +124,7 @@ public class TitleDetailDelayTable extends BorderPane
                 spinner.getEditor().setStyle("-fx-text-inner-color: lightgray;");
                 //spinner.getEditor().setTextFill(Color.LIGHTGRAY);
             }
-            
+
             this.spinner.getValueFactory().setValue(item);
             setGraphic(spinner);
         }
@@ -216,7 +216,7 @@ public class TitleDetailDelayTable extends BorderPane
 
     /**
      * This function extracts the option from detail "option:info"
-     * 
+     *
      * @param titleDetailDelay
      * @return enum Option_d (mailto, cmd, sevrpv)
      */
@@ -241,7 +241,7 @@ public class TitleDetailDelayTable extends BorderPane
 
     /**
      * This function extracts the info from detail "option:info"
-     * 
+     *
      * @param titleDetailDelay
      * @return information eg : mail, command, PV
      */

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerNode.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -125,6 +125,8 @@ public class AlarmServerNode extends AlarmClientNode
 
             if (! Objects.equals(this.severity_pv_name, severity_pv_name))
             {
+                logger.log(Level.INFO, "Changing severity PV for " + getPathName() + " from '" + this.severity_pv_name + "' to '" + severity_pv_name + "'");
+                SeverityPVHandler.clear(this.severity_pv_name);
                 this.severity_pv_name = severity_pv_name;
                 // Initial update, since severity may not change for a while
                 if (severity_pv_name != null)

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/SeverityPVHandler.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/SeverityPVHandler.java
@@ -36,14 +36,15 @@ public class SeverityPVHandler
     // this value is not written to the PV right away for two reasons:
     //
     // 1) This could result in many updates. Channel Access/PV Access might
-    //    suppress intermediate values and so will displays, but we want to coalesce
-    //    multiple updates to the same PV.
-    // 2) For alarm with few changes, imagine that the IOC hosting the PV is down so PV cannot be written,
-    //    Once IOC then comes back up, severity PV would have wrong value until the alarm state changes.
+    //    suppress intermediate values and displays also tend to throttle updates,
+    //    but we want to coalesce updates at the source to reduce overall traffic.
+    // 2) For alarms with few changes, imagine that the IOC hosting the PV is down so PV cannot be written.
+    //    Once the IOC reappears on the network, severity PV would have wrong value
+    //    until the alarm state changes and the PV is then written.
     //
-    // 'updates' thus tracks the most recent value for each PV.
-    // Separate thread writes them to PVs and - on success - removes from 'updates'.
-    // Map coalesces multiple updates to a PV between writes,
+    // To avoid both issues, 'updates' tracks the most recent value for each PV,
+    // and a separate thread 'updates' to PVs and - on success - removes from 'updates'.
+    // The map coalesces multiple updates to a PV between writes,
     // and writes to missing PVs are repeated until they succeed.
 
     /** PVs that are currently handled */


### PR DESCRIPTION
When changing the configuration, old PVs that could not be written were left in the 'updates' map, so server continued attempts to write them, and their timeout delayed updates to valid severity PVs.

Now writes to "sevrpv:" PVs have a separately configurable timeout (default 5 sec), and when a "sevrpv:" setting is changed, updates for the previously used PV that might still be pending are cleared.