### PR TITLE
SAR

### DIFF
--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/search/SearchUtil.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/search/SearchUtil.java
@@ -324,8 +324,7 @@ public class SearchUtil {
         List<Query> pvQueries = new ArrayList<>();
         for (String value : pvNames) {
             for (String pattern : value.split("[|,;]")) {
-                pvQueries.add(TermQuery.of(t -> t.field("pvList.pvName").value(pattern.trim()))._toQuery());
-                pvQueries.add(TermQuery.of(t -> t.field("pvList.readbackPvName").value(pattern.trim()))._toQuery());
+                pvQueries.add(MatchQuery.of(m -> m.field("pvList").query(pattern.trim()))._toQuery());
             }
         }
         Query pvsQuery = pvQuery.queries(pvQueries).build()._toQuery();

--- a/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/web/controllers/SearchControllerTest.java
+++ b/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/web/controllers/SearchControllerTest.java
@@ -100,7 +100,7 @@ public class SearchControllerTest {
 
         SearchRequest searchRequest = searchUtil.buildSearchRequestForPvs(List.of("abc"));
         assertEquals(ES_CONFIGURATION_INDEX, searchRequest.index().get(0));
-        assertEquals("pvList.pvName", searchRequest.query().bool().must().get(0).disMax().queries().get(0).term().field());
-        assertEquals("abc", searchRequest.query().bool().must().get(0).disMax().queries().get(0).term().value().stringValue());
+        assertEquals("pvList", searchRequest.query().bool().must().get(0).disMax().queries().get(0).match().field());
+        assertEquals("abc", searchRequest.query().bool().must().get(0).disMax().queries().get(0).match().query().stringValue());
     }
 }


### PR DESCRIPTION
using match removes the need for explicitly adding queries for pv's and read back pv's