### PR TITLE
implement completable future on PV class

### DIFF
--- a/core/pv/src/main/java/org/phoebus/pv/PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/PV.java
@@ -10,7 +10,6 @@ package org.phoebus.pv;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -236,17 +235,17 @@ public class PV
 
     /** Issue a read request
      *
-     *  <p>{@link Future} allows waiting for
+     *  <p>{@link CompletableFuture} allows waiting for
      *  and obtaining the result, or its <code>get()</code>
      *  calls will provide an error.
      *
      *  <p>As a side effect, registered listeners will
      *  also receive the value obtained by this call.
      *
-     *  @return {@link Future} for obtaining the result or Exception
+     *  @return {@link CompletableFuture} for obtaining the result or Exception
      *  @exception Exception on error
      */
-    public Future<VType> asyncRead() throws Exception
+    public CompletableFuture<VType> asyncRead() throws Exception
     {
         // Default: Return last known value
         return CompletableFuture.completedFuture(last_value);
@@ -270,17 +269,17 @@ public class PV
 
     /** Write value with confirmation
      *
-     *  <p>{@link Future} can be used to await completion
+     *  <p>{@link CompletableFuture} can be used to await completion
      *  of the write.
      *  The <code>get()</code> will not return a useful value (null),
      *  but they will throw an error if the write failed.
      *
      *  @param new_value Value to write to the PV
-     *  @return {@link Future} for awaiting completion or exception
+     *  @return {@link CompletableFuture} for awaiting completion or exception
      *  @exception Exception on error
      *  @see #write(Object)
      */
-    public Future<?> asyncWrite(final Object new_value) throws Exception
+    public CompletableFuture<?> asyncWrite(final Object new_value) throws Exception
     {   // Default: Normal write, declare 'done' right away
         write(new_value);
         return CompletableFuture.completedFuture(null);

--- a/core/pv/src/main/java/org/phoebus/pv/ca/JCA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/ca/JCA_PV.java
@@ -420,7 +420,7 @@ public class JCA_PV extends PV implements ConnectionListener, MonitorListener, A
     }
 
     @Override
-    public Future<VType> asyncRead() throws Exception
+    public CompletableFuture<VType> asyncRead() throws Exception
     {
         final DBRType type = channel.getFieldType();
         if (type == null   ||  type == DBRType.UNKNOWN)
@@ -453,7 +453,7 @@ public class JCA_PV extends PV implements ConnectionListener, MonitorListener, A
     }
 
     @Override
-    public Future<?> asyncWrite(final Object new_value) throws Exception
+    public CompletableFuture<?> asyncWrite(final Object new_value) throws Exception
     {
         final PutCallbackFuture result = new PutCallbackFuture();
         performWrite(new_value, result);

--- a/core/pv/src/main/java/org/phoebus/pv/opva/PVA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/opva/PVA_PV.java
@@ -8,6 +8,7 @@
 package org.phoebus.pv.opva;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 
@@ -249,7 +250,7 @@ class PVA_PV extends PV implements ChannelRequester, MonitorRequester
 
     /** {@inheritDoc} */
     @Override
-    public Future<VType> asyncRead() throws Exception
+    public CompletableFuture<VType> asyncRead() throws Exception
     {
         final PVGetHandler result = new PVGetHandler(this);
         channel.createChannelGet(result, read_request);
@@ -265,7 +266,7 @@ class PVA_PV extends PV implements ChannelRequester, MonitorRequester
 
     /** {@inheritDoc} */
     @Override
-    public Future<?> asyncWrite(Object new_value) throws Exception
+    public CompletableFuture<?> asyncWrite(Object new_value) throws Exception
     {
         if (enum_labels != null  &&  new_value instanceof String)
         {   // Convert string-for-enum into index of corresponding label

--- a/core/pv/src/main/java/org/phoebus/pv/opva/PVGetHandler.java
+++ b/core/pv/src/main/java/org/phoebus/pv/opva/PVGetHandler.java
@@ -27,7 +27,7 @@ import org.epics.vtype.VType;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-class PVGetHandler extends PVRequester implements ChannelGetRequester, Future<VType>
+class PVGetHandler extends PVRequester implements ChannelGetRequester
 {
     final private PVA_PV pv;
 

--- a/core/pv/src/main/java/org/phoebus/pv/opva/PVPutHandler.java
+++ b/core/pv/src/main/java/org/phoebus/pv/opva/PVPutHandler.java
@@ -25,6 +25,7 @@ import org.epics.pvdata.pv.PVStructure;
 import org.epics.pvdata.pv.Status;
 import org.epics.pvdata.pv.Structure;
 import org.phoebus.pv.PV;
+import org.epics.vtype.VType;
 
 /** A {@link ChannelPutRequester} for writing a value to a {@link PVA_PV},
  *  indicating completion via a {@link Future}
@@ -32,7 +33,7 @@ import org.phoebus.pv.PV;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-class PVPutHandler extends PVRequester implements ChannelPutRequester, Future<Object>
+class PVPutHandler extends PVRequester implements ChannelPutRequester
 {
     final private PV pv;
     final private Object new_value;
@@ -136,7 +137,7 @@ class PVPutHandler extends PVRequester implements ChannelPutRequester, Future<Ob
 
     // Future
     @Override
-    public Object get() throws InterruptedException, ExecutionException
+    public VType get() throws InterruptedException, ExecutionException
     {
         updates.await();
         if (error != null)
@@ -146,7 +147,7 @@ class PVPutHandler extends PVRequester implements ChannelPutRequester, Future<Ob
 
     // Future
     @Override
-    public Object get(final long timeout, final TimeUnit unit) throws InterruptedException,
+    public VType get(final long timeout, final TimeUnit unit) throws InterruptedException,
             ExecutionException, TimeoutException
     {
         if (! updates.await(timeout, unit))

--- a/core/pv/src/main/java/org/phoebus/pv/opva/PVRequester.java
+++ b/core/pv/src/main/java/org/phoebus/pv/opva/PVRequester.java
@@ -9,15 +9,17 @@ package org.phoebus.pv.opva;
 
 import static org.phoebus.pv.PV.logger;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import org.epics.pvdata.pv.MessageType;
 import org.epics.pvdata.pv.Requester;
+import org.epics.vtype.VType;
 
 /** Base for PVAccess {@link Requester}
  *  @author Kay Kasemir
  */
-class PVRequester implements Requester
+class PVRequester extends CompletableFuture<VType> implements Requester
 {
     @Override
     public String getRequesterName()

--- a/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
+++ b/core/pv/src/main/java/org/phoebus/pv/pva/PVA_PV.java
@@ -8,6 +8,7 @@
 package org.phoebus.pv.pva;
 
 import java.util.BitSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -96,11 +97,11 @@ public class PVA_PV extends PV
         }
 
     @Override
-    public Future<VType> asyncRead() throws Exception
+    public CompletableFuture<VType> asyncRead() throws Exception
     {
         final Future<PVAStructure> data = channel.read(name_helper.getRequest());
         // Wrap into Future that converts PVAStructure into VType
-        return new Future<>()
+        return new CompletableFuture<>()
         {
             @Override
             public boolean cancel(final boolean mayInterruptIfRunning)
@@ -190,7 +191,7 @@ public class PVA_PV extends PV
     }
 
     @Override
-    public Future<?> asyncWrite(final Object new_value) throws Exception
+    public CompletableFuture<?> asyncWrite(final Object new_value) throws Exception
     {
         // Perform a put with completion,
         // i.e., process target and block until processing completes,

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -275,7 +275,7 @@ public class PVAChannel extends SearchRequest.Channel implements AutoCloseable
     *  @throws Exception on error
     *  @return {@link Future} for awaiting completion and getting Exception in case of error
     */
-    public Future<Void> write(final boolean completion, final String request, final Object new_value) throws Exception
+    public CompletableFuture<Void> write(final boolean completion, final String request, final Object new_value) throws Exception
     {
         return new PutRequest(this, completion, request, new_value);
     }


### PR DESCRIPTION
Hello

Similarly to my previous PR, this implements the `CompletableFuture` rather than the `Future` class on the `PV` method return values. 

This allows use of the useful `CompletableFuture` API methods. 

One additional question, the code for `asyncWrite` looks a bit strange, it doesn't seem to wait for the result of the write, and just returns null. Its probably a case of me not knowing java very well, but I would be interested in the reasoning there. 

Thanks