### PR TITLE
Update PlainExportJob.java

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/PlainExportJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/PlainExportJob.java
@@ -55,12 +55,7 @@ public class PlainExportJob extends ExportJob
     {
         super.printExportInfo(out);
         out.println(comment + "Format     : " + formatter.toString());
-        out.println(comment);
-        out.println(comment + "Data is in TAB-delimited columns, for import into e.g. Excel.");
-        out.println(comment + "The 'Time' column contains values like '2018-02-04 21:58:47.065'.");
-        out.println(comment + "In your spreadsheet program, a custom column format like");
-        out.println(comment + "    'yyyy-mm-d h:mm:ss.000'");
-        out.println(comment + "might be required to show the full timestamp detail.");
+        out.println(comment + "Spreadsheet: TAB-delimited import and format time as yyyy-mm-d h:mm:ss.000");
         out.println();
     }
 


### PR DESCRIPTION
Current versions of Excel on Windows experience strange issues when importing the tab-separated data browser export files.

No problems with Excel on Mac, but Excel on Windows can behave similar to what's described on  https://answers.microsoft.com/en-us/msoffice/forum/all/excel-data-import-from-textcsv-is-incorrectly/c14fcb58-6698-45a7-a9d8-5beb9d997503, columns may be missing or without values.

Changing the comment at the start of the file to just this essential spreadsheet format hint circumvents import issues for Excel on Windows.