### PR TITLE
Add phoebus.name.folder.preference varibale

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/workbench/Locations.java
+++ b/core/framework/src/main/java/org/phoebus/framework/workbench/Locations.java
@@ -73,7 +73,7 @@ public class Locations
         {
             if (folder_name_preference == null) 
             {
-            name_folder_preference = ".phoebus";
+            folder_name_preference = ".phoebus";
             }
             phoebus_user = new File(System.getProperty("user.home"), folder_name_preference).getAbsolutePath();
             System.setProperty(PHOEBUS_USER, phoebus_user);


### PR DESCRIPTION
I propose this modification to the `Locations.java` file.

This modification adds the `phoebus.name.folder.preference` variable. This way, it is possible to create an executable with the `-Dphoebus.name.folder.preference=<name_folder>` option using `jpackage` to modify the name of the preference folder located in the user's directory.

See the discussion: #3025.

