### PR TITLE
CSSTUDIO-1976 Escape newlines in TextField "text" to prevent newlines from being removed in Label widgets.

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -563,7 +563,7 @@ public class PropertyPanelSection extends GridPane
                         final MacroizedWidgetProperty<?> other_prop = (MacroizedWidgetProperty<?>) w.getProperty(macro_prop.getName());
                         undo.execute(new SetMacroizedWidgetPropertyAction(other_prop, result.get()));
                     }
-                    text.setText(result.get());
+                    text.setText(result.get().replaceAll("\n", "\\\\n"));
                     Tooltip.install(text, new Tooltip(result.get()));
                 });
                 field = new HBox(text, open_editor);


### PR DESCRIPTION
This merge-request adds a mechanism that escapes newline characters from the `TextField` associated with the text of Label Widgets under widget Properties.

It fixes an issue that can be reproduced as follows:

1. Create a Label widget.
2. Enter a text that contains newlines, such as (by clicking on the "Open Editor" button with label "..."):
```
Line 1
Line 2
Line 3
```
3. Click anywhere else in the OPI, so that the Label widget is now de-selected.
4. The newline characters of the entered text have now been removed, and the text of the Label widget is now: 
```Line 1Line 2Line 3```

I have tested the fix under Linux and Windows.