### PR TITLE
CSSTUDIO-2581 Bugfix of the issue that the WebViewer of the Logbook application is sometimes used to open links in log entries

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/web/HyperLinkRedirectListener.java
+++ b/core/ui/src/main/java/org/phoebus/ui/web/HyperLinkRedirectListener.java
@@ -71,7 +71,9 @@ public class HyperLinkRedirectListener implements ChangeListener<State>, EventLi
             for (int i = 0; i < anchors.getLength(); i++) {
                 Node node = anchors.item(i);
                 EventTarget eventTarget = (EventTarget) node;
-                eventTarget.addEventListener(CLICK_EVENT, this, false);
+                eventTarget.addEventListener(CLICK_EVENT,
+                                             new HyperLinkRedirectListener(webView), // Note: A new instance MUST be created here, otherwise NullPointerExceptions may be thrown when trying to run the event handler!
+                                             false);
             }
         }
     }

--- a/core/ui/src/main/java/org/phoebus/ui/web/HyperLinkRedirectListener.java
+++ b/core/ui/src/main/java/org/phoebus/ui/web/HyperLinkRedirectListener.java
@@ -48,7 +48,7 @@ import java.util.logging.Logger;
  * <a href="https://stackoverflow.com/questions/15555510/javafx-stop-opening-url-in-webview-open-in-browser-instead">
  * this Stackoverflow post</a>.
  */
-public class HyperLinkRedirectListener implements ChangeListener<State>, EventListener {
+public class HyperLinkRedirectListener implements ChangeListener<State> {
     private static final String CLICK_EVENT = "click";
     private static final String ANCHOR_TAG = "a";
 
@@ -72,21 +72,23 @@ public class HyperLinkRedirectListener implements ChangeListener<State>, EventLi
                 Node node = anchors.item(i);
                 EventTarget eventTarget = (EventTarget) node;
                 eventTarget.addEventListener(CLICK_EVENT,
-                                             new HyperLinkRedirectListener(webView), // Note: A new instance MUST be created here, otherwise NullPointerExceptions may be thrown when trying to run the event handler!
+                                             new HyperLinkRedirectEventListener(), // Note: A new instance MUST be created here, otherwise NullPointerExceptions may be thrown when trying to run the event handler!
                                              false);
             }
         }
     }
 
-    @Override
-    public void handleEvent(Event event) {
-        HTMLAnchorElement anchorElement = (HTMLAnchorElement) event.getCurrentTarget();
-        String href = anchorElement.getHref();
-        try {
-            ApplicationService.createInstance("web", new URI(href));
-            event.preventDefault();
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Failed to launch WebBrowserApplication", e);
+    private class HyperLinkRedirectEventListener implements EventListener {
+        @Override
+        public void handleEvent(Event event) {
+            HTMLAnchorElement anchorElement = (HTMLAnchorElement) event.getCurrentTarget();
+            String href = anchorElement.getHref();
+            try {
+                ApplicationService.createInstance("web", new URI(href));
+                event.preventDefault();
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, "Failed to launch WebBrowserApplication", e);
+            }
         }
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/web/HyperLinkRedirectListener.java
+++ b/core/ui/src/main/java/org/phoebus/ui/web/HyperLinkRedirectListener.java
@@ -81,11 +81,11 @@ public class HyperLinkRedirectListener implements ChangeListener<State> {
     private class HyperLinkRedirectEventListener implements EventListener {
         @Override
         public void handleEvent(Event event) {
+            event.preventDefault();
             HTMLAnchorElement anchorElement = (HTMLAnchorElement) event.getCurrentTarget();
             String href = anchorElement.getHref();
             try {
                 ApplicationService.createInstance("web", new URI(href));
-                event.preventDefault();
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "Failed to launch WebBrowserApplication", e);
             }


### PR DESCRIPTION
The WebViewer in the Logbook application should launch an external web browser when clicking on links, and usually does so. However, when switching very rapidly between log entries, the mechanism is sometimes disabled for some reason. As a result, links are opened in the WebViewer instance in the Logbook application, which they shouldn't be.

Based on testing, the cause seems to be that the class `HyperLinkRedirectListener` _simultaneously_ acts as a `ChangeListener<State>` _and_ as `EventListener`: the _same_ object is used as a `ChangeListener<State>` for the web engine and also as the event listener for any clicks on any hyperlinks in log entries. This seems to cause the issue.

This pull request:

1. Separates the implementations of `HyperLinkRedirectListener` and `ChangeListener<State>`, resulting in increased readability of the code; and
2. Creates a new instance of the event listener in question for every hyperlink in log entries, which, based on testing, seems to resolve the bug.