### PR TITLE
backward compatibility for layout management see PR #3250

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -43,7 +43,7 @@ public class Preferences
     @Preference public static String default_save_path;
     /** layout_dir */
     @Preference public static String layout_dir;
-    /** layout_default */
+    /** layout_default absolute path*/
     @Preference public static String layout_default;
     /** print_landscape */
     @Preference public static boolean print_landscape;

--- a/core/ui/src/main/java/org/phoebus/ui/Preferences.java
+++ b/core/ui/src/main/java/org/phoebus/ui/Preferences.java
@@ -45,6 +45,8 @@ public class Preferences
     @Preference public static String layout_dir;
     /** layout_default absolute path*/
     @Preference public static String layout_default;
+    /** layout_default absolute path*/
+    @Preference public static boolean save_layout_in_layout_dir;
     /** print_landscape */
     @Preference public static boolean print_landscape;
     /** ok_severity_text_color */

--- a/core/ui/src/main/java/org/phoebus/ui/application/SaveLayoutHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/SaveLayoutHelper.java
@@ -157,19 +157,24 @@ public class SaveLayoutHelper
     private static boolean saveState(List<Stage> stagesToSave, final String layout)
     {
         final String memento_filename = layout + ".memento";
-        //Always Save in user location for backward compatibilty
-        final File memento_file = new File(Locations.user(), memento_filename);
-        //Save also in layout_dir as absolute path instead of user relative location 
-        String layout_dir = Preferences.layout_dir;
-        File layoutDir = null;
-        if(layout_dir != null && !layout_dir.isBlank() && !layout_dir.contains("$(")) {
-            layoutDir = new File(layout_dir);
-            if(!layoutDir.exists()) {
-                layoutDir.mkdir();
+        //By default save in user location folder 
+        File tmpMementoFile = new File(Locations.user(), memento_filename);
+      
+        //Save in layout_dir as absolute path if save_in_layout_dir is enable
+        boolean save_in_layout_dir = Preferences.save_layout_in_layout_dir;
+        if(save_in_layout_dir) {
+            String layout_dir = Preferences.layout_dir;
+            if(layout_dir != null && !layout_dir.isBlank() && !layout_dir.contains("$(")) {
+                File layoutDir = new File(layout_dir);
+                // the folder could be in read only
+                if(layoutDir.exists() && layoutDir.canWrite()) {
+                    tmpMementoFile = new File(layoutDir, memento_filename);
+                }
             }
         }
+     
+        final File memento_file = tmpMementoFile;
         
-        final File memento_custom = layoutDir != null ? new File(layoutDir, memento_filename):null;
         // File.exists() is blocking in nature.
         // To combat this the phoebus application maintains a list of *.memento files that are in the default directory.
         // Check if the file name is in the list, and confirm a file overwrite with the user.
@@ -188,10 +193,8 @@ public class SaveLayoutHelper
             boolean menuVisible = PhoebusApplication.INSTANCE.isMenuVisible();
             boolean toolbarVisible = PhoebusApplication.INSTANCE.isToolbarVisible();
             boolean statusBarVisible = PhoebusApplication.INSTANCE.isStatusbarVisible();
+            
             MementoHelper.saveState(stagesToSave, memento_file, null, null,menuVisible, toolbarVisible, statusBarVisible);
-            if(memento_custom != null){
-                MementoHelper.saveState(stagesToSave, memento_custom, null, null,menuVisible, toolbarVisible, statusBarVisible);
-            }
             // After the layout has been saved,
             // update menu to include the newly saved layout
             PhoebusApplication.INSTANCE.createLoadLayoutsMenu();

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -96,7 +96,7 @@ default_save_path=
 # Set the path to a folder with default layouts
 layout_dir=
 
-# Set default layout at start
+# Set default layout at start absolutepath
 layout_default=
 
 # Compute print scaling in 'landscape' mode?

--- a/core/ui/src/main/resources/phoebus_ui_preferences.properties
+++ b/core/ui/src/main/resources/phoebus_ui_preferences.properties
@@ -99,6 +99,9 @@ layout_dir=
 # Set default layout at start absolutepath
 layout_default=
 
+# If enable layout are saved in layout_dir instead of default user location
+save_layout_in_layout_dir=false
+
 # Compute print scaling in 'landscape' mode?
 # Landscape mode is generally most suited for printouts
 # of displays or plots, because the monitor tends to be 'wide'.


### PR DESCRIPTION
backward compatibility for layout management see comment in PR #3250
- layout_default defines an absolute path to memento
- layout_dir defines an absolute folder for layout
- layout argument at launch is take in account as absolute path 
- if layout is not defined , layout_default preferences is checked and manage as absolute path
- SaveLayout action always save in user location and also in layout_dir if it's defined