### PR TITLE
CSSTUDIO-1988 In the Data Browser, prevent a dirty-mark when the scale if being updated by auto-scale functionality.

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/DataBrowserInstance.java
@@ -95,7 +95,12 @@ public class DataBrowserInstance implements AppInstance
 
         @Override
         public void changedAxis(final Optional<AxisConfig> axis)
-        {   setDirty(true);   }
+        {
+            if (!axis.isPresent() || !axis.get().autoScaleUpdateInProgress)
+            {
+                setDirty(true);
+            }
+        }
 
         @Override
         public void itemAdded(final ModelItem item)

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/AxisConfig.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/AxisConfig.java
@@ -58,6 +58,8 @@ public class AxisConfig
     /** Logarithmic scale? */
     private boolean log_scale;
 
+    public boolean autoScaleUpdateInProgress = false;
+
     /** Initialize with defaults
      *  @param name Axis name
      */
@@ -227,7 +229,11 @@ public class AxisConfig
             this.min = max;
             this.max = min;
         }
+
+        autoScaleUpdateInProgress = true;
         fireAxisChangeEvent();
+        autoScaleUpdateInProgress = false;
+
     }
 
     /** @return <code>true</code> if grid lines are drawn */


### PR DESCRIPTION
The merge-requests prevents a dirty-mark when the min- and max-values of the scale are updated by the auto-scale functionality.

It is intended to improve Phoebus' behavior in the following situation:
1. In the Data Browser, load a .plt file that contains an axis with auto-scale enabled.
2. Whenever the min- and/or max-value(s) of the scale are updated by the auto-scale functionality, the dirty-mark * appears on the tab associated with the Data Browser.

This merge-request changes the behavior so that if the update of the scale is due to the auto-scale functionality, no dirty-mark appears (and "Save" is not enabled). If the auto-scale behavior is subsequently disabled, then _that_ (i.e., the disabling of auto-scale) is a change, and a dirty-mark appears.