### PR TITLE
CSSTUDIO-2889 Bugfix: Set 'changeListenerAdded' to 'false' when the change listener has finished running.

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -466,6 +466,7 @@ public class DockPane extends TabPane
                                 f.accept((Scene) newValue);
                             }
                             sceneProperty().removeListener(this);
+                            changeListenerAdded = false;
                         }
                     }
                 };


### PR DESCRIPTION
This pull request fixes a bug in `DockPane.deferUntilInScene()`: when replacing a layout (using "Load Layout") a `DockPane` may be re-used, but its `Scene` may be set to `null`. `DockPane.deferUntilInScene()` didn't handle this case, since the variable `changeListenerAdded` was not reset to `false` once the change listener had finished running.