### PR TITLE
Update the widget info to allow simpler selection of PV's

### DIFF
--- a/core/types/src/main/java/org/phoebus/core/types/TimeStampedProcessVariable.java
+++ b/core/types/src/main/java/org/phoebus/core/types/TimeStampedProcessVariable.java
@@ -2,6 +2,9 @@ package org.phoebus.core.types;
 
 import java.time.Instant;
 
+/**
+ * A PV with a Timestamp
+ */
 @SuppressWarnings("nls")
 public class TimeStampedProcessVariable extends ProcessVariable {
 


### PR DESCRIPTION
Based on some of use case discussion we had during the codeathon. I have updated the WidgetInfo in the display builder to simplify the process of selecting a set of PV's from an screen or a widget

![image](https://github.com/ControlSystemStudio/phoebus/assets/2111304/21e43567-7294-408d-af09-6dfb2521d295)
