### PR TITLE
CSSTUDIO-1950 Remove calls to `fireItemDataConfigChanged()` when archivers are removed from instances of `PVItem`.

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -242,9 +242,11 @@ public class PVItem extends ModelItem
     /** @param archive Archive to remove as a source from this item. */
     public void removeArchiveDataSource(final ArchiveDataSource archive)
     {
-        // Archive removed -> (Probably) no need to get new data
-        if (archives.remove(archive))
+        boolean change = archives.remove(archive);
+        if (!Preferences.use_default_archives && change) {
+            // Archive removed -> (Probably) no need to get new data
             fireItemDataConfigChanged(false);
+        }
     }
 
     /** @param archs Archives to remove as a source from this item. Ignored when not used. */
@@ -254,7 +256,7 @@ public class PVItem extends ModelItem
         for (ArchiveDataSource archive : archs)
             if (archives.remove(archive))
                 change = true;
-        if (change)
+        if (!Preferences.use_default_archives && change)
             fireItemDataConfigChanged(false);
     }
 

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -243,19 +243,14 @@ public class PVItem extends ModelItem
     public void removeArchiveDataSource(final ArchiveDataSource archive)
     {
         // Archive removed -> (Probably) no need to get new data
-        if (archives.remove(archive))
-            fireItemDataConfigChanged(false);
+        archives.remove(archive);
     }
 
     /** @param archs Archives to remove as a source from this item. Ignored when not used. */
     public void removeArchiveDataSource(final List<ArchiveDataSource> archs)
     {
-        boolean change = false;
         for (ArchiveDataSource archive : archs)
-            if (archives.remove(archive))
-                change = true;
-        if (change)
-            fireItemDataConfigChanged(false);
+            archives.remove(archive);
     }
 
     /** Replace existing archive data sources with given archives

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -243,14 +243,19 @@ public class PVItem extends ModelItem
     public void removeArchiveDataSource(final ArchiveDataSource archive)
     {
         // Archive removed -> (Probably) no need to get new data
-        archives.remove(archive);
+        if (archives.remove(archive))
+            fireItemDataConfigChanged(false);
     }
 
     /** @param archs Archives to remove as a source from this item. Ignored when not used. */
     public void removeArchiveDataSource(final List<ArchiveDataSource> archs)
     {
+        boolean change = false;
         for (ArchiveDataSource archive : archs)
-            archives.remove(archive);
+            if (archives.remove(archive))
+                change = true;
+        if (change)
+            fireItemDataConfigChanged(false);
     }
 
     /** Replace existing archive data sources with given archives


### PR DESCRIPTION
This merge-request removes calls to `fireItemDataConfigChanged()` when archivers are removed from instances of `PVItem`.

I am not sure this fix is a "correct" fix or not, and therefore I would like to ask about your opinion on this.

The intention with the merge-request is to fix an issue that occurs when some configured archivers don't archive a specific PV: if a Data Browser configuration is loaded that contains a PV that some archivers don't archive, then those archivers will automatically be removed from the `PVItem` instance associated with the PV in question by calling `removeArchiveDataSource()`. The function `removeArchiveDataSource()`, in turn, calls the function `fireDataItemChanged()`, which, in turn, (at least when I reproduce the issue) calls 7 different instances of `ModelListeners.changedItemDataConfig()`. One of the invoked instances is `DataBrowserInstance.changedItemDataConfig()`, which, in turn, calls `setDirty(true)`.

The result is that about 1 second or so after loading the Data Browser configuration, the dirty mark is set even though no change in the Data Browser configuration has occurred.

By removing the call to fireItemDataConfigChanged() in removeArchiveDataSource(), the dirty mark is not set and the issue doesn't occur. However, a consequence is that the 6 instances of `ModelListeners.changedItemDataConfig()` other than  `DataBrowserInstance.changedItemDataConfig()` _are also not invoked_. When I reproduce the issue, the instances in question are:
 1. `TracesTab.changedItemDataConfig()`
 2. `TimeAxisTab.changedItemDataConfig()`
 3. `AxesTab.changedItemDataConfig()`
 4. `MiscTab.changedItemDataConfig()`
 5. `StatisticsTabController.changedItemDataConfig()`
 6. `Controller.changedItemDataConfig()`

Do these functions need to be invoked when an archiver is removed from a PV?