### PR TITLE
Consistent Alarm naming convention between Alarm Table and Alarm Log Table

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -148,6 +148,33 @@ public class AlarmLogTableController {
         setClient(client);
     }
 
+	private final String replaceKey(final String key) {
+		String repKey = key;
+		if(key == Keys.SEVERITY.getName())
+			repKey = "alarm_severity";
+		else if(key == Keys.MESSAGE.getName())
+			repKey = "alarm_message";
+		else if(key == Keys.CURRENTSEVERITY.getName())
+			repKey = "pv_severity";
+		else if(key == Keys.CURRENTMESSAGE.getName())
+			repKey = "pv_message";
+
+		return repKey;
+	}
+
+	private String recoverKey(String key) {
+		if(key.contains("alarm_severity")) 
+			key = "severity";
+		else if(key.contains("alarm_message")) 
+			key = "message";
+		else if(key.contains("pv_severity")) 
+			key = "current_severity";
+		else if(key.contains("pv_message")) 
+			key = "current_message";
+
+		return key;
+	}
+
     @FXML
     public void initialize() {
         resize.setText("<");
@@ -294,7 +321,7 @@ public class AlarmLogTableController {
                 searchParameters.entrySet().stream()
                         .filter(e -> !e.getKey().getName().equals(Keys.ROOT.getName())) // Exclude alarm config (root) as selection is managed in drop-down
                         .sorted(Map.Entry.comparingByKey())
-                        .map((e) -> e.getKey().getName().trim() + "=" + e.getValue().trim())
+                        .map((e) -> replaceKey(e.getKey().getName().trim()) + "=" + e.getValue().trim())
                         .collect(Collectors.joining("&")));
 
         searchParameters.addListener(
@@ -303,7 +330,7 @@ public class AlarmLogTableController {
                                 .sorted(Entry.comparingByKey())
                                 .filter(e -> !e.getKey().getName().equals(Keys.ROOT.getName())) // Exclude alarm config (root) as selection is managed in drop-down
                                 .filter(e -> !e.getValue().equals(""))
-                                .map((e) -> e.getKey().getName().trim() + "=" + e.getValue().trim())
+                                .map((e) -> replaceKey(e.getKey().getName().trim()) + "=" + e.getValue().trim())
                                 .collect(Collectors.joining("&"))));
 
         query.setOnKeyPressed(keyEvent -> {
@@ -398,7 +425,7 @@ public class AlarmLogTableController {
         searchParameters.put(Keys.STARTTIME, TimeParser.format(java.time.Duration.ofDays(7)));
         searchParameters.put(Keys.ENDTIME, TimeParser.format(java.time.Duration.ZERO));
 
-        query.setText(searchParameters.entrySet().stream().sorted(Map.Entry.comparingByKey()).map((e) -> e.getKey().getName().trim() + "=" + e.getValue().trim()).collect(Collectors.joining("&")));
+        query.setText(searchParameters.entrySet().stream().sorted(Map.Entry.comparingByKey()).map((e) -> replaceKey(e.getKey().getName().trim()) + "=" + e.getValue().trim()).collect(Collectors.joining("&")));
     }
 
     public void setAlarmMessages(List<AlarmLogTableItem> alarmMessages) {
@@ -488,7 +515,7 @@ public class AlarmLogTableController {
         searchTerms.forEach(s -> {
             String[] splitString = s.split("=");
             if (splitString.length > 1) {
-                String key = splitString[0];
+                String key = recoverKey(splitString[0]);
                 searchKeywords.add(key);
                 String value = splitString[1];
                 if (lookup.containsKey(key)) {

--- a/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages.properties
+++ b/app/alarm/logging-ui/src/main/resources/org/phoebus/applications/alarm/logging/ui/messages.properties
@@ -16,35 +16,56 @@
 #  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #
 AlarmInformation=Alarm Information
-Command=Command
-Config=Config
 ConfigurationInfo=Configuration Info
 ConfigurationInfoNotFound=Configuration info not found.
 Configurations=Configurations:
-CurrentMessage=Current Message
-CurrentSeverity=Current Severity
-EndTime=End Time
+#
+Config=Config
+#
+Severity=Alarm Severity
+Message=Alarm Message
+Time=Alarm Time
+#
+MessageTime=Alarm Log Time
+CurrentSeverity=PV Severity
+CurrentMessage=PV Message
+#
+Command=Command
+#
+User=User
 Host=Host
-Message=Message
-MessageTime=Message Time
+#
+Value=Alarm Value
+#
+TimeDelta=Time Delta
+StartTime=Start Time
+EndTime=End Time
+#
 Mode=Mode
+#
 NoSearchResults=No Search Results
 Query=Query: 
 Search=Search
 Configuration=Configuration(s):
-Severity=Severity
-StartTime=Start Time
-Time=Time
-User=User
-Value=Value
-TimeDelta=Time Delta
+# Table Column Visibility
+#
 ConfigVisible=true
-ValueVisible=false
-MTimeVisible=true
-TimeDeltaVisible=false
+# PV : Always TRUE
+# Severity : Alarm Severity Column
 CSeverityVisible=true
+# Message : Alarm Message Column
 CMessageVisible=true
+# Value : PV Value Column
+ValueVisible=false
+# MessageTime : Alarm Log Time
+MTimeVisible=true
+# Time Delta Column
+TimeDeltaVisible=false
+# Command Column
 CommandVisible=true
+# Phoebus User Columm
 UserVisible=true
+# Phoebus Host Column
 HostVisible=true
+#
 

--- a/app/alarm/model/src/main/resources/alarm_preferences.properties
+++ b/app/alarm/model/src/main/resources/alarm_preferences.properties
@@ -65,7 +65,7 @@ alarm_tree_startup_ms=2000
 
 # Order of columns in alarm table
 # Allows re-ordering as well as omitting columns
-alarm_table_columns=Icon, PV, Description, Alarm Severity, Alarm Status, Alarm Time, Alarm Value, PV Severity, PV Status
+alarm_table_columns=Icon, PV, Description, Alarm Severity, Alarm Message, Alarm Time, Alarm Value, PV Severity, PV Message
 
 # By default, the alarm table uses the common alarm severity colors
 # for both the text color and the background of cells in the "Severity" column.

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -442,7 +442,7 @@ public class AlarmTableUI extends BorderPane
         sevcol.setCellFactory(c -> new SeverityLevelCell());
         cols.add(sevcol);
 
-        col = new TableColumn<>("Alarm Status");
+        col = new TableColumn<>("Alarm Message");
         col.setPrefWidth(130);
         col.setReorderable(false);
         col.setCellValueFactory(cell -> cell.getValue().status);
@@ -470,7 +470,7 @@ public class AlarmTableUI extends BorderPane
         sevcol.setCellFactory(c -> new SeverityLevelCell());
         cols.add(sevcol);
 
-        col = new TableColumn<>("PV Status");
+        col = new TableColumn<>("PV Message");
         col.setPrefWidth(130);
         col.setReorderable(false);
         col.setCellValueFactory(cell -> cell.getValue().pv_status);

--- a/core/launcher/src/main/resources/logging.properties
+++ b/core/launcher/src/main/resources/logging.properties
@@ -49,6 +49,7 @@ org.python.level = WARNING
 org.postgresql.level = WARNING
 
 # Core packages
+org.phoebus.framework.jobs.level = WARNING
 org.phoebus.framework.rdb.level = WARNING
 org.phoebus.framework.workbench.level = WARNING
 org.phoebus.security.level = WARNING
@@ -78,7 +79,7 @@ org.csstudio.display.converter.medm.level = INFO
 org.csstudio.display.converter.edm.level = INFO
 org.csstudio.opibuilder.converter.model.level = INFO
 org.csstudio.opibuilder.converter.parser.level = INFO
-org.phoebus.applications.alarm.level = INFO
+org.phoebus.applications.alarm.level = WARNING
 org.phoebus.applications.email.level = WARNING
 org.csstudio.scan.level = WARNING
 org.phoebus.sns.level = WARNING

--- a/services/alarm-logger/src/main/resources/application.properties
+++ b/services/alarm-logger/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 version=@project.version@
 
 # The server port for the rest service
-server.port=8080
+server.port=9000
 
 # Disable the spring banner
 spring.main.banner-mode=off

--- a/services/save-and-restore/src/main/resources/application.properties
+++ b/services/save-and-restore/src/main/resources/application.properties
@@ -3,7 +3,7 @@ app.version=@project.version@
 app.name=@project.artifactId@
 
 # The server port for the rest service
-server.port=8080
+server.port=9100
 
 # Elasticsearch connection parameters
 elasticsearch.network.host=localhost


### PR DESCRIPTION
@shroffk and @kasemir 

As we've discussed and agreed, here is the pull request to contain the consistent and meaningful naming convention within the Alarm Table and the Alarm Log Table.

Here is the table which we've developed so far. 

Name | Proposed Name | Area
-- | -- | --
PV | PV | Alarm Table
Description | Description | Alarm Table
PV Severity | PV Severity | Alarm Table
PV Status | PV Message | Alarm Table
Alarm Severity | Alarm Severity | Alarm Table
Alarm Status | Alarm Message | Alarm Table
Alarm Time | Alarm Time | Alarm Table
Alarm Value | Alarm Value | Alarm Table
  |   |  
Config | Config | Alarm Log Table
PV | PV | Alarm Log Table
Severity | Alarm Severity | Alarm Log Table
Message | Alarm Message | Alarm Log Table
Time | Alarm Time | Alarm Log Table
Message Time | Alarm Log Time | Alarm Log Table
Current Severtiy | PV Severity | Alarm Log Table
Current Message | PV Message | Alarm Log Table
User | User | Alarm Log Table
Host | Host | Alarm Log Table
Value | Alarm Value |  
Time Delta | Time Delta | Alarm Log Table
Command | Command | Alarm Log Table
  |   |  
PV | PV | Alarm Log Table Search
Severity | Alarm Severity | Alarm Log Table Search
Message | Alarm Message | Alarm Log Table Search
Current Severity | PV Severity | Alarm Log Table Search
Current Message | PV Message | Alarm Log Table Search
User | User | Alarm Log Table Search
Time | Alarm Log Time | Alarm Log Table Search
Start Time | Start Time | Alarm Log Table Search
End Time | End Time | Alarm Log Table Search
Command | Command | Alarm Log Table Search

Please let me know what you think.

@shroffk we also have to work together to update the alarm documentation to reflect these changes. 

Thanks,

@jeonghanlee, Soo Ryu, and @Sangil-Lee at ALS-U Controls, LBNL.

