### PR TITLE
fix: Enhance MQTT client connection status check.

### DIFF
--- a/core/pv-mqtt/src/main/java/org/phoebus/pv/mqtt/MQTT_PV.java
+++ b/core/pv-mqtt/src/main/java/org/phoebus/pv/mqtt/MQTT_PV.java
@@ -205,9 +205,8 @@ public class MQTT_PV extends PV
         }
         catch (Exception ex)
         {
-            logger.log(Level.SEVERE, "Could not parse message: '" + new_value + "' to " + getName());
-
-            throw new Exception("Failed to parse message", ex);
+            notifyListenersOfDisconnect();
+            logger.log(Level.WARNING, "Could not parse message: '" + new_value + "' to " + getName());
         }
     }
 

--- a/core/pv-mqtt/src/main/java/org/phoebus/pv/mqtt/MQTT_PV.java
+++ b/core/pv-mqtt/src/main/java/org/phoebus/pv/mqtt/MQTT_PV.java
@@ -177,8 +177,7 @@ public class MQTT_PV extends PV
         }
         catch (Exception ex)
         {
-            logger.log(Level.WARNING, "Failed to unsubscribe PV from topic " + topicStr);
-            ex.printStackTrace();
+            logger.log(Level.WARNING, "Failed to unsubscribe PV from topic " + topicStr, ex);
         }
     }
 
@@ -206,7 +205,7 @@ public class MQTT_PV extends PV
         catch (Exception ex)
         {
             notifyListenersOfDisconnect();
-            logger.log(Level.WARNING, "Could not parse message: '" + new_value + "' to " + getName());
+            logger.log(Level.WARNING, "Could not parse message: '" + new_value + "' to " + getName(), ex);
         }
     }
 


### PR DESCRIPTION
Regarding issue core/pv-mqtt: MQTT client can't reconnect after String to Double conversion parsing error #3308, here is the patch to improve the MQTT client's connection status check.