### PR TITLE
CSSTUDIO-2555 Bugfix: edit the source of log entries (if available), not the description of log entries.

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUpdateController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUpdateController.java
@@ -273,7 +273,15 @@ public class LogEntryUpdateController {
         titleProperty.set(logEntry.getTitle());
 
         textArea.textProperty().bindBidirectional(descriptionProperty);
-        descriptionProperty.set(logEntry.getSource() != null ? logEntry.getSource() : logEntry.getDescription());
+        if (logEntry.getSource() != null) {
+            descriptionProperty.set(logEntry.getSource());
+        }
+        else if (logEntry.getDescription() != null) {
+            descriptionProperty.set(logEntry.getDescription());
+        }
+        else {
+            descriptionProperty.set("");
+        }
         descriptionProperty.addListener((observable, oldValue, newValue) -> isDirty = true);
 
         Image tagIcon = ImageCache.getImage(LogEntryUpdateController.class, "/icons/add_tag.png");

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUpdateController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUpdateController.java
@@ -273,7 +273,7 @@ public class LogEntryUpdateController {
         titleProperty.set(logEntry.getTitle());
 
         textArea.textProperty().bindBidirectional(descriptionProperty);
-        descriptionProperty.set(logEntry.getDescription() != null ? logEntry.getDescription() : "");
+        descriptionProperty.set(logEntry.getSource() != null ? logEntry.getSource() : logEntry.getDescription());
         descriptionProperty.addListener((observable, oldValue, newValue) -> isDirty = true);
 
         Image tagIcon = ImageCache.getImage(LogEntryUpdateController.class, "/icons/add_tag.png");


### PR DESCRIPTION
This PR implements a change to the Edit window of the logbook application: the result of `getSource()` is used (if available) instead of the result of `getDescription()`. As a consequence, editing formatted logs is easier: formatting (such as headings, etc.) is not lost when editing a log entry, and does not have to be recreated again.

To provide a concrete example, consider the following log-entry:
```
# Test 1
## Test 1.1
### Test 1.1.1
```

Currently (without this PR), when editing this log-entry, it would appear as
```
Test 1
Test 1.1
Test 1.1.1
```
and the formatting has to be recreated.