### PR TITLE
CSSTUDIO-2880 Run refresh() atomically on the UI thread.

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -435,7 +435,7 @@ public class LogEntryTableViewController extends LogbookSearchController {
         return query.getValue().getQuery();
     }
 
-    private synchronized void refresh() {
+    private void refresh() {
         Runnable refreshRunnable = () -> {
             if (this.searchResult != null) {
                 List<TableViewListItem> selectedLogEntries = new ArrayList<>(tableView.getSelectionModel().getSelectedItems());


### PR DESCRIPTION
This pull request changes `LogEntryTableViewController.refresh()` so that it runs "atomically" on the UI thread.

Before this pull request, the code to select the previously selected item was run using `Platform.runLater()`, which resulted in a brief period of time where no item was selected in the table view. When `refresh()` was called in quick succession, this could cause the selected item to become not selected upon refresh.