### PR TITLE
CSSTUDIO-2038 When org.phoebus.ui/home_display="", map home button to the Welcome screen

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -794,9 +794,15 @@ public class PhoebusApplication extends Application {
         home_display_button.setTooltip(new Tooltip(Messages.HomeTT));
         toolBar.getItems().add(home_display_button);
 
-        final TopResources homeResource = TopResources.parse(Preferences.home_display);
 
-        home_display_button.setOnAction(event -> openResource(homeResource.getResource(0), false));
+        if (!Preferences.home_display.isEmpty()) {
+            final TopResources homeResource = TopResources.parse(Preferences.home_display);
+            home_display_button.setOnAction(event -> openResource(homeResource.getResource(0), false));
+        }
+        else {
+            Welcome welcome = new Welcome();
+            home_display_button.setOnAction(event -> welcome.create());
+        }
 
         top_resources_button = new MenuButton(null, ImageCache.getImageView(getClass(), "/icons/fldr_obj.png"));
         top_resources_button.setTooltip(new Tooltip(Messages.TopResources));


### PR DESCRIPTION
This PR adds the functionality that if the option `org.phoebus.ui/home_display` is set to the empty string, then the home button is mapped to the Welcome screen.

The motivation for this change is that this is a reasonable default behavior.

(Currently, an `IndexOutOfBoundsException` is thrown if `org.phoebus.ui/home_display` is set to the empty string.)