### PR TITLE
Override default EPICS protocol for save&restore service. Updated doc.

### DIFF
--- a/services/save-and-restore/doc/index.rst
+++ b/services/save-and-restore/doc/index.rst
@@ -5,7 +5,7 @@ The save-and-restore service implements service as a collection
 of REST endpoints. These can be used by clients to manage configurations (aka save sets) and
 snapshots, to compare snapshots and to restore PV values from snapshots.
 
-The service is packaged as a self-contained Spring Boot jar file. External dependencies are limited to a JVM (Java 11+)
+The service is packaged as a self-contained Spring Boot jar file. External dependencies are limited to a JVM (Java 17+)
 and a running instance of Elasticsearch (8.x).
 
 Running the service
@@ -13,6 +13,18 @@ Running the service
 
 The file ``application.properties`` lists a few settings that can be customized to each site's need, e.g.
 connection parameters for Elasticsearch.
+
+Server-side IOC communication
+-----------------------------
+
+The service exposes endpoints for reading and writing PVs, i.e. to create or restore snapshots. Depending on the
+setup this server-side IOC communication may need some configuration:
+
+For ca (channel access) the service must be started with the ``-Dca.use_env=true`` Java option, and the list of
+gateways - if any - must be set as a system environment named ``EPICS_CA_ADDR_LIST``.
+
+For pva (pv access) the service must be started with the ``-DdefaultProtocol=pva`` Java option, and the list of
+gateways - if any - must be set as a system environment named ``EPICS_PVA_ADDR_LIST``.
 
 Elasticsearch setup
 -------------------

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/application/Application.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/application/Application.java
@@ -17,6 +17,7 @@
  */
 package org.phoebus.service.saveandrestore.application;
 
+import org.phoebus.pv.PVPool;
 import org.phoebus.service.saveandrestore.migration.MigrateRdbToElastic;
 import org.phoebus.service.saveandrestore.persistence.dao.impl.elasticsearch.ElasticsearchDAO;
 import org.springframework.boot.SpringApplication;
@@ -55,6 +56,13 @@ public class Application {
      */
     public static void main(String[] args) {
 
+        // Hack: PVPool reads properties from dependency jar. Override of default
+        // protocol done here by direct access to PVPool.default_type.
+        String defaultProtocol = System.getProperty("defaultProtocol");
+        if(defaultProtocol != null && !defaultProtocol.isEmpty()){
+            PVPool.default_type = defaultProtocol;
+        }
+        System.out.println("Using default EPICS protocol: " + PVPool.default_type);
         // load the default properties
         final Properties properties = PropertiesHelper.getProperties();
 


### PR DESCRIPTION
Updated doc to clarify how to start the service to override default protocol and how to configure address list.