### PR TITLE
Updating ImageDecoder to allow null names from #2659

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/pva/ImageDecoder.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/ImageDecoder.java
@@ -202,7 +202,7 @@ public class ImageDecoder
         if (codec_info != null)
         {
             final PVAString name = codec_info.get("name");
-            if (name != null  &&  !name.get().isBlank())
+            if (name != null  &&  name.get() != null && !name.get().isBlank())
             {
                 // For compressed data, values is ubyte[] and
                 // codec.parameters holds original data type code


### PR DESCRIPTION
This might actually be contentious if others want to catch "improper" NTNDArrays, but it already is allowing blank names, so a null name isn't too different.

This is a PR in reference to #2659 