### PR TITLE
CSSTUDIO-2025 In the Alarm Log application, always use the Kafka server specified in `phoebus.ini`

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableInstance.java
@@ -10,6 +10,7 @@ package org.phoebus.applications.alarm.ui.table;
 import static org.phoebus.applications.alarm.AlarmSystem.logger;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
@@ -75,7 +76,7 @@ class AlarmTableInstance implements AppInstance
     {
         final String[] parsed = AlarmURI.parseAlarmURI(input);
         server = AlarmSystem.server;
-        config_name = parsed[1];
+        config_name = Arrays.stream(AlarmSystem.config_names).anyMatch(config_name -> config_name.equals(parsed[1])) ? parsed[1] : AlarmSystem.config_name;
 
         try
         {

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableInstance.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
+import org.apache.kafka.common.KafkaException;
 import org.phoebus.applications.alarm.AlarmSystem;
 import org.phoebus.applications.alarm.client.AlarmClient;
 import org.phoebus.applications.alarm.ui.AlarmConfigSelector;
@@ -73,22 +74,30 @@ class AlarmTableInstance implements AppInstance
     private Node create(final URI input) throws Exception
     {
         final String[] parsed = AlarmURI.parseAlarmURI(input);
-        server = parsed[0];
+        server = AlarmSystem.server;
         config_name = parsed[1];
 
         try
         {
-            client = new AlarmClient(server, config_name, AlarmSystem.kafka_properties);
-            table = new AlarmTableUI(client);
-            mediator = new AlarmTableMediator(client, table);
-            client.addListener(mediator);
-            client.start();
+            try {
+                client = new AlarmClient(server, config_name, AlarmSystem.kafka_properties);
+            }
+            catch (KafkaException e) {
+                logger.log(Level.SEVERE, "Failed to connect to Kafka server: " + e.getMessage());
+            }
 
+            table = new AlarmTableUI(client);
             if (AlarmSystem.config_names.length > 0)
             {
                 final AlarmConfigSelector configs = new AlarmConfigSelector(config_name, this::changeConfig);
                 // Place after "Active Alarms: 12" and strut
                 table.getToolbar().getItems().add(2, configs);
+            }
+
+            if (client != null) {
+                mediator = new AlarmTableMediator(client, table);
+                client.addListener(mediator);
+                client.start();
             }
 
             return table;


### PR DESCRIPTION
This PR implements the following two changes to how the Alarm Log application is restored:

 1. Currently, the server stored in the file `.phoebus/memento` is used for restoring instances of the Alarm Log application. This PR changes the initialization to instead always use the Kafka server specified in `phoebus.ini`. (I.e., to always use the server specified under `org.phoebus.applications.alarm/server`.)
 2. It adds a check for whether the config name stored in `.phoebus/memento` is available in the list of config names specified in `phoebus.ini` (i.e., the option `org.phoebus.applications.alarm/config_names`): if it is, then the stored config name is used, otherwise the default config name specified by the option `org.phoebus.applications.alarm/config_name` is used.