### PR TITLE
Make save_credentials global

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookUIPreferences.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookUIPreferences.java
@@ -24,7 +24,6 @@ public class LogbookUIPreferences
 {
     @Preference public static String[] default_logbooks;
     @Preference public static String default_logbook_query;
-    @Preference public static boolean save_credentials;
     @Preference public static String calendar_view_item_stylesheet;
     @Preference public static String level_field_name;
     @Preference public static String markup_help;

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
@@ -49,6 +49,7 @@ import org.phoebus.security.store.SecureStore;
 import org.phoebus.security.tokens.AuthenticationScope;
 import org.phoebus.security.tokens.ScopedAuthenticationToken;
 import org.phoebus.security.tokens.SimpleAuthenticationToken;
+import org.phoebus.ui.Preferences;
 import org.phoebus.ui.dialog.ListSelectionPopOver;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.util.time.TimestampFormats;
@@ -258,7 +259,7 @@ public class LogEntryEditorController {
                 }
             });
         });
-        if (LogbookUIPreferences.save_credentials) {
+        if (Preferences.save_credentials) {
             fetchStoredUserCredentials();
         }
 
@@ -439,7 +440,7 @@ public class LogEntryEditorController {
                         completionHandler.handleResult(result);
                     }
                     // Set username and password in secure store if submission of log entry completes successfully
-                    if (LogbookUIPreferences.save_credentials) {
+                    if (Preferences.save_credentials) {
                         // Get the SecureStore. Store username and password.
                         try {
                             SecureStore store = new SecureStore();

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUpdateController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUpdateController.java
@@ -46,6 +46,7 @@ import org.phoebus.security.store.SecureStore;
 import org.phoebus.security.tokens.AuthenticationScope;
 import org.phoebus.security.tokens.ScopedAuthenticationToken;
 import org.phoebus.security.tokens.SimpleAuthenticationToken;
+import org.phoebus.ui.Preferences;
 import org.phoebus.ui.dialog.ListSelectionPopOver;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.util.time.TimestampFormats;
@@ -241,7 +242,7 @@ public class LogEntryUpdateController {
                 }
             });
         });
-        if (LogbookUIPreferences.save_credentials) {
+        if (Preferences.save_credentials) {
             fetchStoredUserCredentials();
         }
 
@@ -420,7 +421,7 @@ public class LogEntryUpdateController {
                         completionHandler.handleResult(result);
                     }
                     // Set username and password in secure store if submission of log entry completes successfully
-                    if (LogbookUIPreferences.save_credentials) {
+                    if (Preferences.save_credentials) {
                         // Get the SecureStore. Store username and password.
                         try {
                             SecureStore store = new SecureStore();

--- a/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
+++ b/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
@@ -8,9 +8,6 @@ default_logbooks=Scratch Pad
 # The default query for logbook applications
 default_logbook_query=desc=*&start=12 hours&end=now
 
-# Whether or not to save user credentials to file so they only have to be entered once when making log entries.
-save_credentials=false
-
 # Stylesheet for the items in the log calendar view
 calendar_view_item_stylesheet=Agenda.css
 

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookUiPreferences.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookUiPreferences.java
@@ -24,7 +24,6 @@ public class LogbookUiPreferences
 {
     @Preference public static String[] default_logbooks;
     @Preference public static String default_logbook_query;
-    @Preference public static boolean  save_credentials;
     @Preference public static String calendar_view_item_stylesheet;
     @Preference public static String level_field_name;
 

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/FieldsViewController.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/FieldsViewController.java
@@ -33,6 +33,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import org.phoebus.logbook.ui.LogbookUiPreferences;
 import org.phoebus.logbook.ui.Messages;
+import org.phoebus.ui.Preferences;
 import org.phoebus.util.time.TimestampFormats;
 
 import java.net.URL;
@@ -147,7 +148,7 @@ public class FieldsViewController implements Initializable{
         });
 
         userField.requestFocus();
-        if (LogbookUiPreferences.save_credentials)
+        if (Preferences.save_credentials)
         {
             model.fetchStoredUserCredentials();
         }

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
@@ -31,6 +31,7 @@ import org.phoebus.logbook.TagImpl;
 import org.phoebus.logbook.ui.LogbookUiPreferences;
 import org.phoebus.security.store.SecureStore;
 import org.phoebus.security.tokens.SimpleAuthenticationToken;
+import org.phoebus.ui.Preferences;
 
 import javax.imageio.ImageIO;
 import java.io.File;
@@ -84,7 +85,8 @@ public class LogEntryModel {
     private final SimpleBooleanProperty readyToSubmit;         // Used internally. Backs read only property above.
 
     /**
-     * Property that allows the model to define when the application needs to update the username and password text fields. Only used if save_credentials=true
+     * Property that allows the model to define when the application needs to update the username and password text fields.
+     * Only used if save_credentials=true
      */
     private final ReadOnlyBooleanProperty updateCredentialsProperty; // To be broadcast through getUpdateCredentialsProperty.
     private final SimpleBooleanProperty updateCredentials;         // Used internally. Backs read only property above.
@@ -517,7 +519,7 @@ public class LogEntryModel {
 
         // Sumission should be synchronous such that clients can intercept failures
 
-        if (LogbookUiPreferences.save_credentials) {
+        if (Preferences.save_credentials) {
             // Get the SecureStore. Store username and password.
             try {
                 SecureStore store = new SecureStore();

--- a/app/logbook/ui/src/main/resources/log_ui_preferences.properties
+++ b/app/logbook/ui/src/main/resources/log_ui_preferences.properties
@@ -8,9 +8,6 @@ default_logbooks=Scratch Pad
 # The default query for logbook applications
 default_logbook_query=search=*&start=12 hours&end=now
 
-# Whether or not to save user credentials to file so they only have to be entered once when making log entries.
-save_credentials=false
-
 # Stylesheet for the items in the log calendar view
 calendar_view_item_stylesheet=Agenda.css
 

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/client/SaveAndRestoreJerseyClient.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/client/SaveAndRestoreJerseyClient.java
@@ -51,6 +51,9 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    /**
+     * Should be accessed through {@link #getClient()} to ensure proper usage of cached credentials, if available.
+     */
     private static final Client client;
 
     private static HTTPBasicAuthFilter httpBasicAuthFilter;
@@ -70,7 +73,14 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
         defaultClientConfig.getSingletons().add(jacksonJsonProvider);
 
         client = Client.create(defaultClientConfig);
+    }
 
+    public SaveAndRestoreJerseyClient() {
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setSerializationInclusion(Include.NON_NULL);
+    }
+
+    private Client getClient(){
         try {
             SecureStore store = new SecureStore();
             ScopedAuthenticationToken scopedAuthenticationToken = store.getScopedAuthenticationToken(AuthenticationScope.SAVE_AND_RESTORE);
@@ -85,11 +95,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
         } catch (Exception e) {
             logger.log(Level.WARNING, "Unable to retrieve credentials from secure store", e);
         }
-    }
-
-    public SaveAndRestoreJerseyClient() {
-        mapper.registerModule(new JavaTimeModule());
-        mapper.setSerializationInclusion(Include.NON_NULL);
+        return client;
     }
 
     @Override
@@ -109,7 +115,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public List<Node> getCompositeSnapshotReferencedNodes(String uniqueNodeId) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/composite-snapshot/" + uniqueNodeId + "/nodes");
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/composite-snapshot/" + uniqueNodeId + "/nodes");
 
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON).get(ClientResponse.class);
         if (response.getStatus() != ClientResponse.Status.OK.getStatusCode()) {
@@ -128,7 +134,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public List<SnapshotItem> getCompositeSnapshotItems(String uniqueNodeId) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/composite-snapshot/" + uniqueNodeId + "/items");
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/composite-snapshot/" + uniqueNodeId + "/items");
 
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON).get(ClientResponse.class);
         if (response.getStatus() != ClientResponse.Status.OK.getStatusCode()) {
@@ -159,7 +165,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public Node createNewNode(String parentNodeId, Node node) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/node")
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/node")
                 .queryParam("parentNodeId", parentNodeId);
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .entity(node, CONTENT_TYPE_JSON)
@@ -183,7 +189,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public Node updateNode(Node nodeToUpdate, boolean customTimeForMigration) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/node")
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/node")
                 .queryParam("customTimeForMigration", customTimeForMigration ? "true" : "false");
 
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
@@ -209,7 +215,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     }
 
     private ClientResponse getCall(String relativeUrl) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + relativeUrl);
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + relativeUrl);
 
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON).get(ClientResponse.class);
         if (response.getStatus() != ClientResponse.Status.OK.getStatusCode()) {
@@ -227,7 +233,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public void deleteNodes(List<String> nodeIds) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/node");
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/node");
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .entity(nodeIds, CONTENT_TYPE_JSON)
                 .delete(ClientResponse.class);
@@ -254,7 +260,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     @Override
     public Node moveNodes(List<String> sourceNodeIds, String targetNodeId) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/move")
+                getClient().resource(Preferences.jmasarServiceUrl + "/move")
                         .queryParam("to", targetNodeId);
 
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
@@ -276,7 +282,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     @Override
     public Node copyNodes(List<String> sourceNodeIds, String targetNodeId) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/copy")
+                getClient().resource(Preferences.jmasarServiceUrl + "/copy")
                         .queryParam("to", targetNodeId);
 
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
@@ -298,7 +304,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     @Override
     public String getFullPath(String uniqueNodeId) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/path/" + uniqueNodeId);
+                getClient().resource(Preferences.jmasarServiceUrl + "/path/" + uniqueNodeId);
         ClientResponse response = webResource.get(ClientResponse.class);
 
         if (response.getStatus() != ClientResponse.Status.OK.getStatusCode()) {
@@ -321,7 +327,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     @Override
     public Configuration createConfiguration(String parentNodeId, Configuration configuration) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/config")
+                getClient().resource(Preferences.jmasarServiceUrl + "/config")
                         .queryParam("parentNodeId", parentNodeId);
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .entity(configuration, CONTENT_TYPE_JSON)
@@ -340,7 +346,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public Configuration updateConfiguration(Configuration configuration) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/config");
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/config");
 
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .entity(configuration, CONTENT_TYPE_JSON)
@@ -366,7 +372,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     @Override
     public Snapshot createSnapshot(String parentNodeId, Snapshot snapshot) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/snapshot")
+                getClient().resource(Preferences.jmasarServiceUrl + "/snapshot")
                         .queryParam("parentNodeId", parentNodeId);
         ClientResponse response;
         try {
@@ -391,7 +397,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     @Override
     public Snapshot updateSnapshot(Snapshot snapshot) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/snapshot");
+                getClient().resource(Preferences.jmasarServiceUrl + "/snapshot");
         ClientResponse response;
         try {
             response = webResource.accept(CONTENT_TYPE_JSON)
@@ -416,7 +422,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     @Override
     public CompositeSnapshot createCompositeSnapshot(String parentNodeId, CompositeSnapshot compositeSnapshot) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/composite-snapshot")
+                getClient().resource(Preferences.jmasarServiceUrl + "/composite-snapshot")
                         .queryParam("parentNodeId", parentNodeId);
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .entity(compositeSnapshot, CONTENT_TYPE_JSON)
@@ -436,7 +442,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     @Override
     public List<String> checkCompositeSnapshotConsistency(List<String> snapshotNodeIds) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/composite-snapshot-consistency-check");
+                getClient().resource(Preferences.jmasarServiceUrl + "/composite-snapshot-consistency-check");
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .entity(snapshotNodeIds, CONTENT_TYPE_JSON)
                 .post(ClientResponse.class);
@@ -455,7 +461,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public CompositeSnapshot updateCompositeSnapshot(CompositeSnapshot compositeSnapshot) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/composite-snapshot");
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/composite-snapshot");
 
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .entity(compositeSnapshot, CONTENT_TYPE_JSON)
@@ -474,7 +480,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public SearchResult search(MultivaluedMap<String, String> searchParams) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/search")
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/search")
                 .queryParams(searchParams);
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .get(ClientResponse.class);
@@ -492,7 +498,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public Filter saveFilter(Filter filter) {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/filter");
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/filter");
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .entity(filter, CONTENT_TYPE_JSON)
                 .put(ClientResponse.class);
@@ -510,7 +516,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
 
     @Override
     public List<Filter> getAllFilters() {
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/filters");
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/filters");
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .get(ClientResponse.class);
         if (response.getStatus() != ClientResponse.Status.OK.getStatusCode()) {
@@ -530,7 +536,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     public void deleteFilter(String name) {
         // Filter name may contain space chars, need to URL encode these.
         String filterName = name.replace(" ", "%20");
-        WebResource webResource = client.resource(Preferences.jmasarServiceUrl + "/filter/" + filterName);
+        WebResource webResource = getClient().resource(Preferences.jmasarServiceUrl + "/filter/" + filterName);
         ClientResponse response = webResource.accept(CONTENT_TYPE_JSON)
                 .delete(ClientResponse.class);
         if (response.getStatus() != ClientResponse.Status.OK.getStatusCode()) {
@@ -554,7 +560,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     public List<Node> addTag(TagData tagData) {
 
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/tags");
+                getClient().resource(Preferences.jmasarServiceUrl + "/tags");
         ClientResponse response;
         try {
             response = webResource.accept(CONTENT_TYPE_JSON)
@@ -585,7 +591,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
      */
     public List<Node> deleteTag(TagData tagData) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/tags");
+                getClient().resource(Preferences.jmasarServiceUrl + "/tags");
         ClientResponse response;
         try {
             response = webResource.accept(CONTENT_TYPE_JSON)
@@ -610,7 +616,7 @@ public class SaveAndRestoreJerseyClient implements org.phoebus.applications.save
     @Override
     public UserData authenticate(String userName, String password) {
         WebResource webResource =
-                client.resource(Preferences.jmasarServiceUrl + "/login")
+                getClient().resource(Preferences.jmasarServiceUrl + "/login")
                         .queryParam("username", userName)
                         .queryParam("password", password);
         ClientResponse response;

--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -86,6 +86,7 @@ public class Preferences
     @Preference public static int[] alarm_area_panel_undefined_severity_background_color;
     /** cache_hint_for_picture_and_symbol_widgets */
     @Preference public static String cache_hint_for_picture_and_symbol_widgets;
+    @Preference public static boolean save_credentials;
 
     static
     {

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -128,3 +128,9 @@ alarm_area_panel_undefined_severity_background_color=200,0,200,200
 # default caching behavior is used (i.e., caching is DISABLED,
 # and the cache hint is set to "CacheHint.DEFAULT").
 cache_hint_for_picture_and_symbol_widgets=
+
+
+# Whether or not to save user credentials to file or memory so they only have to be entered once. Note that this
+# applies to all scopes/applications prompting for credentials.
+# See also setting org.phoebus.security/secure_store_target
+save_credentials=false


### PR DESCRIPTION
This converts the save_credentials setting in logbook modules to a  single global one in core-ui.

Will require clients to update:
```
org.phoebus.logbook.olog.ui/save_credentials -> org.phoebus.ui/save_credentials
org.phoebus.logbook.ui/save_credentials -> org.phoebus.ui/save_credentials
```
Also a bug fix in save&restore credentials handling.