### PR TITLE
ant: core-vtype now needs core-pva

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,12 +6,12 @@
 <project name="Phoebus" default="services">
 
   <target name="clean" description="Remove all artifacts">
+    <ant target="clean" dir="core/pva"/>
     <ant target="clean" dir="core/vtype"/>
     <ant target="clean" dir="core/formula"/>
     <ant target="clean" dir="core/framework"/>
     <ant target="clean" dir="core/util"/>
     <ant target="clean" dir="core/email"/>
-    <ant target="clean" dir="core/pva"/>
     <ant target="clean" dir="core/pv"/>
     <ant target="clean" dir="core/security"/>
     <ant target="clean" dir="core/types"/>
@@ -82,12 +82,12 @@
     <!--
     <echo message="App classpath: ${toString:app-classpath}"/>
     -->
+    <ant dir="core/pva"/>
     <ant dir="core/vtype"/>
     <ant dir="core/formula"/>
     <ant dir="core/framework"/>
     <ant dir="core/util"/>
     <ant dir="core/email"/>
-    <ant dir="core/pva"/>
     <ant dir="core/pv"/>
     <ant dir="core/security"/>
     <ant dir="core/types"/>

--- a/core/vtype/build.xml
+++ b/core/vtype/build.xml
@@ -8,6 +8,7 @@
         <fileset dir="${dependencies}/phoebus-target/target/lib">
           <include name="*.jar"/>
         </fileset>
+        <pathelement path="../pva/${build}/core-pva-${version}.jar"/>
       </classpath>
     </javac>
   	<jar destfile="${build}/core-vtype-${version}.jar">


### PR DESCRIPTION
#2937 made core-vtype depend on core-pva and thus changed the required build order