### PR TITLE
CSSTUDIO-2460 Bugfix for the Logbook application: Delete temporary file when file attachment object is garbage collected.

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SingleLogEntryDisplayController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SingleLogEntryDisplayController.java
@@ -188,7 +188,14 @@ public class SingleLogEntryDisplayController extends HtmlAwareController {
             Collection<Attachment> attachments = logEntry.getAttachments().stream()
                     .filter((attachment) -> attachment.getName() != null && !attachment.getName().isEmpty())
                     .map((attachment) -> {
-                        OlogAttachment fileAttachment = new OlogAttachment();
+                        OlogAttachment fileAttachment = new OlogAttachment() {
+                            @Override
+                            protected void finalize() {
+                                if (getFile() != null && getFile().exists()) {
+                                    getFile().delete();
+                                }
+                            }
+                        };
                         fileAttachment.setContentType(attachment.getContentType());
                         fileAttachment.setThumbnail(false);
                         fileAttachment.setFileName(attachment.getName());


### PR DESCRIPTION
This PR adds a finalizer that deletes the temporary file containing an attachment when the corresponding object `OlogAttachment fileAttachment` is garbage collected.

We have observed an excessive amount of duplicated temporary files under `/tmp/` generated by the Logbook application; the files in question seem to have been generated by the periodic refresh of the current search query in the application "Logbook": if a logbook entry that contains at least one attachment is opened at the time of the refresh, a new temporary file is created for every attachment in the logbook entry. If a logbook entry is left open for a period of time, then a number of duplicated files are created that is proportional to the amount of time the logbook entry is left open for. (I believe the default is to refresh the logbook query every 30 seconds, and then a new file is created every 30 seconds for every attachment of the opened logbook entry.)