### PR TITLE
CSSTUDIO-2043 recalculate annotation item index

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/DeleteItemsCommand.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/properties/DeleteItemsCommand.java
@@ -22,62 +22,69 @@ import org.phoebus.ui.undo.UndoableActionManager;
 /** Undo-able command to delete items
  *  @author Kay Kasemir
  */
-public class DeleteItemsCommand extends UndoableAction
-{
+public class DeleteItemsCommand extends UndoableAction {
     final private Model model;
     final private List<ModelItem> items;
 
     /** Register and perform the command
-     *  @param operations_manager OperationsManager where command will be reg'ed
+     *  @param operations_manager OperationsManager where command will be registered
      *  @param model Model were PV is to be added
      *  @param items Model items to delete
      */
     public DeleteItemsCommand(final UndoableActionManager operations_manager,
-            final Model model, final List<ModelItem> items)
-    {
+            final Model model, final List<ModelItem> items) {
         super(Messages.DeleteItem);
         this.model = model;
-        // This list could be a reference to the
-        // model's list.
-        // Since we will loop over this list,
-        // assert that there are no comodification problems
-        // by creating a copy.
+        // This list could be a reference to the model's list.
+        // Since we will loop over this list, assert that there are no co-modification problems by creating a copy.
         this.items = new ArrayList<>(items);
         operations_manager.execute(this);
     }
 
     /** {@inheritDoc} */
     @Override
-    public void run()
-    {
-        // Check for annotations to remove because their item is deleted
+    public void run() {
+        for (ModelItem item : items) {
+            final List<AnnotationInfo> annotations = deleteAnnotations(item);
+
+            model.removeItem(item);
+
+            // Any changes?
+            if (!annotations.equals(model.getAnnotations()))
+                model.setAnnotations(annotations);
+        }
+    }
+
+    private List<AnnotationInfo> deleteAnnotations(ModelItem item) {
         final List<AnnotationInfo> annotations = new ArrayList<>(model.getAnnotations());
-        for (ModelItem item : items)
-        {
-            final int item_index = model.getItems().indexOf(item);
-            annotations.removeIf(anno -> anno.getItemIndex() == item_index);
+        final int item_index = model.getItems().indexOf(item);
+
+        // Check for annotations to remove because their item is deleted
+        //     possibly recalculate item index for remaining annotations
+        if (annotations.removeIf(anno -> anno.getItemIndex() == item_index)
+                && !annotations.isEmpty()
+                && item_index < (model.getItems().size() - 1)) {
+            for (int i=0; i<annotations.size(); i++) {
+                AnnotationInfo ai = annotations.get(i);
+                if (ai.getItemIndex() >= item_index) {
+                    // annotation item index - 1, not item_index - 1
+                    annotations.remove(i);
+                    annotations.add(i, new AnnotationInfo(ai.isInternal(), ai.getItemIndex()-1, ai.getTime(), ai.getValue(), ai.getOffset(), ai.getText()));
+                }
+            }
         }
 
-        // Any changes?
-        if (! annotations.equals(model.getAnnotations()))
-            model.setAnnotations(annotations);
-
-        for (ModelItem item : items)
-            model.removeItem(item);
+        // annotations after item has been deleted
+        return annotations;
     }
 
     /** {@inheritDoc} */
     @Override
-    public void undo()
-    {
-        for (ModelItem item : items)
-        {
-            try
-            {
+    public void undo() {
+        for (ModelItem item : items) {
+            try {
                 model.addItem(item);
-            }
-            catch (Exception ex)
-            {
+            } catch (Exception ex) {
                 ExceptionDetailsErrorDialog.openError(
                         Messages.Error,
                         MessageFormat.format(Messages.AddItemErrorFmt, item.getName()),
@@ -86,4 +93,5 @@ public class DeleteItemsCommand extends UndoableAction
         }
         // Note that we do not restore removed annotations at this time...
     }
+
 }


### PR DESCRIPTION
Fix issues related to annotations for traces in data browser
- delete of trace with annotation does not adjust item index for remaining annotations
- undo, after delete of trace with annotation, does not bring back annotation
- annotation item index with value -1

Related to 
- https://github.com/ControlSystemStudio/phoebus/issues/1848