### PR TITLE
"Disable Until" issue to the alarm log table of the Phoebus

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmConfigMessage.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/messages/AlarmConfigMessage.java
@@ -239,7 +239,7 @@ public class AlarmConfigMessage {
         map.put("config", getConfig());
         map.put("user", getUser());
         map.put("host", getHost());
-        map.put("enabled", enabled.toString());
+        map.put("enabled", String.valueOf(enabled.enabled));
         map.put("latching", Boolean.toString(isLatching()));
         map.put("config_msg", toString());
         map.put("message_time", formatter.withZone(ZoneId.of("UTC")).format(getMessage_time()));


### PR DESCRIPTION
Hi Kunal @shroffk 

Please check this, and let me know what you think. We need to talk about how we can handle the "Disable until" time stamp **history** or **log** more serious later, since this patch only allows us to run the alarm service especially, alarm log table within Phoebus.

-  Set the "Disable Until" function for a certain period of time for the enabled alarm.
-  After clicking OK, the defined "Disable Until" timestamp is sent to a broker (Kafka service) as a Kafka stream.
-  The alarm server (Kafka consumer) checks the "Disable Until" setting every cycle (1000 ms)  and decides whether to enable the disabled alarm or not.
- The alarm logger (Kafka consumer) converts the received Kafka stream message for the "Disable Until" timestamp into an alarm configuration message and stores it in the running elasticsearch service as a json file. At this point, it saves it as "TimeStamp string" instead of "Boolean true or false".
- The alarm log table in Phoebus creates a query to retrieve its information manually and automatically.
- The alarm logger REST service returns the result to the alarm log table in Phoebus. 
- At this point, the alarm log table cannot handle the null exception due to the wrong data format which is a string format instead of Boolean.
- However, a typical web browser can handle the null exception.
- This patch only allow us to use forcefully the Boolean data type in order to prevent null exception in the alarm log table of Phoebus.

We may use `isEnabled()` instead of `enabled.enabled`. If you want to prefer `isEnabled()`, please let me know, I will change the code.
