### PR TITLE
CSSTUDIO-2487 Add documentation when building the Phoebus package in 'phoebus-product' using maven

### DIFF
--- a/phoebus-product/src/assembly/package.xml
+++ b/phoebus-product/src/assembly/package.xml
@@ -27,6 +27,15 @@
       </includes>
     </fileSet>
     <fileSet>
+      <directory>${project.parent.basedir}/docs/build/html</directory>
+      <outputDirectory>/doc</outputDirectory>
+      <excludes>
+        <exclude>.doctrees/**</exclude>
+        <exclude>.buildinfo</exclude>
+        <exclude>objects.inv</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
       <directory>${project.build.directory}/lib</directory>
       <outputDirectory>/lib</outputDirectory>
       <includes>


### PR DESCRIPTION
This pull request adds the Phoebus documentation (if it has been built, by for example running `mvn -Dsphinx -Nverify` in the `phoebus` source directory) to the Phoebus package that is created when building `phoebus-product` using maven.

The intention is to facilitate the inclusion of the documentation when deploying the built Phoebus package.

If the documentation has not been built, then it is not included.