### PR TITLE
CSSTUDIO-2076 Bugfix: add a leading forward slash and replace backslashes in file-paths with forward slashes in `DisplayInfo.forModel()`

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
@@ -112,7 +112,9 @@ public class DisplayInfo
      */
     public static DisplayInfo forModel(final DisplayModel model)
     {
-        return new DisplayInfo(model.getUserData(DisplayModel.USER_DATA_INPUT_FILE),
+        String filepath = model.getUserData(DisplayModel.USER_DATA_INPUT_FILE);
+        String filepath_withForwardSlashes = !filepath.substring(0,1).equals("/") ? "/" + filepath.replace('\\', '/') : filepath;
+        return new DisplayInfo(filepath_withForwardSlashes,
                 model.getDisplayName(),
                 model.propMacros().getValue(),
                 false);

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
@@ -119,7 +119,9 @@ public class DisplayInfo
                 && !userDataInputFile.startsWith("examples:")
                 && !userDataInputFile.startsWith("file:")
                 && !userDataInputFile.startsWith("http:")
-                && !userDataInputFile.startsWith("https:")) {
+                && !userDataInputFile.startsWith("https:")
+                && !userDataInputFile.startsWith("ftp:")
+                && !userDataInputFile.startsWith("jar:")) {
                 // Add leading '/' and replace occurrences of '\' by '/' in the file path on Windows:
                 path = "/" + userDataInputFile.replace('\\', '/');
             }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
@@ -112,9 +112,23 @@ public class DisplayInfo
      */
     public static DisplayInfo forModel(final DisplayModel model)
     {
-        String filepath = model.getUserData(DisplayModel.USER_DATA_INPUT_FILE);
-        String filepath_withForwardSlashes = !filepath.substring(0,1).equals("/") ? "/" + filepath.replace('\\', '/') : filepath;
-        return new DisplayInfo(filepath_withForwardSlashes,
+        String path;
+        {
+            String userDataInputFile = model.getUserData(DisplayModel.USER_DATA_INPUT_FILE);
+            if (   !userDataInputFile.startsWith("/")
+                && !userDataInputFile.startsWith("examples:")
+                && !userDataInputFile.startsWith("file:")
+                && !userDataInputFile.startsWith("http:")
+                && !userDataInputFile.startsWith("https:")) {
+                // Add leading '/' and replace occurrences of '\' by '/' in the file path on Windows:
+                path = "/" + userDataInputFile.replace('\\', '/');
+            }
+            else {
+                path = userDataInputFile;
+            }
+        }
+
+        return new DisplayInfo(path,
                 model.getDisplayName(),
                 model.propMacros().getValue(),
                 false);

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
@@ -13,6 +13,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.util.Locale;
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DisplayModel;
@@ -115,13 +116,14 @@ public class DisplayInfo
         String path;
         {
             String userDataInputFile = model.getUserData(DisplayModel.USER_DATA_INPUT_FILE);
-            if (   !userDataInputFile.startsWith("/")
-                && !userDataInputFile.startsWith("examples:")
-                && !userDataInputFile.startsWith("file:")
-                && !userDataInputFile.startsWith("http:")
-                && !userDataInputFile.startsWith("https:")
-                && !userDataInputFile.startsWith("ftp:")
-                && !userDataInputFile.startsWith("jar:")) {
+            String userDataInputFile_lowerCase = userDataInputFile.toLowerCase(Locale.ROOT);
+            if (   !userDataInputFile_lowerCase.startsWith("/")
+                && !userDataInputFile_lowerCase.startsWith("examples:")
+                && !userDataInputFile_lowerCase.startsWith("file:")
+                && !userDataInputFile_lowerCase.startsWith("http:")
+                && !userDataInputFile_lowerCase.startsWith("https:")
+                && !userDataInputFile_lowerCase.startsWith("ftp:")
+                && !userDataInputFile_lowerCase.startsWith("jar:")) {
                 // Add leading '/' and replace occurrences of '\' by '/' in the file path on Windows:
                 path = "/" + userDataInputFile.replace('\\', '/');
             }


### PR DESCRIPTION
This PR adds a leading forward slash and replaces backslashes in file-paths with forward slashes in `DisplayInfo.forModel()` so that filepaths are compared correctly in `DisplayRuntimeInstance.trackCurrentModel()`.

A consequence of this is that running instances of OPIs are located when running "Execute Display" under Windows. (At the moment, they are not located, and new instances are created when running "Execute Display".)