### PR TITLE
CSSTUDIO-2015 Remember open tabs in the "Navigation Tabs" widget.

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
@@ -57,13 +57,13 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
     private final DirtyFlag dirty_tabs = new DirtyFlag();
     private final DirtyFlag dirty_tab_look = new DirtyFlag();
     private final DirtyFlag dirty_active_tab = new DirtyFlag();
-    private class SelectedNavigationTabsWidget extends MutablePair<Integer, HashMap<String, SelectedNavigationTabsWidget>> {
-        public SelectedNavigationTabsWidget() {
+    private class SelectedNavigationTabs extends MutablePair<Integer, HashMap<String, SelectedNavigationTabs>> {
+        public SelectedNavigationTabs() {
             left = 0;
             right = new HashMap<>();
         }
     };
-    protected SelectedNavigationTabsWidget selectedNavigationTabsWidget = new SelectedNavigationTabsWidget();
+    protected SelectedNavigationTabs selectedNavigationTabs = new SelectedNavigationTabs();
     private final UntypedWidgetPropertyListener sizesChangedListener = this::sizesChanged;
     private final UntypedWidgetPropertyListener tabLookChangedListener = this::tabLookChanged;
     private final WidgetPropertyListener<Integer> activeTabChangedListener = this::activeTabChanged;
@@ -186,7 +186,7 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
         dirty_active_tab.mark();
         toolkit.scheduleUpdate(this);
         tab_display_listener.propertyChanged(null, null, null);
-        selectedNavigationTabsWidget.left = tab_index;
+        selectedNavigationTabs.left = tab_index;
     }
 
     /** Update to the next pending display
@@ -247,19 +247,19 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
                          .stream()
                          .filter(widget -> widget instanceof NavigationTabsWidget)
                          .forEach(widget -> {
-                             NavigationTabsWidget navigationTabsWidget = (NavigationTabsWidget) widget;
-                             NavigationTabsRepresentation navigationTabsRepresentation = (NavigationTabsRepresentation) navigationTabsWidget.getUserData(Widget.USER_DATA_REPRESENTATION);
-                             SelectedNavigationTabsWidget selectedNavigationTabsWidget_forWidget;
-                             if (!selectedNavigationTabsWidget.right.containsKey(navigationTabsWidget.getName())) {
-                                 selectedNavigationTabsWidget_forWidget = new SelectedNavigationTabsWidget();
-                                 selectedNavigationTabsWidget.right.put(navigationTabsWidget.getName(), selectedNavigationTabsWidget_forWidget);
+                             NavigationTabsWidget nestedNavigationTabsWidget = (NavigationTabsWidget) widget;
+                             NavigationTabsRepresentation nestedNavigationTabsRepresentation = (NavigationTabsRepresentation) nestedNavigationTabsWidget.getUserData(Widget.USER_DATA_REPRESENTATION);
+                             SelectedNavigationTabs nestedNavigationTabsRepresentation_selectedNavigationTabs;
+                             if (!selectedNavigationTabs.right.containsKey(nestedNavigationTabsWidget.getName())) {
+                                 nestedNavigationTabsRepresentation_selectedNavigationTabs = new SelectedNavigationTabs();
+                                 selectedNavigationTabs.right.put(nestedNavigationTabsWidget.getName(), nestedNavigationTabsRepresentation_selectedNavigationTabs);
                              }
                              else {
-                                 selectedNavigationTabsWidget_forWidget = selectedNavigationTabsWidget.right.get(navigationTabsWidget.getName());
+                                 nestedNavigationTabsRepresentation_selectedNavigationTabs = selectedNavigationTabs.right.get(nestedNavigationTabsWidget.getName());
                              }
-                             navigationTabsRepresentation.selectedNavigationTabsWidget = selectedNavigationTabsWidget_forWidget;
-                             if (navigationTabsWidget.propTabs().size() > selectedNavigationTabsWidget_forWidget.left) {
-                                 navigationTabsWidget.propActiveTab().setValue(selectedNavigationTabsWidget_forWidget.left);
+                             nestedNavigationTabsRepresentation.selectedNavigationTabs = nestedNavigationTabsRepresentation_selectedNavigationTabs;
+                             if (nestedNavigationTabsWidget.propTabs().size() > nestedNavigationTabsRepresentation_selectedNavigationTabs.left) {
+                                 nestedNavigationTabsWidget.propActiveTab().setValue(nestedNavigationTabsRepresentation_selectedNavigationTabs.left);
                              }
                         });
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
@@ -262,7 +262,6 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
                              SelectedNavigationTabs nestedNavigationTabsRepresentation_selectedNavigationTabs;
 
                              if (!selectedNavigationTabsHashMapForCurrentTab.containsKey(nestedNavigationTabsWidget.getName())) {
-                                 //int activeTab = nestedNavigationTabsWidget.propTabs().size() > nestedNavigationTabsWidget.propActiveTab().getValue() ? 0 : nestedNavigationTabsWidget.propActiveTab().getValue();
                                  nestedNavigationTabsRepresentation_selectedNavigationTabs = new SelectedNavigationTabs(nestedNavigationTabsWidget.propActiveTab().getValue());
                                  selectedNavigationTabsHashMapForCurrentTab.put(nestedNavigationTabsWidget.getName(), nestedNavigationTabsRepresentation_selectedNavigationTabs);
                              }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
@@ -58,12 +58,12 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
     private final DirtyFlag dirty_tab_look = new DirtyFlag();
     private final DirtyFlag dirty_active_tab = new DirtyFlag();
     private class SelectedNavigationTabs extends MutablePair<Integer, HashMap<String, SelectedNavigationTabs>> {
-        public SelectedNavigationTabs() {
-            left = 0;
+        public SelectedNavigationTabs(int activeTab) {
+            left = activeTab;
             right = new HashMap<>();
         }
     };
-    protected SelectedNavigationTabs selectedNavigationTabs = new SelectedNavigationTabs();
+    protected SelectedNavigationTabs selectedNavigationTabs = new SelectedNavigationTabs(0);
     private final UntypedWidgetPropertyListener sizesChangedListener = this::sizesChanged;
     private final UntypedWidgetPropertyListener tabLookChangedListener = this::tabLookChanged;
     private final WidgetPropertyListener<Integer> activeTabChangedListener = this::activeTabChanged;
@@ -251,16 +251,17 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
                              NavigationTabsRepresentation nestedNavigationTabsRepresentation = (NavigationTabsRepresentation) nestedNavigationTabsWidget.getUserData(Widget.USER_DATA_REPRESENTATION);
                              SelectedNavigationTabs nestedNavigationTabsRepresentation_selectedNavigationTabs;
                              if (!selectedNavigationTabs.right.containsKey(nestedNavigationTabsWidget.getName())) {
-                                 nestedNavigationTabsRepresentation_selectedNavigationTabs = new SelectedNavigationTabs();
+                                 int activeTab = nestedNavigationTabsWidget.propTabs().size() > model_widget.propActiveTab().getValue() ? 0 : model_widget.propActiveTab().getValue();
+                                 nestedNavigationTabsRepresentation_selectedNavigationTabs = new SelectedNavigationTabs(activeTab);
                                  selectedNavigationTabs.right.put(nestedNavigationTabsWidget.getName(), nestedNavigationTabsRepresentation_selectedNavigationTabs);
                              }
                              else {
                                  nestedNavigationTabsRepresentation_selectedNavigationTabs = selectedNavigationTabs.right.get(nestedNavigationTabsWidget.getName());
+                                 if (nestedNavigationTabsWidget.propTabs().size() > nestedNavigationTabsRepresentation_selectedNavigationTabs.left) {
+                                     nestedNavigationTabsWidget.propActiveTab().setValue(nestedNavigationTabsRepresentation_selectedNavigationTabs.left);
+                                 }
                              }
                              nestedNavigationTabsRepresentation.selectedNavigationTabs = nestedNavigationTabsRepresentation_selectedNavigationTabs;
-                             if (nestedNavigationTabsWidget.propTabs().size() > nestedNavigationTabsRepresentation_selectedNavigationTabs.left) {
-                                 nestedNavigationTabsWidget.propActiveTab().setValue(nestedNavigationTabsRepresentation_selectedNavigationTabs.left);
-                             }
                         });
 
                 model_widget.runtimePropEmbeddedModel().setValue(new_model);


### PR DESCRIPTION
This PR adds support to Phoebus to remember the open tabs in nested occurrences of the Navigator Tabs widget.

When switching between tabs, the Navigator Tabs widget closes/disposes the OPIs that are not the currently opened one. If an OPI that is inside of a tab of a Navigator Tabs widget ("A") in turn contains a Navigator Tabs ("B"), then the information about which tab is currently opened in "B" is lost when another tab of "A" is opened.

This PR adds the functionality to the Navigator Tabs widget to remember which tabs are opened in nested Navigator Tabs widgets, and re-activates the corresponding tabs when a tab is selected and its OPI has been loaded.

**Note:** There is another widget that is similar to the Navigator Tabs widget: the Tabs widget. The functionality has not been implemented for the Tabs widget in this PR.