### PR TITLE
CSSTUDIO-1928 Fix autoscale of logarithmic axes

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
@@ -263,9 +263,7 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
     public boolean setValueRange(T low, T high)
     {
         synchronized (this)
-        {   // Any change at all?
-            if (low.equals(range.getLow())  &&  high.equals(range.getHigh()))
-                return false;
+        {
             logger.log(Level.FINE, "Axis {0}: Value range {1} ... {2}",
                                    new Object[] { getName(), low, high });
             // Adjust range if necessary
@@ -277,6 +275,11 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
                 logger.log(Level.WARNING, "Axis {0}: Bad value range {1} ... {2}. Adjusting the range to {3} ... {4}.",
                                           new Object[] { getName(), low, high, newLow, newHigh });
             }
+
+            // Any change at all?
+            if (newLow.equals(range.getLow())  &&  newHigh.equals(range.getHigh()))
+                return false;
+
             range = new AxisRange<>(newLow, newHigh);
             transform.config(newLow, newHigh, low_screen, high_screen);
         }

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
@@ -268,17 +268,8 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
                 return false;
             logger.log(Level.FINE, "Axis {0}: Value range {1} ... {2}",
                                    new Object[] { getName(), low, high });
-            // Adjust range if necessary
-            Pair<T, T> possiblyNewLowAndHigh = ticks.adjustRange(low, high);
-            T newLow = possiblyNewLowAndHigh.getKey();
-            T newHigh = possiblyNewLowAndHigh.getValue();
-            if (newLow != low || newHigh != high)
-            {
-                logger.log(Level.WARNING, "Axis {0}: Bad value range {1} ... {2}. Adjusting the range to {3} ... {4}.",
-                                          new Object[] { getName(), low, high, newLow, newHigh });
-            }
-            range = new AxisRange<>(newLow, newHigh);
-            transform.config(newLow, newHigh, low_screen, high_screen);
+            range = new AxisRange<>(low, high);
+            transform.config(low, high, low_screen, high_screen);
         }
         dirty_ticks = true;
         requestLayout();
@@ -361,8 +352,7 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
     {
         if (! dirty_ticks)
             return;
-        Pair<T, T> adjustedRange = ticks.adjustRange(range.getLow(), range.getHigh());
-        range = new AxisRange<>(adjustedRange.getKey(), adjustedRange.getValue());
+
         if (horizontal)
             ticks.compute(range.getLow(), range.getHigh(), gc, getBounds().width);
         else

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
@@ -361,11 +361,12 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
     {
         if (! dirty_ticks)
             return;
-        final AxisRange<T> safe_range = range;
+        Pair<T, T> adjustedRange = ticks.adjustRange(range.getLow(), range.getHigh());
+        range = new AxisRange<>(adjustedRange.getKey(), adjustedRange.getValue());
         if (horizontal)
-            ticks.compute(safe_range.getLow(), safe_range.getHigh(), gc, getBounds().width);
+            ticks.compute(range.getLow(), range.getHigh(), gc, getBounds().width);
         else
-            ticks.compute(safe_range.getLow(), safe_range.getHigh(), gc, getBounds().height);
+            ticks.compute(range.getLow(), range.getHigh(), gc, getBounds().height);
         // If ticks changed, the layout of tick labels may change
         requestLayout();
         requestRefresh();

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
@@ -364,8 +364,7 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
     {
         if (! dirty_ticks)
             return;
-        Pair<T, T> adjustedRange = ticks.adjustRange(range.getLow(), range.getHigh());
-        range = new AxisRange<>(adjustedRange.getKey(), adjustedRange.getValue());
+        setValueRange(range.getLow(), range.getHigh()); // Performs checks and possibly adjusts range.
         if (horizontal)
             ticks.compute(range.getLow(), range.getHigh(), gc, getBounds().width);
         else

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AxisPart.java
@@ -272,7 +272,7 @@ public abstract class AxisPart<T extends Comparable<T>> extends PlotPart impleme
             T newHigh = possiblyNewLowAndHigh.getValue();
             if (newLow != low || newHigh != high)
             {
-                logger.log(Level.WARNING, "Axis {0}: Bad value range {1} ... {2}. Adjusting the range to {3} ... {4}.",
+                logger.log(Level.WARNING, "Axis {0}: Invalid value range {1,number,#.###############E0} ... {2,number,#.###############E0}. Adjusting the range to {3,number,#.###############E0} ... {4,number,#.###############E0}.",
                                           new Object[] { getName(), low, high, newLow, newHigh });
             }
 

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
@@ -78,13 +78,7 @@ public class LinearTicks extends Ticks<Double>
         if (Math.abs(high - low) < 3*Math.ulp(low)) {
             high = low + 3*Math.ulp(low);
         }
-
-        if (high < low) {
-            return new Pair<>(high, low);
-        }
-        else {
-            return new Pair<>(low, high);
-        }
+        return new Pair<>(low, high);
     }
 
     /** {@inheritDoc} */

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
@@ -90,7 +90,7 @@ public class LinearTicks extends Ticks<Double>
         double newHigh = adjustedRange.getValue();
 
         if (newLow != low || newHigh != high) {
-            logger.log(Level.WARNING, "Bad value range for a linear scale {0} ... {1}. Adjusting the range to {2} ... {3}.",
+            logger.log(Level.WARNING, "Invalid value range for a linear scale {0,number,#.###############E0} ... {1,number,#.###############E0}. Adjusting the range to {2,number,#.###############E0} ... {3,number,#.###############E0}.",
                     new Object[] {low, high, newLow, newHigh });
             high = newHigh;
             low = newLow;

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
@@ -85,6 +85,17 @@ public class LinearTicks extends Ticks<Double>
     @Override
     public void compute(Double low, Double high, final Graphics2D gc, final int screen_width)
     {
+        Pair<Double, Double> adjustedRange = adjustRange(low, high);
+        double newLow = adjustedRange.getKey();
+        double newHigh = adjustedRange.getValue();
+
+        if (newLow != low || newHigh != high) {
+            logger.log(Level.WARNING, "Bad value range for a linear scale {0} ... {1}. Adjusting the range to {2} ... {3}.",
+                    new Object[] {low, high, newLow, newHigh });
+            high = newHigh;
+            low = newLow;
+        }
+
         logger.log(Level.FINE, "Compute linear ticks, width {0}, for {1} - {2}",
                                new Object[] { screen_width, low, high });
 

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LogTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LogTicks.java
@@ -67,7 +67,7 @@ public class LogTicks extends LinearTicks
         double newHigh = adjustedRange.getValue();
 
         if (newLow != low || newHigh != high) {
-            logger.log(Level.WARNING, "Bad value range for a logarithmic scale {0} ... {1}. Adjusting the range to {2} ... {3}.",
+            logger.log(Level.WARNING, "Invalid value range for a logarithmic scale {0,number,#.###############E0} ... {1,number,#.###############E0}. Adjusting the range to {2,number,#.###############E0} ... {3,number,#.###############E0}.",
                     new Object[] {low, high, newLow, newHigh });
             high = newHigh;
             low = newLow;

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LogTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LogTicks.java
@@ -60,10 +60,21 @@ public class LogTicks extends LinearTicks
 
     /** {@inheritDoc} */
     @Override
-    public void compute(final Double low, final Double high, final Graphics2D gc, final int screen_width)
+    public void compute(Double low, Double high, final Graphics2D gc, final int screen_width)
     {
+        Pair<Double, Double> adjustedRange = adjustRange(low, high);
+        double newLow = adjustedRange.getKey();
+        double newHigh = adjustedRange.getValue();
+
+        if (newLow != low || newHigh != high) {
+            logger.log(Level.WARNING, "Bad value range for a logarithmic scale {0} ... {1}. Adjusting the range to {2} ... {3}.",
+                    new Object[] {low, high, newLow, newHigh });
+            high = newHigh;
+            low = newLow;
+        }
+
         logger.log(Level.FINE, "Compute log ticks, width {0}, for {1} - {2}",
-                               new Object[] { screen_width, low, high });
+                new Object[] { screen_width, low, high });
 
         double low_exp_exact = Log10.log10(low);
         double high_exp_exact = Log10.log10(high);

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotProcessor.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/PlotProcessor.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 
+import javafx.util.Pair;
 import org.csstudio.javafx.rtplot.Axis;
 import org.csstudio.javafx.rtplot.AxisRange;
 import org.csstudio.javafx.rtplot.Messages;
@@ -490,32 +491,26 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                         }
                     }
                     if (axis.isLogarithmic())
-                    {   // Perform adjustment in log space.
-                        // But first, refuse to deal with <= 0
-                        if (low <= 0.0)
-                            low = 1;
-                        if (high <= low)
-                            high = low * 100.0;
-                        low = Log10.log10(low);
-                        high = Log10.log10(high);
-                    }
-                    final ValueRange rounded = roundValueRange(low, high);
-                    low = rounded.getLow();
-                    high = rounded.getHigh();
-                    if (axis.isLogarithmic())
                     {
-                        low = Log10.pow10(low);
-                        high = Log10.pow10(high);
+                        low = Log10.pow10(Math.floor(Log10.log10(low))); // Note: may set "low" to 0.0.
+                        high = Log10.pow10(Math.ceil(Log10.log10(high)));
+                        Pair<Double, Double> adjustedRange = axis.ticks.adjustRange(low, high);
+                        low = adjustedRange.getKey();
+                        high = adjustedRange.getValue();
+
                     }
-                    else
-                    {   // Stretch range a little bit
+                    else {
+                        final ValueRange rounded = roundValueRange(low, high);
+                        low = rounded.getLow();
+                        high = rounded.getHigh();
+                        // Stretch range a little bit
                         // (but not for log scale, where low just above 0
                         //  could be stretched to <= 0)
                         final double headroom = (high - low) * 0.05;
                         low -= headroom;
                         high += headroom;
-
                     }
+
                     // Autoscale happens 'all the time'.
                     // Do not use undo, but notify listeners.
                     if (low != high)


### PR DESCRIPTION
This pull-request fixes auto-scaling of logarithmic axes.

Previously, the min-value of a logarithmic axis could be set to invalid values by the auto-scale functionality, which could result in too much memory usage or warnings in the Error Log.

This PR also:

- Fixes `LinearTicks.adjustRange()` to not check whether `low < high` (since `LinearTicks.compute()` supports both orderings)
- Adds invocations of `adjustRange()` in the beginning of both `LinearTicks.compute()` and `LogTicks.compute()` in order to check that the range that is given as an input is a valid range for the scale in question. If it is not, the range is adjusted, and a warning is printed.
- Adds an invocation of `adjustRange()` to `AxisPart.computeTicks()` in order to possibly adjust the range before calling `ticks.compute()`.
- Fixes `AxisPart.setValueRange()` to _first_ adjust the range, and _then_ compare the resulting range to the old range, before deciding _not_ to update the range.