### PR TITLE
Self-update: Support "mac-aarch64" in addition to (old, Intel) "mac"

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,11 @@ To build for a different platform, create the `dependencies` in one of these way
     # Either create the build platform for Linux..
     ( cd phoebus; mvn clean verify  -Djavafx.platform=linux  -f dependencies/pom.xml )
 
-    # or Mac OS X ..
+    # or Mac OS X (Intel)
     ( cd phoebus; mvn clean verify  -Djavafx.platform=mac    -f dependencies/pom.xml )
+
+    # or Mac OS X (M2)
+    ( cd phoebus; mvn clean verify  -Djavafx.platform=mac-aarch64  -f dependencies/pom.xml )
 
     # or Windows:
     ( cd phoebus; mvn clean verify  -Djavafx.platform=win    -f dependencies/pom.xml )

--- a/app/update/mk_update_settings.sh
+++ b/app/update/mk_update_settings.sh
@@ -6,7 +6,7 @@ then
     echo ''
     echo 'URL, for example http://your.update.site/path/to/product-$(arch).zip,'
     echo 'is where the update process will check for a new version.'
-    echo 'It may contain $(arch), which gets replaced by "linux", "mac" or "win"'
+    echo 'It may contain $(arch), which gets replaced by "linux", "mac", "mac-aarch64" or "win"'
     echo 'depending on the OS.'
     echo ''
     echo 'Redirect the output into a file settings.ini'

--- a/app/update/src/main/java/org/phoebus/applications/update/Update.java
+++ b/app/update/src/main/java/org/phoebus/applications/update/Update.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -130,7 +130,12 @@ abstract public class Update
         if (PlatformInfo.is_linux)
             return text.replace("$(arch)", "linux");
         else if (PlatformInfo.is_mac_os_x)
-            return text.replace("$(arch)", "mac");
+        {
+            if ("aarch64".equalsIgnoreCase(System.getProperty("os.arch")))
+                return text.replace("$(arch)", "mac-aarch64");
+            else
+                return text.replace("$(arch)", "mac");
+        }
         else
             return text.replace("$(arch)", "win");
     }

--- a/dependencies/ant_settings.xml
+++ b/dependencies/ant_settings.xml
@@ -52,23 +52,27 @@
   </target>
 	
   <target name="jfxarch" description="Determine JavaFX architecture">
-    <!-- Check if target platform is for linux, mac, win -->
+    <!-- Check if target platform is for linux, plain mac, mac-aarch64, win -->
     <fileset dir="${dependencies}/phoebus-target/target/lib" id="jfxfiles">
       <include name="javafx-base-*-linux.jar"/>
       <include name="javafx-base-*-mac.jar"/>
+      <include name="javafx-base-*-mac-aarch64.jar"/>
       <include name="javafx-base-*-win.jar"/>
     </fileset>
     
     <echo message="JFX 'base' File: ${toString:jfxfiles}"/>
     
     <condition property="jfxarch" value="linux">
-      <contains string="${toString:jfxfiles}" substring="-linux"/>
+      <contains string="${toString:jfxfiles}" substring="-linux.jar"/>
     </condition>
     <condition property="jfxarch" value="mac">
-      <contains string="${toString:jfxfiles}" substring="-mac"/>
+      <contains string="${toString:jfxfiles}" substring="-mac.jar"/>
+    </condition>
+    <condition property="jfxarch" value="mac-aarch64">
+      <contains string="${toString:jfxfiles}" substring="-mac-aarch64.jar"/>
     </condition>
     <condition property="jfxarch" value="win">
-      <contains string="${toString:jfxfiles}" substring="-win"/>
+      <contains string="${toString:jfxfiles}" substring="-win.jar"/>
     </condition>
     <!-- Simpler, but requires full name incl. version. Cannot use 'javafx-base-*-linux.jar'
     <available file="phoebus-target/target/lib/javafx-base-11-linux.jar" property="jfxarch" value="linux" />


### PR DESCRIPTION
"mac" JDK and JavaFX binaries run fine on "mac-aarch64" aka Apple Silicon aka M2, but require Rosetta which might not be desired or considered slow