### PR TITLE
Add a table with the intended use case of each widget category to the documentation

### DIFF
--- a/app/display/editor/doc/widgets.rst
+++ b/app/display/editor/doc/widgets.rst
@@ -3,9 +3,38 @@ Widgets
 =======
 
 The Display Builder application supports a set of widgets which can be used to create control GUIs. The widgets are
-organized based on functionality as shown below
+organized according to the categories *Graphics*, *Monitors*, *Controls*, *Plots*, *Structure*, and *Miscellaneous*:
 
 .. image:: images/widgets.png
+   :align: center
+
+Each category corresponds to an intended use case of the widgets belonging to the category:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+   :align: center
+
+   * - Widget Category
+     - Intended Use Case
+
+   * - `Graphics`
+     - Static graphical elements
+
+   * - `Monitors`
+     - Displaying values from PVs
+
+   * - `Controls`
+     - Writing values to PVs
+
+   * - `Plots`
+     - Plotting PV values
+
+   * - `Structure`
+     - Grouping widgets and embedding displays
+
+   * - `Miscellaneous`
+     - 3D Viewer, Web Browser
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This pull-request adds a table to the documentation containing the intended use case that each widget category corresponds to.