### PR TITLE
Improve a logic to select whether SSH key or Username

### DIFF
--- a/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLogger.java
+++ b/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLogger.java
@@ -115,17 +115,22 @@ public class AlarmConfigLogger implements Runnable {
             }
         }
         // Set up the ssh keys if used
-        if(Boolean.parseBoolean(props.getProperty("use_ssh_keys", "false"))) {
-            File sshDir = new File(FS.DETECTED.userHome(), ".ssh");
-            JGitKeyCache cache = new JGitKeyCache();
-            SshdSessionFactoryBuilder builder = new SshdSessionFactoryBuilder();
-            if(props.containsKey("private_key")) {
-                File key = new File(props.getProperty("private_key"));
-                builder.setDefaultKeysProvider(file -> new CachingKeyPairProvider(List.of(key.getAbsoluteFile().toPath()), cache));
-            }
-            builder.setHomeDirectory(FS.DETECTED.userHome());
-            builder.setSshDirectory(sshDir);
-            sshdSessionFactory = builder.build(cache);
+        if(props.containsKey("use_ssh_keys") && Boolean.parseBoolean(props.getProperty("use_ssh_keys"))) {
+			try {
+				File sshDir = new File(FS.DETECTED.userHome(), ".ssh");
+				JGitKeyCache cache = new JGitKeyCache();
+				SshdSessionFactoryBuilder builder = new SshdSessionFactoryBuilder();
+				if(props.containsKey("private_key")) {
+					File key = new File(props.getProperty("private_key"));
+					builder.setDefaultKeysProvider(file -> new CachingKeyPairProvider(List.of(key.getAbsoluteFile().toPath()), cache));
+				}
+				builder.setHomeDirectory(FS.DETECTED.userHome());
+				builder.setSshDirectory(sshDir);
+				sshdSessionFactory = builder.build(cache);
+			} catch (NullPointerException  e) {
+					logger.log(Level.WARNING, "Failed to open .ssh/private_key", e);
+			}
+
         }
         // Setup basic username/password auth
         if (props.containsKey("username") && props.containsKey("password")) {
@@ -268,7 +273,7 @@ public class AlarmConfigLogger implements Runnable {
                             PushCommand pushCommand = git.push();
                             pushCommand.setRemote(REMOTE_NAME);
                             pushCommand.setForce(true);
-                            if (Boolean.parseBoolean(props.getProperty("use_ssh_keys", "false"))) {
+                            if (Boolean.parseBoolean(props.getProperty("use_ssh_keys"))) {
                                 pushCommand.setTransportConfigCallback(transport -> {
                                     SshTransport sshTransport = (SshTransport) transport;
                                     sshTransport.setSshSessionFactory(sshdSessionFactory);


### PR DESCRIPTION
@shroffk This is our try to improve the logic behind your mind, which we (@jeonghanlee  and 
@Sangil-Lee ) figured out. I think your mind is brilliant ;) 


We tested the following both cases:

## Username
In `alarm_config_logger.properties`,

```
remote.location=https://git_repo/...
use_ssh_keys = false
username = aaa
password = bbb
```

## SSH Key

```
remote.location=git@git_repo/...
use_ssh_keys = true
```
In this case, we also rename `.ssh` folder, and saw `SshException` in a log. After reverting to `.ssh`, everything worked well.

Please let me know what you think.

