### PR TITLE
Fix databrowser trace issue for visibility of annotations

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Controller.java
@@ -453,6 +453,7 @@ public class Controller
             public void changedItemVisibility(final ModelItem item)
             {
                 plot.updateTrace(item);
+                changedAnnotations();
             }
 
             @Override
@@ -486,7 +487,13 @@ public class Controller
                 if (changing_annotations)
                     return;
                 changing_annotations = true;
-                plot.setAnnotations(model.getAnnotations());
+                List<AnnotationInfo> annotations = new ArrayList<>();
+                for (AnnotationInfo ai : model.getAnnotations()) {
+                    if (model.getItems().get(ai.getItemIndex()).isVisible()) {
+                        annotations.add(ai);
+                    }
+                }
+                plot.setAnnotations(annotations);
                 changing_annotations = false;
             }
         };


### PR DESCRIPTION
Annotations has to be reset for plot when there is change for visibility of item in model.