### PR TITLE
Add null check when restoring snapshot containing disconnected items

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTableViewController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTableViewController.java
@@ -353,7 +353,9 @@ public class SnapshotTableViewController extends BaseSnapshotTableViewController
             for (SnapshotItem entry : snapshot.getSnapshotData().getSnapshotItems()) {
                 TableEntry e = tableEntryItems.get(getPVKey(entry.getConfigPv().getPvName(), entry.getConfigPv().isReadOnly()));
 
-                boolean restorable = e.selectedProperty().get() && !e.readOnlyProperty().get() &&
+                boolean restorable = e.selectedProperty().get() &&
+                        !e.readOnlyProperty().get() &&
+                        entry.getValue() != null &&
                         !entry.getValue().equals(VNoData.INSTANCE);
 
                 if (restorable) {


### PR DESCRIPTION
Fixes the case where user restores a snapshot containing items related to disconnected PVs.