### PR TITLE
CSSTUDIO-2012 Add "Line Spacing" option to the Widget Properties of the Label widget

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
@@ -240,6 +240,7 @@ public class Messages
                          WidgetProperties_LevelLoLo,
                          WidgetProperties_LimitsFromPV,
                          WidgetProperties_LineColor,
+                         WidgetProperties_LineSpacing,
                          WidgetProperties_LineWidth,
                          WidgetProperties_Locale,
                          WidgetProperties_Macros,

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/LabelWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/LabelWidget.java
@@ -28,11 +28,14 @@ import org.csstudio.display.builder.model.WidgetCategory;
 import org.csstudio.display.builder.model.WidgetConfigurator;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyCategory;
+import org.csstudio.display.builder.model.WidgetPropertyDescriptor;
 import org.csstudio.display.builder.model.persist.ModelReader;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.NamedWidgetFonts;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.persist.WidgetFontService;
+import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
 import org.csstudio.display.builder.model.properties.HorizontalAlignment;
 import org.csstudio.display.builder.model.properties.RotationStep;
 import org.csstudio.display.builder.model.properties.VerticalAlignment;
@@ -104,11 +107,16 @@ public class LabelWidget extends MacroWidget
     private volatile WidgetProperty<WidgetColor> background;
     private volatile WidgetProperty<Boolean> transparent;
     private volatile WidgetProperty<WidgetFont> font;
+    private volatile WidgetProperty<Integer> lineSpacing;
     private volatile WidgetProperty<HorizontalAlignment> horizontal_alignment;
     private volatile WidgetProperty<VerticalAlignment> vertical_alignment;
     private volatile WidgetProperty<RotationStep> rotation_step;
     private volatile WidgetProperty<Boolean> auto_size;
     private volatile WidgetProperty<Boolean> wrap_words;
+
+    /** 'line_spacing' property */
+    public static final WidgetPropertyDescriptor<Integer> propLineSpacing =
+            CommonWidgetProperties.newIntegerPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "line_spacing", Messages.WidgetProperties_LineSpacing);
 
     /** Constructor */
     public LabelWidget()
@@ -122,6 +130,7 @@ public class LabelWidget extends MacroWidget
         super.defineProperties(properties);
         properties.add(text = propText.createProperty(this, Messages.LabelWidget_Text));
         properties.add(font = propFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.DEFAULT)));
+        properties.add(lineSpacing = propLineSpacing.createProperty(this, 0));
         properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(background = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(transparent = propTransparent.createProperty(this, true));
@@ -150,6 +159,12 @@ public class LabelWidget extends MacroWidget
     public WidgetProperty<WidgetFont> propFont()
     {
         return font;
+    }
+
+    /** @return 'line_spacing' property */
+    public WidgetProperty<Integer> propLineSpacing()
+    {
+        return lineSpacing;
     }
 
     /** @return 'foreground_color' property */

--- a/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
+++ b/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
@@ -223,6 +223,7 @@ WidgetProperties_LevelLow=Level Low
 WidgetProperties_LevelLoLo=Level LoLo
 WidgetProperties_LimitsFromPV=Limits from PV
 WidgetProperties_LineColor=Line Color
+WidgetProperties_LineSpacing=Line Spacing
 WidgetProperties_LineWidth=Line Width
 WidgetProperties_Locale=Locale
 WidgetProperties_Macros=Macros

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
@@ -71,6 +71,7 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
         model_widget.propVerticalAlignment().addUntypedPropertyListener(styleChangedListener);
         model_widget.propRotationStep().addUntypedPropertyListener(styleChangedListener);
         model_widget.propWrapWords().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propLineSpacing().addUntypedPropertyListener(styleChangedListener);
 
         // Changing the text might require a resize,
         // so handle those properties together.
@@ -93,6 +94,7 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
         model_widget.propWrapWords().removePropertyListener(styleChangedListener);
         model_widget.propText().removePropertyListener(contentChangedListener);
         model_widget.propAutoSize().removePropertyListener(contentChangedListener);
+        model_widget.propLineSpacing().removePropertyListener(styleChangedListener);
         super.unregisterListeners();
     }
 
@@ -173,6 +175,8 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
                 jfx_node.setBackground(new Background(new BackgroundFill(color, CornerRadii.EMPTY, Insets.EMPTY)));
             }
             jfx_node.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
+            Integer lineSpacing = model_widget.propLineSpacing().getValue();
+            jfx_node.setLineSpacing(lineSpacing);
         }
     }
 }


### PR DESCRIPTION
This PR adds the option "Line Spacing" to the Label widget.

By setting a value (note that the value can also be negative!), it is possible to set the line spacing between lines for Label widgets containing two or more lines of text.