### PR TITLE
General dependency vulnerabilities see #2300

### DIFF
--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -158,8 +158,8 @@
     </dependency>
     <!-- JDBC connectors For Oracle, see ORACLE_JDBC_JAR -->
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
       <version>${mysql.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
     <jackson.version>2.12.3</jackson.version>
     <batik.version>1.17</batik.version>
     <mockito.version>2.23.4</mockito.version>
-    <postgresql.driver.version>42.6.0</postgresql.driver.version>
+    <postgresql.driver.version>42.6.2</postgresql.driver.version>
     <!-- When connections to older MySQL server fail because of CLIENT_PLUGIN_AUTH, downgrade to 5.1.45 -->
-    <mysql.version>8.0.30</mysql.version>
+    <mysql.version>8.4.0</mysql.version>
     <jetty.version>9.4.30.v20200611</jetty.version>
     <apache.commons.math.version>3.6.1</apache.commons.math.version>
     <junit.version>5.8.2</junit.version>

--- a/services/archive-engine/pom.xml
+++ b/services/archive-engine/pom.xml
@@ -69,8 +69,8 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
       <version>${mysql.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Postgresql.driver.version 42.6.0 update to (latest) 42.6.2 mysql.version 8.0.30 update to (latest) mysql.version 8.4.0 (driver renamed from mysql:mysql-connector-java to com.mysql:mysql-connector-j)