### PR TITLE
Update jython

### DIFF
--- a/dependencies/phoebus-target/.classpath
+++ b/dependencies/phoebus-target/.classpath
@@ -112,7 +112,7 @@
     <classpathentry exported="true" kind="lib" path="target/lib/junit-jupiter-params-5.8.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/junit-platform-commons-1.8.2.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/junit-platform-engine-1.8.2.jar"/>
-    <classpathentry exported="true" kind="lib" path="target/lib/jython-standalone-2.7.3.jar"/>
+    <classpathentry exported="true" kind="lib" path="target/lib/jython-standalone-2.7.4b1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/jzlib-1.1.3.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/kafka-clients-3.6.1.jar"/>
     <classpathentry exported="true" kind="lib" path="target/lib/kafka-streams-3.6.1.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <guava.version>32.1.1-jre</guava.version>
     <log4j-to-slf4j.version>2.17.1</log4j-to-slf4j.version>
     <derby.version>10.16.1.1</derby.version>
-    <jython.version>2.7.3</jython.version>
+    <jython.version>2.7.4b1</jython.version>
     <jgit.version>6.7.0.202309050840-r</jgit.version>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>


### PR DESCRIPTION
The update from 7.0.3 to 7.0.4b1 seems minor, but it fixes an Eclipse compiler error because org.w3c.dom.html is found both in the JDK and in the jython 7.0.3 jar, resulting in the error

```
org.w3c.dom.html is accessible from more than one module: <unnamed>, jdk.xml.dom
```
https://github.com/jython/jython/commit/28008a3ff42811402257410eb5dd81eb2d996bf7

Also good to see that there's at least some housekeeping going on with jython