### PR TITLE
Fix handling of multiple Kafka hosts when creating alarm tree

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeInstance.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeInstance.java
@@ -49,7 +49,9 @@ class AlarmTreeInstance implements AppInstance
         this.app = app;
 
         // split input with/without (raw) query
-        final URI resource = new URI(input.getScheme(), input.getUserInfo(), input.getHost(), input.getPort(), input.getPath(), null, null);
+        // When the URI specifies multiple host / port pairs getHost() will not
+        // work, so we use getAuthority() instead.
+        final URI resource = new URI(input.getScheme(), input.getAuthority(), input.getPath(), null, null);
         String itemName = AlarmURI.getRawQueryParametersValues(input).get(AlarmURI.QUERY_PARAMETER_ITEM_NAME);
         itemName = itemName != null ? URLDecoder.decode(itemName, StandardCharsets.UTF_8) : null;
 


### PR DESCRIPTION
When multiple Kafka hosts are specified as part of the alarm URI, the URI cannot be parsed as a *server-based* URI, only as a *registry-based* URI. This means that the `getHosts()`, `getPort()`, and `getUserInfo()` methods return null. Therefore, we have to use `getAuthority()` instead when cloning the URI.

This PR closes #3071.
