### PR TITLE
Fixing unnecessary creation of Olog temp files

### DIFF
--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogObjectMappers.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/model/OlogObjectMappers.java
@@ -112,6 +112,7 @@ public class OlogObjectMappers {
             String fileMetadataDescription = node.get("fileMetadataDescription").asText();
             OlogAttachment a = new OlogAttachment();
             a.setFileName(filename);
+            a.setId(id);
             a.setContentType(fileMetadataDescription);
             return a;
         }


### PR DESCRIPTION
When user opens an Olog entry containing image attachments, these will be downloaded and saved as temp files using the ```Files.createTempFile``` API. However, the periodic search will trigger a new download and new files, which are saved under new file names. So, when a log entry containing multiple large image attachments is "in view", free disk space will gradually shrink.

This PR addresses the issue of repeatedly saving the same attachment under a new name.

This PR does **not** address the issue of repeated download of attachments already present locally. Such a fix requires more thinking and work in regards to where and how temporary files are stored.