### PR TITLE
Execute command when parent_dir not on local filesystem

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
@@ -280,12 +280,12 @@ public class ActionUtil
             // Resolve command relative to the source widget model (not 'top'!)
             final DisplayModel widget_model = source_widget.getDisplayModel();
             final String parent_file = widget_model.getUserData(DisplayModel.USER_DATA_INPUT_FILE);
-            final String parent_dir = ModelResourceUtil.getDirectory(parent_file);
+            String parent_dir = ModelResourceUtil.getDirectory(parent_file);
 
             // Check if the parent_dir exists or is reachable. If not, use "." as the parent_dir.
             File parentDirectory = new File(parent_dir);
             if (!parentDirectory.exists() || !parentDirectory.isDirectory()) {
-              logger.log(Level.WARNING, "Parent directory {0} does not exist or is not reachable. Using current directory instead.", parent_dir);
+              logger.log(Level.WARNING, "Parent directory {0} does not exist or is not reachable. Using current directory instead to execute command.", parent_dir);
               parent_dir = ".";
             }
             // Execute (this is already running on background thread)

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/ActionUtil.java
@@ -282,6 +282,12 @@ public class ActionUtil
             final String parent_file = widget_model.getUserData(DisplayModel.USER_DATA_INPUT_FILE);
             final String parent_dir = ModelResourceUtil.getDirectory(parent_file);
 
+            // Check if the parent_dir exists or is reachable. If not, use "." as the parent_dir.
+            File parentDirectory = new File(parent_dir);
+            if (!parentDirectory.exists() || !parentDirectory.isDirectory()) {
+              logger.log(Level.WARNING, "Parent directory {0} does not exist or is not reachable. Using current directory instead.", parent_dir);
+              parent_dir = ".";
+            }
             // Execute (this is already running on background thread)
             logger.log(Level.FINE, "Executing command {0} in {1}", new Object[] { command, parent_dir });
             final CommandExecutor executor = new CommandExecutor(command, new File(parent_dir));


### PR DESCRIPTION
This PR handles the situation when execute command operation is needed to be performed for a BOB file that exists on external webserver. In such case, commands will be executed in current directory.