### PR TITLE
Allow adding a permissive hostname verifier to the olog rest client

### DIFF
--- a/app/logbook/olog/client-es/src/main/resources/olog_es_preferences.properties
+++ b/app/logbook/olog/client-es/src/main/resources/olog_es_preferences.properties
@@ -15,6 +15,9 @@ debug=false
 # The connection timeout for the Jersey client, in ms. 0 = infinite.
 connectTimeout=0
 
+# Enable a permissive hostname verifier
+permissive_hostname_verifier=true
+
 # Comma separated list of "Levels" in the create logbook entry UI.
 # Sites may wish to customize (and localize) this.
 levels=Urgent,Suggestion,Info,Request,Problem


### PR DESCRIPTION
Maybe we might want to explore adding this to the other rest clients too... but if we are switching to java httpclient (https://docs.oracle.com/en/java/javase/17/docs/api/java.net.http/java/net/http/HttpClient.html) then we might have to redo this solution again