### PR TITLE
PVA: TCPHandler started receiver too early

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
@@ -124,9 +124,11 @@ class ClientTCPHandler extends TCPHandler
         last_life_sign = last_message_sent = System.currentTimeMillis();
         final long period = Math.max(1, PVASettings.EPICS_PVA_CONN_TMO * 1000L / 30 * 3);
         alive_check = timer.scheduleWithFixedDelay(this::checkResponsiveness, period, period, TimeUnit.MILLISECONDS);
-        // Don't start the send thread, yet.
+
+        // Start receiver, but not the send thread, yet.
         // To prevent sending messages before the server is ready,
         // it's started when server confirms the connection.
+        startReceiver();
     }
 
     private static Socket createSocket(final InetSocketAddress address, final boolean tls) throws Exception

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
@@ -12,6 +12,7 @@ import static org.epics.pva.PVASettings.logger;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.logging.Level;
 
 import org.epics.pva.common.CommandHandlers;
@@ -62,10 +63,11 @@ class ServerTCPHandler extends TCPHandler
     public ServerTCPHandler(final PVAServer server, final Socket client, final TLSHandshakeInfo tls_info) throws Exception
     {
         super(client, false);
-        this.server = server;
+        this.server = Objects.requireNonNull(server);
         this.tls_info = tls_info;
 
         server.register(this);
+        startReceiver();
         startSender();
 
         // Initialize TCP connection by setting byte order..


### PR DESCRIPTION
While ServerTCPHandler was still constructed and its `server` still null, the receiver could already invoke `onReceiverExited`.

Now the derived classes, ServerTCPHandler and ClientTCPHandler, start the receiver when fully constructed.

See #2871