### PR TITLE
Option to customize logbook app name reinstated

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableApp.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableApp.java
@@ -5,6 +5,7 @@ import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.framework.spi.AppResourceDescriptor;
 import org.phoebus.logbook.*;
 import org.phoebus.ui.javafx.ImageCache;
+import org.phoebus.util.text.Strings;
 
 import java.net.URI;
 import java.util.logging.Logger;
@@ -24,6 +25,10 @@ public class LogEntryTableApp implements AppResourceDescriptor {
     @Override
     public void start() {
         logFactory = LogService.getInstance().getLogFactories().get(LogbookPreferences.logbook_factory);
+        String displayName = LogbookUIPreferences.log_entry_table_display_name;
+        if(!Strings.isNullOrEmpty(displayName)){
+            DISPLAY_NAME = displayName;
+        }
     }
 
     @Override

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookUIPreferences.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogbookUIPreferences.java
@@ -31,6 +31,7 @@ public class LogbookUIPreferences
     @Preference public static boolean log_entry_groups_support;
     @Preference public static boolean log_entry_update_support;
     @Preference public static String[] hidden_properties;
+    @Preference public static String log_entry_table_display_name;
     @Preference public static String log_entry_calendar_display_name;
     @Preference public static String log_attribute_desc;
     @Preference public static int search_result_page_size;

--- a/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
+++ b/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
@@ -36,6 +36,9 @@ log_entry_update_support=true
 # business logic, but should not be rendered in the properties view.
 hidden_properties=Log Entry Group
 
+# Log Entry Table display name. If non-empty it overrides default "Log Entry Table"
+log_entry_table_display_name=
+
 # Log Entry Calendar display name. If non-empty it overrides default "Log Entry Calendar"
 log_entry_calendar_display_name=
 


### PR DESCRIPTION
Fixes complaints mentioned in #3163 
@tynanford, this makes it possible to customize the app name again using ```org.phoebus.logbook.olog.ui/log_entry_table_display_name```