### PR TITLE
ActionButton: Fix text (foreground) color

### DIFF
--- a/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/opibuilder.css
+++ b/app/display/representation-javafx/src/main/resources/org/csstudio/display/builder/representation/javafx/opibuilder.css
@@ -65,22 +65,6 @@
     -fx-text-overrun: clip;
 }
 
-/* Action buttons with multiple actions become a MenuButton
- * with popup items for each action.
- * The text fill of that context menu uses a ladder()
- * to become black vs. white based on the background color
- * .. of the _button_, while the background of the context menu
- * remains white.
- * This can result in white text on white background.
- *  -> Force black text for the context menu.
- *
- * See MenuButtonDemo
- */
-.action_button_item .label
-{
-    -fx-text-fill: black;
-}
-
 /** Used by MenuButton (Action Button Widget)
  *  to hide the 'down' arrow when button is too narrow
  */

--- a/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/MenuButtonDemo.java
+++ b/app/display/representation-javafx/src/test/java/org/csstudio/display/builder/representation/javafx/sandbox/MenuButtonDemo.java
@@ -45,7 +45,6 @@ public class MenuButtonDemo extends ApplicationWrapper
         button1.getStyleClass().add("action_button");
 
         final MenuItem item = new MenuItem("Action Button Item");
-        item.getStyleClass().add("action_button_item");
         final MenuButton button2 = new MenuButton("Dark Button", null, item, new MenuItem("Plain Item"));
 
         button2.setStyle(JFXUtil.shadedStyle(new WidgetColor(100, 0, 0)));


### PR DESCRIPTION
The text/foreground color was not dependably applied.

While we called `setTextFill(foreground)`, there was a contradicting CSS entry that set the `.action_button_item .label` to `-fx-text-fill: black`.
The widget would somewhat randomly show either the desired text color or black as the display was edited.

To get the desired foreground (text) and background color in both the plain action "button" and the "menu button" used when there are multiple actions, setting the "-fx-text-fill" as well as the "-fx-text-base-color" seems to be required, so all coloring is now based on the widget style, not `setTextFill`.