### PR TITLE
CSSTUDIO-2009 Bugfix: Fix update of Linear Meter scale when the lowest value is set to 0.0.

### DIFF
--- a/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterRepresentation.java
+++ b/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterRepresentation.java
@@ -275,7 +275,7 @@ public class LinearMeterRepresentation extends RegionBaseRepresentation<Pane, Li
     private void valueChanged(WidgetProperty<?> property, Object old_value, Object new_value)
     {
         synchronized (meter) {    // "synchronized (meter) { ... }" is due to the reading of values from "meter.linearMeter",
-                                  // which may otherwise be intreleaved with writes to these values.
+                                  // which may otherwise be interleaved with writes to these values.
             if (new_value instanceof VDouble ) {
                 VDouble vDouble = ((VDouble) new_value);
                 double newValue = vDouble.getValue();

--- a/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterScale.java
+++ b/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterScale.java
@@ -54,9 +54,7 @@ public class LinearMeterScale extends NumericAxis
         this.p1x = p1x;
         this.p1y = p1y;
         this.scale = s;
-        if( Double.compare(this.range.getLow(),0.0) != 0){
-            this.offset = this.range.getLow();
-        }
+        this.offset = this.range.getLow();
 
         dirty_ticks = true;
         requestLayout();


### PR DESCRIPTION
This pull-request fixes an issue where the scale of the Linear Meter widget didn't update correctly when the lowest value was 0.0. The fix consists to setting `offset` to the lowest value also when the lowest value is 0.0 in the event handler `LinearMeterRepresentation.valueChanged()`. A typo is also fixed.