### PR TITLE
CSSTUDIO-2040 Use absolute time in the automatically attached `.plt` file when creating a logbook entry from the DataBrowser

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/selection/DatabrowserSelection.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/selection/DatabrowserSelection.java
@@ -12,6 +12,7 @@ import org.csstudio.trends.databrowser3.model.Model;
 import org.csstudio.trends.databrowser3.model.ModelItem;
 import org.csstudio.trends.databrowser3.persistence.XMLPersistence;
 import org.csstudio.trends.databrowser3.ui.plot.ModelBasedPlot;
+import org.phoebus.util.time.TimeInterval;
 import org.phoebus.util.time.TimeRelativeInterval;
 
 import javafx.scene.image.Image;
@@ -51,6 +52,13 @@ public class DatabrowserSelection {
     public TimeRelativeInterval getPlotTime()
     {
         return model.getTimerange();
+    }
+
+    public void makeTimeRangeAbsolute()
+    {
+        TimeInterval absoluteInterval = model.getTimerange().toAbsoluteInterval();
+        TimeRelativeInterval absoluteTimeInterval = TimeRelativeInterval.of(absoluteInterval.getStart(), absoluteInterval.getEnd());
+        model.setTimerange(absoluteTimeInterval);
     }
 
     /**

--- a/app/trends/rich-adapters/src/main/java/org/phoebus/apps/trends/rich/adapters/DatabrowserAdapterFactory.java
+++ b/app/trends/rich-adapters/src/main/java/org/phoebus/apps/trends/rich/adapters/DatabrowserAdapterFactory.java
@@ -74,6 +74,8 @@ public class DatabrowserAdapterFactory implements AdapterFactory {
                                        .appendDescription(getBody(databrowserSelection));
             try
             {
+                databrowserSelection.makeTimeRangeAbsolute();
+
                 final File image_file = databrowserSelection.getPlot() == null ? null : new Screenshot(databrowserSelection.getPlot()).writeToTempfile("image");
                 if(image_file != null){
                     log.attach(AttachmentImpl.of(image_file));


### PR DESCRIPTION
This PR implements a conversion from relative time to absolute time for the automatically attached `.plt` file when creating a logbook entry from the DataBrowser.

The motivation for this change is that it is natural that an attached `.plt` file has absolute start- and end-times when creating logbook entries.