### PR TITLE
pva: Recover from TCP connection error

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -262,9 +262,14 @@ public class PVAClient implements AutoCloseable
             }
             return null;
         });
-        // In case of connection errors (TCP connection blocked by firewall),
-        // tcp will be null
-        if (tcp != null)
+        // In case of connection errors, tcp will be null
+        if (tcp == null)
+        {   // Cannot connect to server on provided port? Likely a server or firewall problem.
+            // On the next search, that same server might reply and then we fail the same way on connect.
+            // Still, no way around re-registering the search so we succeed once the server is fixed.
+            search.register(channel, false /* not "now" but eventually */);
+        }
+        else
         {
             if (tcp.updateGuid(guid))
                 logger.log(Level.FINE, "Search-only TCP handler received GUID, now " + tcp);


### PR DESCRIPTION
.. by restarting the channel search.
@jacomago reported an issue where connections to a broken gateway resulted in replies to name searches via UDP but the TCP connection then failed.
A similar issue has recently been discussed for the channel access client, https://github.com/epics-base/jca/issues/36
The decision there was, yes, restarting the PV name search can create a loop where we keep getting the same search reply but the TCP connection then fails. Still, if we don't search the PV again, we'll never connect even after the server problem has been fixed.

This PR makes the PVA client restart searches when the TCP connection fails, with a short delay of 5 seconds and then backing off as usual, to prevent a tight loop.