### PR TITLE
Downgrade to JavaFX 21.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <epics.version>7.0.10</epics.version>
     <epics.util.version>1.0.7</epics.util.version>
     <vtype.version>1.0.7</vtype.version>
-    <openjfx.version>22.0.2</openjfx.version>
+    <openjfx.version>21.0.3</openjfx.version>
     <jackson.version>2.12.3</jackson.version>
     <batik.version>1.17</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
As discussed in monthly meerting 2024-12-11. Once 5.x of the project has been released to Maven, upgrade to JavaFX 23 (or 24?) and JDK 21+ is projected.

Resolves #3156 