### PR TITLE
mvn antrun parameters

### DIFF
--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -277,15 +277,16 @@
         -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <phase>verify</phase>
             <configuration>
               <failOnError>true</failOnError>
-              <tasks>
+              <target>
                 <echo message="Copying doc/" />
                 <ant antfile="build.xml" target="copy-doc" />
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
Looks like maven changed the `antrun` parameters. `tasks` will now result in an error, must use `target` instead. Older versions on the other hand would fail on the unknown `target` option.

Using `tasks` and requesting a newer version.