### PR TITLE
EDM converter: Use button's PV name in write PV action

### DIFF
--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeMessageButtonClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeMessageButtonClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -132,8 +132,9 @@ public class Convert_activeMessageButtonClass extends ConverterBase<Widget>
                     logger.log(Level.WARNING, "EDM message 'push' button '" + desc + "' lacks both 'press' and 'release'; writing empty string");
                 }
 
-                b.propActions().setValue(new ActionInfos(List.of(new WritePVActionInfo(desc, pv, value))));
-            }
+                // Set the button's $(pv_name) macro to the PV name, and use that within the write-PV action
+                b.propPVName().setValue(pv);
+                b.propActions().setValue(new ActionInfos(List.of(new WritePVActionInfo(desc, "$(pv_name)", value))));            }
 
             if (mb.getPassword() != null)
             {

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeMessageButtonClass.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/widgets/Convert_activeMessageButtonClass.java
@@ -134,7 +134,8 @@ public class Convert_activeMessageButtonClass extends ConverterBase<Widget>
 
                 // Set the button's $(pv_name) macro to the PV name, and use that within the write-PV action
                 b.propPVName().setValue(pv);
-                b.propActions().setValue(new ActionInfos(List.of(new WritePVActionInfo(desc, "$(pv_name)", value))));            }
+                b.propActions().setValue(new ActionInfos(List.of(new WritePVActionInfo(desc, "$(pv_name)", value))));
+            }
 
             if (mb.getPassword() != null)
             {


### PR DESCRIPTION
Assume an EDM display with a button that writes to a PV `$(P)$(R)FPGA:reboot`.
That used to be converted into this:

![before](https://github.com/ControlSystemStudio/phoebus/assets/1932421/76247267-5fea-4626-94bc-b2ce5afa68e7)

The action would write to the desired PV, but the GUI is a little confusing because the PV is only shown within the action.
That's not out of the oridinary, after all the display file that an open-display action opens is also only shown in the action itself, not the button. Besides, a button could have several options to write to more than one PV.
Still, for a button that writes to a PV having that button itself show an empty PV name can be confusing.

With this update, the display converted from EDM will use the following:

![nopw](https://github.com/ControlSystemStudio/phoebus/assets/1932421/84356b0e-88fa-407b-8d52-83eb90c97138)

The PV name is placed in the button's PV Name property, and the write-pv action fetches that as `$(pv_name)`, using the same default `$(pv_name)` for the action's PV name that you get when you interactively add a write PV action to a widget.