### PR TITLE
CSSTUDIO-2074 Bugfix: Call undo.execute() instead of undo.add().

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/ArraySizePropertyBinding.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/properties/ArraySizePropertyBinding.java
@@ -83,7 +83,7 @@ public class ArraySizePropertyBinding extends WidgetPropertyBinding<Spinner<Inte
             for (Widget w : other)
             {
                 final ArrayWidgetProperty other_prop = (ArrayWidgetProperty) w.getProperty(path);
-                undo.add(new RemoveArrayElementAction<>(other_prop));
+                undo.execute(new RemoveArrayElementAction<>(other_prop));
             }
         }
     };


### PR DESCRIPTION
This PR fixes the following bug with the `ArrayWidgetProperty`: if one selects multiple instances of a widget that contains an `ArrayWidgetProperty` (e.g., two or more Multi State LED widgets), and removes items from the `ArrayWidgetProperty` (e.g., reduces the number of states of the selected Multi State LED widgets), then the items are only removed from the first of the selected widgets, and not the others.