### PR TITLE
Scan Server: Sanitize XML

### DIFF
--- a/services/scan-server/.classpath
+++ b/services/scan-server/.classpath
@@ -8,6 +8,8 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-util"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-pv"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/core-pv-ca"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/core-pv-pva"/>
         <classpathentry combineaccessrules="false" kind="src" path="/core-vtype"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/app-scan-model"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>


### PR DESCRIPTION
While a little hard to do, it's possible to submit a scan with unprintable characters like `(char) 7` in the name or potentially some other text.

When then fetching the information back from the scan server, the `XMLStreamWriter` will not escape such characters as for example `&#7;`. We could perform such escapes ourselves, but when clients like Safari then receive the XML, they will un-escape it back into char 7 and complain about invalid XML.

Based on
 * https://en.wikipedia.org/wiki/Valid_characters_in_XML
 * https://stackoverflow.com/questions/404107/why-are-control-characters-illegal-in-xml-1-0
 * https://learn.microsoft.com/en-us/previous-versions/troubleshoot/msxml/error-when-xml-contains-low-order-ascii

such 'control' characters are simply not supported in XML.

This patch will replace them with underscores to get valid XML and issue a warning, which allows end users to track down the source of the invalid data. Without this patch, the XML from the scan server was invalid and the scan monitor for example would then show nothing, making it hard for end users to determine what's wrong.