### PR TITLE
CSSTUDIO-1905 Improve caching of ImageView of the widgets "Picture" and "Symbol"

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
@@ -58,7 +58,7 @@ public class PictureRepresentation extends JFXBaseRepresentation<ImageView, Pict
         final ImageView iv = new ImageView();
         iv.setSmooth(true);
         iv.setCache(true);
-        iv.setCacheHint(CacheHint.SCALE);
+        iv.setCacheHint(CacheHint.SCALE);  // Prevents excessive VRAM usage when zooming in using the D3D library for rendering under Windows.
         iv.getTransforms().addAll(translate, rotation);
         return iv;
     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
@@ -11,6 +11,7 @@ import static org.csstudio.display.builder.representation.ToolkitRepresentation.
 
 import java.util.logging.Level;
 
+import javafx.scene.CacheHint;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
@@ -56,6 +57,8 @@ public class PictureRepresentation extends JFXBaseRepresentation<ImageView, Pict
     {
         final ImageView iv = new ImageView();
         iv.setSmooth(true);
+        iv.setCache(true);
+        iv.setCacheHint(CacheHint.SCALE);
         iv.getTransforms().addAll(translate, rotation);
         return iv;
     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import javafx.scene.CacheHint;
 import org.csstudio.display.builder.model.ArrayWidgetProperty;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.DisplayModel;
@@ -412,6 +413,9 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
 
     @Override
     protected StackPane createJFXNode ( ) throws Exception {
+
+        imageView.setCache(true);
+        imageView.setCacheHint(CacheHint.SCALE); // Prevents excessive VRAM usage when zooming in using the D3D library for rendering under Windows.
 
         autoSize = model_widget.propAutoSize().getValue();
         symbol = new Symbol(); //getDefaultSymbol();


### PR DESCRIPTION
This merge-request fixes an issue with excessive VRAM usage when zooming in on a Picture or Symbol widget using the D3D library for rendering under Windows.

**Picture Widget.** When working on an OPI that contains a large image as a background that is rendered by an instance of the Picture widget, Phoebus would freeze and become unresponsive when zooming in on the OPI, when running Phoebus under Windows using the D3D library for rendering. Under Linux (using the ES2 driver for rendering), the Phoebus application remained responsive under the same circumstance.

A workaround was to launch Phoebus with the flag **-Dprism.maxvram=2048M** or higher, depending on the computer (the default value is 512M).

In contrast, Phoebus remained responsive under Linux even when launching Phoebus with the flag **-Dprism.maxvram=50M**.
(On the other hand, exceptions are thrown also under Linux with this low amount of VRAM in this circumstance, but the application doesn't freeze.)

Setting the cache hint of the `ImageView` that holds the displayed image to `Cache.Hint.SCALE` seems to solve the problem: Phoebus remains responsive under Windows even when launching Phoebus with the flag **-Dprism.maxvram=100M**. It therefore seems likely that the problem is related to the default caching policy of D3D somehow. As an additional benefit, zooming is much smoother under both Linux and Windows under this change.

**Symbol Widget.** Freezes are also observed when zooming in on OPIs that contain instances of the Symbol widget (even though the widget sizes are small). Setting the caching policy in the same way as for the Picture widget seems to solve this issue, as well, and it seems likely that the cause of the problem is the same as for the Picture widget.

**Reduced Image Quality?** It is of course possible that the quality of the rendered image is reduced, but to me it looks acceptable in the instance I am looking at. I don't know whether it would be preferable to disable caching after a zoom operation has completed?