### PR TITLE
CSSTUDIO-1986 Prevent selection of widgets in the Widget Tree using the arrow keys.

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
@@ -358,6 +358,11 @@ public class SelectedWidgetUITracker extends Tracker
         inline_editor = null;
     }
 
+    private boolean requestFocusIsDisabled = false;
+    public void setDisableRequestFocus(boolean requestFocusIsDisabled) {
+        this.requestFocusIsDisabled = requestFocusIsDisabled;
+    }
+
     /** Locate widgets that would be 'clicked' by a mouse event's location */
     private class ClickWidgets extends RecursiveTask<Boolean>
     {
@@ -635,9 +640,10 @@ public class SelectedWidgetUITracker extends Tracker
 
         bindToWidgets();
 
-        // Get focus to allow use of arrow keys
-        Platform.runLater(() -> tracker.requestFocus());
-
+        if (!requestFocusIsDisabled) {
+            // Get focus to allow use of arrow keys
+            Platform.runLater(() -> tracker.requestFocus());
+        }
     }
 
     @Override

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
@@ -331,9 +331,11 @@ public class WidgetTree
                         : wot.getTab().getWidget();
                     if (! widgets.contains(widget))
                         widgets.add(widget);
-                };
+                }
                 logger.log(Level.FINE, "Selected in tree: {0}", widgets);
+                editor.getSelectedWidgetUITracker().setDisableRequestFocus(true);
                 editor.getWidgetSelectionHandler().setSelection(widgets);
+                editor.getSelectedWidgetUITracker().setDisableRequestFocus(false);
             }
             finally
             {

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
@@ -244,51 +244,6 @@ public class WidgetTree
 
         bindSelections();
         tree_view.setOnKeyPressed(this::handleKeyPress);
-        tree_view.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            // This prevents the arrow-key events from being propagated,
-            // preventing counter-intuitive behavior when arrow-keys are
-            // pressed in some situations. (Otherwise, when pressing an
-            // arrow-key, a widget would be selected, and the next arrow-
-            // key event would be processed by the selected widget
-            // instead of the tree-widget, usually resulting in a
-            // translation of the widget.)
-            if (event.getCode().isArrowKey()) {
-                event.consume();
-            }
-        });
-        tree_view.focusedProperty().addListener(
-                (observable, oldValue, newValue) -> {
-                    if (newValue) {
-                        // This event handler ensures that whenever the Widget Tree
-                        // becomes focused and widgets are selected in the widget tree,
-                        // then those widgets are selected in the Display Editor.
-                        // In particular, this ensures that key-press-events are
-                        // directed to the widgets in question.
-                        ObservableList<TreeItem<WidgetOrTab>> tree_selection = tree_view.getSelectionModel().getSelectedItems();
-
-                        if (! active.compareAndSet(false, true))
-                            return;
-                        try
-                        {
-                            final List<Widget> widgets = new ArrayList<>(tree_selection.size());
-                            for (TreeItem<WidgetOrTab> item : tree_selection)
-                            {
-                                final WidgetOrTab wot = item.getValue();
-                                final Widget widget = wot.isWidget()
-                                        ? wot.getWidget()
-                                        : wot.getTab().getWidget();
-                                if (! widgets.contains(widget))
-                                    widgets.add(widget);
-                            };
-                            logger.log(Level.FINE, "Selected in tree: {0}", widgets);
-                            editor.getWidgetSelectionHandler().setSelection(widgets);
-                        }
-                        finally
-                        {
-                            active.set(false);
-                        }
-                    }
-                });
 
         return tree_view;
     }

--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/tree/WidgetTree.java
@@ -244,6 +244,51 @@ public class WidgetTree
 
         bindSelections();
         tree_view.setOnKeyPressed(this::handleKeyPress);
+        tree_view.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            // This prevents the arrow-key events from being propagated,
+            // preventing counter-intuitive behavior when arrow-keys are
+            // pressed in some situations. (Otherwise, when pressing an
+            // arrow-key, a widget would be selected, and the next arrow-
+            // key event would be processed by the selected widget
+            // instead of the tree-widget, usually resulting in a
+            // translation of the widget.)
+            if (event.getCode().isArrowKey()) {
+                event.consume();
+            }
+        });
+        tree_view.focusedProperty().addListener(
+                (observable, oldValue, newValue) -> {
+                    if (newValue) {
+                        // This event handler ensures that whenever the Widget Tree
+                        // becomes focused and widgets are selected in the widget tree,
+                        // then those widgets are selected in the Display Editor.
+                        // In particular, this ensures that key-press-events are
+                        // directed to the widgets in question.
+                        ObservableList<TreeItem<WidgetOrTab>> tree_selection = tree_view.getSelectionModel().getSelectedItems();
+
+                        if (! active.compareAndSet(false, true))
+                            return;
+                        try
+                        {
+                            final List<Widget> widgets = new ArrayList<>(tree_selection.size());
+                            for (TreeItem<WidgetOrTab> item : tree_selection)
+                            {
+                                final WidgetOrTab wot = item.getValue();
+                                final Widget widget = wot.isWidget()
+                                        ? wot.getWidget()
+                                        : wot.getTab().getWidget();
+                                if (! widgets.contains(widget))
+                                    widgets.add(widget);
+                            };
+                            logger.log(Level.FINE, "Selected in tree: {0}", widgets);
+                            editor.getWidgetSelectionHandler().setSelection(widgets);
+                        }
+                        finally
+                        {
+                            active.set(false);
+                        }
+                    }
+                });
 
         return tree_view;
     }

--- a/core/ui/src/main/java/org/phoebus/ui/javafx/Tracker.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/Tracker.java
@@ -179,7 +179,7 @@ public class Tracker extends Group
         // Keep the keyboard focus to actually get key events.
         // The RTImagePlot will also listen to mouse moves and try to keep the focus,
         // so the active tracker uses an event filter to have higher priority
-        tracker.addEventFilter(MouseEvent.MOUSE_MOVED, event ->
+        tracker.addEventFilter(MouseEvent.MOUSE_CLICKED, event ->
         {
             event.consume();
             tracker.requestFocus();


### PR DESCRIPTION
This pull-request prevents the selection of widgets using arrow keys in the Widget Tree. Keyboard shortcuts (e.g., `Ctrl + g` for grouping widgets) continue to work.

The intention of the pull-request is to prevent counter-intuitive behavior when the Widget Tree is selected when pressing the arrow keys. The issue can be reproduced as follows:
 1. Open an OPI that contains the widgets "Widget 1", "Widget 2", and "Widget 3".
 2. Right-click on the OPI and open the Widget Tree. Suppose that "Widget 1" is above "Widget 2", which in turn is above "Widget 3" in the list that the Widget Tree displays.
 3. Left-click on "Widget 1", so that "Widget 1" is selected.
 4. Left-click again on the Widget Tree, but this time on the white area below "Widget 1", "Widget 2", and "Widget 3". The consequence is that "Widget 1" is still selected in the Widget Tree, but the focus is on the Widget Tree instead of on "Widget 1".
 5. Press the down-arrow key on the keyboard. Now "Widget 2" is selected, _and_ the focus is also on "Widget 2".
 6. Press the down-arrow key on the keyboard. Now "Widget 2" is moved down (moved in the y-direction) in the OPI.

That the down-arrow key changes meaning between step 5 and 6 is counter-intuitive.

With the changes in this pull-request, it is no longer possible to select widgets using the arrow keys in the Widget Tree. Instead, the foucs is placed on any selected widgets. If there are no selected widgets, the arrow keys will not have an effect when the Widget Tree is in focus.