### PR TITLE
Fix AlarmStateInitializer to store most recent kafka records from the alarm state topic

### DIFF
--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
@@ -94,14 +94,8 @@ public class AlarmStateInitializer
         final ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
         for (final ConsumerRecord<String, String> record : records)
         {
-            if (record.key().length() < 6)
-            {
-                logger.log(Level.WARNING, "Invalid key, expecting type:path, got " + record.key());
-                continue;
-            }
-            final String type = record.key().substring(0, 6);
             // Only handle state updates
-            if (type.equals(AlarmSystem.STATE_PREFIX))
+            if (record.key().startsWith(AlarmSystem.STATE_PREFIX))
             {
                 final String path = record.key().substring(6);
                 final String node_config = record.value();

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
@@ -97,7 +97,7 @@ public class AlarmStateInitializer
             // Only handle state updates
             if (record.key().startsWith(AlarmSystem.STATE_PREFIX))
             {
-                final String path = record.key().substring(6);
+                final String path = record.key().substring(AlarmSystem.STATE_PREFIX.length());
                 final String node_config = record.value();
                 try
                 {

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
@@ -94,7 +94,7 @@ public class AlarmStateInitializer
         final ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
         for (final ConsumerRecord<String, String> record : records)
         {
-            if (record.key().length() < 2)
+            if (record.key().length() < 6)
             {
                 logger.log(Level.WARNING, "Invalid key, expecting type:path, got " + record.key());
                 continue;

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmStateInitializer.java
@@ -99,11 +99,11 @@ public class AlarmStateInitializer
                 logger.log(Level.WARNING, "Invalid key, expecting type:path, got " + record.key());
                 continue;
             }
-            final String type = record.key().substring(0, 2);
+            final String type = record.key().substring(0, 6);
             // Only handle state updates
             if (type.equals(AlarmSystem.STATE_PREFIX))
             {
-                final String path = record.key().substring(3);
+                final String path = record.key().substring(6);
                 final String node_config = record.value();
                 try
                 {


### PR DESCRIPTION
Fixes #3078 

Change the end index of the substring() call to 6 so that it will be possible for `type` to equal the `AlarmSystem.STATE_PREFIX` in the equality check.

After I made this change, confirmed that acknowledgements do persist between alarm server reboots.

Although the change is minor this does cause this code block to be hit that wasn't possible before. Reading through the code it looks ok to me, and testing showed things seemed to be working as expected.

The eventual change this leads to outside this class is that initial_states will have something to pass to the `AlarmServerPV` here:

https://github.com/ControlSystemStudio/phoebus/blob/6a6c5be6ae17e578e4fae0faf14c84ff81a8d856/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java#L394