### PR TITLE
Alarm log table refactor

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -150,7 +150,7 @@ public class AlarmLogTableController {
     public void initialize() {
         resize.setText("<");
         tableView.getColumns().clear();
-        configCol = new TableColumn<>("Config");
+
         configCol.setCellValueFactory(
                 alarmMessage -> new SimpleStringProperty(alarmMessage.getValue().getConfig()));
         tableView.getColumns().add(configCol);
@@ -159,7 +159,6 @@ public class AlarmLogTableController {
         pvCol.setCellValueFactory(alarmMessage -> new SimpleStringProperty(alarmMessage.getValue().getPv()));
         tableView.getColumns().add(pvCol);
 
-        severityCol = new TableColumn<>("Severity");
         severityCol.setCellValueFactory(
                 alarmMessage -> new SimpleStringProperty(alarmMessage.getValue().getSeverity()));
         severityCol.setCellFactory(alarmLogTableTypeStringTableColumn -> new TableCell<>() {
@@ -179,12 +178,17 @@ public class AlarmLogTableController {
         });
         tableView.getColumns().add(severityCol);
 
-        messageCol = new TableColumn<>("Message");
         messageCol.setCellValueFactory(
                 alarmMessage -> new SimpleStringProperty(alarmMessage.getValue().getMessage()));
         tableView.getColumns().add(messageCol);
 
-        timeCol = new TableColumn<>("Time");
+        valueCol.setCellValueFactory(
+                alarmMessage -> {
+                    String value = alarmMessage.getValue().getValue(); 
+                    return new SimpleStringProperty(value);
+                });
+        tableView.getColumns().add(valueCol);
+
         timeCol.setCellValueFactory(
                 alarmMessage -> {
                     if (alarmMessage.getValue().getTime() != null) {
@@ -195,7 +199,6 @@ public class AlarmLogTableController {
                 });
         tableView.getColumns().add(timeCol);
 
-        msgTimeCol = new TableColumn<>("Message Time");
         msgTimeCol.setCellValueFactory(
                 alarmMessage -> {
                     String time = TimestampFormats.MILLI_FORMAT.format(alarmMessage.getValue().getMessage_time());
@@ -203,17 +206,14 @@ public class AlarmLogTableController {
                 });
         tableView.getColumns().add(msgTimeCol);
 
-        deltaTimeCol = new TableColumn<>("Time Delta");
         deltaTimeCol.setCellValueFactory(
                 alarmMessage -> {
                     java.time.Duration delta = java.time.Duration.between(alarmMessage.getValue().getMessage_time(), Instant.now());
                     return new SimpleStringProperty(delta.toHours() + ":" + delta.toMinutesPart() + ":" + delta.toSecondsPart()
                             + "." + delta.toMillisPart());
                 });
-        deltaTimeCol.setVisible(false);
         tableView.getColumns().add(deltaTimeCol);
 
-        currentSeverityCol = new TableColumn<>("Current Severity");
         currentSeverityCol.setCellValueFactory(
                 alarmMessage -> new SimpleStringProperty(alarmMessage.getValue().getCurrent_severity()));
         currentSeverityCol.setCellFactory(alarmLogTableTypeStringTableColumn -> new TableCell<>() {
@@ -234,12 +234,10 @@ public class AlarmLogTableController {
         });
         tableView.getColumns().add(currentSeverityCol);
 
-        currentMessageCol = new TableColumn<>("Current Message");
         currentMessageCol.setCellValueFactory(
                 alarmMessage -> new SimpleStringProperty(alarmMessage.getValue().getCurrent_message()));
         tableView.getColumns().add(currentMessageCol);
 
-        commandCol = new TableColumn<>("Command");
         commandCol.setCellValueFactory(
                 alarmMessage -> {
                     String action = alarmMessage.getValue().getCommand();
@@ -258,12 +256,10 @@ public class AlarmLogTableController {
                 });
         tableView.getColumns().add(commandCol);
 
-        userCol = new TableColumn<>("User");
         userCol.setCellValueFactory(
                 alarmMessage -> new SimpleStringProperty(alarmMessage.getValue().getUser()));
         tableView.getColumns().add(userCol);
 
-        hostCol = new TableColumn<>("Host");
         hostCol.setCellValueFactory(
                 alarmMessage -> new SimpleStringProperty(alarmMessage.getValue().getHost()));
         tableView.getColumns().add(hostCol);

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AdvancedSearchView.fxml
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AdvancedSearchView.fxml
@@ -48,7 +48,7 @@
                     <TextField fx:id="searchHost" GridPane.columnSpan="2" GridPane.rowIndex="13" />
                     <Label text="%Command" GridPane.rowIndex="14" />
                     <TextField fx:id="searchCommand" GridPane.columnSpan="2" GridPane.rowIndex="15" />
-                    <Label text="%Time" GridPane.columnSpan="2" GridPane.rowIndex="16">
+                    <Label text="%MessageTime" GridPane.columnSpan="2" GridPane.rowIndex="16">
                         <GridPane.margin>
                             <Insets top="5.0" />
                         </GridPane.margin>

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.fxml
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.fxml
@@ -68,19 +68,20 @@
                         </VBox>
                         <TableView fx:id="tableView" onContextMenuRequested="#createContextMenu" prefHeight="591.0" prefWidth="1000.0" tableMenuButtonVisible="true">
                             <columns>
-                                <TableColumn fx:id="configCol" minWidth="50.0" prefWidth="75.0" text="%Config" />
+                                <TableColumn fx:id="configCol" minWidth="50.0" prefWidth="75.0" text="%Config" visible="%ConfigVisible" />
                                 <TableColumn fx:id="pvCol" minWidth="50.0" prefWidth="75.0" text="PV" />
                                 <TableColumn fx:id="severityCol" minWidth="50.0" prefWidth="75.0" text="%Severity" />
                                 <TableColumn fx:id="messageCol" minWidth="50.0" prefWidth="75.0" text="%Message" />
-                                <TableColumn fx:id="valueCol" minWidth="50.0" prefWidth="75.0" text="%Value" />
+                                <TableColumn fx:id="valueCol" minWidth="50.0" prefWidth="75.0" text="%Value" visible="%ValueVisible" />
                                 <TableColumn fx:id="timeCol" minWidth="50.0" prefWidth="75.0" text="%Time" />
-                                <TableColumn fx:id="msgTimeCol" minWidth="50.0" prefWidth="75.0" text="%MessageTime" />
-                                <TableColumn fx:id="currentSeverityCol" minWidth="50.0" prefWidth="75.0" text="%CurrentSeverity" />
-                                <TableColumn fx:id="currentMessageCol" minWidth="50.0" prefWidth="75.0" text="%CurrentMessage" />
+                                <TableColumn fx:id="msgTimeCol" minWidth="50.0" prefWidth="75.0" text="%MessageTime" visible="%MTimeVisible"/>
+                                <TableColumn fx:id="deltaTimeCol" minWidth="50.0" prefWidth="75.0" text="%TimeDelta" visible="%TimeDeltaVisible"/>
+                                <TableColumn fx:id="currentSeverityCol" minWidth="50.0" prefWidth="75.0" text="%CurrentSeverity" visible="%CSeverityVisible" />
+                                <TableColumn fx:id="currentMessageCol" minWidth="50.0" prefWidth="75.0" text="%CurrentMessage" visible="%CMessageVisible" />
                                 <TableColumn fx:id="mode" minWidth="50.0" prefWidth="75.0" text="%Mode" />
-                                <TableColumn fx:id="commandCol" minWidth="50.0" prefWidth="75.0" text="%Command" />
-                                <TableColumn fx:id="userCol" minWidth="50.0" prefWidth="75.0" text="%User" />
-                                <TableColumn fx:id="hostCol" minWidth="50.0" prefWidth="75.0" text="%Host" />
+                                <TableColumn fx:id="commandCol" minWidth="50.0" prefWidth="75.0" text="%Command" visible="%CommandVisible" />
+                                <TableColumn fx:id="userCol" minWidth="50.0" prefWidth="75.0" text="%User" visible="%UserVisible" />
+                                <TableColumn fx:id="hostCol" minWidth="50.0" prefWidth="75.0" text="%Host" visible="%HostVisible" />
                             </columns>
                             <columnResizePolicy>
                                 <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages.properties
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages.properties
@@ -37,3 +37,14 @@ StartTime=Start Time
 Time=Time
 User=User
 Value=Value
+TimeDelta=Time Delta
+ConfigVisible=true
+ValueVisible=false
+MTimeVisible=true
+TimeDeltaVisible=false
+CSeverityVisible=true
+CMessageVisible=true
+CommandVisible=true
+UserVisible=true
+HostVisible=true
+

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages_fr.properties
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages_fr.properties
@@ -20,3 +20,14 @@ StartTime=Heure de début
 Time=Heure
 User=Utilisateur
 Value=Valeur
+TimeDelta=Heure Delta
+ConfigVisible=true
+ValueVisible=false
+MTimeVisible=true
+TimeDeltaVisible=false
+CSeverityVisible=true
+CMessageVisible=true
+CommandVisible=true
+UserVisible=true
+HostVisible=true
+


### PR DESCRIPTION
Hi Kay @kasemir and Kunal @shroffk

We would like to suggest a small workaround solution for the alarm log table layout and its headers.

We have been struggling to figure out what each of the alarm log table headers means. Now we have intensively studied their physical meanings. Then we saw some problems with the alarm log table. Here is our "workaround" solution to minimize any impact on the existing table definitions.

We don't change their original definitions, but introduce a method to define all header names in a site-specific way. We have also added the ability to configure the visibility of the Alarm Log table in a similar and limited way.

Our intention is to implement their configuration dynamically, but due to the mixed configurations from everywhere, we decide to "replace" the site-specific configuration during the build process. This keeps our work to a minimum and keeps all other sites the same as before.

- Fixed the mismatch time definition in the search bar to use its `message time` instead of `time`. We selected `message time` because the log table also contains "ACK" events. (Currently method does not provide the clear way to see the exact alarm event if user wants to focus the `time` However, the previous our PR, the time delta should be in the acceptable range in most case. Thus, we use the `message time` (It is quite confusing, I prefer `Alarm Log Time`). 
- Added the alarm value option to the alarm log table since we already record the value changes within the alarm log service. (Currently method has one issue, which we will do another PR later)
- See attached file with message time (default) and value (after execution, I enabled the option)

![1](https://github.com/user-attachments/assets/432e9d1b-ec30-47b9-b8dd-7c5e496425c7)

The configurable options are defined in `messages.properties`. We kept it as the same as before.

https://github.com/jeonghanlee/phoebus/blob/2a92aa6f0e07b1a3f265c285fc73cc0a9ef79ea6/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages.properties



Technically, based on this pull request, we would like to redefine our Alarm Log Table according to the following file

https://github.com/jeonghanlee/phoebus-env/blob/master/site-template/alarm-logger_logtable-messages.properties

And its screen is here also.

![2](https://github.com/user-attachments/assets/7c7cdc58-5d1b-4a01-8e61-1a8940759178)

With this method, we have zero impact on the current Phoebus Alarm Log Table, and give ourselves quite a bit of flexibility to optimize our environment without much discussion.

Some day later, I want to discuss all definitions of Alarm Table and Alarm Log Tables with you. However, we don't have enough resources to make it look perfect. 

Thanks,

@jeonghanlee, Soo Ryu, and @Sangil-Lee at ALS-U Controls, LBNL.

