### PR TITLE
All fields of PVAStructure must be added to BitSet in a put request

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
@@ -11,6 +11,7 @@ import static org.epics.pva.PVASettings.logger;
 
 import java.nio.ByteBuffer;
 import java.util.BitSet;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
@@ -137,17 +138,31 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
                 fail(ex);
             }
 
+            // Bitset to describe which field(s) we're about to write
+            final BitSet changed = new BitSet();
             if (field instanceof PVAStructure)
             {
                 final PVAStructure struct = (PVAStructure) field;
                 // For enumerated type, write to index.
                 if ("enum_t".equals(struct.getStructureName()) ||
-                    data.getStructureName().toLowerCase().indexOf("ntenum") > 0)
+                        data.getStructureName().toLowerCase().indexOf("ntenum") > 0){
                     field = struct.get("index");
+                }
+                else{
+                    // Must also set bits for the elements of the structure
+                    List<PVAData> elements = struct.getElements();
+                    if(elements != null){
+                        for(int i = 0; i < elements.size(); i++){
+                            changed.set(data.getIndex(elements.get(i)));
+                        }
+                    }
+                }
             }
+            // Set bit for the field to write
+            changed.set(data.getIndex(field));
 
             // Bitset to describe which field we're about to write
-            final BitSet changed = new BitSet();
+            //final BitSet changed = new BitSet();
             changed.set(data.getIndex(field));
             logger.log(Level.FINE, () -> "Updated structure elements: " + changed);
             PVABitSet.encodeBitSet(changed, buffer);

--- a/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
@@ -150,7 +150,7 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
                 }
                 else{
                     // Must also set bits for the elements of the structure
-                    List<PVAData> elements = struct.getElements();
+                    List<PVAData> elements = struct.get();
                     if(elements != null){
                         for(int i = 0; i < elements.size(); i++){
                             changed.set(data.getIndex(elements.get(i)));

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
@@ -78,6 +78,13 @@ public class PVAStructure extends PVADataWithID
      */
     private final List<PVAData> elements;
 
+    /**
+     * @return The elements {@link List}
+     */
+    public List<PVAData> getElements(){
+        return elements;
+    }
+
     /** @param name Name of the structure (may be "")
      *  @param struct_name Type name of the structure (may be "")
      *  @param elements Elements, must be named

--- a/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
+++ b/core/pva/src/main/java/org/epics/pva/data/PVAStructure.java
@@ -78,12 +78,6 @@ public class PVAStructure extends PVADataWithID
      */
     private final List<PVAData> elements;
 
-    /**
-     * @return The elements {@link List}
-     */
-    public List<PVAData> getElements(){
-        return elements;
-    }
 
     /** @param name Name of the structure (may be "")
      *  @param struct_name Type name of the structure (may be "")


### PR DESCRIPTION
Attaching an Epics db example and bob file.

In the bob file an Action Button is writing hard coded values to the PVATable record implemented in the db example.

[Archive.zip](https://github.com/ControlSystemStudio/phoebus/files/12831513/Archive.zip)

Initial values for the table can be set like so:

```pvput TST:ResultsTable value.A=[1,2] value=[7,8]```