### PR TITLE
Make toolbar entries configurable

### DIFF
--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScanMonitorMenuEntry.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScanMonitorMenuEntry.java
@@ -11,6 +11,7 @@ import org.csstudio.scan.ScanSystem;
 import org.phoebus.framework.workbench.ApplicationService;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.spi.MenuEntry;
+import org.phoebus.ui.spi.ToolbarEntry;
 
 import javafx.scene.image.Image;
 
@@ -18,7 +19,7 @@ import javafx.scene.image.Image;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ScanMonitorMenuEntry implements MenuEntry
+public class ScanMonitorMenuEntry implements MenuEntry, ToolbarEntry
 {
     @Override
     public String getName()

--- a/app/scan/ui/src/main/resources/META-INF/services/org.phoebus.ui.spi.ToolbarEntry
+++ b/app/scan/ui/src/main/resources/META-INF/services/org.phoebus.ui.spi.ToolbarEntry
@@ -1,0 +1,1 @@
+org.csstudio.scan.ui.monitor.ScanMonitorMenuEntry

--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -25,6 +25,8 @@ public class Preferences
     @Preference public static String home_display;
     /** top_resources */
     @Preference public static String top_resources;
+    /** toolbar_entries */
+    @Preference public static String toolbar_entries;
     /** splash */
     @Preference public static boolean splash;
     /** welcome */

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -935,27 +935,31 @@ public class PhoebusApplication extends Application {
         homeIcon.setFitHeight(16.0);
         homeIcon.setFitWidth(16.0);
         home_display_button = new Button(null, homeIcon);
-        home_display_button.setTooltip(new Tooltip(Messages.HomeTT));
-        toolBar.getItems().add(home_display_button);
+        if (! Preferences.toolbar_entries.contains("!Home"))
+        {
+            home_display_button.setTooltip(new Tooltip(Messages.HomeTT));
+            toolBar.getItems().add(home_display_button);
 
-
-        if (!Preferences.home_display.isEmpty()) {
-            final TopResources homeResource = TopResources.parse(Preferences.home_display);
-            home_display_button.setOnAction(event -> openResource(homeResource.getResource(0), false));
-        }
-        else {
-            Welcome welcome = new Welcome();
-            home_display_button.setOnAction(event -> welcome.create());
+            if (!Preferences.home_display.isEmpty()) {
+                final TopResources homeResource = TopResources.parse(Preferences.home_display);
+                home_display_button.setOnAction(event -> openResource(homeResource.getResource(0), false));
+            }
+            else {
+                Welcome welcome = new Welcome();
+                home_display_button.setOnAction(event -> welcome.create());
+            }
         }
 
         top_resources_button = new MenuButton(null, ImageCache.getImageView(getClass(), "/icons/fldr_obj.png"));
         top_resources_button.setTooltip(new Tooltip(Messages.TopResources));
         top_resources_button.setDisable(true);
-        toolBar.getItems().add(top_resources_button);
+        if (! Preferences.toolbar_entries.contains("!Top Resources"))
+            toolBar.getItems().add(top_resources_button);
 
         layout_menu_button = new MenuButton(null, ImageCache.getImageView(getClass(), "/icons/layouts.png"));
         layout_menu_button.setTooltip(new Tooltip(Messages.LayoutTT));
-        toolBar.getItems().add(layout_menu_button);
+        if (! Preferences.toolbar_entries.contains("!Layouts"))
+            toolBar.getItems().add(layout_menu_button);
 
         // Contributed Entries
         ToolbarEntryService.getInstance().listToolbarEntries().forEach((entry) -> {

--- a/core/ui/src/main/java/org/phoebus/ui/application/ToolbarEntryService.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ToolbarEntryService.java
@@ -1,21 +1,53 @@
 package org.phoebus.ui.application;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.ServiceLoader.Provider;
-import java.util.stream.Collectors;
 
+import org.phoebus.ui.Preferences;
 import org.phoebus.ui.spi.ToolbarEntry;
 
 public class ToolbarEntryService {
 
     private static ToolbarEntryService toolbarEntryService;
-    private ServiceLoader<ToolbarEntry> loader;
-    private List<ToolbarEntry> toolbarEntries;
+    private List<ToolbarEntry> toolbarEntries = new ArrayList<>();
 
     private ToolbarEntryService() {
-        loader = ServiceLoader.load(ToolbarEntry.class);
-        toolbarEntries = loader.stream().map(Provider::get).collect(Collectors.toList());
+        final List<ToolbarEntry>  available = new ArrayList<>();
+        ServiceLoader.load(ToolbarEntry.class).forEach(available::add);
+
+        // Add desired toolbar entries in specified order
+        for (String desired : Preferences.toolbar_entries.split(" *, *"))
+        {
+            if (desired.equals("*"))
+            {    // Add all that are left, done
+                toolbarEntries.addAll(available);
+                break;
+            }
+            // Should desired entry actually be removed?
+            boolean suppress = desired.startsWith("!");
+            if (suppress)
+                desired = desired.substring(1);
+            // Skip entries handled in PhoebusApplication
+            if (desired.equals("Home") ||  desired.equals("Top Resources")  ||  desired.equals("Layouts"))
+                continue;
+            // Add specific 'desired' entry
+            ToolbarEntry found = null;
+            for (ToolbarEntry entry : available)
+                if (entry.getName().equalsIgnoreCase(desired))
+                {
+                    found = entry;
+                    break;
+                }
+            if (found != null)
+            {
+                available.remove(found);
+                if (! suppress)
+                    toolbarEntries.add(found);
+            }
+            else
+                System.out.println("toolbar_entries: Cannot find '" + desired + "'");
+        }
     }
 
     public static synchronized ToolbarEntryService getInstance() {

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -69,7 +69,7 @@ home_display=examples:/01_main.bob?app=display_runtime,Example Display
 # Only Home and File Browser:
 #
 #    Home, !Top Resources, !Layouts, File Browser
-toolbar_entries=Home, !Top Resources, !Layouts, File Browser
+toolbar_entries=Home, Top Resources, Layouts, File Browser, *
 
 # How many array elements to show when formatting as text?
 max_array_formatting=256

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -42,6 +42,35 @@ top_resources=examples:/01_main.bob?app=display_runtime,Example Display | pv://?
 # Home display file. "Home display" button will navigate to this display.
 home_display=examples:/01_main.bob?app=display_runtime,Example Display
 
+# Toolbar entries
+#
+# Apps like the file browser contribute a toolbar entry.
+# This setting can control which toolbar entries are shown
+# and for the most part also in which order.
+#
+# Format: Comma-separated list of entries.
+#
+# The special entry "*" adds all remaining available toolbar entries.
+# An entry starting with "!" removes that item from the avialable entries.
+# The order of the initial buttons "Home, Top Resources, Layouts"
+# cannot be changed, but they can be suppressed by adding "!",
+# for example "Home, !Top Resources, !Layouts"
+#
+# Examples:
+#
+# Default buttons, then all remaining available items:
+#
+#    Home, Top Resources, Layouts, *
+#
+# Default buttons, then assert that File Browser comes next:
+#
+#    Home, Top Resources, Layouts, File Browser, *
+#
+# Only Home and File Browser:
+#
+#    Home, !Top Resources, !Layouts, File Browser
+toolbar_entries=Home, !Top Resources, !Layouts, File Browser
+
 # How many array elements to show when formatting as text?
 max_array_formatting=256
 

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -51,7 +51,7 @@ home_display=examples:/01_main.bob?app=display_runtime,Example Display
 # Format: Comma-separated list of entries.
 #
 # The special entry "*" adds all remaining available toolbar entries.
-# An entry starting with "!" removes that item from the avialable entries.
+# An entry starting with "!" removes that item from the available entries.
 # The order of the initial buttons "Home, Top Resources, Layouts"
 # cannot be changed, but they can be suppressed by adding "!",
 # for example "Home, !Top Resources, !Layouts"


### PR DESCRIPTION
Introduces preference setting for listing toolbar entries.

Format: Comma-separated list of entries.

The special entry "*" adds all remaining available toolbar entries,
basically what used to happen, without any control over their order.

An entry starting with "!" removes that item from the available entries.
The order of the initial buttons "Home, Top Resources, Layouts"
cannot be changed because they're somewhat special, for example using a drop-down
instead of a button, and being added in PhoebusApplication.
But they can still be suppressed by adding "!", for example "Home, !Top Resources, !Layouts"

Examples:

Default buttons, then all remaining available items:

    Home, Top Resources, Layouts, *

Default buttons, then assert that File Browser comes next:

    Home, Top Resources, Layouts, File Browser, *

Only Home and File Browser:

    Home, !Top Resources, !Layouts, File Browser


Fixes #2888