### PR TITLE
fix the bug in the creation of the userpassword credential for git push

### DIFF
--- a/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLogger.java
+++ b/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLogger.java
@@ -128,7 +128,7 @@ public class AlarmConfigLogger implements Runnable {
             sshdSessionFactory = builder.build(cache);
         }
         // Setup basic username/password auth
-        if (props.contains("username") && props.contains("password")) {
+        if (props.containsKey("username") && props.containsKey("password")) {
             usernamePasswordCredentialsProvider = new UsernamePasswordCredentialsProvider(
                     props.getProperty("username"),
                     props.getProperty("password"));


### PR DESCRIPTION
@jeonghanlee 
fixed a bug in how the username/password credentials were created.

Tested with pushing alarm config changes to remote repo hosted on github using https and username/password