### PR TITLE
Secure PVA demo

### DIFF
--- a/core/pva/TLS.md
+++ b/core/pva/TLS.md
@@ -99,5 +99,30 @@ Then run a demo client
 java -cp target/classes org/epics/pva/client/PVAClientMain monitor demo
 ```
 
+
+More
+----
+
 Add `-Djavax.net.debug=all` to see encryption information.
+
+For example, when receiving subscription updates for a string PV with status and timestamp,
+the log messages indicate that the encrypted data size of 74 bytes is almost twice the size
+of the decrypted payload of 41 bytes: 
+
+```
+javax.net.ssl|DEBUG|91|TCP receiver /127.0.0.1|2023-05-05 15:57:37.299 EDT|SSLSocketInputRecord.java:214|READ: TLSv1.2 application_data, length = 74
+javax.net.ssl|DEBUG|91|TCP receiver /127.0.0.1|2023-05-05 15:57:37.299 EDT|SSLSocketInputRecord.java:493|Raw read (
+  0000: 65 27 79 1D 33 5D 7C AB   A6 06 86 31 0D 9C 10 70  e'y.3].....1...p
+  0010: 3C 85 58 D3 FD AA 81 57   00 0A 04 DF 37 3D EE 31  <.X....W....7=.1
+  0020: C4 2A CE E5 24 A3 E8 F3   F2 B6 7E 64 BE 32 9E 71  .*..$......d.2.q
+  0030: F8 29 81 C4 3F 61 D0 E4   D1 D5 A7 BC 5A 21 D0 B8  .)..?a......Z!..
+  0040: F5 5F DD 5E DE 59 79 F8   45 86                    ._.^.Yy.E.
+)
+javax.net.ssl|DEBUG|91|TCP receiver /127.0.0.1|2023-05-05 15:57:37.300 EDT|SSLCipher.java:1935|Plaintext after DECRYPTION (
+  0000: CA 02 40 0D 21 00 00 00   01 00 00 00 00 02 02 03  ..@.!...........
+  0010: 0B 56 61 6C 75 65 20 69   73 20 38 33 B1 5F 55 64  .Value is 83._Ud
+  0020: 00 00 00 00 10 0E AD 11   00                       .........
+```
+
+
 

--- a/core/pva/TLS.md
+++ b/core/pva/TLS.md
@@ -89,7 +89,7 @@ Step 4: Configure and run the demo client
 Set environment variables to inform the server about its keystore:
 
 ```
-export EPICS_PVA_SERVER_KEYSTORE=/path/to/KEYSTORE
+export EPICS_PVA_CLIENT_TRUSTSTORE=/path/to/TRUSTSTORE
 export EPICS_PVA_STOREPASS=changeit
 ```
 

--- a/core/pva/TLS.md
+++ b/core/pva/TLS.md
@@ -1,0 +1,103 @@
+Secure Socket Support
+=====================
+
+The server and client provide a simple preview of TLS-enabled "secure socket" communication.
+
+By default, the server and client will use plain TCP sockets to communicate.
+By configuring a keystore for the server and a truststore for the client,
+the communication can be switched to secure (TLS) sockets.
+The sockets are encrypted, and clients will only communicate with trusted servers.
+
+Step 1: Create a server KEYSTORE that contains a public and private key.
+-------
+
+The server passes the public key to clients. Clients then use that to encrypt messages
+to the server which only the server can decode with its private key.
+
+```
+keytool -genkey -alias mykey -keystore KEYSTORE -keyalg RSA
+```
+
+Use password `changeit`.
+
+
+To check, note "Entry type: PrivateKeyEntry" because the certificate holds both a public and private key:
+
+```
+keytool -list -v -keystore KEYSTORE
+```
+
+This example so far only uses self-signed certificates.
+An operational setup might prefer to sign them by a publicly trusted certificate authority.
+
+
+Step 2: Create a client TRUSTSTORE to register the public server key
+-------
+
+Clients check this list of public keys to identify trusted servers.
+Clients can technically use the keystore we just created, but
+they should really only have access to the server's public key.
+In addition, you may want to add public keys from more than one server into
+the client truststore.
+
+First export the server's public key.
+
+```
+keytool -export -alias mykey -keystore KEYSTORE -rfc -file mykey.cer
+```
+
+Import the certificate into a new client truststore.
+
+```
+keytool -import -alias mykey -file mykey.cer -keystore TRUSTSTORE
+```
+
+To check, note "Entry type: trustedCertEntry" because the truststore contains only public keys:
+
+```
+keytool -list -v -keystore TRUSTSTORE
+```
+
+While the key and trust files were created with the Java keytool,
+they are compatible with generic open SSL tools:
+
+```
+openssl pkcs12 -info -in KEYSTORE -nodes
+```
+
+
+Step 3: Configure and run the demo server
+-------
+
+Set environment variables to inform the server about its keystore:
+
+```
+export EPICS_PVA_SERVER_KEYSTORE=/path/to/KEYSTORE
+export EPICS_PVA_STOREPASS=changeit
+```
+
+Then run a demo server
+
+```
+java -cp target/classes org/epics/pva/server/ServerDemo
+```
+
+
+Step 4: Configure and run the demo client
+-------
+
+Set environment variables to inform the server about its keystore:
+
+```
+export EPICS_PVA_SERVER_KEYSTORE=/path/to/KEYSTORE
+export EPICS_PVA_STOREPASS=changeit
+```
+
+Then run a demo client
+
+```
+java -cp target/classes org/epics/pva/client/PVAClientMain monitor demo
+```
+
+Add `-Djavax.net.debug=all` to see encryption information.
+

--- a/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
@@ -22,12 +22,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
-import javax.net.SocketFactory;
-
 import org.epics.pva.PVASettings;
 import org.epics.pva.common.CommandHandlers;
 import org.epics.pva.common.PVAHeader;
 import org.epics.pva.common.RequestEncoder;
+import org.epics.pva.common.SecureSockets;
 import org.epics.pva.common.TCPHandler;
 import org.epics.pva.data.PVATypeRegistry;
 import org.epics.pva.server.Guid;
@@ -120,7 +119,7 @@ class ClientTCPHandler extends TCPHandler
 
     private static Socket createSocket(InetSocketAddress address) throws Exception
     {
-        final Socket socket = SocketFactory.getDefault().createSocket(address.getAddress(), address.getPort());
+        final Socket socket = SecureSockets.getClientFactory().createSocket(address.getAddress(), address.getPort());
         socket.setTcpNoDelay(true);
         socket.setKeepAlive(true);
         return socket;

--- a/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,8 @@ package org.epics.pva.client;
 import static org.epics.pva.PVASettings.logger;
 
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.nio.ByteBuffer;
-import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -21,6 +21,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
+
+import javax.net.SocketFactory;
 
 import org.epics.pva.PVASettings;
 import org.epics.pva.common.CommandHandlers;
@@ -116,12 +118,11 @@ class ClientTCPHandler extends TCPHandler
         // it's started when server confirms the connection.
     }
 
-    private static SocketChannel createSocket(InetSocketAddress address) throws Exception
+    private static Socket createSocket(InetSocketAddress address) throws Exception
     {
-        final SocketChannel socket = SocketChannel.open(address);
-        socket.configureBlocking(true);
-        socket.socket().setTcpNoDelay(true);
-        socket.socket().setKeepAlive(true);
+        final Socket socket = SocketFactory.getDefault().createSocket(address.getAddress(), address.getPort());
+        socket.setTcpNoDelay(true);
+        socket.setKeepAlive(true);
         return socket;
     }
 

--- a/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.epics.pva.common;
+
+import static org.epics.pva.PVASettings.logger;
+
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import java.util.logging.Level;
+
+import javax.net.ServerSocketFactory;
+import javax.net.SocketFactory;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+/** Helpers for creating secure sockets
+ *
+ *  By default, provide plain TCP sockets.
+ *
+ *  To enable TLS sockets, EPICS_PVA_SERVER_KEYSTORE can be set to
+ *  select a keystore for the server, and EPICS_PVA_CLIENT_TRUSTSTORE can define
+ *  a trust store for the client.
+ *  The optional password for both is in EPICS_PVA_STOREPASS.
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class SecureSockets
+{
+    private static ServerSocketFactory server_sockets;
+    private static SocketFactory client_sockets;
+
+    private static synchronized void initialize() throws Exception
+    {
+        final String pass = System.getenv("EPICS_PVA_STOREPASS");
+        final char[] password = pass != null ? pass.toCharArray() : null;
+
+        final String keyfile = System.getenv("EPICS_PVA_SERVER_KEYSTORE");
+        if (keyfile != null  &&  keyfile.length() > 0)
+        {
+            logger.log(Level.INFO, "Loading keystore '" + keyfile + "'");
+            final KeyStore key_store = KeyStore.getInstance("PKCS12");
+            key_store.load(new FileInputStream(keyfile), password);
+
+            final KeyManagerFactory key_manager = KeyManagerFactory.getInstance("PKIX");
+            key_manager.init(key_store, password);
+
+            final SSLContext context = SSLContext.getInstance("TLS");
+            context.init(key_manager.getKeyManagers(), null, null);
+
+            server_sockets = context.getServerSocketFactory();
+        }
+        else
+            server_sockets = ServerSocketFactory.getDefault();
+
+        final String trustfile = System.getenv("EPICS_PVA_CLIENT_TRUSTSTORE");
+        if (trustfile != null  &&  trustfile.length() > 0)
+        {
+            logger.log(Level.INFO, "Loading truststore '" + trustfile + "'");
+            final KeyStore trust_store = KeyStore.getInstance("PKCS12");
+            trust_store.load(new FileInputStream(trustfile), password);
+
+            final TrustManagerFactory trust_manager = TrustManagerFactory.getInstance("PKIX");
+            trust_manager.init(trust_store);
+
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(null, trust_manager.getTrustManagers(), null);
+
+            client_sockets = context.getSocketFactory();
+        }
+        else
+            client_sockets = SocketFactory.getDefault();
+    }
+
+    /** @return Factory for plain or secure server sockets
+     *  @throws Exception on error
+     */
+    public static ServerSocketFactory getServerFactory() throws Exception
+    {
+        initialize();
+        return server_sockets;
+    }
+
+    /** @return Factory for plain or secure client sockets
+     *  @throws Exception on error
+     */
+    public static SocketFactory getClientFactory() throws Exception
+    {
+        initialize();
+        return client_sockets;
+    }
+}

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,8 @@ package org.epics.pva.server;
 import static org.epics.pva.PVASettings.logger;
 
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.nio.ByteBuffer;
-import java.nio.channels.SocketChannel;
 import java.util.logging.Level;
 
 import org.epics.pva.common.CommandHandlers;
@@ -53,7 +53,7 @@ class ServerTCPHandler extends TCPHandler
     /** Auth info, e.g. client user info and his/her permissions */
     private volatile ServerAuth auth = ServerAuth.Anonymous;
 
-    public ServerTCPHandler(final PVAServer server, final SocketChannel client) throws Exception
+    public ServerTCPHandler(final PVAServer server, final Socket client) throws Exception
     {
         super(client, false);
         this.server = server;

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPListener.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPListener.java
@@ -20,9 +20,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-import javax.net.ServerSocketFactory;
-
 import org.epics.pva.PVASettings;
+import org.epics.pva.common.SecureSockets;
 
 /** Listen to TCP connections
  *
@@ -160,7 +159,7 @@ class ServerTCPListener
      */
     private static ServerSocket createBoundSocket(final InetSocketAddress addr) throws Exception
     {
-        final ServerSocket socket = ServerSocketFactory.getDefault().createServerSocket();
+        final ServerSocket socket = SecureSockets.getServerFactory().createServerSocket();
         try
         {
             socket.setReuseAddress(true);


### PR DESCRIPTION
Adds environment variables EPICS_PVA_SERVER_KEYSTORE, EPICS_PVA_CLIENT_TRUSTSTORE.
When configured, the server and client use TLS sockets for the TCP communication.
In combination with TCP name lookup, the communication can thus be fully encrypted. Moreover, clients will only communicate with known servers.

TLS.md gives details.

This is of course a limited demo because only servers based on core-pva will support the TLS sockets,
there is no support for runtime changes to the certificates,
and it's an all or nothing approach, not concurrently allowing both plain and secure connections.
Nevertheless, it's a first demo and has no impact unless EPICS_PVA_SERVER_KEYSTORE and EPICS_PVA_CLIENT_TRUSTSTORE are defined.