### PR TITLE
Table: Changing data clears cell colors

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TableWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TableWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,10 +49,9 @@ import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.properties.WidgetFont;
 import org.epics.util.array.ListDouble;
 import org.epics.util.array.ListNumber;
-import org.epics.vtype.Array;
+import org.epics.vtype.VStringArray;
 import org.epics.vtype.VTable;
 import org.epics.vtype.VType;
-import org.epics.vtype.VStringArray;
 import org.phoebus.framework.persistence.XMLUtil;
 import org.w3c.dom.Element;
 
@@ -508,6 +507,8 @@ public class TableWidget extends VisibleWidget
      */
     public void setValue(final Object data)
     {
+        // Changing the data invalidates cell colors
+        cell_colors.setValue(null);
         value.setValue(data);
     }
 
@@ -535,7 +536,7 @@ public class TableWidget extends VisibleWidget
             value.add(cells);
         }
         // Assert row with enough cells
-        List<String> cells = value.get(row);
+        final List<String> cells = value.get(row);
         while (column >= cells.size())
             cells.add("");
         cells.set(column, cell_text);

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TableRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TableRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -361,9 +361,12 @@ public class TableRepresentation extends RegionBaseRepresentation<StringTable, T
                 }
             }
         }
-        if (dirty_data.checkAndClear())
+        if (dirty_data.checkAndClear())         // Show data with current coloring
+        { 
             jfx_node.setData(data);
-        if (dirty_cell_colors.checkAndClear())
+            jfx_node.setCellColors(cell_colors);
+        }
+        if (dirty_cell_colors.checkAndClear())  // Keep data, only update colors
             jfx_node.setCellColors(cell_colors);
         if (dirty_set_selection.checkAndClear())
             jfx_node.setSelection(model_widget.runtimePropSetSelection().getValue());


### PR DESCRIPTION
#2782 found that table cell colors are ignored after changing the data.

Reason was a combination of script setting the same colors, so no perceived change in coloring, and changes in data neither clearing nor re-using the coloring.

Now changing the value will clear coloring, and then setting colors actually has an effect.
Table example always contained a comment "Changing the value of a table removes all cell colors." so this was always the intended but not fully implemented behavior.