### PR TITLE
Add example of preference key construction

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -333,6 +333,11 @@ Preferences Listing
 The following preference settings are available for the various application features.
 To use them in your settings file, remember to prefix each setting with the package name.
 
+eg. for the 'drop_failed_archives' preference in the 'trends.databrowser3' section
+(package name 'org.csstudio.trends.databrowser3') add a line like: ::
+
+    org.csstudio.trends.databrowser3/drop_failed_archives=true
+
 """)
         for pack in sorted(pref_files.keys()):
             pref_file = pref_files[pack]


### PR DESCRIPTION
Adds an example of how package and preference names are concatenated in a `settings.ini` file.