### PR TITLE
Toolbar entry for opening a data browser.

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/OpenDataBrowser.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/OpenDataBrowser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2018-2024 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,15 @@ package org.csstudio.trends.databrowser3;
 import org.phoebus.framework.workbench.ApplicationService;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.spi.MenuEntry;
+import org.phoebus.ui.spi.ToolbarEntry;
 
 import javafx.scene.image.Image;
 
-/** Menu entry for opening data browser
+/** Menu and toolbar entry for opening data browser
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class OpenDataBrowser implements MenuEntry
+public class OpenDataBrowser implements MenuEntry, ToolbarEntry
 {
     @Override
     public String getName()

--- a/app/databrowser/src/main/resources/META-INF/services/org.phoebus.ui.spi.ToolbarEntry
+++ b/app/databrowser/src/main/resources/META-INF/services/org.phoebus.ui.spi.ToolbarEntry
@@ -1,0 +1,1 @@
+org.csstudio.trends.databrowser3.OpenDataBrowser


### PR DESCRIPTION
Adds an entry to the toolbar for opening a data browser, as was available in the Eclipse-based version.

To avoid unwanted clutter on the toolbar, note that it can be controlled via `org.phoebus.ui/toolbar_entries`, for example by suppressing the "Data Browser" button it like this:

```
org.phoebus.ui/toolbar_entries=Home, Top Resources, Layouts, File
Browser, !Send To Log Book, !Scan Monitor, !Data Browser, *
```