### PR TITLE
fixed orphan periodicSearch instances after Alarm Log Table tab is cl…

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.java
@@ -48,7 +48,7 @@ public class AlarmLogTable implements AppInstance {
             });
             tab = new DockItem(this, loader.load());
             controller = loader.getController();
-            tab.setOnClosed(event -> {
+            tab.addClosedNotification(() -> {
                 controller.shutdown();
             });
             if (resource != null) {


### PR DESCRIPTION
Hi Kunal, @shroffk 

As I mentioned to you last week when I was at BNL, this is the solution on that subject.

Currently, the last - there are many things we are still studying, but we believe this is the critical issue on the alarm services performance is the orphaned process of periodicSearch (as a single thread) executed by the creation of the AlarmLogTable UI. If users "close" and "open" AlarmLogTable UI several times, the number of orphaned processes (threads) will increase continuously at 10-second intervals. So there are many threads that have random (user behavior) intervals. This causes unpredictable stability problems for the Phoebus UI, alarm services and OS resources. 

And the solution which is in the pull request is what @kasemir suggested at https://github.com/ControlSystemStudio/phoebus/blob/d6206dd0db8fc800f3a4bddd577e6235240ffc16/core/ui/src/main/java/org/phoebus/ui/docking/DockItem.java#L88

We've also seen several class uses that work incorrectly, but we're not including them in this pull request to keep our request as simple as possible.

However, I do recommend updating the following area to follow best practices that we know well.

```bash
$ grep -r setOnClosed
app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java:        properties_tab.setOnClosed(event ->
app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java:            search_tab.setOnClosed(event -> autoMinimizeLeft());
app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java:            export_tab.setOnClosed(evt -> autoMinimizeBottom());
app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java:            inspect_tab.setOnClosed(evt -> autoMinimizeBottom());
app/databrowser/src/main/java/org/csstudio/trends/databrowser3/ui/Perspective.java:            waveform_tab.setOnClosed(evt -> autoMinimizeBottom());
app/logbook/ui/src/main/java/org/phoebus/logbook/ui/LogEntryCalender.java:        tab.setOnClosed(event -> {
app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTable.java:            tab.setOnClosed(event -> controller.shutdown());
app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryCalender.java:            tab.setOnClosed(event -> {
```

Best,

@jeonghanlee, Soo Ryu, and @Sangil-Lee at ALS-U Controls, LBNL.