### PR TITLE
RTTank: Fix log scaling

### DIFF
--- a/app/display/model/src/main/resources/examples/monitors_tank.bob
+++ b/app/display/model/src/main/resources/examples/monitors_tank.bob
@@ -60,4 +60,29 @@
     <y>60</y>
     <width>60</width>
   </widget>
+  <widget type="tank" version="2.0.0">
+    <name>Tank_2</name>
+    <pv_name>sim://sine(10, 1000, 10, 1)</pv_name>
+    <x>440</x>
+    <y>90</y>
+    <width>110</width>
+    <height>310</height>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <limits_from_pv>false</limits_from_pv>
+    <minimum>10.0</minimum>
+    <maximum>1000.0</maximum>
+  </widget>
+  <widget type="tank" version="2.0.0">
+    <name>Tank_3</name>
+    <pv_name>sim://sine(10, 1000, 10, 1)</pv_name>
+    <x>580</x>
+    <y>90</y>
+    <width>110</width>
+    <height>310</height>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <limits_from_pv>false</limits_from_pv>
+    <minimum>10.0</minimum>
+    <maximum>1000.0</maximum>
+    <log_scale>true</log_scale>
+  </widget>
 </display>

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTTank.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTTank.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2017 Oak Ridge National Laboratory.
+ * Copyright (c) 2014-2023 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -275,7 +275,14 @@ public class RTTank extends Canvas
             level = plot_bounds.height;
         else if (max == min)
             level = 0;
-        else
+        else if (scale.isLogarithmic()) // by mellguth2, https://github.com/ControlSystemStudio/phoebus/issues/2726
+        {   // refuse to try any mapping if negatives or zero are involved
+            if (min <= 0 || max <= 0.0 || current <= 0.0)
+                level = 0;
+            else
+                level = (int) (plot_bounds.height * Math.log(current/min) / Math.log(max/min));
+        }
+        else // linear scale
             level = (int) (plot_bounds.height * (current - min) / (max - min) + 0.5);
 
         final int arc = Math.min(plot_bounds.width, plot_bounds.height) / 10;


### PR DESCRIPTION
#2726 mentions problems with the tank widget log scale.

For example, the value 500 which shows correctly in the linear configuration on the left looks like a value of 100 for the log scale on the right:

![Screenshot 2024-02-02 at 2 38 36 PM](https://github.com/ControlSystemStudio/phoebus/assets/1932421/a8830993-1ecc-4f54-9acd-3e4945e8ed32)

This update as provided by @mellguth2 results in 500 looking like 500 on either scale:

![Screenshot 2024-02-02 at 2 41 46 PM](https://github.com/ControlSystemStudio/phoebus/assets/1932421/15b13be0-b782-4e60-9c09-a20f06d2a3f4)
