### PR TITLE
 PVA: Support EPICS_PVAS_TLS_OPTIONS

### DIFF
--- a/core/pva/TLS.md
+++ b/core/pva/TLS.md
@@ -66,7 +66,7 @@ The essential commands are also in `make_tls_simple.sh`
 Step 3: Configure and run the demo server
 -------
 
-Set environment variable `EPICS_PVAS_TLS_KEYCHAIN`` to inform the server about its keystore.
+Set environment variable `EPICS_PVAS_TLS_KEYCHAIN` to inform the server about its keystore.
 The format of this setting is `/path/to/file;password`.
 If you used `make_tls_simple.sh`, that would be `demo/KEYSTORE;changeit`.
 

--- a/core/pva/make_tls_ca.sh
+++ b/core/pva/make_tls_ca.sh
@@ -1,37 +1,41 @@
+# More elaborate example, see TLS.md "Use a Certification Authority"
 rm -rf demo
 mkdir demo
 cd demo
 
+# Create our own CA, and make its public certificate available as `myca.cer`:
 keytool -genkeypair -alias myca -keystore ca.p12 -storepass changeit -dname "CN=myca" -keyalg RSA -ext BasicConstraints=ca:true
 keytool -list -v                -keystore ca.p12 -storepass changeit
 keytool -exportcert -alias myca -keystore ca.p12 -storepass changeit -rfc -file myca.cer
 keytool -printcert -file myca.cer
 
+# For clients, create a truststore that holds the public certificate of our CA
 keytool -importcert -alias myca  -keystore trust_ca.p12 -storepass changeit -file myca.cer  -noprompt
 keytool -list -v                 -keystore trust_ca.p12 -storepass changeit
 
+# Now create a server keypair for use by the IOC:
 keytool -genkeypair -alias myioc -keystore ioc.p12 -storepass changeit -dname "CN=myioc" -keyalg RSA
 keytool -list -v                 -keystore ioc.p12 -storepass changeit
 
+# Create signing request, sign with our CA, import signed cert into ioc.p12
 keytool -certreq -alias myioc -keystore ioc.p12 -storepass changeit -file myioc.csr
 keytool -gencert -alias myca  -keystore ca.p12  -storepass changeit -ext SubjectAlternativeName=DNS:myioc -ext KeyUsage=digitalSignature -ext ExtendedKeyUsage=serverAuth,clientAuth -infile myioc.csr -outfile myioc.cer
 keytool -printcert -file myioc.cer
-
 keytool -importcert -alias myca  -keystore ioc.p12 -storepass changeit -file myca.cer  -noprompt
 keytool -importcert -alias myioc -keystore ioc.p12 -storepass changeit -file myioc.cer
 keytool -list -v                 -keystore ioc.p12 -storepass changeit
 
+# Create client keypair so client can authenticate as "Fred F."
 keytool -genkeypair -alias myclient -keystore client.p12 -storepass changeit -dname "CN=Fred F." -keyalg RSA
 keytool -list -v                 -keystore client.p12 -storepass changeit
 
+# Sign client certificate with our CA
 keytool -certreq -alias myclient -keystore client.p12 -storepass changeit -file myclient.csr
 keytool -gencert -alias myca     -keystore ca.p12     -storepass changeit -ext SubjectAlternativeName=DNS:client -ext KeyUsage=digitalSignature -ext ExtendedKeyUsage=serverAuth,clientAuth -infile myclient.csr -outfile myclient.cer
 keytool -printcert -file myclient.cer
-
 keytool -importcert -alias myca  -keystore client.p12 -storepass changeit -file myca.cer  -noprompt
 keytool -importcert -alias myclient -keystore client.p12 -storepass changeit -file myclient.cer
 keytool -list -v                 -keystore client.p12 -storepass changeit
-
 
 echo "*************************************************************"
 echo "***************** trust_ca **********************************"

--- a/core/pva/make_tls_simple.sh
+++ b/core/pva/make_tls_simple.sh
@@ -1,9 +1,16 @@
+# Minimal example, see TLS.md steps 1-4
+
 rm -rf demo
 mkdir demo
 cd demo
 
+
+# Creates a key pair for the server
 keytool -genkey -alias mykey -dname "CN=server" -keystore KEYSTORE -storepass changeit -keyalg RSA
+# Export the public key
 keytool -export -alias mykey -keystore KEYSTORE -storepass changeit -rfc -file mykey.cer
+
+# Create a trust store for the client to make it aware of the server's public key
 keytool -import -alias mykey -file mykey.cer -keystore TRUSTSTORE -storepass changeit -noprompt
 
 echo "*************************************************************"

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -144,6 +144,24 @@ public class PVASettings
      */
     public static String EPICS_PVAS_TLS_KEYCHAIN = "";
 
+    /** Secure server options
+     *
+     *  <ul>
+     *  <li><code>client_cert=optional</code>:
+     *      Default; clients can provide certificate for "X509" authentication,
+     *      but may also use "ca" or "anonymous" authentication
+     *  <li><code>client_cert=require</code>:
+     *      Clients must provide certificate for "X509" authentication.
+     *      Socket with otherwise be closed during initial handshake.
+     *      Server will log "SSLHandshakeException: Empty client certificate chain",
+     *      client will log "SSLHandshakeException: Received fatal alert: bad_certificate"
+     *  </ul>
+     */
+    public static String EPICS_PVAS_TLS_OPTIONS = "";
+
+    /** Does EPICS_PVAS_TLS_OPTIONS contain "client_cert=require"? */
+    public static boolean require_client_cert;
+
     /** Path to PVA client keystore and truststore, a PKCS12 file that contains the certificates or root CA
      *  that the client will trust when verifying a server certificate,
      *  and optional client certificate used with x509 authentication to establish the client's name.
@@ -237,6 +255,8 @@ public class PVASettings
         EPICS_PVA_CONN_TMO = get("EPICS_PVA_CONN_TMO", EPICS_PVA_CONN_TMO);
         EPICS_PVA_MAX_ARRAY_FORMATTING = get("EPICS_PVA_MAX_ARRAY_FORMATTING", EPICS_PVA_MAX_ARRAY_FORMATTING);
         EPICS_PVAS_TLS_KEYCHAIN = get("EPICS_PVAS_TLS_KEYCHAIN", EPICS_PVAS_TLS_KEYCHAIN);
+        EPICS_PVAS_TLS_OPTIONS = get("EPICS_PVAS_TLS_OPTIONS", EPICS_PVAS_TLS_OPTIONS);
+        require_client_cert =  EPICS_PVAS_TLS_OPTIONS.contains("client_cert=require");
         EPICS_PVA_TLS_KEYCHAIN = get("EPICS_PVA_TLS_KEYCHAIN", EPICS_PVA_TLS_KEYCHAIN);
         EPICS_PVA_SEND_BUFFER_SIZE = get("EPICS_PVA_SEND_BUFFER_SIZE", EPICS_PVA_SEND_BUFFER_SIZE);
         EPICS_PVA_FAST_BEACON_MIN = get("EPICS_PVA_FAST_BEACON_MIN", EPICS_PVA_FAST_BEACON_MIN);

--- a/core/pva/src/main/java/org/epics/pva/client/PVAClientMain.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClientMain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 import org.epics.pva.PVASettings;
 import org.epics.pva.data.PVAData;
@@ -59,6 +60,7 @@ public class PVAClientMain
     private static void setLogLevel(final Level level)
     {
         PVASettings.logger.setLevel(level);
+        Logger.getLogger("jdk.event.security").setLevel(level);
     }
 
     /** Get info for each PV on the list, then close PV

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPListener.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPListener.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
 
 import org.epics.pva.PVASettings;
@@ -219,7 +220,15 @@ class ServerTCPListener
                         if (client instanceof SSLSocket)
                         {
                             logger.log(Level.FINE, () -> Thread.currentThread().getName() + " accepted TLS client " + client.getRemoteSocketAddress());
-                            tls_info = TLSHandshakeInfo.fromSocket((SSLSocket) client);
+                            try
+                            {
+                                tls_info = TLSHandshakeInfo.fromSocket((SSLSocket) client);
+                            }
+                            catch (SSLHandshakeException ssl)
+                            {
+                                logger.log(Level.FINE, "SSL Handshake error for " + client.getRemoteSocketAddress(), ssl);
+                                continue;
+                            }
                         }
                         else
                             logger.log(Level.WARNING, () -> Thread.currentThread().getName() + " expected TLS client " + client.getRemoteSocketAddress() + " but did not get SSLSocket");


### PR DESCRIPTION
.. to track corresponding support in PVXS, https://github.com/mdavidsaver/pvxs/pull/53

`EPICS_PVAS_TLS_OPTIONS` can now be set to `client_cert=optional` or `client_cert=require`.
The latter causes the server to require client certificates, otherwise the socket is closed during the initial TLS handshake
