### PR TITLE
handle file-url in open display action

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
@@ -421,7 +421,7 @@ public class ModelResourceUtil
 //            final long milli = Math.round(1000 + Math.random()*4000);
 //            Thread.sleep(milli);
 //        }
-        if (resource_name.startsWith("http"))
+        if (resource_name.startsWith("http") || resource_name.startsWith("file:/"))
             return openURL(resource_name);
 
         // Handle legacy RCP URL


### PR DESCRIPTION
As I understood the documentation, it should be possible to use a file url like file:///absolute/path/to/my.bob in the open display action. Currently, open display action can only handle http or abosolute paths (with out the file:// part). This PR fixes it.