### PR TITLE
Make number of steps in loop command predictable

### DIFF
--- a/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
@@ -138,8 +138,9 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
     {
         final SimulatedDevice device = context.getDevice(context.getMacros().resolveMacros(command.getDeviceName()));
 
-        final double start = getLoopStart();
         final double step  = getLoopStep();
+        // step is < 0 means we are stepping down
+        double start = step < 0 ? getLoopEnd() : getLoopStart();
         int num_steps = getNumSteps();
         for (int i = 0; i < num_steps; i++)
             simulateStep(context, device, start + i * step);

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
@@ -84,7 +84,7 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
     @Override
     public long getWorkUnits()
     {
-        final long iterations = 1 + Math.round(Math.abs((command.getEnd() - command.getStart()) / command.getStepSize()));
+        final long iterations = getNumSteps();
         long body_units = 0;
         for (ScanCommandImpl<?> command : implementation)
             body_units += command.getWorkUnits();
@@ -129,7 +129,7 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
     }
 
     public int getNumSteps() {
-        return (int)Math.ceil(Math.abs(((getLoopEnd() - getLoopStart()) / getLoopStep()))) + 1;
+        return (int)Math.ceil(Math.abs(((command.getEnd() - command.getStart()) / command.getStepSize()))) + 1;
     }
 
     /** {@inheritDoc} */

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
@@ -204,9 +204,11 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
         else
             condition = null;
 
-        double start = getLoopStart();
         double step  = getLoopStep();
+        // step is < 0 means we are stepping down
+        double start = step < 0 ? getLoopEnd() : getLoopStart();
         int num_steps = getNumSteps();
+
         for (int i = 0; i < num_steps; i++)
             executeStep(context, device, condition, readback, start + i * step);
     }

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
@@ -129,7 +129,7 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
     }
 
     public int getNumSteps() {
-        return (int)Math.ceil(Math.abs(((getLoopEnd() - getLoopStart()) / getLoopStep())));
+        return (int)Math.ceil(Math.abs(((getLoopEnd() - getLoopStart()) / getLoopStep()))) + 1;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
In the previous situation, the loop command was executed as 
```java
for (double value = start; value <= end; value += step)
```
which made the number of steps in the loop highly unpredictable due to finite precision errors. It seems that there was left some possibility to change the loop step and end "on the fly", though I don't see how the values could ever change given a `LoopCommand` instance. 

Making the number of steps in the loop command easily computable would make it a lot easier to make 2D plots from scans executed with the scan server, as the image dimensions can be computed ahead of time (without using an O(n) algorithm, i.e. just doing the for loop).

Perhaps I missed something in why/how the loop bounds can be changed on the fly, unless one somehow inherits and re-implements `LoopCommand` with some overrides, but this seems like a strange edge case to take into account.

Perhaps you prefer a floor or round on the `getNumSteps`, I just figured the closest behavior to the "old" implementation would be this, because of the <= comparison.