### PR TITLE
CSSTUDIO-2081 Add context menu item "Copy: Append PV to Clipboard".

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/Messages.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/Messages.java
@@ -14,7 +14,8 @@ public class Messages
 {
     // Keep in alphabetical order and aligned with messages.properties
     /** Localized message */
-    public static String NavigateBack_TT,
+    public static String AppendPVNameToClipboard,
+                         NavigateBack_TT,
                          NavigateForward_TT,
                          OpenDataBrowser,
                          OpenInEditor,

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuAppendPvToClipboard.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuAppendPvToClipboard.java
@@ -1,0 +1,52 @@
+package org.csstudio.display.builder.runtime.app;
+
+import javafx.scene.image.Image;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
+import org.phoebus.core.types.ProcessVariable;
+import org.phoebus.framework.selection.Selection;
+import org.phoebus.ui.javafx.ImageCache;
+import org.phoebus.ui.spi.ContextMenuEntry;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ContextMenuAppendPvToClipboard implements ContextMenuEntry {
+    @Override
+    public String getName() {
+        return org.csstudio.display.builder.runtime.Messages.AppendPVNameToClipboard;
+    }
+
+    private Image icon = ImageCache.getImage(ImageCache.class, "/icons/copy.png");
+    @Override
+    public Image getIcon() {
+        return icon;
+    }
+
+    @Override
+    public Class<?> getSupportedType() {
+        return ProcessVariable.class;
+    }
+
+    @Override
+    public void call(final Selection selection)
+    {
+        List<ProcessVariable> pvs = selection.getSelections();
+        String pvNamesToAppendToClipboard = pvs.stream().map(ProcessVariable::getName).collect(Collectors.joining(System.lineSeparator()));
+
+        Clipboard clipboard = Clipboard.getSystemClipboard();
+        String newContentInClipboard;
+        {
+            String existingContentInClipboard;
+            if (clipboard.hasString()) {
+                existingContentInClipboard = clipboard.getString() + System.lineSeparator();
+            } else {
+                existingContentInClipboard = "";
+            }
+            newContentInClipboard = existingContentInClipboard + pvNamesToAppendToClipboard;
+        }
+        ClipboardContent newContent = new ClipboardContent();
+        newContent.putString(newContentInClipboard);
+        clipboard.setContent(newContent);
+    }
+}

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -98,6 +98,10 @@ public class DisplayRuntimeInstance implements AppInstance
     /** Toolbar button for navigation */
     private ButtonBase navigate_backward, navigate_forward;
 
+    public String getDisplayName() {
+        return active_model.getDisplayName();
+    }
+
     /** Obtain the DisplayRuntimeInstance of a display
      *  @param model {@link DisplayModel}
      *  @return {@link DisplayRuntimeInstance}

--- a/app/display/runtime/src/main/resources/META-INF/services/org.phoebus.ui.spi.ContextMenuEntry
+++ b/app/display/runtime/src/main/resources/META-INF/services/org.phoebus.ui.spi.ContextMenuEntry
@@ -1,1 +1,2 @@
 org.csstudio.display.builder.runtime.app.ProbeDisplayContextMenuEntry
+org.csstudio.display.builder.runtime.app.ContextMenuAppendPvToClipboard

--- a/app/display/runtime/src/main/resources/org/csstudio/display/builder/runtime/messages.properties
+++ b/app/display/runtime/src/main/resources/org/csstudio/display/builder/runtime/messages.properties
@@ -1,3 +1,4 @@
+AppendPVNameToClipboard=Copy: Append PV to Clipboard
 NavigateBack_TT=Open previous display
 NavigateForward_TT=Open next display
 OpenDataBrowser=Open Data Browser


### PR DESCRIPTION
This PR adds the context menu item "Copy: Append PV to Clipboard".

The initial part of the name "Copy:" is there since context menu items are ordered alphabetically, and this makes the context menu item appear next to the other Copy-context menu items.

Discussion of functionality: https://github.com/ControlSystemStudio/phoebus/discussions/3100

**EDIT:** I have added a getter-function `getDisplayName()` to DisplayRuntimeInstance (https://github.com/ControlSystemStudio/phoebus/pull/3103/commits/6d865aa1f387375ec1d186e4af4bdc3f78fcc6d1). This is not needed for the other change in this PR, but it is needed for our site-specific plugin that implements the other context menu items we would like to add. (In that sense it is a related change for us.) If someone objects to the inclusion of this getter function here, I will take it out of the PR again.