### PR TITLE
Fix for failed PV write to enum type

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PutRequest.java
@@ -147,6 +147,8 @@ class PutRequest extends CompletableFuture<Void> implements RequestEncoder, Resp
                 if ("enum_t".equals(struct.getStructureName()) ||
                         data.getStructureName().toLowerCase().indexOf("ntenum") > 0){
                     field = struct.get("index");
+                    // Set bit for the field to write
+                    changed.set(data.getIndex(field));
                 }
                 else{
                     // Must also set bits for the elements of the structure


### PR DESCRIPTION
Bug introduced in d6fb4028a6f5aab4a4a3b89fd3b6871e856d732d (Feb 2nd). A bit surprising no-one has seen it, or maybe very few still use pvacces...