### PR TITLE
Replace http client for alarm log app

### DIFF
--- a/app/alarm/logging-ui/pom.xml
+++ b/app/alarm/logging-ui/pom.xml
@@ -39,11 +39,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-client</artifactId>
-      <version>1.19</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
@@ -62,11 +57,6 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AdvancedSearchViewController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AdvancedSearchViewController.java
@@ -1,6 +1,5 @@
 package org.phoebus.applications.alarm.logging.ui;
 
-import com.sun.jersey.api.client.WebResource;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.value.ObservableValue;
@@ -21,6 +20,7 @@ import org.phoebus.util.time.TimeParser;
 import org.phoebus.util.time.TimeRelativeInterval;
 import org.phoebus.util.time.TimestampFormats;
 
+import java.net.http.HttpClient;
 import java.util.logging.Logger;
 
 import static org.phoebus.ui.time.TemporalAmountPane.Type.TEMPORAL_AMOUNTS_AND_NOW;
@@ -57,7 +57,8 @@ public class AdvancedSearchViewController {
 
     PopOver timeSearchPopover;
 
-    private WebResource searchClient;
+    //private WebResource searchClient;
+    private HttpClient httpClient;
 
     // Search parameters
     ObservableMap<Keys, String> searchParameters;
@@ -65,8 +66,8 @@ public class AdvancedSearchViewController {
     @FXML
     private AnchorPane advancedSearchPane;
 
-    public AdvancedSearchViewController(WebResource client){
-        this.searchClient = client;
+    public AdvancedSearchViewController(HttpClient httpClient) {
+        this.httpClient = httpClient;
     }
 
     @FXML
@@ -169,7 +170,7 @@ public class AdvancedSearchViewController {
         });
     }
 
-    public void setSearchParameters(ObservableMap<Keys, String> params){
+    public void setSearchParameters(ObservableMap<Keys, String> params) {
         searchParameters = params;
         searchParameters.addListener((MapChangeListener<Keys, String>) change -> {
             searchPV.setText(searchParameters.get(Keys.PV));
@@ -194,7 +195,7 @@ public class AdvancedSearchViewController {
         searchCommand.setText(searchParameters.get(Keys.COMMAND));
     }
 
-    public AnchorPane getPane(){
+    public AnchorPane getPane() {
         return advancedSearchPane;
     }
 }

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogConfigSearchJob.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogConfigSearchJob.java
@@ -1,17 +1,20 @@
 package org.phoebus.applications.alarm.logging.ui;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sun.jersey.api.client.WebResource;
 import org.phoebus.framework.jobs.Job;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.jobs.JobRunnableWithCancel;
+import org.phoebus.util.http.QueryParamsHelper;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -23,7 +26,7 @@ import java.util.function.Consumer;
  * @author Kunal Shroff
  */
 public class AlarmLogConfigSearchJob extends JobRunnableWithCancel {
-    private final WebResource client;
+    private final HttpClient httpClient;
     private final String pattern;
 
     private final Consumer<AlarmLogTableItem> alarmMessageHandler;
@@ -31,20 +34,20 @@ public class AlarmLogConfigSearchJob extends JobRunnableWithCancel {
 
     private final ObjectMapper objectMapper;
 
-    public static Job submit(WebResource client,
+    public static Job submit(HttpClient httpClient,
                              final String pattern,
                              final Consumer<AlarmLogTableItem> alarmMessageHandler,
                              final BiConsumer<String, Exception> errorHandler) {
         return JobManager.schedule("searching alarm log messages for : " + pattern,
-                new AlarmLogConfigSearchJob(client, pattern, alarmMessageHandler, errorHandler));
+                new AlarmLogConfigSearchJob(httpClient, pattern, alarmMessageHandler, errorHandler));
     }
 
-    private AlarmLogConfigSearchJob(WebResource client,
+    private AlarmLogConfigSearchJob(HttpClient httpClient,
                                     String pattern,
                                     Consumer<AlarmLogTableItem> alarmMessageHandler,
                                     BiConsumer<String, Exception> errorHandler) {
         super();
-        this.client = client;
+        this.httpClient = httpClient;
         this.pattern = pattern;
         this.alarmMessageHandler = alarmMessageHandler;
         this.errorHandler = errorHandler;
@@ -66,8 +69,17 @@ public class AlarmLogConfigSearchJob extends JobRunnableWithCancel {
             try {
                 MultivaluedMap<String, String> map = new MultivaluedHashMap<>();
                 map.put("config", Arrays.asList(pattern));
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(Preferences.service_uri + "/search/alarm/config?" + QueryParamsHelper.mapToQueryParams(map)))
+                        .header("Content-Type", MediaType.APPLICATION_JSON)
+                        .GET()
+                        .build();
+
+                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
                 List<AlarmLogTableItem> result = objectMapper
-                        .readValue(client.path("/search/alarm/config").queryParams(map).accept(MediaType.APPLICATION_JSON).get(String.class),
+                        .readValue(response.body(),
                                 new TypeReference<List<AlarmLogTableItem>>() {
                                 });
                 if (result.size() >= 1) {
@@ -75,7 +87,7 @@ public class AlarmLogConfigSearchJob extends JobRunnableWithCancel {
                 } else {
                     alarmMessageHandler.accept(null);
                 }
-            } catch (JsonProcessingException e) {
+            } catch (Exception e) {
                 errorHandler.accept("Failed to search for alarm logs ", e);
             }
         };

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogSearchJob.java
@@ -3,7 +3,6 @@ package org.phoebus.applications.alarm.logging.ui;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sun.jersey.api.client.WebResource;
 import javafx.collections.ObservableMap;
 import org.phoebus.applications.alarm.logging.ui.AlarmLogTableQueryUtil.Keys;
 import org.phoebus.framework.jobs.Job;
@@ -11,10 +10,17 @@ import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.jobs.JobMonitor;
 import org.phoebus.framework.jobs.JobRunnable;
 import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.util.http.QueryParamsHelper;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -34,25 +40,26 @@ public class AlarmLogSearchJob implements JobRunnable {
     private final BiConsumer<String, Exception> errorHandler;
 
     private final ObjectMapper objectMapper;
-    private final WebResource client;
+    //private final WebResource client;
+    private final HttpClient httpClient;
 
     private final PreferencesReader prefs = new PreferencesReader(AlarmLogTableApp.class,
             "/alarm_logging_preferences.properties");
 
-    public static Job submit(WebResource client,
+    public static Job submit(HttpClient httpClient,
                              final String pattern,
                              Boolean isNodeTable,
                              ObservableMap<Keys, String> searchParameters,
                              final Consumer<List<AlarmLogTableItem>> alarmMessageHandler,
                              final BiConsumer<String, Exception> errorHandler) {
         return JobManager.schedule("searching alarm log messages for : " + pattern,
-                new AlarmLogSearchJob(client, isNodeTable, searchParameters, alarmMessageHandler, errorHandler));
+                new AlarmLogSearchJob(httpClient, isNodeTable, searchParameters, alarmMessageHandler, errorHandler));
     }
 
-    private AlarmLogSearchJob(WebResource client, Boolean isNodeTable, ObservableMap<Keys, String> searchParameters,
+    private AlarmLogSearchJob(HttpClient httpClient, Boolean isNodeTable, ObservableMap<Keys, String> searchParameters,
                               Consumer<List<AlarmLogTableItem>> alarmMessageHandler, BiConsumer<String, Exception> errorHandler) {
         super();
-        this.client = client;
+        this.httpClient = httpClient;
         this.searchParameters = searchParameters;
         this.alarmMessageHandler = alarmMessageHandler;
         this.errorHandler = errorHandler;
@@ -69,19 +76,26 @@ public class AlarmLogSearchJob implements JobRunnable {
         int size = prefs.getInt("results_max_size");
 
         MultivaluedMap<String, String> map = new MultivaluedHashMap<>();
-        searchParameters.forEach((key, value) -> { if (!value.equals("")) map.add(key.getName(), value); });
+        searchParameters.forEach((key, value) -> {
+            if (!value.equals("")) map.add(key.getName(), value);
+        });
         map.putIfAbsent("size", List.of(String.valueOf(size)));
 
         try {
 
             long start = System.currentTimeMillis();
-            String resultStr = client.path("/search/alarm")
-                    .queryParams(map)
-                    .accept(MediaType.APPLICATION_JSON).get(String.class);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(Preferences.service_uri + "/search/alarm?" + QueryParamsHelper.mapToQueryParams(map)))
+                    .header("Content-Type", MediaType.APPLICATION_JSON)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
             logger.log(Level.FINE, "String response = " + (System.currentTimeMillis() - start));
             start = System.currentTimeMillis();
-            List<AlarmLogTableItem> result = objectMapper.readValue(resultStr, new TypeReference<>() {
+            List<AlarmLogTableItem> result = objectMapper.readValue(response.body(), new TypeReference<>() {
             });
             logger.log(Level.FINE, "Object mapper response = " + (System.currentTimeMillis() - start));
             alarmMessageHandler.accept(result);

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.java
@@ -2,13 +2,13 @@ package org.phoebus.applications.alarm.logging.ui;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.util.Arrays;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import com.sun.jersey.api.client.WebResource;
 import org.phoebus.framework.nls.NLS;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
@@ -34,12 +34,12 @@ public class AlarmLogTable implements AppInstance {
             loader.setControllerFactory(clazz -> {
                 try {
                     if(clazz.isAssignableFrom(AlarmLogTableController.class)){
-                        return clazz.getConstructor(WebResource.class)
-                                .newInstance(app.getClient());
+                        return clazz.getConstructor(HttpClient.class)
+                                .newInstance(app.httpClient());
                     }
                     else if(clazz.isAssignableFrom(AdvancedSearchViewController.class)){
-                        return clazz.getConstructor(WebResource.class)
-                                .newInstance(app.getClient());
+                        return clazz.getConstructor(HttpClient.class)
+                                .newInstance(app.httpClient());
                     }
                 } catch (Exception e) {
                     Logger.getLogger(AlarmLogTable.class.getName()).log(Level.SEVERE, "Failed to construct controller for Alarm Log Table View", e);

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.sun.jersey.api.client.WebResource;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
@@ -55,6 +54,7 @@ import org.phoebus.util.time.TimestampFormats;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.http.HttpClient;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -133,7 +133,7 @@ public class AlarmLogTableController {
     private List<AlarmLogTableItem> alarmMessages;
 
     private Job alarmLogSearchJob;
-    private WebResource searchClient;
+    private HttpClient httpClient;
 
     @FXML
     private ProgressIndicator progressIndicator;
@@ -144,7 +144,7 @@ public class AlarmLogTableController {
 
     private final ContextMenu configsContextMenu = new ContextMenu();
 
-    public AlarmLogTableController(WebResource client) {
+    public AlarmLogTableController(HttpClient client) {
         setClient(client);
     }
 
@@ -364,7 +364,7 @@ public class AlarmLogTableController {
                 sortTableCol = tableView.getSortOrder().get(0);
                 sortColType = sortTableCol.getSortType();
             }
-            alarmLogSearchJob = AlarmLogSearchJob.submit(searchClient, searchString, isNodeTable, searchParameters,
+            alarmLogSearchJob = AlarmLogSearchJob.submit(httpClient, searchString, isNodeTable, searchParameters,
                     result -> Platform.runLater(() -> {
                         setAlarmMessages(result);
                         searchInProgress.set(false);
@@ -411,8 +411,8 @@ public class AlarmLogTableController {
         }
     }
 
-    public void setClient(WebResource client) {
-        this.searchClient = client;
+    public void setClient(HttpClient client) {
+        this.httpClient = client;
     }
 
     /**
@@ -541,7 +541,7 @@ public class AlarmLogTableController {
                     })
                     .collect(Collectors.toList());
             // TODO place holder method for showing additional alarm info
-            AlarmLogConfigSearchJob.submit(searchClient,
+            AlarmLogConfigSearchJob.submit(httpClient,
                     configs.get(0),
                     result -> Platform.runLater(() -> {
                         Alert alarmInfo = new Alert(Alert.AlertType.INFORMATION);

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/Preferences.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/Preferences.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 European Spallation Source ERIC.
+ */
+
+package org.phoebus.applications.alarm.logging.ui;
+
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.Preference;
+
+public class Preferences {
+
+    @Preference
+    public static String service_uri;
+
+    @Preference
+    public static int results_max_size;
+
+    static
+    {
+        AnnotatedPreferences.initialize(Preferences.class, "/alarm_logging_preferences.properties");
+    }
+}

--- a/app/logbook/olog/client-es/pom.xml
+++ b/app/logbook/olog/client-es/pom.xml
@@ -11,11 +11,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>4.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>

--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
@@ -9,8 +9,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import org.phoebus.logbook.Attachment;
 import org.phoebus.logbook.LogClient;
 import org.phoebus.logbook.LogEntry;
@@ -30,7 +28,10 @@ import org.phoebus.security.store.SecureStore;
 import org.phoebus.security.tokens.AuthenticationScope;
 import org.phoebus.security.tokens.ScopedAuthenticationToken;
 import org.phoebus.util.http.HttpRequestMultipartBody;
+import org.phoebus.util.http.QueryParamsHelper;
 
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import java.io.InputStream;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
@@ -158,7 +159,7 @@ public class OlogHttpClient implements LogClient {
      */
     private LogEntry save(LogEntry log, LogEntry inReplyTo) throws LogbookException {
         try {
-            MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+            javax.ws.rs.core.MultivaluedMap<String, String> queryParams = new javax.ws.rs.core.MultivaluedHashMap<>();
             queryParams.putSingle("markup", "commonmark");
             if (inReplyTo != null) {
                 queryParams.putSingle("inReplyTo", Long.toString(inReplyTo.getId()));
@@ -172,7 +173,7 @@ public class OlogHttpClient implements LogClient {
             }
 
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(Preferences.olog_url + "/logs/multipart?" + mapToQueryParams(queryParams)))
+                    .uri(URI.create(Preferences.olog_url + "/logs/multipart?" + QueryParamsHelper.mapToQueryParams(queryParams)))
                     .header("Content-Type", httpRequestMultipartBody.getContentType())
                     .header(OLOG_CLIENT_INFO_HEADER, CLIENT_INFO)
                     .header("Authorization", basicAuthenticationHeader)

--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
@@ -240,7 +240,7 @@ public class OlogHttpClient implements LogClient {
     private SearchResult findLogs(MultivaluedMap<String, String> searchParams) throws RuntimeException {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(Preferences.olog_url +
-                        "/logs/search?" + mapToQueryParams(searchParams)))
+                        "/logs/search?" + QueryParamsHelper.mapToQueryParams(searchParams)))
                 .header(OLOG_CLIENT_INFO_HEADER, CLIENT_INFO)
                 .header("Content-Type", CONTENT_TYPE_JSON)
                 .GET()
@@ -465,21 +465,6 @@ public class OlogHttpClient implements LogClient {
             LOGGER.log(Level.WARNING, "failed to obtain attachment", e);
             return null;
         }
-    }
-
-
-    private String mapToQueryParams(MultivaluedMap<String, String> map) {
-        StringBuilder stringBuilder = new StringBuilder();
-        map.keySet().forEach(k -> {
-            List<String> value = map.get(k);
-            if (value != null && !value.isEmpty()) {
-                stringBuilder.append(k).append("=");
-                stringBuilder.append(String.join(",",
-                        value.stream().map(v -> URLEncoder.encode(v, StandardCharsets.UTF_8)).toList()));
-                stringBuilder.append("&");
-            }
-        });
-        return stringBuilder.toString();
     }
 
     /**

--- a/core/util/pom.xml
+++ b/core/util/pom.xml
@@ -8,6 +8,11 @@
   <artifactId>core-util</artifactId>
   <dependencies>
     <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>${junit.version}</version>

--- a/core/util/src/main/java/org/phoebus/util/http/QueryParamsHelper.java
+++ b/core/util/src/main/java/org/phoebus/util/http/QueryParamsHelper.java
@@ -11,7 +11,17 @@ import java.util.List;
 
 public class QueryParamsHelper {
 
+    /**
+     * Converts a {@link MultivaluedMap<String, String>} to a URL encoded query parameter {@link String}. Attempts to
+     * be fault-tolerant: <code>null</code> or empty {@link List}s values are ignored and not appended to the
+     * returned query parameter {@link String}. See also unit test class.
+     * @param map Map of key/value pairs where each value is expected to be a {@link List} of {@link String}s.
+     * @return A URL encoded {@link String} that can be appended in a http URL, e.g. <code>key1=value1,value2&key2=value3</code>.
+     */
     public static String mapToQueryParams(MultivaluedMap<String, String> map) {
+        if(map == null || map.isEmpty()){
+            return "";
+        }
         StringBuilder stringBuilder = new StringBuilder();
         map.keySet().forEach(k -> {
             List<String> value = map.get(k);
@@ -22,6 +32,10 @@ public class QueryParamsHelper {
                 stringBuilder.append("&");
             }
         });
-        return stringBuilder.toString();
+        String queryParams = stringBuilder.toString();
+        if("".equals(queryParams)){
+            return "";
+        }
+        return queryParams.substring(0, queryParams.length() - 1);
     }
 }

--- a/core/util/src/main/java/org/phoebus/util/http/QueryParamsHelper.java
+++ b/core/util/src/main/java/org/phoebus/util/http/QueryParamsHelper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 European Spallation Source ERIC.
+ */
+
+package org.phoebus.util.http;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class QueryParamsHelper {
+
+    public static String mapToQueryParams(MultivaluedMap<String, String> map) {
+        StringBuilder stringBuilder = new StringBuilder();
+        map.keySet().forEach(k -> {
+            List<String> value = map.get(k);
+            if (value != null && !value.isEmpty()) {
+                stringBuilder.append(k).append("=");
+                stringBuilder.append(String.join(",",
+                        value.stream().map(v -> URLEncoder.encode(v, StandardCharsets.UTF_8)).toList()));
+                stringBuilder.append("&");
+            }
+        });
+        return stringBuilder.toString();
+    }
+}

--- a/core/util/src/test/java/org/phoebus/util/http/QueryParamsHelperTest.java
+++ b/core/util/src/test/java/org/phoebus/util/http/QueryParamsHelperTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 European Spallation Source ERIC.
+ */
+
+package org.phoebus.util.http;
+
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class QueryParamsHelperTest {
+
+    @Test
+    public void testBasic(){
+        MultivaluedMap<String, String> map = new MultivaluedHashMap<>();
+        map.put("key1", List.of("value1", "value2"));
+        map.put("key2", List.of("value 3"));
+        map.put("key3", List.of("value:4"));
+
+        String queryParamString = QueryParamsHelper.mapToQueryParams(map);
+
+        assertEquals(queryParamString, "key1=value1,value2&key2=value+3&key3=value%3A4&");
+    }
+}

--- a/core/util/src/test/java/org/phoebus/util/http/QueryParamsHelperTest.java
+++ b/core/util/src/test/java/org/phoebus/util/http/QueryParamsHelperTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -23,6 +24,27 @@ public class QueryParamsHelperTest {
 
         String queryParamString = QueryParamsHelper.mapToQueryParams(map);
 
-        assertEquals(queryParamString, "key1=value1,value2&key2=value+3&key3=value%3A4&");
+        assertEquals("key1=value1,value2&key2=value+3&key3=value%3A4", queryParamString);
+
+        queryParamString = QueryParamsHelper.mapToQueryParams(new MultivaluedHashMap<>());
+        assertEquals("", queryParamString);
+
+        queryParamString = QueryParamsHelper.mapToQueryParams(null);
+        assertEquals("", queryParamString);
+
+        map = new MultivaluedHashMap<>();
+        map.put("key1", null);
+        map.put("key2", List.of("value3"));
+
+        queryParamString = QueryParamsHelper.mapToQueryParams(map);
+        assertEquals("key2=value3", queryParamString);
+
+        map = new MultivaluedHashMap<>();
+        map.put("key1", null);
+        map.put("key2", Collections.emptyList());
+
+        queryParamString = QueryParamsHelper.mapToQueryParams(map);
+        assertEquals("", queryParamString);
+
     }
 }

--- a/services/alarm-logger/pom.xml
+++ b/services/alarm-logger/pom.xml
@@ -77,11 +77,11 @@
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
     </dependency>
-    <dependency>
+    <!--<dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
       <version>2.0.1</version>
-    </dependency>
+    </dependency>-->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>


### PR DESCRIPTION
Replaces Jersey for the native http client in the alarm log app.

A few more changes: 

1. Common code needed to create valid request params from ```MultiValuedMap``` moved to core-util. Reduces code duplication.
2. Superfluous jakarta-json dependency in alarm log app removed.