### PR TITLE
Upgrade to Java FX 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <epics.version>7.0.10</epics.version>
     <epics.util.version>1.0.7</epics.util.version>
     <vtype.version>1.0.7</vtype.version>
-    <openjfx.version>19</openjfx.version>
+    <openjfx.version>21.0.3</openjfx.version>
     <jackson.version>2.12.3</jackson.version>
     <batik.version>1.17</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
This PR is very simple: It replaces the dependency on JavaFX 17 with Java FX 21 (the newest revision 21.0.3, to be exact).

This upgrade resolves the two issues discussed in #2999.