### PR TITLE
Move Utilities.toRawValue to core-vtype

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/datamigration/git/FileUtilities.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/datamigration/git/FileUtilities.java
@@ -24,7 +24,7 @@ import org.epics.util.stats.Range;
 import org.epics.vtype.*;
 import org.phoebus.applications.saveandrestore.model.ConfigPv;
 import org.phoebus.applications.saveandrestore.model.SnapshotItem;
-import org.phoebus.applications.saveandrestore.ui.VDisconnectedData;
+import org.phoebus.core.vtypes.VDisconnectedData;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/filehandler/csv/CSVImporter.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/filehandler/csv/CSVImporter.java
@@ -80,7 +80,7 @@ import org.phoebus.applications.saveandrestore.model.Snapshot;
 import org.phoebus.applications.saveandrestore.model.SnapshotData;
 import org.phoebus.applications.saveandrestore.model.SnapshotItem;
 import org.phoebus.applications.saveandrestore.ui.SaveAndRestoreService;
-import org.phoebus.applications.saveandrestore.ui.VDisconnectedData;
+import org.phoebus.core.vtypes.VDisconnectedData;
 import org.phoebus.applications.saveandrestore.ui.configuration.ConfigurationFromSelectionController;
 import org.phoebus.framework.nls.NLS;
 

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreService.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreService.java
@@ -34,6 +34,8 @@ import org.phoebus.applications.saveandrestore.model.search.SearchResult;
 import org.phoebus.applications.saveandrestore.client.SaveAndRestoreClient;
 import org.phoebus.applications.saveandrestore.client.SaveAndRestoreJerseyClient;
 
+import org.phoebus.core.vtypes.VDisconnectedData;
+
 import javax.ws.rs.core.MultivaluedMap;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/Utilities.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/Utilities.java
@@ -23,7 +23,7 @@ import org.epics.util.array.*;
 import org.epics.util.number.*;
 import org.epics.util.text.NumberFormats;
 import org.epics.vtype.*;
-import org.phoebus.core.vtypes.VTypeHelper;
+import org.phoebus.core.vtypes.VDisconnectedData;
 
 import java.math.BigInteger;
 import java.text.NumberFormat;
@@ -282,60 +282,7 @@ public final class Utilities {
     }
 
     /**
-     * Extracts the raw value from the given data object. The raw value is either one of the primitive wrappers or some
-     * list type if the value is an {@link Array}.
-     *
-     * @param type the value to extract the raw data from
-     * @return the raw data
-     */
-    public static Object toRawValue(VType type) {
-        if (type == null) {
-            return null;
-        }
-        if (type instanceof VNumberArray) {
-            if (type instanceof VIntArray || type instanceof VUIntArray) {
-                return VTypeHelper.toIntegers(type);
-            } else if (type instanceof VDoubleArray) {
-                return VTypeHelper.toDoubles(type);
-            } else if (type instanceof VFloatArray) {
-                return VTypeHelper.toFloats(type);
-            } else if (type instanceof VLongArray || type instanceof VULongArray) {
-                return VTypeHelper.toLongs(type);
-            } else if (type instanceof VShortArray || type instanceof VUShortArray) {
-                return VTypeHelper.toShorts(type);
-            } else if (type instanceof VByteArray || type instanceof VUByteArray) {
-                return VTypeHelper.toBytes(type);
-            }
-        } else if (type instanceof VEnumArray) {
-            List<String> data = ((VEnumArray) type).getData();
-            return data.toArray(new String[data.size()]);
-        } else if (type instanceof VStringArray) {
-            List<String> data = ((VStringArray) type).getData();
-            return data.toArray(new String[data.size()]);
-        } else if (type instanceof VBooleanArray) {
-            return VTypeHelper.toBooleans(type);
-        } else if (type instanceof VNumber) {
-            return ((VNumber) type).getValue();
-        } else if (type instanceof VEnum) {
-            return ((VEnum) type).getIndex();
-        } else if (type instanceof VString) {
-            return ((VString) type).getValue();
-        } else if (type instanceof VBoolean) {
-            return ((VBoolean) type).getValue();
-        } else if (type instanceof VTable) {
-            VTable vTable = (VTable) type;
-            int columnCount = vTable.getColumnCount();
-            List dataArrays = new ArrayList();
-            for (int i = 0; i < columnCount; i++) {
-                dataArrays.add(toPVArrayType("Col " + i, vTable.getColumnData(i)));
-            }
-            return new PVAStructure(PVATable.STRUCT_NAME, "", dataArrays);
-        }
-        return null;
-    }
-
-    /**
-     * Transforms the value of the given {@link VType} to a human-readable string. This method uses formatting to format
+     * Transforms the value of the given {@link VType} to a human readable string. This method uses formatting to format
      * all values, which may result in the arrays being truncated.
      *
      * @param type the data to transform

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/VDisconnectedData.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/VDisconnectedData.java
@@ -17,6 +17,8 @@
  */
 package org.phoebus.applications.saveandrestore.ui;
 
+import org.epics.vtype.Alarm;
+import org.epics.vtype.AlarmProvider;
 import org.epics.vtype.VType;
 
 /**
@@ -26,7 +28,7 @@ import org.epics.vtype.VType;
  * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
  *
  */
-public final class VDisconnectedData extends VType{
+public final class VDisconnectedData extends VType implements AlarmProvider {
 
     private static final long serialVersionUID = -2399970529728581034L;
 
@@ -47,6 +49,11 @@ public final class VDisconnectedData extends VType{
     @Override
     public String toString() {
         return TO_STRING;
+    }
+
+    @Override
+    public Alarm getAlarm() {
+        return Alarm.disconnected();
     }
 
 

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SaveAndRestorePV.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SaveAndRestorePV.java
@@ -20,7 +20,7 @@
 package org.phoebus.applications.saveandrestore.ui.snapshot;
 
 import org.epics.vtype.VType;
-import org.phoebus.applications.saveandrestore.ui.VDisconnectedData;
+import org.phoebus.core.vtypes.VDisconnectedData;
 import org.phoebus.applications.saveandrestore.ui.VNoData;
 import org.phoebus.pv.PV;
 import org.phoebus.pv.PVPool;

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTableViewController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTableViewController.java
@@ -34,6 +34,8 @@ import org.phoebus.applications.saveandrestore.Preferences;
 import org.phoebus.applications.saveandrestore.SafeMultiply;
 import org.phoebus.applications.saveandrestore.model.*;
 import org.phoebus.applications.saveandrestore.ui.*;
+import org.phoebus.core.vtypes.VTypeHelper;
+import org.phoebus.core.vtypes.VDisconnectedData;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.util.time.TimestampFormats;
 
@@ -358,7 +360,7 @@ public class SnapshotTableViewController extends BaseSnapshotTableViewController
                     final SaveAndRestorePV pv = pvs.get(getPVKey(e.pvNameProperty().get(), e.readOnlyProperty().get()));
                     if (entry.getValue() != null) {
                         try {
-                            pv.getPv().write(Utilities.toRawValue(entry.getValue()));
+                            pv.getPv().write(VTypeHelper.toObject(entry.getValue()));
                         } catch (Exception writeException) {
                             restoreFailedPVNames.add(entry.getConfigPv().getPvName());
                         } finally {

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/TableEntry.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/TableEntry.java
@@ -16,6 +16,7 @@ import org.epics.pva.data.nt.PVAAlarm;
 import org.epics.vtype.*;
 import org.phoebus.applications.saveandrestore.model.ConfigPv;
 import org.phoebus.applications.saveandrestore.ui.*;
+import org.phoebus.core.vtypes.VDisconnectedData;
 
 import java.time.Instant;
 import java.util.ArrayList;

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/VDeltaCellEditor.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/VDeltaCellEditor.java
@@ -23,7 +23,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import org.phoebus.applications.saveandrestore.ui.Utilities;
-import org.phoebus.applications.saveandrestore.ui.VDisconnectedData;
+import org.phoebus.core.vtypes.VDisconnectedData;
 import org.phoebus.applications.saveandrestore.ui.VNoData;
 import org.phoebus.applications.saveandrestore.ui.VTypePair;
 

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/VTypeCellEditor.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/VTypeCellEditor.java
@@ -26,6 +26,7 @@ import javafx.scene.image.ImageView;
 import javafx.util.StringConverter;
 import org.epics.vtype.*;
 import org.phoebus.applications.saveandrestore.ui.*;
+import org.phoebus.core.vtypes.VDisconnectedData;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/save-and-restore/app/src/test/java/org/phoebus/applications/saveandrestore/ui/UtilitiesTest.java
+++ b/app/save-and-restore/app/src/test/java/org/phoebus/applications/saveandrestore/ui/UtilitiesTest.java
@@ -22,6 +22,7 @@ import org.epics.pva.data.*;
 import org.epics.util.array.*;
 import org.epics.vtype.*;
 import org.junit.jupiter.api.Test;
+import org.phoebus.core.vtypes.VDisconnectedData;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -302,112 +303,6 @@ public class UtilitiesTest {
         result = Utilities.valueFromString("string", val);
         assertTrue(result instanceof VString);
         assertEquals("string", ((VString) result).getValue());
-    }
-
-    /**
-     * Tests {@link Utilities#toRawValue(VType)}.
-     */
-    @Test
-    public void testToRawValue() {
-        Alarm alarm = Alarm.none();
-        Display display = Display.none();
-        Time time = Time.now();
-
-        assertNull(Utilities.toRawValue(null));
-
-        VType val = VDouble.of(5d, alarm, time, display);
-        Object d = Utilities.toRawValue(val);
-        assertTrue(d instanceof Double);
-        assertEquals(5.0, d);
-
-        val = VFloat.of(5f, alarm, time, display);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof Float);
-        assertEquals(5.0f, d);
-
-        val = VLong.of(5L, alarm, time, display);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof Long);
-        assertEquals(5L, d);
-
-        val = VInt.of(5, alarm, time, display);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof Integer);
-        assertEquals(5, d);
-
-        val = VShort.of((short) 5, alarm, time, display);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof Short);
-        assertEquals((short) 5, d);
-
-        val = VByte.of((byte) 5, alarm, time, display);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof Byte);
-        assertEquals((byte) 5, d);
-
-        val = VEnum.of(1, EnumDisplay.of("first", "second", "third"), alarm, time);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof Integer);
-        assertEquals(1, d);
-
-        val = VString.of("third", alarm, time);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof String);
-        assertEquals("third", d);
-
-        ArrayDouble arrayDouble = ArrayDouble.of(1, 2, 3, 4, 5);
-        val = VDoubleArray.of(arrayDouble, alarm, time, display);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof double[]);
-        for (int i = 0; i < ((double[]) d).length; i++) {
-            assertEquals(arrayDouble.getDouble(i), ((double[]) d)[i], 0);
-        }
-
-        val = VStringArray.of(Arrays.asList("a", "b", "c"), alarm, time);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof String[]);
-
-        val = VBooleanArray.of(ArrayBoolean.of(true, false, true), alarm, time);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof boolean[]);
-        assertTrue(((boolean[]) d)[0]);
-        assertFalse(((boolean[]) d)[1]);
-
-        val = VEnumArray.of(ArrayInteger.of(0, 1, 2, 3, 4), EnumDisplay.of("a", "b", "c", "d", "e"), alarm, time);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof String[]);
-        assertEquals("a", ((String[]) d)[0]);
-        assertEquals("e", ((String[]) d)[4]);
-
-        val = VBoolean.of(true, alarm, time);
-        d = Utilities.toRawValue(val);
-        assertTrue(d instanceof Boolean);
-        assertTrue(((Boolean) d));
-
-        assertNull(Utilities.toRawValue(VDisconnectedData.INSTANCE));
-
-        List<Class<?>> types = Arrays.asList(Integer.TYPE, Integer.TYPE, Integer.TYPE);
-        List<Object> values = Arrays.asList(ArrayInteger.of(-1, 2, 3), ArrayInteger.of(1, 2, 3), ArrayUInteger.of(11, 22, 33));
-        List<String> names = Arrays.asList("a", "b", "c");
-        VTable vTable = VTable.of(types, names, values);
-
-        d = Utilities.toRawValue(vTable);
-        assertInstanceOf(PVAStructure.class, d);
-        PVAStructure pvaStructure = (PVAStructure) d;
-        assertEquals(3, pvaStructure.get().size());
-        assertInstanceOf(PVAIntArray.class, pvaStructure.get().get(0));
-        assertInstanceOf(PVAIntArray.class, pvaStructure.get().get(1));
-        assertInstanceOf(PVAIntArray.class, pvaStructure.get().get(2));
-
-        PVAIntArray pvaIntArray = (PVAIntArray) pvaStructure.get().get(0);
-        assertEquals(3, pvaIntArray.get().length);
-        assertArrayEquals(new int[]{-1, 2, 3}, pvaIntArray.get());
-        pvaIntArray = (PVAIntArray) pvaStructure.get().get(1);
-        assertArrayEquals(new int[]{1, 2, 3}, pvaIntArray.get());
-        assertEquals(3, pvaIntArray.get().length);
-        pvaIntArray = (PVAIntArray) pvaStructure.get().get(2);
-        assertArrayEquals(new int[]{11, 22, 33}, pvaIntArray.get());
-        assertEquals(3, pvaIntArray.get().length);
     }
 
 

--- a/core/vtype/src/main/java/org/phoebus/core/vtypes/VDisconnectedData.java
+++ b/core/vtype/src/main/java/org/phoebus/core/vtypes/VDisconnectedData.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.phoebus.core.vtypes;
+
+import org.epics.vtype.VType;
+
+/**
+ *
+ * <code>VDisconnectedData</code> represents a {@link VType} for a disconnected PV, where the data type is not known.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public final class VDisconnectedData extends VType {
+
+    private static final long serialVersionUID = -2399970529728581034L;
+
+    /** The singleton instance */
+    public static final VDisconnectedData INSTANCE = new VDisconnectedData();
+
+    private static final String TO_STRING = "---";
+    public static final String DISCONNECTED = "DISCONNECTED";
+
+    private VDisconnectedData() {
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return TO_STRING;
+    }
+
+
+    public String getName(){ return "";}
+
+}

--- a/core/vtype/src/main/java/org/phoebus/core/vtypes/VTypeHelper.java
+++ b/core/vtype/src/main/java/org/phoebus/core/vtypes/VTypeHelper.java
@@ -506,4 +506,49 @@ public class VTypeHelper {
         }
         return false;
     }
+
+    /**
+     * Extracts the raw value from the given data object. The raw value is either one of the primitive wrappers or some
+     * kind of a list type if the value is an {@link Array}.
+     *
+     * @param type the value to extract the raw data from
+     * @return the raw data
+     */
+    public static Object toObject(VType type) {
+        if (type == null) {
+            return null;
+        }
+        if (type instanceof VNumberArray) {
+            if (type instanceof VIntArray || type instanceof VUIntArray) {
+                return VTypeHelper.toIntegers(type);
+            } else if (type instanceof VDoubleArray) {
+                return VTypeHelper.toDoubles(type);
+            } else if (type instanceof VFloatArray) {
+                return VTypeHelper.toFloats(type);
+            } else if (type instanceof VLongArray || type instanceof VULongArray) {
+                return VTypeHelper.toLongs(type);
+            } else if (type instanceof VShortArray || type instanceof VUShortArray) {
+                return VTypeHelper.toShorts(type);
+            } else if (type instanceof VByteArray || type instanceof VUByteArray) {
+                return VTypeHelper.toBytes(type);
+            }
+        } else if (type instanceof VEnumArray) {
+            List<String> data = ((VEnumArray) type).getData();
+            return data.toArray(new String[data.size()]);
+        } else if (type instanceof VStringArray) {
+            List<String> data = ((VStringArray) type).getData();
+            return data.toArray(new String[data.size()]);
+        } else if (type instanceof VBooleanArray) {
+            return VTypeHelper.toBooleans(type);
+        } else if (type instanceof VNumber) {
+            return ((VNumber) type).getValue();
+        } else if (type instanceof VEnum) {
+            return ((VEnum) type).getIndex();
+        } else if (type instanceof VString) {
+            return ((VString) type).getValue();
+        } else if (type instanceof VBoolean) {
+            return ((VBoolean) type).getValue();
+        }
+        return null;
+    }
 }

--- a/core/vtype/src/main/java/org/phoebus/core/vtypes/VTypeHelper.java
+++ b/core/vtype/src/main/java/org/phoebus/core/vtypes/VTypeHelper.java
@@ -8,6 +8,7 @@
 package org.phoebus.core.vtypes;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.epics.util.array.ListBoolean;
@@ -533,7 +534,8 @@ public class VTypeHelper {
                 return VTypeHelper.toBytes(type);
             }
         } else if (type instanceof VEnumArray) {
-            List<String> data = ((VEnumArray) type).getData();
+            var indexes = ((VEnumArray) type).getIndexes();
+            List<Integer> data = indexes.toArray(new ArrayList<Integer>());
             return data.toArray(new String[data.size()]);
         } else if (type instanceof VStringArray) {
             List<String> data = ((VStringArray) type).getData();

--- a/core/vtype/src/main/java/org/phoebus/core/vtypes/VTypeHelper.java
+++ b/core/vtype/src/main/java/org/phoebus/core/vtypes/VTypeHelper.java
@@ -535,8 +535,8 @@ public class VTypeHelper {
             }
         } else if (type instanceof VEnumArray) {
             var indexes = ((VEnumArray) type).getIndexes();
-            List<Integer> data = indexes.toArray(new ArrayList<Integer>());
-            return data.toArray(new String[data.size()]);
+            var array = new int[indexes.size()];
+            return indexes.toArray(array);
         } else if (type instanceof VStringArray) {
             List<String> data = ((VStringArray) type).getData();
             return data.toArray(new String[data.size()]);

--- a/core/vtype/src/test/java/org/phoebus/core/vtypes/VTypeHelperTest.java
+++ b/core/vtype/src/test/java/org/phoebus/core/vtypes/VTypeHelperTest.java
@@ -22,33 +22,8 @@ import org.epics.util.array.ListUByte;
 import org.epics.util.array.ListUInteger;
 import org.epics.util.array.ListULong;
 import org.epics.util.array.ListUShort;
-import org.epics.vtype.Alarm;
-import org.epics.vtype.Array;
-import org.epics.vtype.Display;
-import org.epics.vtype.EnumDisplay;
-import org.epics.vtype.Time;
-import org.epics.vtype.VBoolean;
-import org.epics.vtype.VBooleanArray;
-import org.epics.vtype.VByteArray;
-import org.epics.vtype.VDouble;
-import org.epics.vtype.VDoubleArray;
-import org.epics.vtype.VEnum;
-import org.epics.vtype.VEnumArray;
-import org.epics.vtype.VFloatArray;
-import org.epics.vtype.VInt;
-import org.epics.vtype.VIntArray;
-import org.epics.vtype.VLongArray;
-import org.epics.vtype.VNumber;
-import org.epics.vtype.VNumberArray;
-import org.epics.vtype.VShortArray;
-import org.epics.vtype.VStatistics;
-import org.epics.vtype.VString;
-import org.epics.vtype.VStringArray;
-import org.epics.vtype.VTable;
-import org.epics.vtype.VType;
-import org.epics.vtype.VUIntArray;
-import org.epics.vtype.VULongArray;
-import org.epics.vtype.VUShortArray;
+
+import org.epics.vtype.*;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -564,4 +539,85 @@ public class VTypeHelperTest {
 
         assertTrue(VTypeHelper.toBooleans(VDouble.of(7.0, alarm, time, display)).length == 0);
     }
+
+    @Test
+    public void testToObject() {
+        Alarm alarm = Alarm.none();
+        Display display = Display.none();
+        Time time = Time.now();
+
+        assertNull(VTypeHelper.toObject(null));
+
+        VType val = VDouble.of(5d, alarm, time, display);
+        Object d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof Double);
+        assertEquals(5.0, d);
+
+        val = VFloat.of(5f, alarm, time, display);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof Float);
+        assertEquals(5.0f, d);
+
+        val = VLong.of(5L, alarm, time, display);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof Long);
+        assertEquals(5L, d);
+
+        val = VInt.of(5, alarm, time, display);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof Integer);
+        assertEquals(5, d);
+
+        val = VShort.of((short) 5, alarm, time, display);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof Short);
+        assertEquals((short) 5, d);
+
+        val = VByte.of((byte) 5, alarm, time, display);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof Byte);
+        assertEquals((byte) 5, d);
+
+        val = VEnum.of(1, EnumDisplay.of("first", "second", "third"), alarm, time);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof Integer);
+        assertEquals(1, d);
+
+        val = VString.of("third", alarm, time);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof String);
+        assertEquals("third", d);
+
+        ArrayDouble arrayDouble = ArrayDouble.of(1, 2, 3, 4, 5);
+        val = VDoubleArray.of(arrayDouble, alarm, time, display);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof double[]);
+        for (int i = 0; i < ((double[]) d).length; i++) {
+            assertEquals(arrayDouble.getDouble(i), ((double[]) d)[i], 0);
+        }
+
+        val = VStringArray.of(Arrays.asList("a", "b", "c"), alarm, time);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof String[]);
+
+        val = VBooleanArray.of(ArrayBoolean.of(true, false, true), alarm, time);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof boolean[]);
+        assertTrue(((boolean[]) d)[0]);
+        assertFalse(((boolean[]) d)[1]);
+
+        val = VEnumArray.of(ArrayInteger.of(0, 1, 2, 3, 4), EnumDisplay.of("a", "b", "c", "d", "e"), alarm, time);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof String[]);
+        assertEquals("a", ((String[]) d)[0]);
+        assertEquals("e", ((String[]) d)[4]);
+
+        val = VBoolean.of(true, alarm, time);
+        d = VTypeHelper.toObject(val);
+        assertTrue(d instanceof Boolean);
+        assertTrue(((Boolean) d));
+
+        assertNull(VTypeHelper.toObject(VDisconnectedData.INSTANCE));
+    }
+
 }

--- a/core/vtype/src/test/java/org/phoebus/core/vtypes/VTypeHelperTest.java
+++ b/core/vtype/src/test/java/org/phoebus/core/vtypes/VTypeHelperTest.java
@@ -608,9 +608,9 @@ public class VTypeHelperTest {
 
         val = VEnumArray.of(ArrayInteger.of(0, 1, 2, 3, 4), EnumDisplay.of("a", "b", "c", "d", "e"), alarm, time);
         d = VTypeHelper.toObject(val);
-        assertTrue(d instanceof String[]);
-        assertEquals("a", ((String[]) d)[0]);
-        assertEquals("e", ((String[]) d)[4]);
+        assertTrue(d instanceof int[]);
+        assertEquals(0, ((int[]) d)[0]);
+        assertEquals(4, ((int[]) d)[4]);
 
         val = VBoolean.of(true, alarm, time);
         d = VTypeHelper.toObject(val);


### PR DESCRIPTION
Hi there, in the process of doing another pull request I found that it would be a good idea to refactor the `Utilities.toRawValue` method in the save-and-restore ui code into the shared `vtype` library. This is because converting a `VType` to a  native java object was useful in my usecase and sounds like a generally useful thing to want to do. 

I also thought it would be best to take the associated `VDisconnectedData` type into the `vtype` library as well, given it shows up in the `Utilities.toRawValue` tests. 

Another minor change when making the modifications to the tests was to use wildcard import for the V types as they now pretty much import all the classes into the file.