### PR TITLE
Add the missing Latch status  into the Alarm Logger History

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -1,7 +1,6 @@
 package org.phoebus.applications.alarm.logging.ui;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -259,11 +258,9 @@ public class AlarmLogTableController {
                                     return null;
                                 }
                                 final boolean latching = jsonNode.get("latching").asBoolean();
-                                return new SimpleStringProperty(latching ? "Latched" : "Enabled");
-                            } catch (JsonParseException e) {
-                                logger.log(Level.SEVERE, "Error parsing JSON in alarmMesssage " + e.getMessage());
+                                return new SimpleStringProperty(latching ? "Enabled:Latched" : "Enabled:Unlatch");
                             } catch (Exception e) {
-                                logger.log(Level.SEVERE, "Unexpected error in alarmMessage" + e.getMessage());
+                                logger.log(Level.SEVERE, "Unexpected error in alarmMessage" + e);
                             }
                         }
                     }

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -1,6 +1,8 @@
 package org.phoebus.applications.alarm.logging.ui;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sun.jersey.api.client.WebResource;
@@ -40,6 +42,7 @@ import javafx.util.Duration;
 import org.phoebus.applications.alarm.AlarmSystem;
 import org.phoebus.applications.alarm.logging.ui.AlarmLogTableQueryUtil.Keys;
 import org.phoebus.applications.alarm.model.SeverityLevel;
+import org.phoebus.applications.alarm.model.json.JsonModelReader;
 import org.phoebus.applications.alarm.ui.AlarmUI;
 import org.phoebus.framework.jobs.Job;
 import org.phoebus.framework.selection.SelectionService;
@@ -249,7 +252,19 @@ public class AlarmLogTableController {
                         if (!en) {
                             return new SimpleStringProperty("Disabled");
                         } else {
-                            return new SimpleStringProperty("Enabled");
+                            try {
+                                final JsonNode jsonNode = (JsonNode) JsonModelReader.parseJsonText(alarmMessage.getValue().getConfig_msg());
+                                if (jsonNode == null) {
+                                    logger.log(Level.WARNING, "There is no JasonNode");
+                                    return null;
+                                }
+                                final boolean latching = jsonNode.get("latching").asBoolean();
+                                return new SimpleStringProperty(latching ? "Latched" : "Enabled");
+                            } catch (JsonParseException e) {
+                                logger.log(Level.SEVERE, "Error parsing JSON in alarmMesssage " + e.getMessage());
+                            } catch (Exception e) {
+                                logger.log(Level.SEVERE, "Unexpected error in alarmMessage" + e.getMessage());
+                            }
                         }
                     }
                     return null;


### PR DESCRIPTION
Hi Kunal @shroffk and Kay @kasemir 

The current alarm logger service couldn't record users' latch configuration. This PR allows the alarm logger service to record the `latch` status within `Enabled` status inside its command placeholder. Following Kay's suggestion, we added the `latch` status to the `command` placeholder. Thus, the `command` can be one of the following three states within the alarm logger service to keep the options that users can select within their user interface consistent. The logger table doesn't show every user-driven alarm event nicely, still this critical event should be recorded within the Alarm Logger Services. So, we can check their alarm changes whenever we really need to do. 

- Disabled
- Enabled:Latched
- Enabled:Unlatch

The following figure shows how it will be on Phoebus.

![1](https://github.com/user-attachments/assets/5c61e6b6-0dd0-4272-a84c-c9fa964b6e44)



@jeonghanlee, Soo Ryu, and @Sangil-Lee at ALS-U Controls, LBNL.

Thank you, @kasemir for your suggestion regarding the Java exception handling. We are learning Java very slowly. 