### PR TITLE
Default format 'precision' was ignored for arrays

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
+++ b/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2024 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.util.logging.Logger;
 
 import org.epics.util.array.ListNumber;
 import org.epics.vtype.Display;
+import org.epics.vtype.DisplayProvider;
 import org.epics.vtype.VBoolean;
 import org.epics.vtype.VDouble;
 import org.epics.vtype.VEnum;
@@ -62,9 +63,9 @@ public class FormatOptionHandler
     {
         if (precision < 0)
         {
-            if (value instanceof VNumber)
+            if (value instanceof DisplayProvider)
             {
-                final NumberFormat format = ( (VNumber) value ).getDisplay().getFormat();
+                final NumberFormat format = ( (DisplayProvider) value ).getDisplay().getFormat();
                 if (format instanceof DecimalFormat)
                     precision = ( (DecimalFormat) format ).getMaximumFractionDigits();
             }


### PR DESCRIPTION
Now used because checking for DisplayProvider instead of just VNumber.

Turns out `caget` also ignores the precision for array data, so the behavior was compatible, but probably better to honor the display precision.