### PR TITLE
Basic listener so interested parties can see who opened a given resource

### DIFF
--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitListener.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitListener.java
@@ -44,4 +44,7 @@ public interface ToolkitListener
      *  @param value The value
      */
     default public void handleWrite(Widget widget, Object value) {};
+
+    default public void handleMethodCalled(Object... user_args) {};
+
 }

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitListener.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitListener.java
@@ -45,6 +45,11 @@ public interface ToolkitListener
      */
     default public void handleWrite(Widget widget, Object value) {};
 
+    /**
+     * A method was called from the UI that other listeners might be interested in.
+     * @param user_args Zero or more objects relevant to what was called.
+     *      Case-specific Implementations should expect and check these.
+     */
     default public void handleMethodCalled(Object... user_args) {};
 
 }

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
@@ -689,6 +689,20 @@ abstract public class ToolkitRepresentation<TWP extends Object, TW> implements E
         }
     }
 
+    public void fireMethodCall(Object... user_args) {
+        for (final ToolkitListener listener : listeners)
+        {
+            try
+            {
+                listener.handleMethodCalled(user_args);
+            }
+            catch (final Throwable ex)
+            {
+                logger.log(Level.WARNING, "Failure when firing method-call event for " + Thread.currentThread().getStackTrace()[1].getMethodName(), ex);
+            }
+        }
+    };
+
     /** Close the toolkit's "window" that displays a model
      *  @param model Model that has been represented in this toolkit
      *  @throws Exception on error

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -11,6 +11,7 @@ import static org.csstudio.display.builder.runtime.WidgetRuntime.logger;
 
 
 import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -286,8 +287,11 @@ public class DisplayRuntimeInstance implements AppInstance
      */
     public void loadDisplayFile(final DisplayInfo info)
     {
+        DisplayInfo old_info = display_info.orElse(null);
         // If already executing another display, shut it down
         disposeModel();
+
+        ArrayList<DisplayInfo> dst_src = new ArrayList<>();
 
         // Set input ASAP so that other requests to open this
         // resource will find this instance and not start
@@ -324,7 +328,9 @@ public class DisplayRuntimeInstance implements AppInstance
                 {
                     representation.awaitRepresentation(30, TimeUnit.SECONDS);
                     representation_init.run();
-                    representation.fireMethodCall(info, applicationThreadStackTrace);
+                    dst_src.add(info);
+                    dst_src.add(old_info);
+                    representation.fireMethodCall(dst_src, applicationThreadStackTrace);
                     logger.log(Level.FINE, "Done with representing model of " + info.getPath());
                 }
                 catch (TimeoutException | InterruptedException ex)

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -294,6 +294,8 @@ public class DisplayRuntimeInstance implements AppInstance
         // another instance
         dock_item.setInput(info.toURI());
 
+        representation.fireMethodCall((Object)display_info);
+
         // Now that old model is no longer represented,
         // show info.
         // Showing this info before disposeModel()

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -276,7 +276,7 @@ public class DisplayRuntimeInstance implements AppInstance
     }
 
     /** @return Current display info or <code>null</code> */
-    DisplayInfo getDisplayInfo()
+    public DisplayInfo getDisplayInfo()
     {
         return display_info.orElse(null);
     }
@@ -294,7 +294,7 @@ public class DisplayRuntimeInstance implements AppInstance
         // another instance
         dock_item.setInput(info.toURI());
 
-        representation.fireMethodCall((Object)display_info);
+        StackTraceElement[] applicationThreadStackTrace = Thread.currentThread().getStackTrace();
 
         // Now that old model is no longer represented,
         // show info.
@@ -324,6 +324,7 @@ public class DisplayRuntimeInstance implements AppInstance
                 {
                     representation.awaitRepresentation(30, TimeUnit.SECONDS);
                     representation_init.run();
+                    representation.fireMethodCall(info, applicationThreadStackTrace);
                     logger.log(Level.FINE, "Done with representing model of " + info.getPath());
                 }
                 catch (TimeoutException | InterruptedException ex)


### PR DESCRIPTION
As part of the 'UX Analytics' project, we can see from a 'push' perspective where an 'OpenDisplay' action leads. but I got to thinking this weekend that I'd also like to know how a display appeared if it wasn't from another OpenDisplay action - e.g. FileBrowser, Top Resources menu, context menu, or the back/forward buttons. 

My best guess at accomplishing this is a static 'service' to notify zero or more registered listeners. I figure that as part of core-ui, it introduces no new dependencies.

If this is OK, notifying interested parties requires a one-line invocation of the static ResourceOpenedNotifierService.NotifyListeners(resourceName, fromWho) in:

1. FileBrowserController (When display is opened)
2. core.ui,PhoebusApplication.createTopResources (attached to menu entries, when they are clicked)
3. display.builder.runtime.app.DisplayRuntimeInstance (When tab is restored)
4. display.builder.runtime.app.ContextMenuSupport? (When display is opened from right-click menu)

Is this a reasonable way to do it, or maybe there's something better?