### PR TITLE
Improve layout management and fix layout issue

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/workbench/WorkbenchPreferences.java
+++ b/core/framework/src/main/java/org/phoebus/framework/workbench/WorkbenchPreferences.java
@@ -27,6 +27,12 @@ public class WorkbenchPreferences
     /** directory of external applications */
     @Preference public static File external_apps_directory;
     
+    /** Phoebus memento folder name default from $(phoebus.folder.name.preference) System property */
+    @Preference public static String  phoebus_folder_name;
+    
+    /** Phoebus user home directory contents memento default from $(phoebus.user) System property */
+    @Preference public static File  phoebus_user;
+    
     /** external applications */
     public static final Collection<String> external_apps;
 

--- a/core/framework/src/main/resources/workbench_preferences.properties
+++ b/core/framework/src/main/resources/workbench_preferences.properties
@@ -34,3 +34,5 @@
 # Directory where external applications are started
 # May use system properties
 external_apps_directory=$(user.home)
+phoebus_folder_name=$(phoebus.folder.name.preference)
+phoebus_user=$(phoebus.user)

--- a/core/framework/src/main/resources/workbench_preferences.properties
+++ b/core/framework/src/main/resources/workbench_preferences.properties
@@ -32,7 +32,13 @@
 # external_app_alog=Alignment Log,alog,/path/to/alog_viewer
 
 # Directory where external applications are started
-# May use system properties
+# May use system properties $(user.home)
 external_apps_directory=$(user.home)
+
+# Phoebus folder name by default .phoebus
+# May use system properties $(phoebus.folder.name.preference)
 phoebus_folder_name=$(phoebus.folder.name.preference)
+
+# Phoebus user home directory path name by default $HOME or %USERPROFILE%
+# May use system properties $(phoebus.folder.name.preference
 phoebus_user=$(phoebus.user)

--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -43,6 +43,8 @@ public class Preferences
     @Preference public static String default_save_path;
     /** layout_dir */
     @Preference public static String layout_dir;
+    /** layout_default */
+    @Preference public static String layout_default;
     /** print_landscape */
     @Preference public static boolean print_landscape;
     /** ok_severity_text_color */

--- a/core/ui/src/main/java/org/phoebus/ui/application/SaveLayoutHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/SaveLayoutHelper.java
@@ -22,6 +22,7 @@ import org.phoebus.framework.autocomplete.ProposalProvider;
 import org.phoebus.framework.autocomplete.ProposalService;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.workbench.Locations;
+import org.phoebus.ui.Preferences;
 import org.phoebus.ui.autocomplete.AutocompleteMenu;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.docking.DockItem;
@@ -156,7 +157,23 @@ public class SaveLayoutHelper
     private static boolean saveState(List<Stage> stagesToSave, final String layout)
     {
         final String memento_filename = layout + ".memento";
-        final File memento_file = new File(Locations.user(), memento_filename);
+        //Take in account layout dir and add Layout folder in the path
+        String layout_dir = Preferences.layout_dir;
+        File user = Locations.user();
+        File parentFolder = null;
+        if(layout_dir != null && !layout_dir.isEmpty() && !layout_dir.contains("$(")) {
+            parentFolder = new File(user , layout_dir);
+            if(!parentFolder.exists()) {
+                parentFolder.mkdir();
+            }
+        }
+        
+        if(parentFolder == null) {
+            parentFolder = user;
+        }
+        
+        final File memento_file = new File(parentFolder, memento_filename);
+        
         // File.exists() is blocking in nature.
         // To combat this the phoebus application maintains a list of *.memento files that are in the default directory.
         // Check if the file name is in the list, and confirm a file overwrite with the user.

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -96,6 +96,9 @@ default_save_path=
 # Set the path to a folder with default layouts
 layout_dir=
 
+# Set default layout at start
+layout_default=
+
 # Compute print scaling in 'landscape' mode?
 # Landscape mode is generally most suited for printouts
 # of displays or plots, because the monitor tends to be 'wide'.


### PR DESCRIPTION
Please find a PR to improve the Layout Management feature : 
1.  Configuration of "phoebus_user" folder also with settings.ini in addition of the $(phoebus.user) variable environnement.
2.  Configuration of "phoebus_folder_name also with settings.ini  in addition of $(phoebus.folder.name.preference) variable environnement. 
3.  Configuration of default layout that can be load at start in settings.ini "org.phoebus.ui/layout_default"  preference
4.  Fix issue with layout_dir preference , it was not taken in account at saving Layout action

See the screenshot here : 
![Layout1](https://github.com/user-attachments/assets/f3b6ba97-2d76-4736-8b36-5134ac7c37a0)

In this way, the user home directory can be configurabled also in settings.ini and not depends  on the  system. It allows a deployement of a Configuration Folder separated from the Phoebus Installation. And allows all the Phoebus Installations to share the same configuration folder.