### PR TITLE
CSSTUDIO-2372 Add Display Name to the information displayed when using the cross-hair cursor in the Data Browser.

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/CursorMarker.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/CursorMarker.java
@@ -143,6 +143,7 @@ class CursorMarker implements Comparable<CursorMarker>
                     final String info = sample.getInfo();
                     if (info != null  &&  info.length() > 0)
                         label += " (" + info + ")";
+                    label += " — " + trace.getName();
                     markers.add(new CursorMarker(cursor_x, axis.getScreenCoord(value), GraphicsUtils.convert(trace.getColor()), label));
                 }
             }


### PR DESCRIPTION
This PR adds the Display Name to the information that is displayed when using the cross-hair cursor in the Data Browser.

The motivation for this feature is that it can be helpful to see which PV a given value is associated with, without having to consult the "Traces" tab, especially when a large number of PVs are displayed in the Data Browser.

There is a GitHub discussion of this feature here: https://github.com/ControlSystemStudio/phoebus/discussions/3095

Screenshot of the functionality:
![screenshot](https://github.com/user-attachments/assets/37c762a5-1bfb-4360-902a-c11c4f7c035c)