### PR TITLE
MEDM Converter: Turn "oval" or "rectangle" with alarm-sensitive fill into MultiStateLED

### DIFF
--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/AbstractADL2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/AbstractADL2Model.java
@@ -177,7 +177,7 @@ public abstract class AbstractADL2Model<WM extends Widget>
         if (dynAttr.getClrMode().equals("alarm")  &&  dynAttr.get_chan() != null)
         {
             // Attach script that sets background color based on alarm severity
-            final String embedded_script =
+            String embedded_script =
                 "from org.csstudio.display.builder.runtime.script import PVUtil\n" +
                 "from org.csstudio.display.builder.model.persist import WidgetColorService\n" +
                 "sevr = PVUtil.getSeverity(pvs[0])\n" +
@@ -193,6 +193,9 @@ public abstract class AbstractADL2Model<WM extends Widget>
                 "    name = 'OK'\n" +
                 "color = WidgetColorService.getColor(name)\n" +
                 "widget.setPropertyValue('background_color', color)\n";
+            // Also set optional line color
+            if (widgetModel.checkProperty("line_color").isPresent())
+                embedded_script += "widget.setPropertyValue('line_color', color)\n";
             final ScriptInfo script = new ScriptInfo(ScriptInfo.EMBEDDED_PYTHON,
                                                      embedded_script,
                                                      true,

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Oval2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Oval2Model.java
@@ -8,13 +8,17 @@ package org.csstudio.opibuilder.adl2boy.translator;
 
 import org.csstudio.display.builder.model.ChildrenProperty;
 import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.persist.NamedWidgetColors;
+import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.widgets.EllipseWidget;
+import org.csstudio.display.builder.model.widgets.MultiStateLEDWidget;
 import org.csstudio.utility.adlparser.fileParser.ADLWidget;
+import org.csstudio.utility.adlparser.fileParser.widgetParts.ADLDynamicAttribute;
 import org.csstudio.utility.adlparser.fileParser.widgets.ADLAbstractWidget;
 import org.csstudio.utility.adlparser.fileParser.widgets.Oval;
 
-public class Oval2Model extends AbstractADL2Model<EllipseWidget> {
+public class Oval2Model extends AbstractADL2Model<Widget> {
 
     public Oval2Model(ADLWidget adlWidget, WidgetColor[] colorMap, Widget parentModel) throws Exception {
         super(adlWidget, colorMap, parentModel);
@@ -31,6 +35,51 @@ public class Oval2Model extends AbstractADL2Model<EllipseWidget> {
         //check fill parameters
         if ( ovalWidget.hasADLBasicAttribute() ) {
             setShapesColorFillLine(ovalWidget);
+        }
+
+        // Does this filled (not just outline) Oval change color based on alarm?
+        // -> Replaced with LED
+        if (ovalWidget.hasADLDynamicAttribute())
+        {
+            final ADLDynamicAttribute dynAttr = ovalWidget.getAdlDynamicAttribute();
+            if (ovalWidget.hasADLBasicAttribute()                               &&
+                !"outline".equals(ovalWidget.getAdlBasicAttribute().getFill())  &&
+                dynAttr.getClrMode().equals("alarm")                            &&
+                dynAttr.get_chan() != null)
+            {
+                final MultiStateLEDWidget led = new MultiStateLEDWidget();
+                TranslatorUtils.copyPosAndSize(widgetModel, led);
+
+                led.propName().setValue(widgetModel.getName());
+
+                // Configure PV and alarm-type colors for states
+                led.propPVName().setValue("=highestSeverity(`" + dynAttr.get_chan() + "`)");
+                led.propBorderAlarmSensitive().setValue(false);
+
+                while (led.propStates().size() < 5)
+                    led.propStates().addElement();
+                led.propStates().getElement(0).label().setValue("");
+                led.propStates().getElement(0).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_OK));
+                led.propStates().getElement(1).label().setValue("");
+                led.propStates().getElement(1).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_MINOR));
+                led.propStates().getElement(2).label().setValue("");
+                led.propStates().getElement(2).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_MAJOR));
+                led.propStates().getElement(3).label().setValue("");
+                led.propStates().getElement(3).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_INVALID));
+                led.propStates().getElement(4).label().setValue("");
+                led.propStates().getElement(4).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_DISCONNECTED));
+
+                // LED has a fixed outline, the 'filled' oval doesn't.
+                // Could add a script to color the outline the same as the LED body, but that's a lot of overhead.
+                // Leaving the default gray border? To make it look closer to MEDM, turn outline transparent.
+                led.propLineColor().setValue(NamedWidgetColors.TRANSPARENT);
+
+                // Replace EllipseWidget with led
+                final Widget parent = widgetModel.getParent().get();
+                ChildrenProperty.getChildren(parent).removeChild(widgetModel);
+                ChildrenProperty.getChildren(parent).addChild(led);
+                widgetModel = led;
+            }
         }
     }
 

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Oval2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Oval2Model.java
@@ -13,6 +13,7 @@ import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.widgets.EllipseWidget;
 import org.csstudio.display.builder.model.widgets.MultiStateLEDWidget;
+import org.csstudio.display.builder.model.widgets.RectangleWidget;
 import org.csstudio.utility.adlparser.fileParser.ADLWidget;
 import org.csstudio.utility.adlparser.fileParser.widgetParts.ADLDynamicAttribute;
 import org.csstudio.utility.adlparser.fileParser.widgets.ADLAbstractWidget;
@@ -37,50 +38,7 @@ public class Oval2Model extends AbstractADL2Model<Widget> {
             setShapesColorFillLine(ovalWidget);
         }
 
-        // Does this filled (not just outline) Oval change color based on alarm?
-        // -> Replaced with LED
-        if (ovalWidget.hasADLDynamicAttribute())
-        {
-            final ADLDynamicAttribute dynAttr = ovalWidget.getAdlDynamicAttribute();
-            if (ovalWidget.hasADLBasicAttribute()                               &&
-                !"outline".equals(ovalWidget.getAdlBasicAttribute().getFill())  &&
-                dynAttr.getClrMode().equals("alarm")                            &&
-                dynAttr.get_chan() != null)
-            {
-                final MultiStateLEDWidget led = new MultiStateLEDWidget();
-                TranslatorUtils.copyPosAndSize(widgetModel, led);
-
-                led.propName().setValue(widgetModel.getName());
-
-                // Configure PV and alarm-type colors for states
-                led.propPVName().setValue("=highestSeverity(`" + dynAttr.get_chan() + "`)");
-                led.propBorderAlarmSensitive().setValue(false);
-
-                while (led.propStates().size() < 5)
-                    led.propStates().addElement();
-                led.propStates().getElement(0).label().setValue("");
-                led.propStates().getElement(0).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_OK));
-                led.propStates().getElement(1).label().setValue("");
-                led.propStates().getElement(1).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_MINOR));
-                led.propStates().getElement(2).label().setValue("");
-                led.propStates().getElement(2).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_MAJOR));
-                led.propStates().getElement(3).label().setValue("");
-                led.propStates().getElement(3).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_INVALID));
-                led.propStates().getElement(4).label().setValue("");
-                led.propStates().getElement(4).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_DISCONNECTED));
-
-                // LED has a fixed outline, the 'filled' oval doesn't.
-                // Could add a script to color the outline the same as the LED body, but that's a lot of overhead.
-                // Leaving the default gray border? To make it look closer to MEDM, turn outline transparent.
-                led.propLineColor().setValue(NamedWidgetColors.TRANSPARENT);
-
-                // Replace EllipseWidget with led
-                final Widget parent = widgetModel.getParent().get();
-                ChildrenProperty.getChildren(parent).removeChild(widgetModel);
-                ChildrenProperty.getChildren(parent).addChild(led);
-                widgetModel = led;
-            }
-        }
+        widgetModel = updateAlarmShapeToLED(ovalWidget, widgetModel);
     }
 
     @Override
@@ -88,5 +46,59 @@ public class Oval2Model extends AbstractADL2Model<Widget> {
             Widget parentModel) {
         widgetModel = new EllipseWidget();
         ChildrenProperty.getChildren(parentModel).addChild(widgetModel);
+    }
+
+    /** Convert alarm-colored shape into LED
+     *  @param shape MEDM oval or rectangle that might use a "dynamic" alarm color
+     *  @param initial Ellipse or RectangleWidget
+     *  @return Initial widget or LED
+     */
+    public static Widget updateAlarmShapeToLED(ADLAbstractWidget shape, Widget initial)
+    {
+        if (!shape.hasADLBasicAttribute() || !shape.hasADLDynamicAttribute())
+            return initial;
+
+        // Does this filled (not just outline) shape change color based on alarm?
+        final ADLDynamicAttribute dynAttr = shape.getAdlDynamicAttribute();
+        if ("outline".equals(shape.getAdlBasicAttribute().getFill())  ||
+            !dynAttr.getClrMode().equals("alarm")                     ||
+            dynAttr.get_chan() == null)
+            return initial;
+
+        // Replace with LED
+        final MultiStateLEDWidget led = new MultiStateLEDWidget();
+        TranslatorUtils.copyPosAndSize(initial, led);
+        led.propName().setValue(initial.getName());
+        led.propSquare().setValue(initial instanceof RectangleWidget);
+
+        // Read alarm severity of PV
+        led.propPVName().setValue("=highestSeverity(`" + dynAttr.get_chan() + "`)");
+        led.propBorderAlarmSensitive().setValue(false);
+
+        // Alarm-type colors for states
+        while (led.propStates().size() < 5)
+            led.propStates().addElement();
+        led.propStates().getElement(0).label().setValue("");
+        led.propStates().getElement(0).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_OK));
+        led.propStates().getElement(1).label().setValue("");
+        led.propStates().getElement(1).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_MINOR));
+        led.propStates().getElement(2).label().setValue("");
+        led.propStates().getElement(2).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_MAJOR));
+        led.propStates().getElement(3).label().setValue("");
+        led.propStates().getElement(3).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_INVALID));
+        led.propStates().getElement(4).label().setValue("");
+        led.propStates().getElement(4).color().setValue(WidgetColorService.getColor(NamedWidgetColors.ALARM_DISCONNECTED));
+
+        // LED has a fixed outline, the 'filled' oval doesn't.
+        // Could add a script to color the outline the same as the LED body, but that's a lot of overhead.
+        // Leaving the default gray border? To make it look closer to MEDM, turn outline transparent.
+        led.propLineColor().setValue(NamedWidgetColors.TRANSPARENT);
+
+        // Replace initial widget with led
+        final Widget parent = initial.getParent().get();
+        ChildrenProperty.getChildren(parent).removeChild(initial);
+        ChildrenProperty.getChildren(parent).addChild(led);
+
+        return led;
     }
 }

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Rectangle2Model.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/Rectangle2Model.java
@@ -14,7 +14,7 @@ import org.csstudio.utility.adlparser.fileParser.ADLWidget;
 import org.csstudio.utility.adlparser.fileParser.widgets.ADLAbstractWidget;
 import org.csstudio.utility.adlparser.fileParser.widgets.Rectangle;
 
-public class Rectangle2Model extends AbstractADL2Model<RectangleWidget> {
+public class Rectangle2Model extends AbstractADL2Model<Widget> {
 
     public Rectangle2Model(ADLWidget adlWidget, WidgetColor[] colorMap, Widget parentModel) throws Exception {
         super(adlWidget, colorMap, parentModel);
@@ -31,6 +31,8 @@ public class Rectangle2Model extends AbstractADL2Model<RectangleWidget> {
         //check fill parameters
         if ( rectWidget.hasADLBasicAttribute() )
             setShapesColorFillLine(rectWidget);
+
+        widgetModel = Oval2Model.updateAlarmShapeToLED(rectWidget, widgetModel);
     }
 
     @Override

--- a/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/TranslatorUtils.java
+++ b/app/display/convert-medm/src/main/java/org/csstudio/opibuilder/adl2boy/translator/TranslatorUtils.java
@@ -5,6 +5,7 @@
 /*************************************************************************/
 package org.csstudio.opibuilder.adl2boy.translator;
 
+import org.csstudio.display.builder.model.Widget;
 import org.csstudio.utility.adlparser.fileParser.ADLWidget;
 import org.csstudio.utility.adlparser.fileParser.WrongADLFormatException;
 import org.csstudio.utility.adlparser.fileParser.widgetParts.ADLBasicAttribute;
@@ -37,5 +38,13 @@ public class TranslatorUtils
             child.setType("dynamic attribute");
             defaultDynamicAttribute = new ADLDynamicAttribute(child);
         }
+    }
+
+    public static void copyPosAndSize(Widget source, Widget dest)
+    {
+        dest.propX().setValue(source.propX().getValue());
+        dest.propY().setValue(source.propY().getValue());
+        dest.propWidth().setValue(source.propWidth().getValue());
+        dest.propHeight().setValue(source.propHeight().getValue());
     }
 }


### PR DESCRIPTION
Tweak converter for example provided by @MarkRivers
If the shape is not filled but just an outline, support alarm-colored outline in the script.
For filled "oval" and "rectangle", avoid the script and instead create a MultiStateLED with `=highestSeverity(..)` as a PV