### PR TITLE
Support the Standalone Alarm Logging service

### DIFF
--- a/services/alarm-logger/README.md
+++ b/services/alarm-logger/README.md
@@ -1,6 +1,7 @@
-# Alarm Logging
+# Alarm Logging Service
 
-Logging alarm state and other messages to an elastic back end.
+The alarm logging service (aka alarm-logger) records all alarm messages to create an archive of all alarm state changes and the associated actions.
+This is an elasticsearch back end.
 
 ## Dependencies ##
 1. Elasticsearch version 8.x OS specific release can be found here:  
@@ -47,6 +48,11 @@ mvn spring-boot:run
 
 Run with `-help` to see command line options,
 including those used to create daily, weekly or monthly indices.
+
+#### Standalone mode
+
+With the `-standalone true` option on the command line or in `application.properties`, you can run the alarm logging service independently of an alarm server.
+It may be useful to troubleshoot the system independently from production alarm services using the alarm log service backup for the long alarm log history.
 
 #### Configuration
 

--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/AlarmLoggingService.java
@@ -274,7 +274,7 @@ public class AlarmLoggingService {
         final List<String> topicNames = Arrays.asList(properties.getProperty("alarm_topics").split(","));
         logger.info("Starting logger for '..State': " + topicNames);
 
-        final boolean standalone = Boolean.valueOf(properties.gerProperty("standalone"));
+        final boolean standalone = Boolean.valueOf(properties.getProperty("standalone"));
 
         // If the standalone is true, ignore the Schedulers for AlarmMessageLogger and AlarmCmdLogger
         // otherwise run the Alarm Logger service as is.

--- a/services/alarm-logger/src/main/resources/application.properties
+++ b/services/alarm-logger/src/main/resources/application.properties
@@ -51,6 +51,9 @@ date_span_units=M
 # Size of the thread pool for message and command loggers. Two threads per topic/configuration are required
 thread_pool_size=4
 
+# Standalone - Alarm Logger Service
+standalone=false
+
 ############################## REST Logging ###############################
 # DEBUG level will log all requests and responses to and from the REST end points
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=INFO


### PR DESCRIPTION
Hi Kunal @shroffk and Kay @kasemir 

Based on our mode of operation, we want to run the alarm logging service (alarm-logger) as a standalone service.

For the elasticsearch folder relocation with the limited requirement, we've verified that the Pheobus alarm log table and the standalone alarm logging service work well without printing our so many error messages regarding the communication to the alarm server (Kafka). This could be a potential use for independent alarm studies without interfering with a production environment. 

Please let us know what you think about this PR.

@jeonghanlee, Soo Ryu, and @Sangil-Lee at ALS-U Controls, LBNL.

P.S. I @jeonghanlee  updated the README to reflect the minimal documentation description of the service. It looks like a lot of the documentation will be updated to reflect what we have changed since a couple of years ago. We can discuss them when we have the meeting together later this year or next year. 
