### PR TITLE
Remove unnecessary dependencies from save-and-restore-util

### DIFF
--- a/app/save-and-restore/util/pom.xml
+++ b/app/save-and-restore/util/pom.xml
@@ -25,22 +25,7 @@
 
         <dependency>
             <groupId>org.phoebus</groupId>
-            <artifactId>core-pva</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.phoebus</groupId>
             <artifactId>core-pv</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.phoebus</groupId>
-            <artifactId>core-pv-pva</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.phoebus</groupId>
-            <artifactId>core-pv-ca</artifactId>
             <version>4.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR removes explicit dependencies on `core-pv-ca`, `core-pv-pva`, and `core-pva` from `save-and-restore-util`. I checked that the module builds fine without these dependencies, and in final products where these modules are needed, they are going to be pulled in through other dependency paths.

Closes #3283.