### PR TITLE
Add option to disable IPv6

### DIFF
--- a/core/pva/README.md
+++ b/core/pva/README.md
@@ -106,9 +106,9 @@ IPv6 Support
 
 Both the server and client support IPv6, which at this time needs to be enabled
 by configuring the `EPICS_PVAS_INTF_ADDR_LIST` of the server respectively the
-`EPICS_PVA_ADDR_LIST` and/or `EPICS_PVA_NAME_SERVERS` of the client to provide the desired IPv6 addresses.
+`EPICS_PVA_ADDR_LIST` and/or `EPICS_PVA_NAME_SERVERS` of the client to provide the desired IPv6 addresses. To completely disable any IPv6 functionality, set `EPICS_PVA_ENABLE_IPV6` to false.
 
-See Javadoc of `EPICS_PVAS_INTF_ADDR_LIST`, `EPICS_PVA_ADDR_LIST` and `EPICS_PVA_NAME_SERVERS` in `PVASettings`
+See Javadoc of `EPICS_PVAS_INTF_ADDR_LIST`, , `EPICS_PVA_ADDR_LIST`, `EPICS_PVA_NAME_SERVERS` and `EPICS_PVA_ENABLE_IPV6` in `PVASettings`
 for details.
 
 Command-line Example

--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -242,6 +242,16 @@ public class PVASettings
      */
     public static int EPICS_PVA_MAX_BEACON_AGE = 300;
 
+
+
+    /** Whether to allow PVA to use IPv6 
+     *
+     *  <p> If this is false then PVA will not attempt to 
+     *   use any IPv6 capability at all. This is useful if your
+     *   system does not have any IPv6 support.  
+     */
+    public static boolean EPICS_PVA_ENABLE_IPV6 = true;
+
     static
     {
         EPICS_PVA_ADDR_LIST = get("EPICS_PVA_ADDR_LIST", EPICS_PVA_ADDR_LIST);
@@ -262,6 +272,7 @@ public class PVASettings
         EPICS_PVA_FAST_BEACON_MIN = get("EPICS_PVA_FAST_BEACON_MIN", EPICS_PVA_FAST_BEACON_MIN);
         EPICS_PVA_FAST_BEACON_MAX = get("EPICS_PVA_FAST_BEACON_MAX", EPICS_PVA_FAST_BEACON_MAX);
         EPICS_PVA_MAX_BEACON_AGE = get("EPICS_PVA_MAX_BEACON_AGE", EPICS_PVA_MAX_BEACON_AGE);
+        EPICS_PVA_ENABLE_IPV6 = get("EPICS_PVA_ENABLE_IPV6", EPICS_PVA_ENABLE_IPV6);
     }
 
     /** Get setting from property, environment or default


### PR DESCRIPTION
This PR addresses issue #2825. It adds in a new config option `EPICS_PVA_ENABLE_IPV6`. The intention of this is to allow  completely disabling any IPv6 functionality. Right now, the current behaviour is even if you do not configure any IPv6 addresses , channels with IPv6 are still created. This causes problems as even if you do not intend to use IPv6, as you still must have this functionality in your system to run the PVA client. This is problematic in our case, as we have a containerized setup which doesn't support IPv6, which we encountered when trying to run [pvws](https://github.com/ornl-epics/pvws). 

I don't have very much familiarity with the Phoebus codebase so I have some questions moving forward.

- I have disabled creation of IPv6 channels in `ClientUDPHandler` with this config option. Is there anywhere else in the codebase I should also disable IPv6 relevant things?
- Since the `udp_beacon` is only IPv6, currently this is just not created with this config option. Should I create it with IPv4, or is it not strictly necessary?
- Should I add in a test for this functionality in the `pva/src/test` folder?

