### PR TITLE
Tabs: Fix editor hangup when active_tab too large

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/ParentHandler.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/util/ParentHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.ArrayWidget;
 import org.csstudio.display.builder.model.widgets.GroupWidget;
 import org.csstudio.display.builder.model.widgets.TabsWidget;
+import org.csstudio.display.builder.model.widgets.TabsWidget.TabItemProperty;
 import org.csstudio.display.builder.model.widgets.VisibleWidget;
 
 import javafx.geometry.Rectangle2D;
@@ -137,8 +138,9 @@ public class ParentHandler
                 else if (widget instanceof TabsWidget)
                 {   // Check children of _selected_ Tab
                     final TabsWidget tabwid = (TabsWidget) widget;
-                    final int selected = tabwid.propActiveTab().getValue();
-                    child_prop = tabwid.propTabs().getValue().get(selected).children();
+                    final List<TabItemProperty> tabs = tabwid.propTabs().getValue();
+                    int selected = Math.min(tabwid.propActiveTab().getValue(), tabs.size()-1);
+                    child_prop = tabs.get(selected).children();
                 }
                 else if (widget instanceof ArrayWidget)
                 {


### PR DESCRIPTION
The `active_tab` of the `Tabs` widget is meant to be within 0..(number of tabs-1). When setting it to a larger value, the editor became defunct with a stack trace similar to this:
```
Exception in thread "JavaFX Application Thread"
java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for
length 2
at java.base/java.util.concurrent.CopyOnWriteArrayList.elementAt(CopyOnWriteArrayList.java:385)
at java.base/java.util.concurrent.CopyOnWriteArrayList.get(CopyOnWriteArrayList.java:398)
at java.base/java.util.Collections$UnmodifiableList.get(Collections.java:1347)
at org.csstudio.display.builder.editor.util.ParentHandler$ParentWidgetSearch.findParent(ParentHandler.java:141)
at org.csstudio.display.builder.editor.util.ParentHandler$ParentWidgetSearch.compute(ParentHandler.java:123)
at org.csstudio.display.builder.editor.util.ParentHandler.locateParent(ParentHandler.java:222)
at org.csstudio.display.builder.editor.tracker.SelectedWidgetUITracker.setPosition(SelectedWidgetUITracker.java:451)
at org.phoebus.ui.javafx.Tracker.setPosition(Tracker.java:410)
at org.csstudio.display.builder.editor.tracker.SelectedWidgetUITracker.updateTrackerFromWidgets(SelectedWidgetUITracker.java:560)
at org.csstudio.display.builder.editor.tracker.SelectedWidgetUITracker.setSelectedWidgets(SelectedWidgetUITracker.java:632)
at org.csstudio.display.builder.editor.WidgetSelectionHandler.setSelection(WidgetSelectionHandler.java:67)
```