### PR TITLE
Fix formatting of alpha value

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXUtil.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXUtil.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.representation.javafx;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -33,7 +34,8 @@ import javafx.scene.text.FontWeight;
 public class JFXUtil extends org.phoebus.ui.javafx.JFXUtil
 {
     private static double font_calibration = 1.0;
-    private static final DecimalFormat RGBA_ALPHA_DECIMAL_FORMAT = new DecimalFormat("0.00");
+    private static final DecimalFormat RGBA_ALPHA_DECIMAL_FORMAT = new DecimalFormat("0.00",
+            DecimalFormatSymbols.getInstance(Locale.US));
 
     static
     {


### PR DESCRIPTION
In ```JFXUtil#webRgbOrHex``` the conversion to a decimal value for the alpha channel is actually sensitive to the region setting on OS level. For regions using comma as decimal character  an alpha of 254 will be converted to ```1,00```, which results in CSS string like ```rgba(r, g, b, 1,00)```, i.e. alpha is 1. But for alpha < 254 the converted value comes out as  ```0,xx```, which feeds ```rgba(r, g, b, 0,xx)``` to CSS, i.e. alpha is 0.

This PR is a fix where the string format uses explicit locale setting (US).