### PR TITLE
doc: show full preference names

### DIFF
--- a/app/databrowser-json/src/main/resources/archive_reader_json_preferences.properties
+++ b/app/databrowser-json/src/main/resources/archive_reader_json_preferences.properties
@@ -1,3 +1,7 @@
+# ---------------------------------------
+# Package org.phoebus.archive.reader.json
+# ---------------------------------------
+
 # Shall a precision of zero for a floating-point value result in this value
 # using a number format without fractional digits (true) or shall it be treated
 # as an indication that the value should be rendered with a default number of

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -340,15 +340,31 @@ eg. for the 'drop_failed_archives' preference in the 'trends.databrowser3' secti
 
 """)
         for pack in sorted(pref_files.keys()):
+            pkgname = None
             pref_file = pref_files[pack]
             out.write("\n")
             out.write(pack + "\n")
             out.write(("-" * len(pack)) + "\n")
             out.write("\n")
             out.write("File " + pref_file + "::\n\n")
+            print('processing', pref_file)
             with open(pref_file) as prefs:
                 for line in prefs:
+                    # expect lines like:
+                    # 1) Special comment with package id.
+                    #   '# Package org.phoebus.applications.alarm\n'
+                    # 2) ignore...
+                    #   '--------------\n'
+                    #   '# ... ignore ...\n'
+                    #   '  \n'
+                    # 4) preference
+                    #   'key = value'
                     line = line.strip()
+                    if line.startswith('# Package'):
+                        pkgname = line.split(' ')[2]
+                    elif line[:1] not in ('', '#', '-'):
+                        assert pkgname is not None, pref_file # preference file missing "# Package ..." name line
+                        line = '%s/%s'%(pkgname, line)
                     out.write("   " + line + "\n")
             out.write("\n")
 


### PR DESCRIPTION
As a follow on to #3187.  Prepend package names when generating `preference_properties.html` so they appear complete, because clearly users will copy+paste without reading the page preamble.

I couldn't immediately see a way to compute the package name from the preferences file name, so I opt to parse out the `# Package ...` line present in (almost) all files.  This parsing is simplistic, looking at the first non-space character.  It also can not fix preference names which appear in comments.

Did I guess the correct package for `app/databrowser-json/src/main/resources/archive_reader_json_preferences.properties`?