### PR TITLE
CSSTUDIO-2539 Bugfix: Mark tabs as having unsaved changes also when `changeCount < 0`

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/app/DisplayEditorInstance.java
@@ -114,7 +114,7 @@ public class DisplayEditorInstance implements AppInstance
         // Mark 'dirty' whenever there's a change, i.e. something to un-do
         editor_gui.getDisplayEditor()
                   .getUndoableActionManager()
-                  .addListener((to_undo, to_redo, changeCount) -> dock_item.setDirty(changeCount > 0));
+                  .addListener((to_undo, to_redo, changeCount) -> dock_item.setDirty(changeCount != 0));
 
         final ContextMenu menu = new ContextMenu();
         final Control menu_node = editor_gui.getDisplayEditor().getContextMenuNode();


### PR DESCRIPTION
This PR fixes the following bug in the Display Editor:

1. Save an OPI so that it has no unsaved changes.
2. Perform a change (e.g., move a widget). The OPI now has unsaved changes.
3. Save the OPI.
4. Undo the last action. The OPI is now marked as having _no_ unsaved changes.

The bug occurs because the code does not handle the case where `changeCount < 0`.