### PR TITLE
CSSTUDIO-1948 Add an option to the Phoebus-initialization file that sets the cache hint of images in the Picture- and Symbol widgets

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
@@ -12,6 +12,7 @@ import static org.csstudio.display.builder.representation.ToolkitRepresentation.
 import java.util.logging.Level;
 
 import javafx.scene.CacheHint;
+import javafx.scene.Node;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
@@ -22,6 +23,7 @@ import org.csstudio.display.builder.model.util.ModelResourceUtil;
 import org.csstudio.display.builder.model.util.ModelThreadPool;
 import org.csstudio.display.builder.model.widgets.PictureWidget;
 import org.csstudio.display.builder.representation.javafx.SVGHelper;
+import org.phoebus.ui.Preferences;
 import org.phoebus.ui.javafx.ImageCache;
 
 import javafx.scene.image.Image;
@@ -52,13 +54,46 @@ public class PictureRepresentation extends JFXBaseRepresentation<ImageView, Pict
     private volatile Rotate rotation = new Rotate(0);
     private volatile Translate translate = new Translate(0,0);
 
+    protected static void setCacheHintAccordingToPreferences(Node node) {
+        if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("") || Preferences.cache_hint_for_picture_and_symbol_widgets.equals("NONE")) {
+            // Use the default caching behavior.
+        }
+        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("DEFAULT")) {
+            node.setCache(true);
+            node.setCacheHint(CacheHint.DEFAULT);
+        }
+        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("SPEED")) {
+            node.setCache(true);
+            node.setCacheHint(CacheHint.SPEED);
+        }
+        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("QUALITY")) {
+            node.setCache(true);
+            node.setCacheHint(CacheHint.QUALITY);
+        }
+        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("SCALE")) {
+            node.setCache(true);
+            node.setCacheHint(CacheHint.SCALE);
+        }
+        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("ROTATE")) {
+            node.setCache(true);
+            node.setCacheHint(CacheHint.ROTATE);
+        }
+        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("SCALE_AND_ROTATE")) {
+            node.setCache(true);
+            node.setCacheHint(CacheHint.SCALE_AND_ROTATE);
+        }
+        else {
+            // Invalid option: log warning and use the default caching behavior.
+            logger.log(Level.WARNING, "The setting '" + Preferences.cache_hint_for_picture_and_symbol_widgets + "' is invalid for the setting 'caching_hint_for_picture_and_symbol_widgets' in the Phoebus initialization file! The default caching behavior will be used. Valid options are: 'NONE', 'DEFAULT', 'SPEED', 'QUALITY', 'SCALE', 'ROTATE', and 'SCALE_AND_ROTATE'.");
+        }
+    }
+
     @Override
     public ImageView createJFXNode() throws Exception
     {
         final ImageView iv = new ImageView();
         iv.setSmooth(true);
-        iv.setCache(true);
-        iv.setCacheHint(CacheHint.SCALE);  // Prevents excessive VRAM usage when zooming in using the D3D library for rendering under Windows.
+        setCacheHintAccordingToPreferences(iv);
         iv.getTransforms().addAll(translate, rotation);
         return iv;
     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
@@ -58,33 +58,21 @@ public class PictureRepresentation extends JFXBaseRepresentation<ImageView, Pict
         if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("") || Preferences.cache_hint_for_picture_and_symbol_widgets.equals("NONE")) {
             // Use the default caching behavior.
         }
-        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("DEFAULT")) {
-            node.setCache(true);
-            node.setCacheHint(CacheHint.DEFAULT);
-        }
-        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("SPEED")) {
-            node.setCache(true);
-            node.setCacheHint(CacheHint.SPEED);
-        }
-        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("QUALITY")) {
-            node.setCache(true);
-            node.setCacheHint(CacheHint.QUALITY);
-        }
-        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("SCALE")) {
-            node.setCache(true);
-            node.setCacheHint(CacheHint.SCALE);
-        }
-        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("ROTATE")) {
-            node.setCache(true);
-            node.setCacheHint(CacheHint.ROTATE);
-        }
-        else if (Preferences.cache_hint_for_picture_and_symbol_widgets.equals("SCALE_AND_ROTATE")) {
-            node.setCache(true);
-            node.setCacheHint(CacheHint.SCALE_AND_ROTATE);
-        }
         else {
-            // Invalid option: log warning and use the default caching behavior.
-            logger.log(Level.WARNING, "The setting '" + Preferences.cache_hint_for_picture_and_symbol_widgets + "' is invalid for the setting 'caching_hint_for_picture_and_symbol_widgets' in the Phoebus initialization file! The default caching behavior will be used. Valid options are: 'NONE', 'DEFAULT', 'SPEED', 'QUALITY', 'SCALE', 'ROTATE', and 'SCALE_AND_ROTATE'.");
+            CacheHint cacheHint = null;
+            try
+            {
+                cacheHint = CacheHint.valueOf(Preferences.cache_hint_for_picture_and_symbol_widgets);
+            }
+            catch (IllegalArgumentException ex)
+            {
+                logger.log(Level.WARNING, "The setting '" + Preferences.cache_hint_for_picture_and_symbol_widgets + "' is invalid for the setting 'caching_hint_for_picture_and_symbol_widgets' in the Phoebus initialization file! The default caching behavior will be used. Valid options are: 'NONE', 'DEFAULT', 'SPEED', 'QUALITY', 'SCALE', 'ROTATE', and 'SCALE_AND_ROTATE'.");
+            }
+
+            if (cacheHint != null) {
+                node.setCache(true);
+                node.setCacheHint(cacheHint);
+            }
         }
     }
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
-import javafx.scene.CacheHint;
 import org.csstudio.display.builder.model.ArrayWidgetProperty;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.DisplayModel;
@@ -414,8 +413,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
     @Override
     protected StackPane createJFXNode ( ) throws Exception {
 
-        imageView.setCache(true);
-        imageView.setCacheHint(CacheHint.SCALE); // Prevents excessive VRAM usage when zooming in using the D3D library for rendering under Windows.
+        PictureRepresentation.setCacheHintAccordingToPreferences(imageView);
 
         autoSize = model_widget.propAutoSize().getValue();
         symbol = new Symbol(); //getDefaultSymbol();

--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -52,6 +52,7 @@ public class Preferences
     @Preference public static int[] alarm_area_panel_major_severity_background_color;
     @Preference public static int[] alarm_area_panel_invalid_severity_background_color;
     @Preference public static int[] alarm_area_panel_undefined_severity_background_color;
+    @Preference public static String cache_hint_for_picture_and_symbol_widgets;
 
     static
     {

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -104,3 +104,27 @@ alarm_area_panel_invalid_severity_background_color=255,0,255
 
 alarm_area_panel_undefined_severity_text_color=192,192,192
 alarm_area_panel_undefined_severity_background_color=200,0,200,200
+
+# When Picture- and/or Symbol widgets are present in an OPI,
+# zooming in under Windows using the D3D graphics library can
+# cause excessive VRAM usage. Setting a cache hint can work as
+# a workaround. Since it has been observed that the cache hints
+# also can cause graphical errors, the setting of a cache hint
+# is a configurable option, which must explicitly be set to
+# have effect.
+#
+# The setting defaults to the default caching behavior.
+#
+# Valid options are:
+#       "" (the empty string) or "NONE" - The default caching behavior: caching is DISABLED, and the cache hint is set to "CacheHint.DEFAULT".
+#       "DEFAULT"                       - Caching is ENABLED, and the cache hint is set to "CacheHint.DEFAULT".
+#       "SPEED"                         - Based on very limited testing, this option seems to work the best as a workaround for the excessive VRAM usage.
+#       "QUALITY"
+#       "SCALE"                         - This option has been observed to cause graphical errors on several systems: rotated widgets have been observed to be translated instead of rotated.
+#       "ROTATE"
+#       "SCALE_AND_ROTATE"
+#
+# If an invalid option is entered, a warning is logged, and the
+# default caching behavior is used (i.e., caching is DISABLED,
+# and the cache hint is set to "CacheHint.DEFAULT").
+cache_hint_for_picture_and_symbol_widgets=


### PR DESCRIPTION
This pull-request implements a new option for the Phoebus-initialization that allows the setting of a cache hint for images in the Picture- and Symbol widgets. By default, the default caching behavior is used.

This merge-request is intended to fix the issue https://github.com/ControlSystemStudio/phoebus/issues/2695.

The code-structure is perhaps not optimal: the `protected static` method `setCacheHintAccordingToPreferences()` is placed in the class `PictureRepresentation`. This method is not only called from `PictureRepresentation`, but also from the class `SymbolRepresentation`. Placing the code in a separate class would be preferred from a structural point-of-view, however, it would introduce an additional class just for the purpose of declaring this method. It is also not difficult to refactor the code if the method needs to be used in other places, as well. If declaring the method in a separate class is preferred, I will change this.

The option that has been added to the Phoebus initialization file is called `cache_hint_for_picture_and_symbol_widgets`, which is very specific. The intention is that the meaning of the option is clearly defined, since it is a workaround around an issue that is not fully understood (and which we don't seem to have control over). A drawback with such a specific name is that if the workaround is to be extended to, e.g., other widgets in the future, then the name is not valid anymore.