### PR TITLE
CSSTUDIO-2014 Sort PVList table after "refresh" & add default sorting according to name.

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/pv/PVList.java
+++ b/core/ui/src/main/java/org/phoebus/ui/pv/PVList.java
@@ -140,6 +140,7 @@ public class PVList extends BorderPane
         name_col.setCellValueFactory(cell -> cell.getValue().name);
         name_col.setMaxWidth(400.0);
         table.getColumns().add(name_col);
+        table.getSortOrder().setAll(name_col); // By default, sort according to PV-name.
 
         final TableColumn<PVInfo, Number> ref_col = new TableColumn<>(Messages.PVListTblReferences);
         ref_col.setCellValueFactory(cell -> cell.getValue().references);

--- a/core/ui/src/main/java/org/phoebus/ui/pv/PVList.java
+++ b/core/ui/src/main/java/org/phoebus/ui/pv/PVList.java
@@ -211,6 +211,7 @@ public class PVList extends BorderPane
             {
                 table.getItems().clear();
                 table.getItems().addAll(items);
+                table.sort();
             });
         });
     }


### PR DESCRIPTION
This pull-request fixes a bug where the PVList application didn't sort the table with PVs after the "refresh" action, and this PR also adds a default sorting according to the name-column of the table when the application is first opened.