### PR TITLE
CSSTUDIO-1891 Alarm Log Table: Ignore unspecified parameters when constructing a search query

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
@@ -64,13 +64,13 @@ public class AlarmLogSearchJob implements JobRunnable {
     @Override
     public void run(JobMonitor monitor) {
         String searchString = "searching for alarm log entries : " +
-                searchParameters.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(","));
+                searchParameters.entrySet().stream().filter(e -> !e.getValue().equals("")).map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(","));
         logger.log(Level.INFO, "Searching for alarm entries: " + searchString);
         monitor.beginTask(searchString);
         int size = prefs.getInt("results_max_size");
 
         MultivaluedMap<String, String> map = new MultivaluedHashMap<>();
-        searchParameters.forEach((key, value) -> map.add(key.getName(), value));
+        searchParameters.forEach((key, value) -> { if (!value.equals("")) map.add(key.getName(), value); });
         map.putIfAbsent("size", List.of(String.valueOf(size)));
 
         try {

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/AlarmLogSearchUtil.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/AlarmLogSearchUtil.java
@@ -79,7 +79,7 @@ public class AlarmLogSearchUtil {
         logger.info("searching for alarm log entires : " +
                 searchParameters.entrySet().stream().map(e -> e.getKey() + ": " + e.getValue()).collect(Collectors.joining()));
 
-        Instant fromInstant = Instant.now().minus(7, ChronoUnit.DAYS);
+        Instant fromInstant = Instant.EPOCH;
         Instant toInstant = Instant.now();
 
         // The maximum search result size


### PR DESCRIPTION
This PR:
 1. On the client-side of the Alarm Log Table application, implements the functionality to ignore unspecified parameters when constructing a search query.
 2. On the server-side of the Alarm Log Table application, sets the default value of the `start` parameter to `Instant.EPOCH` (i.e.: 1970-01-01 00:00).

One consequence of this is that if one removes the `start`-parameter from the query in the client, then `start` will implicitly be set to `Instant.EPOCH`, which for practical purposes should be equivalent to "minus infinity".

On the one hand, this behavior seems more intuitive than the previous behavior, and on the other hand it improves the consistency of Phoebus, since the Logbook application behaves similarly.