### PR TITLE
add back in vtable conversion removed by mistake

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/Utilities.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/Utilities.java
@@ -17,8 +17,6 @@
  */
 package org.phoebus.applications.saveandrestore.ui;
 
-import org.epics.pva.data.*;
-import org.epics.pva.data.nt.PVATable;
 import org.epics.util.array.*;
 import org.epics.util.number.*;
 import org.epics.util.text.NumberFormats;
@@ -1300,65 +1298,4 @@ public final class Utilities {
         return false;
     }
 
-    /**
-     * @param name Data item name
-     * @param object The object subject to conversion
-     * @return Converted object
-     */
-    public static Object toPVArrayType(String name, Object object) {
-        if (object instanceof ListBoolean) {
-            ListBoolean listBoolean = (ListBoolean) object;
-            boolean[] booleans = new boolean[listBoolean.size()];
-            for (int i = 0; i < listBoolean.size(); i++) {
-                booleans[i] = listBoolean.getBoolean(i);
-            }
-            return new PVABoolArray(name, booleans);
-        } else if (object instanceof ListNumber) {
-            ListNumber listNumber = (ListNumber) object;
-            if (object instanceof ArrayByte || object instanceof ArrayUByte) {
-                byte[] bytes = new byte[listNumber.size()];
-                for (int i = 0; i < listNumber.size(); i++) {
-                    bytes[i] = listNumber.getByte(i);
-                }
-                return new PVAByteArray(name, object instanceof ArrayUByte, bytes);
-            } else if (object instanceof ArrayShort || object instanceof ArrayUShort) {
-                short[] shorts = new short[listNumber.size()];
-                for (int i = 0; i < listNumber.size(); i++) {
-                    shorts[i] = listNumber.getShort(i);
-                }
-                return new PVAShortArray(name, object instanceof ArrayUShort, shorts);
-            } else if (object instanceof ArrayInteger || object instanceof ArrayUInteger) {
-                int[] ints = new int[listNumber.size()];
-                for (int i = 0; i < listNumber.size(); i++) {
-                    ints[i] = listNumber.getInt(i);
-                }
-                return new PVAIntArray(name, object instanceof ArrayUInteger, ints);
-            } else if (object instanceof ArrayLong || object instanceof ArrayULong) {
-                long[] longs = new long[listNumber.size()];
-                for (int i = 0; i < listNumber.size(); i++) {
-                    longs[i] = listNumber.getLong(i);
-                }
-                return new PVALongArray(name, object instanceof ArrayULong, longs);
-            } else if (object instanceof ArrayFloat) {
-                float[] floats = new float[listNumber.size()];
-                for (int i = 0; i < listNumber.size(); i++) {
-                    floats[i] = listNumber.getFloat(i);
-                }
-                return new PVAFloatArray(name, floats);
-            } else if (object instanceof ArrayDouble) {
-                double[] doubles = new double[listNumber.size()];
-                for (int i = 0; i < listNumber.size(); i++) {
-                    doubles[i] = listNumber.getDouble(i);
-                }
-                return new PVADoubleArray(name, doubles);
-            } else {
-                throw new IllegalArgumentException("Conversion of type " + object.getClass().getCanonicalName() + " not supported");
-            }
-        } else { // Assume this always is for string arrays
-            Collection<String> list = (Collection<String>) object;
-            String[] strings = new String[list.size()];
-            strings = list.toArray(strings);
-            return new PVAStringArray(name, strings);
-        }
-    }
 }

--- a/app/save-and-restore/app/src/test/java/org/phoebus/applications/saveandrestore/ui/UtilitiesTest.java
+++ b/app/save-and-restore/app/src/test/java/org/phoebus/applications/saveandrestore/ui/UtilitiesTest.java
@@ -23,6 +23,7 @@ import org.epics.util.array.*;
 import org.epics.vtype.*;
 import org.junit.jupiter.api.Test;
 import org.phoebus.core.vtypes.VDisconnectedData;
+import org.phoebus.core.vtypes.VTypeHelper;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -1471,14 +1472,14 @@ public class UtilitiesTest {
     public void testToPVArrayType() {
 
         boolean[] bools = new boolean[]{true, false, true};
-        Object converted = Utilities.toPVArrayType("bools", ArrayBoolean.of(bools));
+        Object converted = VTypeHelper.toPVArrayType("bools", ArrayBoolean.of(bools));
         assertInstanceOf(PVABoolArray.class, converted);
         assertEquals(3, ((PVABoolArray) converted).get().length);
         assertArrayEquals(bools, ((PVABoolArray) converted).get());
         assertEquals("bools", ((PVABoolArray) converted).getName());
 
         byte[] bytes = new byte[]{(byte) -1, (byte) 2, (byte) 3};
-        converted = Utilities.toPVArrayType("bytes", ArrayByte.of(bytes));
+        converted = VTypeHelper.toPVArrayType("bytes", ArrayByte.of(bytes));
         assertInstanceOf(PVAByteArray.class, converted);
         assertEquals(3, ((PVAByteArray) converted).get().length);
         assertArrayEquals(bytes, ((PVAByteArray) converted).get());
@@ -1486,7 +1487,7 @@ public class UtilitiesTest {
         assertFalse(((PVAByteArray) converted).isUnsigned());
 
         bytes = new byte[]{(byte) 1, (byte) 2, (byte) 3};
-        converted = Utilities.toPVArrayType("ubytes", ArrayUByte.of(bytes));
+        converted = VTypeHelper.toPVArrayType("ubytes", ArrayUByte.of(bytes));
         assertInstanceOf(PVAByteArray.class, converted);
         assertEquals(3, ((PVAByteArray) converted).get().length);
         assertArrayEquals(bytes, ((PVAByteArray) converted).get());
@@ -1494,7 +1495,7 @@ public class UtilitiesTest {
         assertTrue(((PVAByteArray) converted).isUnsigned());
 
         short[] shorts = new short[]{(short) -1, (short) 2, (short) 3};
-        converted = Utilities.toPVArrayType("shorts", ArrayShort.of(shorts));
+        converted = VTypeHelper.toPVArrayType("shorts", ArrayShort.of(shorts));
         assertInstanceOf(PVAShortArray.class, converted);
         assertEquals(3, ((PVAShortArray) converted).get().length);
         assertArrayEquals(shorts, ((PVAShortArray) converted).get());
@@ -1502,7 +1503,7 @@ public class UtilitiesTest {
         assertFalse(((PVAShortArray) converted).isUnsigned());
 
         shorts = new short[]{(short) 1, (short) 2, (short) 3};
-        converted = Utilities.toPVArrayType("ushorts", ArrayUShort.of(shorts));
+        converted = VTypeHelper.toPVArrayType("ushorts", ArrayUShort.of(shorts));
         assertInstanceOf(PVAShortArray.class, converted);
         assertEquals(3, ((PVAShortArray) converted).get().length);
         assertArrayEquals(shorts, ((PVAShortArray) converted).get());
@@ -1510,7 +1511,7 @@ public class UtilitiesTest {
         assertTrue(((PVAShortArray) converted).isUnsigned());
 
         int[] ints = new int[]{-1, 2, 3};
-        converted = Utilities.toPVArrayType("ints", ArrayInteger.of(ints));
+        converted = VTypeHelper.toPVArrayType("ints", ArrayInteger.of(ints));
         assertInstanceOf(PVAIntArray.class, converted);
         assertEquals(3, ((PVAIntArray) converted).get().length);
         assertArrayEquals(ints, ((PVAIntArray) converted).get());
@@ -1518,7 +1519,7 @@ public class UtilitiesTest {
         assertFalse(((PVAIntArray) converted).isUnsigned());
 
         ints = new int[]{1, 2, 3};
-        converted = Utilities.toPVArrayType("uints", ArrayUInteger.of(ints));
+        converted = VTypeHelper.toPVArrayType("uints", ArrayUInteger.of(ints));
         assertInstanceOf(PVAIntArray.class, converted);
         assertEquals(3, ((PVAIntArray) converted).get().length);
         assertArrayEquals(ints, ((PVAIntArray) converted).get());
@@ -1526,7 +1527,7 @@ public class UtilitiesTest {
         assertTrue(((PVAIntArray) converted).isUnsigned());
 
         long[] longs = new long[]{-1L, 2L, 3L};
-        converted = Utilities.toPVArrayType("longs", ArrayLong.of(longs));
+        converted = VTypeHelper.toPVArrayType("longs", ArrayLong.of(longs));
         assertInstanceOf(PVALongArray.class, converted);
         assertEquals(3, ((PVALongArray) converted).get().length);
         assertArrayEquals(longs, ((PVALongArray) converted).get());
@@ -1534,7 +1535,7 @@ public class UtilitiesTest {
         assertFalse(((PVALongArray) converted).isUnsigned());
 
         longs = new long[]{1L, 2L, 3L};
-        converted = Utilities.toPVArrayType("ulongs", ArrayULong.of(longs));
+        converted = VTypeHelper.toPVArrayType("ulongs", ArrayULong.of(longs));
         assertInstanceOf(PVALongArray.class, converted);
         assertEquals(3, ((PVALongArray) converted).get().length);
         assertArrayEquals(longs, ((PVALongArray) converted).get());
@@ -1542,14 +1543,14 @@ public class UtilitiesTest {
         assertTrue(((PVALongArray) converted).isUnsigned());
 
         float[] floats = new float[]{-1.0f, 2.0f, 3.0f};
-        converted = Utilities.toPVArrayType("floats", ArrayFloat.of(floats));
+        converted = VTypeHelper.toPVArrayType("floats", ArrayFloat.of(floats));
         assertInstanceOf(PVAFloatArray.class, converted);
         assertEquals(3, ((PVAFloatArray) converted).get().length);
         assertArrayEquals(floats, ((PVAFloatArray) converted).get());
         assertEquals("floats", ((PVAFloatArray) converted).getName());
 
         double[] doubles = new double[]{-1.0, 2.0, 3.0};
-        converted = Utilities.toPVArrayType("doubles", ArrayDouble.of(doubles));
+        converted = VTypeHelper.toPVArrayType("doubles", ArrayDouble.of(doubles));
         assertInstanceOf(PVADoubleArray.class, converted);
         assertEquals(3, ((PVADoubleArray) converted).get().length);
         assertArrayEquals(doubles, ((PVADoubleArray) converted).get());
@@ -1559,7 +1560,7 @@ public class UtilitiesTest {
         strings.add("a");
         strings.add("b");
         strings.add("c");
-        converted = Utilities.toPVArrayType("strings", strings);
+        converted = VTypeHelper.toPVArrayType("strings", strings);
         assertInstanceOf(PVAStringArray.class, converted);
         assertEquals(3, ((PVAStringArray) converted).get().length);
         assertArrayEquals(new String[]{"a", "b", "c"}, ((PVAStringArray) converted).get());

--- a/core/vtype/pom.xml
+++ b/core/vtype/pom.xml
@@ -26,11 +26,6 @@
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
-      <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.phoebus</groupId>
       <artifactId>core-pva</artifactId>
       <version>4.7.4-SNAPSHOT</version>
     </dependency>

--- a/core/vtype/pom.xml
+++ b/core/vtype/pom.xml
@@ -24,5 +24,15 @@
       <version>1.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>core-pv</artifactId>
+      <version>4.7.4-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.phoebus</groupId>
+      <artifactId>core-pva</artifactId>
+      <version>4.7.4-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>

--- a/core/vtype/src/test/java/org/phoebus/core/vtypes/VTypeHelperTest.java
+++ b/core/vtype/src/test/java/org/phoebus/core/vtypes/VTypeHelperTest.java
@@ -24,16 +24,19 @@ import org.epics.util.array.ListULong;
 import org.epics.util.array.ListUShort;
 
 import org.epics.vtype.*;
-import org.junit.jupiter.api.Test;
+import org.epics.pva.data.*;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.List;
 
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class VTypeHelperTest {
 
@@ -616,6 +619,19 @@ public class VTypeHelperTest {
         d = VTypeHelper.toObject(val);
         assertTrue(d instanceof Boolean);
         assertTrue(((Boolean) d));
+
+        List<Class<?>> types = Arrays.asList(Integer.TYPE, Integer.TYPE, Integer.TYPE);
+        List<Object> values = Arrays.asList(ArrayInteger.of(-1, 2, 3), ArrayInteger.of(1, 2, 3), ArrayUInteger.of(11, 22, 33));
+        List<String> names = Arrays.asList("a", "b", "c");
+        VTable vTable = VTable.of(types, names, values);
+
+        d = VTypeHelper.toObject(vTable);
+        assertInstanceOf(PVAStructure.class, d);
+        PVAStructure pvaStructure = (PVAStructure) d;
+        assertEquals(3, pvaStructure.get().size());
+        assertInstanceOf(PVAIntArray.class, pvaStructure.get().get(0));
+        assertInstanceOf(PVAIntArray.class, pvaStructure.get().get(1));
+        assertInstanceOf(PVAIntArray.class, pvaStructure.get().get(2));
 
         assertNull(VTypeHelper.toObject(VDisconnectedData.INSTANCE));
     }


### PR DESCRIPTION
The functionality to convert vTables got removed by accident in the refactor.
Reinstated this functionality.