### PR TITLE
Define `DisplayName` in databrower with PV descriptions if this information is available.

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/ModelItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/ModelItem.java
@@ -172,13 +172,16 @@ abstract public class ModelItem
     /** @param new_display_name New display name
      *  @see #getDisplayName()
      */
-    public void setDisplayName(String new_display_name)
+    public void setDisplayName(final String new_display_name)
     {
-        new_display_name = new_display_name.trim();
-        if (new_display_name.equals(display_name))
-            return;
-        display_name = new_display_name;
-        fireItemLookChanged();
+        if (new_display_name != null) 
+        {
+            new_display_name = new_display_name.trim();
+            if (new_display_name.equals(display_name))
+                return;
+            display_name = new_display_name;
+            fireItemLookChanged();
+        }
     }
 
     /** @param units Units, may be <code>null</code> */

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -85,6 +85,8 @@ public class PVItem extends ModelItem
      * the live buffer is too small to show all the data */
     private boolean automaticRefresh = Preferences.automatic_history_refresh;
 
+    private boolean firstDisplayName = false;
+
     /** Initialize
      *  @param name PV name
      *  @param period Scan period in seconds, &le;0 to 'monitor'
@@ -368,6 +370,12 @@ public class PVItem extends ModelItem
         // Set units unless already defined
         if (getUnits() == null)
             updateUnits(value);
+        // Define the descriptions if they are not already defined and if the PV have this information.
+        if (getDisplayName() == getName() && firstDisplayName == false)
+        {
+            updateDescription(value);
+            firstDisplayName = true;
+        }
         if (automaticRefresh && added &&
             model.isPresent() &&
             samples.isHistoryRefreshNeeded(model.get().getTimerange()))
@@ -388,6 +396,12 @@ public class PVItem extends ModelItem
         setUnits(display.getUnit());
     }
 
+    public void updateDescription(final VType value)
+    {
+        final Display display = Display.displayOf(value);
+        setDisplayName(display.getDescription());
+    }
+    
     /** Scan, i.e. add 'current' value to live samples */
     private void doScan()
     {


### PR DESCRIPTION
Hello,

I am proposing this modification concerning the files `ModelItem.java` and `PVItem.java`.
This change replaces the `display_name` variable with the PV description when adding a PV in `databrowser`.

If no description is provided in the PV, then `display_name` takes the value of the PV name.

Afterwards, if the user wishes, they can manually modify the `display_name`.

I am suggesting this change because it was requested by our users to help them better navigate the data.

I tested it on my machine, and it works well with `PVA`, but not with `CA`.

I did not attempt to make it work with `CA`, as we do not use it on our site.

What do you think of this addition? 

It could likely be improved, but since I'm not a Java specialist, I don't see how to make it better.

#3080 