### PR TITLE
Move saveandrestore.client preference settings into separate file

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/client/SaveAndRestoreJerseyClient.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/client/SaveAndRestoreJerseyClient.java
@@ -64,7 +64,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
         mapper.registerModule(new JavaTimeModule());
         mapper.setSerializationInclusion(Include.NON_NULL);
 
-        PreferencesReader preferencesReader = new PreferencesReader(SaveAndRestoreClient.class, "/save_and_restore_preferences.properties");
+        PreferencesReader preferencesReader = new PreferencesReader(SaveAndRestoreClient.class, "/save_and_restore_client_preferences.properties");
         this.jmasarServiceUrl = preferencesReader.get("jmasar.service.url");
 
         String readTimeoutString = preferencesReader.get("httpClient.readTimeout");

--- a/app/save-and-restore/app/src/main/resources/save_and_restore_client_preferences.properties
+++ b/app/save-and-restore/app/src/main/resources/save_and_restore_client_preferences.properties
@@ -1,0 +1,12 @@
+# ------------------------------------------------------
+# Package org.phoebus.applications.saveandrestore.client
+# ------------------------------------------------------
+
+# The URL to the save-and-restore service
+jmasar.service.url=http://localhost:8080/save-restore
+
+# Read timeout (in ms) used by the Jersey client
+httpClient.readTimeout=1000
+
+# Connect timeout in (ms) used by the Jersey client
+httpClient.connectTimeout=1000

--- a/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
+++ b/app/save-and-restore/app/src/main/resources/save_and_restore_preferences.properties
@@ -16,12 +16,3 @@ default_search_query=tags=golden
 
 # If declared add a date automatically in the name of the snapshot "Take Snapshot"
 #default_snapshot_name_date_format=yyyy-MM-dd HH:mm:ss
-
-# The URL to the save-and-restore service
-jmasar.service.url=http://localhost:8080/save-restore
-
-# Read timeout (in ms) used by the Jersey client
-httpClient.readTimeout=1000
-
-# Connect timeout in (ms) used by the Jersey client
-httpClient.connectTimeout=1000


### PR DESCRIPTION
https://github.com/ControlSystemStudio/phoebus/issues/2922

Tools like the web documentation script and create_settings_template.py rely on the `# Package org...` string in the .properties file to determine which package each setting belongs to, so this is an attempt to get those working again for saveandrestore.client settings