### PR TITLE
Add comment to alarm_logging_preferences.properties

### DIFF
--- a/app/alarm/logging-ui/src/main/resources/alarm_logging_preferences.properties
+++ b/app/alarm/logging-ui/src/main/resources/alarm_logging_preferences.properties
@@ -2,5 +2,7 @@
 # Package org.phoebus.applications.alarm.logging.ui
 # -------------------------------------------------
 
+# The URL of the REST API exposed by the alarm logger service (not the elasticsearch port as it was prior to Phoebus 4.0)
 service_uri = http://localhost:9000
+
 results_max_size = 10000


### PR DESCRIPTION
When updating from Phoebus 4.6.9 to 4.7.2, I had some difficulty connecting the alarm log table to the alarm logger service. I eventually realised it was because I was pointing the service_uri preference to the elasticsearch port when I should have been pointing it to the new REST port. I am adding this comment to help clarify for others.