### PR TITLE
Windows fix for ImageViewer

### DIFF
--- a/app/imageviewer/pom.xml
+++ b/app/imageviewer/pom.xml
@@ -28,5 +28,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/app/imageviewer/src/main/java/org/phoebus/applications/imageviewer/ImageViewerInstance.java
+++ b/app/imageviewer/src/main/java/org/phoebus/applications/imageviewer/ImageViewerInstance.java
@@ -27,6 +27,7 @@ import org.phoebus.ui.docking.DockItemWithInput;
 import org.phoebus.ui.docking.DockPane;
 
 import java.net.URI;
+import java.net.URL;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -60,7 +61,8 @@ public class ImageViewerInstance implements AppInstance {
                 if (queryParams != null && queryParams.contains("watermark=true")) {
                     showWatermark = true;
                 }
-                imageViewerController.setImage(uri.toURL(), showWatermark);
+                URL url = new URL(sanitizeUri(uri));
+                imageViewerController.setImage(url, showWatermark);
             } catch (Exception e) {
                 Logger.getLogger(ImageViewerInstance.class.getName())
                         .log(Level.WARNING, "Unable to load fxml", e);
@@ -75,5 +77,28 @@ public class ImageViewerInstance implements AppInstance {
 
     public void raise() {
         dockItem.select();
+    }
+
+
+    /**
+     * This is a hack for Windows as a URI like &quot;file:/foo/bar?foo=bar&quot; will trigger exception
+     * when calling {@link javax.imageio.ImageIO#read(URL)}
+     * @param uri A {@link URI}, optionally with query params
+     * @return A string sanitized from query params
+     */
+    public static String sanitizeUri(URI uri){
+        String sanitizedUri = uri.toString();
+        String queryParams = uri.getQuery();
+        if (queryParams != null) {
+            int indexOfQueryParams = sanitizedUri.indexOf(queryParams);
+            if(indexOfQueryParams > 0){
+                sanitizedUri = sanitizedUri.substring(0, sanitizedUri.indexOf(queryParams));
+            }
+        }
+        // Also remove trailing ? if present
+        if(sanitizedUri.endsWith("?")){
+            sanitizedUri = sanitizedUri.substring(0, sanitizedUri.length() - 1);
+        }
+        return sanitizedUri;
     }
 }

--- a/app/imageviewer/src/test/java/org/phoebus/applications/imageviewer/ImageViewerInstanceTest.java
+++ b/app/imageviewer/src/test/java/org/phoebus/applications/imageviewer/ImageViewerInstanceTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+package org.phoebus.applications.imageviewer;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ImageViewerInstanceTest {
+
+    @Test
+    public void testUriSanitizer() throws Exception{
+        String uriString = "file:/foo/bar";
+        URI uri = new URI(uriString);
+        String sanitized = ImageViewerInstance.sanitizeUri(uri);
+
+        assertEquals(sanitized, uriString);
+
+        String uriWithQuestionMark = "file:/foo/bar?";
+        sanitized = ImageViewerInstance.sanitizeUri(uri);
+
+        assertEquals(sanitized, uriString);
+
+        String uriWithQueryParams = "file:/foo/bar?foo=bar";
+        sanitized = ImageViewerInstance.sanitizeUri(uri);
+
+        assertEquals(sanitized, uriString);
+    }
+
+}

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsViewController.java
@@ -171,7 +171,7 @@ public class AttachmentsViewController {
                 applications.forEach(app -> {
                     MenuItem appMenuItem = new MenuItem(app.getDisplayName());
                     appMenuItem.setGraphic(ImageCache.getImageView(app.getIconURL()));
-                    appMenuItem.setOnAction(actionEvent -> app.create(selectedResource));
+                    appMenuItem.setOnAction(actionEvent -> showImageAttachment());
                     contextMenu.getItems().add(appMenuItem);
                 });
             }


### PR DESCRIPTION
On Windows the ```ImageIO.read(url)``` fails if the url contains query parameters. 
This PR works around this annoying beahvior.