### PR TITLE
CSSTUDIO-2051 Replace `SynchronousQueue` with `LinkedBlockingDeque` in  `NamedDaemonPool`

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/util/NamedDaemonPool.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/util/NamedDaemonPool.java
@@ -9,8 +9,8 @@ package org.csstudio.display.builder.model.util;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -66,7 +66,7 @@ public class NamedDaemonPool
         // Downside: No way to avoid a gazillion threads.
         return new ThreadPoolExecutor(0, Integer.MAX_VALUE,
                 10L, TimeUnit.SECONDS,
-                new SynchronousQueue<Runnable>(),
+                new LinkedBlockingDeque<>(),
                 new NamedThreadFactory(name));
     }
 


### PR DESCRIPTION
This PR replaces the data-structure `SynchronousQueue` with the data-structure `LinkedBlockingDeque` when calling `new ThreadPoolExecutor(...)` in the class `NamedDaemonPool`.

The motivation for this change is an observed performance increase: based purely on empirical testing, loading an OPI with on the order of 50 symbol widgets each with on the order of 10 different SVG files, the performance is dramatically improved when a `LinkedBlockingDeque` is used instead of a `SynchronousQueue`. I have observed a performance increase both on Windows and on Linux. I have not tested the change on Mac OS.