### PR TITLE
Refactor guava

### DIFF
--- a/app/channel/channelfinder/pom.xml
+++ b/app/channel/channelfinder/pom.xml
@@ -39,10 +39,5 @@
         <artifactId>jersey-client</artifactId>
         <version>1.19</version>
     </dependency>
-    <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-    </dependency>
   </dependencies>
 </project>

--- a/app/channel/channelfinder/src/main/java/org/phoebus/channelfinder/ChannelFinderClientImpl.java
+++ b/app/channel/channelfinder/src/main/java/org/phoebus/channelfinder/ChannelFinderClientImpl.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Joiner;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientResponse;
@@ -1002,7 +1001,7 @@ public class ChannelFinderClientImpl implements ChannelFinderClient {
     public Collection<Channel> findByProperty(String property, String... pattern) throws ChannelFinderException {
         Map<String, String> propertyPatterns = new HashMap<String, String>();
         if (pattern.length > 0) {
-            propertyPatterns.put(property, Joiner.on(",").join(pattern)); //$NON-NLS-1$
+            propertyPatterns.put(property, Arrays.stream(pattern).collect(Collectors.joining(","))); //$NON-NLS-1$
         } else {
             propertyPatterns.put(property, "*"); //$NON-NLS-1$
         }

--- a/app/logbook/inmemory/pom.xml
+++ b/app/logbook/inmemory/pom.xml
@@ -12,10 +12,5 @@
       <artifactId>core-logbook</artifactId>
       <version>4.7.4-SNAPSHOT</version>
     </dependency>
-    <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-    </dependency>
   </dependencies>
 </project>

--- a/app/logbook/inmemory/src/main/java/org/phoebus/applications/logbook/InMemoryLogClient.java
+++ b/app/logbook/inmemory/src/main/java/org/phoebus/applications/logbook/InMemoryLogClient.java
@@ -1,24 +1,47 @@
 package org.phoebus.applications.logbook;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URLConnection;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.time.Instant;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.phoebus.logbook.*;
+import org.phoebus.logbook.Attachment;
+import org.phoebus.logbook.AttachmentImpl;
+import org.phoebus.logbook.LogClient;
+import org.phoebus.logbook.LogEntry;
+import org.phoebus.logbook.LogEntryImpl;
 import org.phoebus.logbook.LogEntryImpl.LogEntryBuilder;
-
-import com.google.common.io.Files;
+import org.phoebus.logbook.Logbook;
+import org.phoebus.logbook.LogbookException;
+import org.phoebus.logbook.LogbookImpl;
+import org.phoebus.logbook.Property;
+import org.phoebus.logbook.PropertyImpl;
+import org.phoebus.logbook.SearchResult;
+import org.phoebus.logbook.Tag;
+import org.phoebus.logbook.TagImpl;
 
 /**
  * A logbook which maintains logentries in memory. It is mainly for testing and debugging purpose.
  */
-public class InMemoryLogClient implements LogClient{
+public class InMemoryLogClient implements LogClient {
     private static Logger logger = Logger.getLogger(InMemoryLogClient.class.getName());
     private final AtomicInteger logIdCounter;
     private final Map<Long, LogEntry> logEntries;
@@ -105,7 +128,7 @@ public class InMemoryLogClient implements LogClient{
                     ext = file.getName().substring(i);
                 }
                 File tempFile = File.createTempFile(prefix, ext);
-                Files.copy(file, tempFile);
+                Files.copy(file.toPath(), tempFile.toPath());
                 tempFile.deleteOnExit();
                 String mimeType = URLConnection.guessContentTypeFromName(tempFile.getName());
                 return AttachmentImpl.of(tempFile, mimeType != null ? mimeType : ext, false);

--- a/app/logbook/olog/ui/pom.xml
+++ b/app/logbook/olog/ui/pom.xml
@@ -41,11 +41,6 @@
             <version>4.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.jfxtras</groupId>
             <artifactId>jfxtras-agenda</artifactId>
             <version>9.0-r1</version>

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AdvancedSearchViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AdvancedSearchViewController.java
@@ -18,7 +18,6 @@
 
 package org.phoebus.logbook.olog.ui;
 
-import com.google.common.base.Strings;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ChangeListener;
@@ -42,6 +41,7 @@ import org.phoebus.logbook.Tag;
 import org.phoebus.ui.dialog.ListSelectionPopOver;
 import org.phoebus.ui.dialog.PopOver;
 import org.phoebus.ui.time.TimeRelativeIntervalPane;
+import org.phoebus.util.text.Strings;
 import org.phoebus.util.time.TimeParser;
 import org.phoebus.util.time.TimeRelativeInterval;
 import org.phoebus.util.time.TimestampFormats;

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsViewController.java
@@ -60,6 +60,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -306,7 +307,7 @@ public class AttachmentsViewController {
             if (targetFile.exists()) {
                 throw new Exception("Target file " + targetFile.getAbsolutePath() + " exists");
             }
-            Files.copy(attachment.getFile().toPath(), targetFile.toPath());
+            Files.copy(attachment.getFile().toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             ExceptionDetailsErrorDialog.openError(splitPane.getParent(), Messages.FileSave, Messages.FileSaveFailed, e);
         }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryCalenderApp.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryCalenderApp.java
@@ -1,6 +1,5 @@
 package org.phoebus.logbook.olog.ui;
 
-import com.google.common.base.Strings;
 import javafx.scene.image.Image;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.framework.spi.AppResourceDescriptor;
@@ -9,6 +8,7 @@ import org.phoebus.logbook.LogFactory;
 import org.phoebus.logbook.LogService;
 import org.phoebus.logbook.LogbookPreferences;
 import org.phoebus.ui.javafx.ImageCache;
+import org.phoebus.util.text.Strings;
 
 import java.net.URI;
 import java.util.logging.Logger;

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableApp.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableApp.java
@@ -1,11 +1,11 @@
 package org.phoebus.logbook.olog.ui;
 
-import com.google.common.base.Strings;
 import javafx.scene.image.Image;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.framework.spi.AppResourceDescriptor;
 import org.phoebus.logbook.*;
 import org.phoebus.ui.javafx.ImageCache;
+import org.phoebus.util.text.Strings;
 
 import java.net.URI;
 import java.util.logging.Logger;

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookQueryUtil.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookQueryUtil.java
@@ -1,7 +1,6 @@
 package org.phoebus.logbook.olog.ui;
 
-import com.google.common.base.Strings;
-import org.checkerframework.checker.units.qual.K;
+import org.phoebus.util.text.Strings;
 import org.phoebus.util.time.TimeParser;
 
 import java.net.URI;

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SearchParameters.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SearchParameters.java
@@ -18,13 +18,13 @@
 
 package org.phoebus.logbook.olog.ui;
 
-import com.google.common.base.Strings;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import org.phoebus.logbook.olog.ui.LogbookQueryUtil.Keys;
+import org.phoebus.util.text.Strings;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/app/logbook/ui/pom.xml
+++ b/app/logbook/ui/pom.xml
@@ -33,11 +33,6 @@
             <version>4.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.jfxtras</groupId>
             <artifactId>jfxtras-agenda</artifactId>
             <version>9.0-r1</version>

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookQueryUtil.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookQueryUtil.java
@@ -11,8 +11,6 @@ import java.util.stream.Collectors;
 
 import org.phoebus.util.time.TimeParser;
 
-import com.google.common.base.Strings;
-
 public class LogbookQueryUtil {
 
     // Ordered search keys

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookQueryUtil.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogbookQueryUtil.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.phoebus.util.text.Strings;
 import org.phoebus.util.time.TimeParser;
 
 public class LogbookQueryUtil {

--- a/core/util/src/main/java/org/phoebus/util/text/Strings.java
+++ b/core/util/src/main/java/org/phoebus/util/text/Strings.java
@@ -1,0 +1,20 @@
+package org.phoebus.util.text;
+
+import java.util.Objects;
+
+public class Strings {
+
+    /**
+     * Based on the the google String.isNullOrEmpty.
+     *
+     * @param str
+     * @return true if the string is null or empty
+     */
+    public static boolean isNullOrEmpty(String str) {
+        if(Objects.isNull(str) || str.isBlank()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/core/util/src/test/java/org/phoebus/util/text/StringsTest.java
+++ b/core/util/src/test/java/org/phoebus/util/text/StringsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2010 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.phoebus.util.text;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for {@link Strings}.
+ *
+ * Based on the tests in google guava @author Kevin Bourrillion
+ */
+public class StringsTest {
+
+
+  @Test
+  public void testIsNullOrEmpty() {
+    assertTrue(Strings.isNullOrEmpty(null));
+    assertTrue(Strings.isNullOrEmpty(""));
+    assertFalse(Strings.isNullOrEmpty("a"));
+  }
+
+}


### PR DESCRIPTION
Based on the discussion at the codeathon I have started removing the use of google.guava

The last remaining requirement is from the `app-databrowser-json` which uses

```
import com.google.common.primitives.ImmutableDoubleArray;
import com.google.common.primitives.ImmutableIntArray;
import com.google.common.primitives.ImmutableLongArray;
```