### PR TITLE
Fix mismatch for Olog entry modified date

### DIFF
--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogLog.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogLog.java
@@ -6,6 +6,7 @@
 package org.phoebus.olog.es.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.phoebus.logbook.Attachment;
 import org.phoebus.logbook.LogEntry;
@@ -188,6 +189,7 @@ public class OlogLog implements LogEntry {
      *
      * @return modifiedDate
      */
+    @JsonProperty("modifyDate")
     @Override
     public Instant getModifiedDate() {
         return modifiedDate;


### PR DESCRIPTION
The Phoebus Olog service uses ```modifyDate```, while the client uses ```modifiedDate```. With the added ```@JsonProperty``` annotation the ```modifiedDate``` is always null, which makes it impossible to indicate updates in the UI.