### PR TITLE
CSSTUDIO-2536 Fix bug with resizing using the keyboard shortcut (CTRL + SHIFT + RIGHT) after an undo of a previous resizing

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/javafx/Tracker.java
+++ b/core/ui/src/main/java/org/phoebus/ui/javafx/Tracker.java
@@ -408,6 +408,7 @@ public class Tracker extends Group
     public final void setPosition(final Rectangle2D position)
     {
         setPosition(position.getMinX(), position.getMinY(), position.getWidth(), position.getHeight());
+        orig = position;
     }
 
     /** Update location and size of tracker


### PR DESCRIPTION
There is a bug in the Display Editor when resizing using the keyboard shortcuts, e.g. using `CTRL + SHIFT + RIGHT` (this is just an example, the bug exists for the other directions and variations as well). To reproduce the bug, the following steps can be followed:

1. Select a widget.
2. Resize the widget by pressing `CTRL + SHIFT + RIGHT`.
3. Undo the change by pressing `CTRL + Z`.
4. Try to resize the widget again by pressing `CTRL + SHIFT + RIGHT`.

I believe that the cause of the bug is a failure to update the variable `Tracker.orig` after performing the undo-operation. This PR fixes the bug by assigning the current position to `Tracker.orig` whenever the function `Tracker.setPosition()` is called.

I am not very familiar with the code in the class `Tracker` and would like to ask for feedback on whether this seems to be the "correct" way to fix the bug or not.