### PR TITLE
Add the archive readers to the common product

### DIFF
--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -118,6 +118,11 @@
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
+            <artifactId>app-trends-archive-reader</artifactId>
+            <version>4.7.4-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.phoebus</groupId>
             <artifactId>app-databrowser-json</artifactId>
             <version>4.7.4-SNAPSHOT</version>
         </dependency>


### PR DESCRIPTION
Adding the archive readers to the common product itself...
site specific products built using the common product will not have to be updated