### PR TITLE
EDM: Convert circle or rect. with dynamic color into (MultiState)LED

### DIFF
--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeCircleClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeCircleClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,6 +8,7 @@
 package org.csstudio.display.converter.edm.widgets;
 
 import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.widgets.BaseLEDWidget;
 import org.csstudio.display.builder.model.widgets.EllipseWidget;
 import org.csstudio.display.converter.edm.EdmConverter;
 import org.csstudio.opibuilder.converter.model.EdmWidget;
@@ -18,33 +19,40 @@ import org.csstudio.opibuilder.converter.model.Edm_activeCircleClass;
  *  @author Matevz, Lei Hu, Xihui Chen et al - Original logic in Opi_.. converter
  */
 @SuppressWarnings("nls")
-public class Convert_activeCircleClass extends ConverterBase<EllipseWidget>
+public class Convert_activeCircleClass extends ConverterBase<Widget>
 {
     public Convert_activeCircleClass(final EdmConverter converter, final Widget parent, final Edm_activeCircleClass r)
     {
         super(converter, parent, r);
+
+        EllipseWidget ell = (EllipseWidget) widget;
 
         // No 'dash' support
         //if (r.getLineStyle().isExistInEDL()  &&
         //    r.getLineStyle().get() == EdmLineStyle.DASH)
 
         if (r.getAttribute("lineWidth").isExistInEDL())
-            widget.propLineWidth().setValue(r.getLineWidth());
+            ell.propLineWidth().setValue(r.getLineWidth());
         else
-            widget.propLineWidth().setValue(1);
-        widget.propTransparent().setValue(! r.isFill());
+            ell.propLineWidth().setValue(1);
+        ell.propTransparent().setValue(! r.isFill());
 
         if (r.isLineAlarm())
-            createAlarmColor(r.getAlarmPv(), widget.propLineColor());
+            createAlarmColor(r.getAlarmPv(), ell.propLineColor());
         else
-            convertColor(r.getLineColor(), r.getAlarmPv(), widget.propLineColor());
+            convertColor(r.getLineColor(), r.getAlarmPv(), ell.propLineColor());
 
         if (r.isFillAlarm()  &&  r.getAlarmPv() != null)
-            createAlarmColor(r.getAlarmPv(), widget.propBackgroundColor());
+            createAlarmColor(r.getAlarmPv(), ell.propBackgroundColor());
         else
-            convertColor(r.getFillColor(), r.getAlarmPv(), widget.propBackgroundColor());
+            convertColor(r.getFillColor(), r.getAlarmPv(), ell.propBackgroundColor());
 
-        widget.propVisible().setValue(!r.isInvisible());
+        ell.propVisible().setValue(!r.isInvisible());
+
+        widget = Convert_activeRectangleClass.convertShapeToLED(widget, r, r.isFillAlarm(), r.getFillColor(), r.getAlarmPv());
+
+        if (widget instanceof BaseLEDWidget)
+            ((BaseLEDWidget)widget).propSquare().setValue(false);
     }
 
     @Override

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeRectangleClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeRectangleClass.java
@@ -80,7 +80,7 @@ public class Convert_activeRectangleClass extends ConverterBase<Widget>
         if (!(fill_alarm || fillColor.isDynamic())  ||   pv_spec == null   ||  pv_spec.isBlank())
             return widget;
 
-        logger.log(Level.INFO, "Checking " + edm.getType() + " with dynamic color for LED conversion");
+        logger.log(Level.FINE, "Checking " + edm.getType() + " with dynamic color for LED conversion");
 
         String pv = convertPVName(pv_spec);
 
@@ -134,7 +134,7 @@ public class Convert_activeRectangleClass extends ConverterBase<Widget>
                         return widget;
                     }
                     final WidgetColor color = convertStaticColor(edm_color);
-                    logger.log(Level.INFO, String.format("State %d (%6.3f to %6.3f) --> %s",
+                    logger.log(Level.FINE, String.format("State %d (%6.3f to %6.3f) --> %s",
                                                          index,
                                                          start_end[0], start_end[1],
                                                          color.toString()));
@@ -142,7 +142,7 @@ public class Convert_activeRectangleClass extends ConverterBase<Widget>
                 }
                 else
                 {
-                    logger.log(Level.INFO, "Colors don't map to integer state ranges");
+                    logger.log(Level.FINE, "Colors don't map to integer state ranges");
                     return widget;
                 }
 

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeRectangleClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeRectangleClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,9 +7,25 @@
  *******************************************************************************/
 package org.csstudio.display.converter.edm.widgets;
 
+import static org.csstudio.display.converter.edm.Converter.logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.csstudio.display.builder.model.ChildrenProperty;
 import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.properties.WidgetColor;
+import org.csstudio.display.builder.model.widgets.BaseLEDWidget;
+import org.csstudio.display.builder.model.widgets.LEDWidget;
+import org.csstudio.display.builder.model.widgets.MultiStateLEDWidget;
 import org.csstudio.display.builder.model.widgets.RectangleWidget;
 import org.csstudio.display.converter.edm.EdmConverter;
+import org.csstudio.opibuilder.converter.model.EdmColor;
+import org.csstudio.opibuilder.converter.model.EdmModel;
 import org.csstudio.opibuilder.converter.model.EdmWidget;
 import org.csstudio.opibuilder.converter.model.Edm_activeRectangleClass;
 
@@ -18,7 +34,7 @@ import org.csstudio.opibuilder.converter.model.Edm_activeRectangleClass;
  *  @author Matevz, Lei Hu, Xihui Chen et al - Original logic in Opi_.. converter
  */
 @SuppressWarnings("nls")
-public class Convert_activeRectangleClass extends ConverterBase<RectangleWidget>
+public class Convert_activeRectangleClass extends ConverterBase<Widget>
 {
     public Convert_activeRectangleClass(final EdmConverter converter, final Widget parent, final Edm_activeRectangleClass r)
     {
@@ -28,7 +44,8 @@ public class Convert_activeRectangleClass extends ConverterBase<RectangleWidget>
         final int linewidth = Math.max(1,  r.getLineWidth());
 
         // EDM applies linewidth inside and outside of widget
-        widget.propLineWidth().setValue(linewidth);
+        final RectangleWidget rect = (RectangleWidget) widget;
+        rect.propLineWidth().setValue(linewidth);
         widget.propX().setValue(r.getX() - converter.getOffsetX() - linewidth/2);
         widget.propY().setValue(r.getY() - converter.getOffsetY() - linewidth/2);
         widget.propWidth().setValue(r.getW()+linewidth);
@@ -38,22 +55,185 @@ public class Convert_activeRectangleClass extends ConverterBase<RectangleWidget>
         //if (r.getLineStyle().isExistInEDL()  &&
         //    r.getLineStyle().get() == EdmLineStyle.DASH)
 
-        widget.propTransparent().setValue(! r.isFill());
+        rect.propTransparent().setValue(! r.isFill());
 
-        widget.propVisible().setValue(!r.isInvisible());
+        rect.propVisible().setValue(!r.isInvisible());
 
         if (r.isLineAlarm() && r.getAlarmPv() != null)
-            createAlarmColor(r.getAlarmPv(), widget.propLineColor());
+            createAlarmColor(r.getAlarmPv(), rect.propLineColor());
         else
-            convertColor(r.getLineColor(), r.getAlarmPv(), widget.propLineColor());
+            convertColor(r.getLineColor(), r.getAlarmPv(), rect.propLineColor());
         if (r.isFillAlarm() && r.getAlarmPv() != null)
-            createAlarmColor(r.getAlarmPv(), widget.propBackgroundColor());
+            createAlarmColor(r.getAlarmPv(), rect.propBackgroundColor());
         else
-            convertColor(r.getFillColor(), r.getAlarmPv(), widget.propBackgroundColor());
+            convertColor(r.getFillColor(), r.getAlarmPv(), rect.propBackgroundColor());
+
+        // Convert to LED?
+        widget = convertShapeToLED(widget, r, r.getFillColor(), r.getAlarmPv());
+    }
+
+    /** Can original widget be replaced with LED because shape uses dynamic color? */
+    protected static Widget convertShapeToLED(final Widget widget, final EdmWidget edm, final EdmColor fillColor, final String pv_spec)
+    {
+        if (!fillColor.isDynamic()  ||   pv_spec == null   ||  pv_spec.isBlank())
+            return widget;
+
+        logger.log(Level.INFO, "Checking " + edm.getType() + " with dynamic color for LED conversion");
+
+        final String pv = convertPVName(pv_spec);
+
+        // EDM dynamic colors are defined as ranges like this:
+        // >=-0.5 && <0.5: "color0"
+        // >=0.5  && <1.5: "color1"
+        // >=1.5  && <2.5: "color2"
+        // >=2.5  && <3.5: "color3"
+        // >=3.5  && <4.5: "color4"
+        // >=4.5  && <=5.5: "color5"
+        //
+        // In most cases, they are then used with enumerated or integer PVs
+        // so values 0, 1, .., 5 map to color0..5.
+        // We assume that case and try to create an LED or MultiStateLED
+        //
+        // If the EDM display was meant to be used with double values,
+        // this will fail.
+        // 1.9 that was resulting in color2 for EDM will now show color1...
+        final List<WidgetColor> colors = new ArrayList<>();
+        int index = 0;
+        for (Entry<String, String> entry : fillColor.getRuleMap().entrySet())
+        {
+            final double[] start_end = parseColorRange(entry.getKey());
+            if (// start...end surrounds   index +- 1
+                ((index-1) <  start_end[0]  &&  start_end[0] <= index  &&
+                 index     <= start_end[1]  &&  start_end[1] < (index+1))
+
+                // Or just start and open end
+                ||
+                ((index-1) <  start_end[0]  &&  start_end[0] <= index  &&
+                 Double.isNaN(start_end[1]))
+               )
+            {
+                final EdmColor edm_color = EdmModel.getColorsList().getColor(entry.getValue());
+                if (edm_color == null)
+                {
+                    logger.log(Level.WARNING, "Dynamic color uses unknown color " + entry.getValue());
+                    return widget;
+                }
+                final WidgetColor color = convertStaticColor(edm_color);
+                logger.log(Level.INFO, String.format("State %d (%6.3f to %6.3f) --> %s",
+                                                     index,
+                                                     start_end[0], start_end[1],
+                                                     color.toString()));
+                colors.add(color);
+            }
+            else
+            {
+                logger.log(Level.INFO, "Colors don't map to integer state ranges");
+                return widget;
+            }
+
+            ++index;
+        }
+
+        BaseLEDWidget replacement = null;
+        if (colors.size() == 2)
+        {
+            logger.log(Level.INFO, "Creating LED for " + pv);
+            logger.log(Level.INFO, "Off color " + colors.get(0));
+            logger.log(Level.INFO, "On  color " + colors.get(1));
+
+            // Create LED in place of original shape
+            final LEDWidget led = new LEDWidget();
+            led.propName().setValue(widget.propName().getValue());
+            led.propX().setValue(widget.propX().getValue());
+            led.propY().setValue(widget.propY().getValue());
+            led.propWidth().setValue(widget.propWidth().getValue());
+            led.propHeight().setValue(widget.propHeight().getValue());
+            led.propSquare().setValue(true);
+
+            // Instead of script, use plain PV and LED behavior
+            led.propPVName().setValue(pv);
+            led.propOffColor().setValue(colors.get(0));
+            led.propOnColor().setValue(colors.get(1));
+
+            // LED should ideally be alarm sensitive, but the shape wasn't, so keep it similar
+            led.propBorderAlarmSensitive().setValue(false);
+
+            replacement = led;
+        }
+        else if (colors.size() > 2)
+        {
+            logger.log(Level.INFO, "Creating MultiStateLED for " + colors.size() + " states of " + pv);
+            for (int i=0; i<colors.size(); ++i)
+                logger.log(Level.INFO, "State " + i + " color " + colors.get(i));
+
+            // Create LED in place of original shape
+            final MultiStateLEDWidget led = new MultiStateLEDWidget();
+            led.propName().setValue(widget.propName().getValue());
+            led.propX().setValue(widget.propX().getValue());
+            led.propY().setValue(widget.propY().getValue());
+            led.propWidth().setValue(widget.propWidth().getValue());
+            led.propHeight().setValue(widget.propHeight().getValue());
+            led.propSquare().setValue(true);
+
+            // Instead of script, use plain PV and LED behavior
+            led.propPVName().setValue(pv);
+            while (led.propStates().size() > colors.size())
+                led.propStates().removeElement();
+            while (led.propStates().size() < colors.size())
+                led.propStates().addElement();
+            for (int i=0; i<colors.size(); ++i)
+            {
+                led.propStates().getElement(i).color().setValue(colors.get(i));
+                led.propStates().getElement(i).label().setValue("");
+            }
+
+            // LED should ideally be alarm sensitive, but the shape wasn't, so keep it similar
+            led.propBorderAlarmSensitive().setValue(false);
+
+            replacement = led;
+        }
+
+        // Replace original shape with LED?
+        if (replacement == null)
+            return widget;
+
+        final ChildrenProperty parent_children = ChildrenProperty.getChildren(widget.getParent().get());
+        parent_children.removeChild(widget);
+        parent_children.addChild(replacement);
+        return replacement;
+    }
+
+
+    private static Pattern start_end = Pattern.compile("\\s*>=\\s*([-+]?[0-9]*\\.?[0-9]*)\\s*&&\\s*<=?\\s*([-+]?[0-9]*\\.?[0-9]*)\\s*");
+    private static Pattern start = Pattern.compile("\\s*>=?\\s*([-+]?[0-9]*\\.?[0-9]*)\\s*");
+
+    /** Parse start and end from ">=-0.5 && <0.5" or ">=4.5  && <=5.5" or just start from ">2.5"
+     *  @param range Range of EDM dynamic color
+     *  @return [start, end], either start or end may be NaN
+     */
+    protected static double[] parseColorRange(final String range)
+    {
+        Matcher matcher = start_end.matcher(range);
+        if (matcher.matches())
+            return new double[]
+            {
+                Double.parseDouble(matcher.group(1)),
+                Double.parseDouble(matcher.group(2))
+            };
+
+        matcher = start.matcher(range);
+        if (matcher.matches())
+            return new double[]
+            {
+                Double.parseDouble(matcher.group(1)),
+                Double.NaN
+            };
+
+        return new double[] { Double.NaN, Double.NaN };
     }
 
     @Override
-    protected RectangleWidget createWidget(final EdmWidget edm)
+    protected Widget createWidget(final EdmWidget edm)
     {
         return new RectangleWidget();
     }

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/ConverterBase.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/ConverterBase.java
@@ -200,8 +200,11 @@ public abstract class ConverterBase<W extends Widget>
     }
 
 
-    /** Find a '=' that is neither preceded by '<', '>', '=' nor followed by '=' */
-    private static final Pattern expand_equal = Pattern.compile("(?<![<>=])=(?!=)");
+    /** Find a single '=' that is neither preceded by '!', '<', '>', '=' nor followed by '='
+     *
+     *  Used to turn '=' into '==' but keep '!=', '<=', '>=', '==' unchanged
+     */
+    private static final Pattern expand_equal = Pattern.compile("(?<![<>=!])=(?!=)");
 
     /** @param expression EDM color rule expression like ">=5 && <10"
      *  @return Display Builder rule expression like "pv0>=5 && pv0<10"

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/ConverterBase.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/ConverterBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,7 +56,7 @@ import org.phoebus.core.vtypes.VTypeHelper;
 @SuppressWarnings("nls")
 public abstract class ConverterBase<W extends Widget>
 {
-    protected final W widget;
+    protected W widget;
 
     public ConverterBase(final EdmConverter converter, final Widget parent, final EdmWidget t)
     {
@@ -245,7 +245,7 @@ public abstract class ConverterBase<W extends Widget>
     /** @param edm Static EDM color
      *  @return {@link WidgetColor}
      */
-    private static WidgetColor convertStaticColor(final EdmColor edm)
+    protected static WidgetColor convertStaticColor(final EdmColor edm)
     {
         // EDM uses 16 bit color values
         final int red   = edm.getRed()   >> 8,

--- a/app/display/convert-edm/src/test/java/org/csstudio/display/converter/edm/CalcPvConverterTest.java
+++ b/app/display/convert-edm/src/test/java/org/csstudio/display/converter/edm/CalcPvConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,9 @@ public class CalcPvConverterTest extends TestHelper
 
         formula = ConverterBase.convertPVName("CALC\\{A+B+C=0?0:1}(HEBA, HUBA, CUBA)");
         assertThat(formula, equalTo("=`HEBA`+`HUBA`+`CUBA`==0?0:1"));
+
+        formula = ConverterBase.convertPVName("CALC\\{A=1&&B!=2}(HEBA, HUBA)");
+        assertThat(formula, equalTo("=`HEBA`==1&&`HUBA`!=2"));
 
         formula = ConverterBase.convertPVName("CALC\\{A+B+C+D+E+F+G+H+I+J+K+L=0?0:1}(SCL_Diag:PS_LW01:Off,SCL_Diag:PS_LW02:Off,SCL_Diag:PS_LW03:Off,SCL_Diag:PS_LW04:Off,SCL_Diag:PS_LW12:Off,SCL_Diag:PS_LW13:Off,SCL_Diag:PS_LW14:Off,SCL_Diag:PS_LW15:Off,SCL_Diag:PS_LW32:Off,LDmp_Diag:PS_LW01:Off,LDmp_Diag:PS_LW02:Off,LDmp_Diag:PS_LW03:Off)");
         assertThat(formula, equalTo("=`SCL_Diag:PS_LW01:Off`+`SCL_Diag:PS_LW02:Off`+`SCL_Diag:PS_LW03:Off`+`SCL_Diag:PS_LW04:Off`+`SCL_Diag:PS_LW12:Off`+`SCL_Diag:PS_LW13:Off`+`SCL_Diag:PS_LW14:Off`+`SCL_Diag:PS_LW15:Off`+`SCL_Diag:PS_LW32:Off`+`LDmp_Diag:PS_LW01:Off`+`LDmp_Diag:PS_LW02:Off`+`LDmp_Diag:PS_LW03:Off`==0?0:1"));


### PR DESCRIPTION
Similar to #2668, check if a circle or rect. has a dynamic color based on a PV or the alarm severity of a PV and convert into LED for 2 states or MultiStateLED when there are more than two states.

Compared to MEDM, EDM fundamentally allows arbitrary value ranges for dynamic colors.
They are typically defined like this:

```
>=-0.5 && <0.5: "color0"
>=0.5  && <1.5: "color1"
>=1.5  && <2.5: "color2"
>=2.5  && <3.5: "color3"
>=3.5  && <4.5: "color4"
>=4.5  && <=5.5: "color5"
```

.. and then used with enumerated or integer PVs so values 0, 1, .., 5 map to "color0..5".
We perform a basic check of the low..high value for each state and then try to create an `LED` or `MultiStateLED` if the states support basic 0, 1, 2, ... index mappings.

Note that if the EDM display was meant to be used with double values, this will fail. For example, a value of 1.9 that was resulting in "color2" for EDM will now show "color1".
In practice, this seems to be a rare exception because the majority of colored circles or rect. are used with  enumerated or integer PVs and converting them to LEDs is desired.
The converter does log all LED conversions at the INFO level.