### PR TITLE
Make DESC field use in databrowser non-default

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -398,11 +398,23 @@ public class PVItem extends ModelItem
         setUnits(display.getUnit());
     }
 
+    /**
+     * Updates the value axis label based on the {@link Preferences#value_axis_label_policy} property.
+     * If the property is set to pv-desc, then DESC field is used if defined and non-empty (works with pva only).
+     * @param value Value of PV update.
+     */
     public void updateDescription(final VType value)
     {
-        final Display display = Display.displayOf(value);
-        if (display.getDescription() != null)
-            setDisplayName(display.getDescription());
+        switch(Preferences.value_axis_label_policy){
+            case "pv-name":
+            default:
+                return;
+            case "pv-desc":
+                final Display display = Display.displayOf(value);
+                if (display.getDescription() != null && !display.getDescription().isEmpty()){
+                    setDisplayName(display.getDescription());
+                }
+        }
     }
 
     /** Scan, i.e. add 'current' value to live samples */

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -414,6 +414,7 @@ public class PVItem extends ModelItem
                 if (display.getDescription() != null && !display.getDescription().isEmpty()){
                     setDisplayName(display.getDescription());
                 }
+                break;
         }
     }
 

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/preferences/Preferences.java
@@ -101,6 +101,10 @@ public class Preferences
     /** Setting */
     @Preference public static boolean config_dialog_supported;
 
+    @Preference
+    public static String value_axis_label_policy;
+
+
     static
     {
         final PreferencesReader prefs = AnnotatedPreferences.initialize(Activator.class, Preferences.class, "/databrowser_preferences.properties");

--- a/app/databrowser/src/main/resources/databrowser_preferences.properties
+++ b/app/databrowser/src/main/resources/databrowser_preferences.properties
@@ -151,3 +151,8 @@ time_span_shortcuts=30 Minutes,-30 min|1 Hour,-1 hour|12 Hours,-12 hour|1 Day,-1
 # Determines if the plot runtime config dialog is supported. Defaults to false as the Data Browser
 # offers the same functionality through its configuration tabs.
 config_dialog_supported=false
+
+# Determines default value axis label policy. Supported options:
+# pv-name: classic policy. Default if this property is not set or set to an unsupported value.
+# pv-desc: use DESC field, if available from PV and non-empty. Works only with pva.
+value_axis_label_policy=pv-name


### PR DESCRIPTION
This PR is a follow-up on #3135.

My users have expressed dissatisfaction over the changed default behavior. Underlying issue is in my view that IOC developers may or may not consider the DESC field to be something for a high level client. There is also a bug in the current implementation: if DESC is not set, then the description is set to an empty string, not to ```null```.

I have added a preference setting to control the default policy: ```pv-name``` or ```pv-desc``` where ```pv-name``` is the default. To use DESC user will need to add ```org.csstudio.trends.databrowser3/value_axis_label_policy=pv-desc``` to the settings file.