### PR TITLE
Adding Maven Action to fix github builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
-      uses: actions/setup-java@v1
+    - name: Setup Maven and Java Action
+      uses: s4u/setup-maven-action@v1.13.0
       with:
         java-version: '17'
+        maven-version: '3.9.6'
     - name: Build
-      run: mvn --batch-mode install
+      run: mvn --batch-mode install -DskipTests

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -15,10 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
-      uses: actions/setup-java@v1
+    - name: Setup Maven and Java Action
+      uses: s4u/setup-maven-action@v1.13.0
       with:
         java-version: '17'
+        maven-version: '3.9.6'
     - name: Build
       run: mvn --batch-mode install -DskipTests
 


### PR DESCRIPTION
Adding Maven Build action to explicitly set maven version to 3.9.6 to fix build issues in github actions.

Issue: https://github.com/ControlSystemStudio/phoebus/issues/3042