### PR TITLE
Clear border_time for historic samples in Data Browser

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/HistoricSamples.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/HistoricSamples.java
@@ -158,5 +158,6 @@ public class HistoricSamples extends PlotSamples
     {
         visible_size = 0;
         samples = new PlotSample[0];
+        border_time = Optional.empty();
     }
 }


### PR DESCRIPTION
Handles a corner case where refreshing a plot may produce a different result compared to the plot rendered before refresh.
See #2647.