### PR TITLE
CSSTUDIO-2041 Bugfix: decode URL before adding it to 'paths'.

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JythonScriptSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/script/internal/JythonScriptSupport.java
@@ -11,6 +11,8 @@ import static org.csstudio.display.builder.runtime.WidgetRuntime.logger;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
@@ -108,7 +110,8 @@ class JythonScriptSupport extends BaseScriptSupport implements AutoCloseable
             // Add the examples/connect2j to path.
             // During development, examples are in
             // "file:/some/path/phoebus/applications/display/model/target/classes/examples"
-            final String examples = ModelPlugin.class.getResource("/examples").toString();
+            String examplesURL = ModelPlugin.class.getResource("/examples").toString();
+            String examples = URLDecoder.decode(examplesURL, StandardCharsets.UTF_8);
             if (examples.startsWith("file:"))
                 paths.add(examples.substring(5) + "/connect2j");
             // In the compiled version, examples are in


### PR DESCRIPTION
This PR fixes an issue when Phoebus is installed in a directory that contains characters that are escaped when part of an URL. (For example, the space character ` ` is escaped by three-character sequence `%20` when it is part of an URL.)

As a consequence of the fact that URLs are not decoded before being interpreted as paths, it is not possible to `import connect2j` in Python scripts in Phoebus when the path of the `connect2j` example contained a space character.

This PR adds a call to the function `URLDecoder.decode()` in order to decode the URL that represents the location of the example-files before interpreting the result as a path.