### PR TITLE
Fix group inset usage when widget is deleted and restored

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -148,8 +148,13 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
 
             //  Reset position and size as if style == Style.NONE.
             int[] insets = new int[4];
-
-            System.arraycopy(model_widget.runtimePropInsets().getValue(), 0, insets, 0, insets.length);
+            // If the widget was deleted and then via 'undo' restored,
+            // this could be a first update while the model item
+            // contains the old 'inset' data.
+            // ==> Ignore 'inset' on first update,
+            // From then on, use the 'insets' which we compute and store below
+            if (! firstUpdate)
+                System.arraycopy(model_widget.runtimePropInsets().getValue(), 0, insets, 0, insets.length);
 
             final boolean hasChildren = !model_widget.runtimeChildren().getValue().isEmpty();
             if (hasChildren)


### PR DESCRIPTION
Fixes strange side effect.

Assume a group with some content:

<img width="239" alt="Screenshot 2023-06-13 at 3 31 16 PM" src="https://github.com/ControlSystemStudio/phoebus/assets/1932421/d8044a7e-da9b-4237-ae77-7644af3c4cdb">

Delete that widget, then restore it via "Undo". Could also use the "Sort Widget" option which will similarly remove and then re-add the widget as the widget order is updated. Either way, the result was this:

<img width="240" alt="Screenshot 2023-06-13 at 3 31 24 PM" src="https://github.com/ControlSystemStudio/phoebus/assets/1932421/0978a667-da20-4e05-a4f9-23fe2c8e6ad9">

The widget location and size remained unchanged, but the content got rendered with the wrong insets because the first update used insets stored in the widget properties from the previous representation.