### PR TITLE
Improve Elasticsearch connection in alarm logging service

### DIFF
--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
@@ -54,6 +54,9 @@ public class AlarmLoggingService {
         System.out.println("-es_port  9200                           - elastic server port");
         System.out.println("-es_urls  http://localhost:9200          - comma-separated list of elastic server URLs");
         System.out.println("-es_sniff  false                         - elastic server sniff feature");
+        System.out.println("-es_auth_header header                   - elastic authorization header");
+        System.out.println("-es_auth_username username               - elastic username");
+        System.out.println("-es_auth_password password               - elastic password");
         System.out.println("-bootstrap.servers localhost:9092        - Kafka server address");
         System.out.println("-kafka_properties /opt/client.properties - Properties file to load kafka client settings from");
         System.out.println("-properties /opt/alarm_logger.properties - Properties file to be used (instead of command line arguments)");
@@ -145,6 +148,32 @@ public class AlarmLoggingService {
                         throw new Exception("es_urls must not be specified if es_port is specified.");
                     iter.remove();
                     properties.put("es_urls",iter.next());
+                    iter.remove();
+                } else if (cmd.equals("-es_auth_header")) {
+                    if (!iter.hasNext())
+                        throw new Exception("Missing -es_auth_header header");
+                    iter.remove();
+                    if (!properties.getProperty("es_auth_username", "").isEmpty())
+                        throw new Exception("es_auth_header must not be specified if es_auth_username is specified.");
+                    if (!properties.getProperty("es_auth_password", "").isEmpty())
+                        throw new Exception("es_auth_header must not be specified if es_auth_password is specified.");
+                    properties.put("es_auth_header",iter.next());
+                    iter.remove();
+                } else if (cmd.equals("-es_auth_username")) {
+                    if (!iter.hasNext())
+                        throw new Exception("Missing -es_auth_username username");
+                    iter.remove();
+                    if (!properties.getProperty("es_auth_header", "").isEmpty())
+                        throw new Exception("es_auth_username must not be specified if es_auth_header is specified.");
+                    properties.put("es_auth_username",iter.next());
+                    iter.remove();
+                } else if (cmd.equals("-es_auth_password")) {
+                    if (!iter.hasNext())
+                        throw new Exception("Missing -es_auth_password password");
+                    iter.remove();
+                    if (!properties.getProperty("es_auth_header", "").isEmpty())
+                        throw new Exception("es_auth_password must not be specified if es_auth_header is specified.");
+                    properties.put("es_auth_password",iter.next());
                     iter.remove();
                 } else if (cmd.equals("-es_sniff")) {
                     if (!iter.hasNext())

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
@@ -52,6 +52,7 @@ public class AlarmLoggingService {
         System.out.println("-topics   Accelerator                    - Alarm topics to be logged, they can be defined as a comma separated list");
         System.out.println("-es_host  localhost                      - elastic server host");
         System.out.println("-es_port  9200                           - elastic server port");
+        System.out.println("-es_urls  http://localhost:9200          - comma-separated list of elastic server URLs");
         System.out.println("-es_sniff  false                         - elastic server sniff feature");
         System.out.println("-bootstrap.servers localhost:9092        - Kafka server address");
         System.out.println("-kafka_properties /opt/client.properties - Properties file to load kafka client settings from");
@@ -123,13 +124,27 @@ public class AlarmLoggingService {
                     if (!iter.hasNext())
                         throw new Exception("Missing -es_host hostname");
                     iter.remove();
+                    if (!properties.getProperty("es_urls", "").isEmpty())
+                        throw new Exception("es_host must not be specified if es_urls is specified.");
                     properties.put("es_host",iter.next());
                     iter.remove();
                 } else if (cmd.equals("-es_port")) {
                     if (!iter.hasNext())
                         throw new Exception("Missing -es_port port number");
                     iter.remove();
+                    if (!properties.getProperty("es_urls", "").isEmpty())
+                        throw new Exception("es_port must not be specified if es_urls is specified.");
                     properties.put("es_port",iter.next());
+                    iter.remove();
+                } else if (cmd.equals("-es_urls")) {
+                    if (!iter.hasNext())
+                        throw new Exception("Missing -es_urls URLs");
+                    if (!properties.getProperty("es_host", "").isEmpty())
+                        throw new Exception("es_urls must not be specified if es_host is specified.");
+                    if (!properties.getProperty("es_port", "").isEmpty())
+                        throw new Exception("es_urls must not be specified if es_port is specified.");
+                    iter.remove();
+                    properties.put("es_urls",iter.next());
                     iter.remove();
                 } else if (cmd.equals("-es_sniff")) {
                     if (!iter.hasNext())

--- a/services/alarm-logger/src/main/resources/application.properties
+++ b/services/alarm-logger/src/main/resources/application.properties
@@ -23,6 +23,11 @@ es_host=
 es_port=
 # Comma-separated list of elastic node URLs. All nodes must belong to the same cluster.
 es_urls=
+# Authorization header sent with elastic requests
+es_auth_header=
+# Username and password sent with elastic requests. Cannot be combined with es_auth_header.
+es_auth_username=
+es_auth_password=
 # Max default size for es queries
 es_max_size=1000
 # Set to 'true' if sniffing to be enabled to discover other cluster nodes

--- a/services/alarm-logger/src/main/resources/application.properties
+++ b/services/alarm-logger/src/main/resources/application.properties
@@ -16,8 +16,13 @@ logging.level.root=WARN
 alarm_topics=Accelerator
 
 # Location of elastic node/s
-es_host=localhost
-es_port=9200
+#
+# Either es_host and es_port or es_urls can be specified.
+# If neither is specified, the URL http://localhost:9200 is used.
+es_host=
+es_port=
+# Comma-separated list of elastic node URLs. All nodes must belong to the same cluster.
+es_urls=
 # Max default size for es queries
 es_max_size=1000
 # Set to 'true' if sniffing to be enabled to discover other cluster nodes


### PR DESCRIPTION
This PR introduces three changes to the alarm logging service:

1. As an alternative to specifying `es_host` and `es_port`, it is now possible to specify `es_urls`. In `es_urls` a scheme can be specified, so it is possible to use HTTPS instead of HTTP. It is also possible to specify multiple URLs belonging to the same Elasticsearch cluster, thus enabling automatic failover when one of the nodes is not available.
2. There are new configuration options `es_auth_header`, `es_auth_username`, and `es_auth_password`. `es_auth_username` and `es_auth_password` can be used to enable HTTP Basic authentication. As an alternative, the `es_auth_header` option can be used to directly set the contents auf the HTTP Authorization header, thus enabling arbitrary authentication schemes.
3. A race condition in `ElasticClientHelper.getInstance()` has been fixed. This race condition could have the effect that contrary to expectation, more than one `ElasticClientHelper` was created. It could also result in an uninitialized instance of `ElasticClientHelper` being returned.

The first two changes are very similar to a [PR](https://github.com/ChannelFinder/ChannelFinderService/pull/127) that was recently merged into the Channel Finder service.
