### PR TITLE
Add widget path to widget info export

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetInfoDialog.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/WidgetInfoDialog.java
@@ -210,7 +210,13 @@ public class WidgetInfoDialog extends Dialog<Boolean>
         buffer.append("PVS (name, state, value, widget path)").append(System.lineSeparator())
                 .append(horizontalRuler).append(System.lineSeparator());
         pvs.stream().sorted(Comparator.comparing(pv -> pv.name)).forEach(pv -> {
-            buffer.append(pv.name).append(itemSeparator).append(pv.state).append(itemSeparator).append(getPVValue(pv.value)).append(System.lineSeparator());
+            buffer.append(pv.name).append(itemSeparator)
+                    .append(pv.state)
+                    .append(itemSeparator)
+                    .append(getPVValue(pv.value))
+                    .append(itemSeparator)
+                    .append(pv.path)
+                    .append(System.lineSeparator());
         });
         buffer.append(System.lineSeparator());
 


### PR DESCRIPTION
The export to file from widget info dialog did not include widget path, despite the header claiming it does.

This is a fix.