### PR TITLE
CSSTUDIO-2207 Bugfix: Escape '[' and ']' in DisplayInfo.toURI().

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayInfo.java
@@ -226,7 +226,10 @@ public class DisplayInfo
 
         // In path, keep ':' and '/', but replace spaces
         // Windows platform tweak replace \ with /
-        buf.append(path.replace(" ", "%20").replace('\\', '/'));
+        buf.append(path.replace(" ", "%20")
+                       .replace('\\', '/')
+                       .replace("[", "%5B")
+                       .replace("]", "%5D"));
 
         // Add macros as path parameters
         boolean first = true;


### PR DESCRIPTION
This PR adds escaping of `[` and `]` to `DisplayInfo.toURI()`.