### PR TITLE
Fix NPE when creating log entry

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableApp.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableApp.java
@@ -74,6 +74,10 @@ public class LogEntryTableApp implements AppResourceDescriptor {
      * @param logEntry A new or updated {@link LogEntry}
      */
     public void handleLogEntryChange(LogEntry logEntry){
-        logEntryTable.logEntryChanged(logEntry);
+        // At this point the logEntryTable might be null, e.g. if log entry editor is launched
+        // before first launch of log entry table app.
+        if(logEntryTable != null){
+            logEntryTable.logEntryChanged(logEntry);
+        }
     }
 }


### PR DESCRIPTION
If user launches log entry editor before first launch of the log entry table view, submission will succeed, but UI will hang due to NPE.

This is a fix.