### PR TITLE
CSSTUDIO-1133 Change condition when selecting distance between major ticks in `LinearTicks.selectNiceStep()`.

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
@@ -254,8 +254,7 @@ public class LinearTicks extends Ticks<Double>
      *  A computed distance of 6.1 turns into 10.0, not 5.0.
      *  @see #selectNiceStep(double)
      */
-    final private static double[] NICE_STEPS = { 10.0, 5.0, 2.0, 1.0 },
-                             NICE_THRESHOLDS = {  6.0, 3.0, 1.2, 0.0 };
+    final private static double[] NICE_STEPS = { 1.0, 2.0, 5.0, 10.0 };
 
     /** To a human viewer, tick distances of 5.0 are easier to see
      *  than for example 7.
@@ -263,16 +262,16 @@ public class LinearTicks extends Ticks<Double>
      *  <p>This method tries to adjust a computed tick distance
      *  to one that is hopefully 'nicer'
      *
-     *  @param distance Original step distance
+     *  @param min_distance Original step distance
      *  @return
      */
-    public static double selectNiceStep(final double distance)
+    public static double selectNiceStep(final double min_distance)
     {
-        final double log = Math.log10(distance);
+        final double log = Math.log10(min_distance);
         final double order_of_magnitude = Math.pow(10, Math.floor(log));
-        final double step = distance / order_of_magnitude;
+        final double step = min_distance / order_of_magnitude;
         for (int i=0; i<NICE_STEPS.length; ++i)
-            if (step >= NICE_THRESHOLDS[i])
+            if (NICE_STEPS[i] * order_of_magnitude >= min_distance)
                 return NICE_STEPS[i] * order_of_magnitude;
         return step * order_of_magnitude;
     }

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/LinearTicks.java
@@ -269,11 +269,10 @@ public class LinearTicks extends Ticks<Double>
     {
         final double log = Math.log10(min_distance);
         final double order_of_magnitude = Math.pow(10, Math.floor(log));
-        final double step = min_distance / order_of_magnitude;
         for (int i=0; i<NICE_STEPS.length; ++i)
             if (NICE_STEPS[i] * order_of_magnitude >= min_distance)
                 return NICE_STEPS[i] * order_of_magnitude;
-        return step * order_of_magnitude;
+        return min_distance;
     }
 
     /** Create decimal format

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Ticks.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Ticks.java
@@ -25,7 +25,7 @@ public abstract class Ticks<XTYPE>
     protected volatile List<MinorTick<XTYPE>> minor_ticks = Collections.emptyList();
 
     /** How many percent of the available space should be used for labels? */
-    final public static int FILL_PERCENTAGE = 60;
+    final public static int FILL_PERCENTAGE = 70;
 
     /** Used to adjust a range to a meaningful range for the chosen scale.
      *  @param low Desired low limit of the axis range.

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/LogTicksTest.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/LogTicksTest.java
@@ -46,7 +46,7 @@ public class LogTicksTest extends TicksTestBase
         System.out.println("Ticks for " + start + " .. " + end + ":");
         text = ticks2text(ticks);
         System.out.println(text);
-        assertThat(text, equalTo("'1.1E3' '1.2E3' "));
+        assertThat(text, equalTo("'1.05E3' '1.10E3' '1.15E3' '1.20E3' "));
 
     }
 }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TicksTestBase.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TicksTestBase.java
@@ -122,7 +122,7 @@ public class TicksTestBase
             assertThat(LinearTicks.selectNiceStep(5.0*order_of_magnitude), equalTo(5.0*order_of_magnitude));
             assertThat(LinearTicks.selectNiceStep(4.0*order_of_magnitude), equalTo(5.0*order_of_magnitude));
             assertThat(LinearTicks.selectNiceStep(3.0*order_of_magnitude), equalTo(5.0*order_of_magnitude));
-            assertThat(LinearTicks.selectNiceStep(2.01*order_of_magnitude), equalTo(2.0*order_of_magnitude));
+            assertThat(LinearTicks.selectNiceStep(1.99*order_of_magnitude), equalTo(2.0*order_of_magnitude));
             assertThat(LinearTicks.selectNiceStep(1.5*order_of_magnitude), equalTo(2.0*order_of_magnitude));
         }
     }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/internal/LinearTicksTest.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/internal/LinearTicksTest.java
@@ -42,7 +42,7 @@ public class LinearTicksTest extends TicksTestBase
             assertThat(LinearTicks.selectNiceStep(5.0*order_of_magnitude), equalTo(5.0*order_of_magnitude));
             assertThat(LinearTicks.selectNiceStep(4.0*order_of_magnitude), equalTo(5.0*order_of_magnitude));
             assertThat(LinearTicks.selectNiceStep(3.0*order_of_magnitude), equalTo(5.0*order_of_magnitude));
-            assertThat(LinearTicks.selectNiceStep(2.01*order_of_magnitude), equalTo(2.0*order_of_magnitude));
+            assertThat(LinearTicks.selectNiceStep(1.99*order_of_magnitude), equalTo(2.0*order_of_magnitude));
             assertThat(LinearTicks.selectNiceStep(1.5*order_of_magnitude), equalTo(2.0*order_of_magnitude));
         }
     }


### PR DESCRIPTION
This pull-request fixes an issue with the step-size selection for linear scales.

`LinearTicks.selectNiceStep()` is called (except for test-cases) only in `LinearTicks.compute()` with the argument `min_distance` set to the minimum distance that doesn't result in too many major ticks on the screen (in the sense that they would be too dense). The call is preceded by the comment `// Round up to the precision used to display values`.

However, `selectNiceStep()` can sometimes also round _down_ (not just _up_) the distance between major ticks.  For example:
 - Suppose that `distance` has been calculated to be `0.29`. (I.e., with `Ticks.FILL_PERCENTAGE` set to `60`, a distance between major ticks of `0.29` would fill up around 60% of the available space with labels of major ticks.)
 - Then on line `272`, `order_of_magnitude` is calculated to be `0.1`.
 - Since `3.0 >= 2.9 >= 1.2` holds, `selectNiceStep()` will return the step size `2.0`.
 - The consequence is that now around 90% of the available space is filled with labels of major ticks, since the distance between the major ticks is only `0.2`, not `0.29` or greater.
 
Too dense scales have been observed when testing the Linear Meter (which uses `NumericAxis` (and therefore `LinearTicks`) for its scale). E.g. (the displayed warning is not directly relevant to the described issue):

![linearTicks](https://github.com/ControlSystemStudio/phoebus/assets/122287276/b6c9f452-dba2-407a-9e54-bd4078165c45)

 
This pull-request changes the implementation of `selectNiceStep()` to instead select the smallest nice step that is larger or equal to the calculated minimum distance.
 
To compensate for the rounding down that sometimes occured previously, `Ticks.FILL_PERCENTAGE` has been increased from `60` to `70`.
 
Test cases had to be updated, since the behavior of `selectNiceStep()` has changed.