### PR TITLE
Reproducible builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,8 @@
     <maven.compiler.target>17</maven.compiler.target>
     <activemq.client.version>5.18.4</activemq.client.version>
     <commons.compress.version>1.26.1</commons.compress.version>
+    <!--suppress UnresolvedMavenProperty -->
+    <project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
   </properties>
   <build>
     <plugins>
@@ -162,6 +164,31 @@
         <!-- Use a version > 3.2.0 by default for reproducible builds.
           See: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
         <version>3.3.0</version>
+      </plugin>
+      <!-- Include the git properties to ensure reproducible builds -->
+      <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>9.0.1</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+          <prefix>git</prefix>
+          <verbose>false</verbose>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <format>json</format>
+          <excludeProperties>
+            <excludeProperty>^git.build.*$</excludeProperty>
+          </excludeProperties>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
           <format>json</format>
           <excludeProperties>
             <excludeProperty>^git.build.*$</excludeProperty>
+            <excludeProperty>^git.local.branch.*$</excludeProperty>
           </excludeProperties>
         </configuration>
       </plugin>


### PR DESCRIPTION
With each packaging of the Phoebus jar there is now a `git.properties` file which includes the commit id associated with this build

Additionally, I use the git commit time to mark the `project.build.outputTimestamp` which can be used to compare builds as follows

```
$ mvn clean verify artifact:compare -DskipTests
```


```
[INFO] Saved aggregate info on build to C:\git\cs-studio\phoebus\services\save-and-restore\target\service-save-and-restore-4.7.4-SNAPSHOT.buildinfo
[INFO] Aggregate buildinfo copied to C:\git\cs-studio\phoebus\target\parent-4.7.4-SNAPSHOT.buildinfo
[INFO] Checking against reference build from central...
[INFO] Reference buildinfo file not found: it will be generated from downloaded reference artifacts
[INFO] Reference build java.version: 17 (from MANIFEST.MF Build-Jdk-Spec)
[INFO] Reference build os.name: Windows (from pom.properties newline)
[INFO] Minimal buildinfo generated from downloaded artifacts: C:\git\cs-studio\phoebus\target\reference\service-save-and-restore-4.7.4-SNAPSHOT.buildinfo
[INFO] Reproducible Build output summary: 183 files ok
[INFO] Reproducible Build output comparison saved to C:\git\cs-studio\phoebus\services\save-and-restore\target\service-save-and-restore-4.7.4-SNAPSHOT.buildcompare
[INFO] Aggregate buildcompare copied to C:\git\cs-studio\phoebus\target\parent-4.7.4-SNAPSHOT.buildcompare
```
