### PR TITLE
CSSTUDIO-2046 Bugfixes: decode escaped characters in URIs in two places.

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
@@ -57,7 +57,7 @@ public class DisplayInfo
         // Get basic file or http 'path' from path
         final String path;
         if (uri.getScheme() == null  ||  uri.getScheme().equals("file"))
-            path = uri.getRawPath();
+            path = uri.getPath();
         else
         {
             final StringBuilder buf = new StringBuilder();

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockItemWithInput.java
@@ -11,6 +11,8 @@ import static org.phoebus.ui.application.PhoebusApplication.logger;
 
 import java.io.File;
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -166,7 +168,8 @@ public class DockItemWithInput extends DockItem
                 name_tab.setTooltip(new Tooltip(Messages.DockNotSaved));
             else
             {
-                name_tab.setTooltip(new Tooltip(input.toString()));
+                String decodedInputURI = URLDecoder.decode(input.toString(), StandardCharsets.UTF_8);
+                name_tab.setTooltip(new Tooltip(decodedInputURI));
                 setLabel(name);
             }
         });


### PR DESCRIPTION
This PR adds decoding of escaped characters in URIs to:
1. The constructor of `DisplayInfo`. As a consequence, Phoebus is able to locate already-opened instances of OPIs that contain spaces in their filenames.
2. The method `DockItemWithInput.setInput()`, so that tool-tips of tabs containing instances of `DockItemWithInput` don't contain escaped characters.