### PR TITLE
fixed the alarm event handler performance issue

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/client/AlarmClient.java
@@ -204,7 +204,7 @@ public class AlarmClient {
         try {
             final String json = new String(JsonModelWriter.commandToBytes(cmd));
             final ProducerRecord<String, String> record = new ProducerRecord<>(command_topic, AlarmSystem.COMMAND_PREFIX + root.getPathName(), json);
-            producer.send(record).get(KAFKA_CLIENT_TIMEOUT, TimeUnit.SECONDS);
+            producer.send(record);
         } catch (final Exception ex) {
             logger.log(Level.WARNING, "Cannot set mode for " + root + " to " + cmd, ex);
             throw ex;
@@ -222,7 +222,7 @@ public class AlarmClient {
         try {
             final String json = new String(JsonModelWriter.commandToBytes(cmd));
             final ProducerRecord<String, String> record = new ProducerRecord<>(command_topic, AlarmSystem.COMMAND_PREFIX + root.getPathName(), json);
-            producer.send(record).get(KAFKA_CLIENT_TIMEOUT, TimeUnit.SECONDS);
+            producer.send(record);
         } catch (final Exception ex) {
             logger.log(Level.WARNING, "Cannot set mode for " + root + " to " + cmd, ex);
             throw ex;
@@ -525,7 +525,7 @@ public class AlarmClient {
     public void sendItemConfigurationUpdate(final String path, final AlarmTreeItem<?> config) throws Exception {
         final String json = new String(JsonModelWriter.toJsonBytes(config));
         final ProducerRecord<String, String> record = new ProducerRecord<>(config_topic, AlarmSystem.CONFIG_PREFIX + path, json);
-        producer.send(record).get(KAFKA_CLIENT_TIMEOUT, TimeUnit.SECONDS);
+        producer.send(record);
     }
 
     /**
@@ -570,7 +570,7 @@ public class AlarmClient {
             final String cmd = acknowledge ? "acknowledge" : "unacknowledge";
             final String json = new String(JsonModelWriter.commandToBytes(cmd));
             final ProducerRecord<String, String> record = new ProducerRecord<>(command_topic, AlarmSystem.COMMAND_PREFIX + item.getPathName(), json);
-            producer.send(record).get(KAFKA_CLIENT_TIMEOUT, TimeUnit.SECONDS);
+            producer.send(record);
         } catch (final Exception ex) {
             logger.log(Level.WARNING, "Cannot acknowledge component " + item, ex);
             throw ex;

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/ServerModel.java
@@ -472,7 +472,7 @@ class ServerModel
         {
             final String json = new_state == null ? null : new String(JsonModelWriter.toJsonBytes(new_state, AlarmLogic.getMaintenanceMode(), AlarmLogic.getDisableNotify()));
             final ProducerRecord<String, String> record = new ProducerRecord<>(config_state_topic, AlarmSystem.STATE_PREFIX + path, json);
-            producer.send(record).get(KAFKA_CLIENT_TIMEOUT, TimeUnit.SECONDS);
+            producer.send(record);
             last_state_update = System.currentTimeMillis();
         }
         catch (Throwable ex)
@@ -491,7 +491,7 @@ class ServerModel
         {
             final String json = config == null ? null : new String(JsonModelWriter.toJsonBytes(config));
             final ProducerRecord<String, String> record = new ProducerRecord<>(config_state_topic, AlarmSystem.CONFIG_PREFIX + path, json);
-            producer.send(record).get(KAFKA_CLIENT_TIMEOUT, TimeUnit.SECONDS);
+            producer.send(record);
         }
         catch (Throwable ex)
         {
@@ -512,7 +512,7 @@ class ServerModel
 
             final String json = JsonModelWriter.talkToString(severity, message);
             final ProducerRecord<String, String> record = new ProducerRecord<>(talk_topic, AlarmSystem.TALK_PREFIX + path, json);
-            producer.send(record).get(KAFKA_CLIENT_TIMEOUT, TimeUnit.SECONDS);
+            producer.send(record);
         }
         catch (Throwable ex)
         {


### PR DESCRIPTION
Hi Kay @kasemir and Kunal @shroffk 

While intensively testing the alarm performance, we noticed that the current alarm server cannot handle simultaneous alarm events (50 alarms with the exact process record time with the reference PV's `TESL` of 50 PVs per second during 10 minutes).

Our suspicion was `Flowable<VType> buffersize`, but increasing the size is not a real solution. While debugging the performance problem, we noticed that the alarm server uses the `producer.send(record).get()` function intensively without returning its metadata in `sendStateUpdate()` in `ServerModel.java`.

We have investigated this `get` function in more detail and concluded that it is the main trouble of alarm performance. This function is `synchronous` and `blocking`. And `send` itself is `asynchronous` and `non-blocking`. 

So here we propose the code without the `get` function, which has been verified that the current (this branch) alarm server can handle simultaneous alarm events (now 100 alarms with the exact process record time with the reference PV's `TESL` - of 50 PVs per second during 10 minutes).

We have seen that there is no use case for handling the return value of the `get` function in other code, so we have removed all these functions everywhere. This may not be the solution if you want to receive some metadata after `.send.get`.

In this case, where you want to handle the metadata, we also find the solution, which is as follows:

```
Producer.send(record, onCompletion override of callback);
```

I don't check the Kafka version, so you can find the appropriate version of Kafka in any version documentation. 

Detailed information can be found at

https://kafka.apache.org/35/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#send(org.apache.kafka.clients.producer.ProducerRecord,org.apache.kafka.clients.producer.Callback)

We now extend our tests to "500, 1000, and 5000 alarm events" to see where the story ends. If all goes well, we finish our test for MAX 5000 alarms with the exact process record time with the reference PV's `TESL` of 50 PVs per second for 10 minutes.

So we want to be very clear about the limits of the alarm services we want to use. 

If we have the system more than 5000 alarm events per second, we will be completely wrong for the control system anyway. 🥲 

@jeonghanlee, Soo Ryu, and @Sangil-Lee at ALS-U Controls, LBNL.