### PR TITLE
Update Action artifact to V4 for fix Build failure due to Action v3 deprecation

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -24,7 +24,7 @@ jobs:
       run: mvn --batch-mode install -DskipTests
 
     - name: Archive build artifacts 
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Phoebus product ${{ matrix.os }}
         path: |


### PR DESCRIPTION
Build failed with Action v3 see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Hello @kasemir & @shroffk .
Build failure is solved with this PR.

Katy