### PR TITLE
Docker files for alarm server

### DIFF
--- a/.github/workflows/alarm-server-docker-image.yml
+++ b/.github/workflows/alarm-server-docker-image.yml
@@ -1,4 +1,4 @@
-name: Save-And-Restore Docker Image CI
+name: Alarm Server Docker Image CI
 
 on:
   push:

--- a/.github/workflows/alarm-server-docker-image.yml
+++ b/.github/workflows/alarm-server-docker-image.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Build and publish the Docker image
       uses: docker/build-push-action@v5
       with: 
-        context: services/save-and-restore
+        context: services/alarm-server
         push: true
         platforms: linux/amd64
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/alarm-server-docker-image.yml
+++ b/.github/workflows/alarm-server-docker-image.yml
@@ -12,6 +12,17 @@ env:
   IMAGE_NAME: ${{ github.repository }}/service-alarm-server
 
 jobs:
+  build-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Maven and Java Action
+        uses: s4u/setup-maven-action@v1.18.0
+        with:
+          java-version: '17'
+          maven-version: '3.9.6'
+      - name: Build
+        run: mvn --batch-mode install -DskipTests
   build-and-push-image:
     permissions:
       contents: read

--- a/.github/workflows/alarm-server-docker-image.yml
+++ b/.github/workflows/alarm-server-docker-image.yml
@@ -1,0 +1,52 @@
+name: Save-And-Restore Docker Image CI
+
+on:
+  push:
+    branches: [ "CSSTUDIO-2989" ]
+    paths: services/alarm-server/**
+    tags:
+      - '**'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/service-alarm-server
+
+jobs:
+  build-and-push-image:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn --batch-mode --update-snapshots package
+    - name: Login to the registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Extract meta-data for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+    - name: Set up Docker Build
+      uses: docker/setup-buildx-action@v3
+    - name: Build and publish the Docker image
+      uses: docker/build-push-action@v5
+      with: 
+        context: services/save-and-restore
+        push: true
+        platforms: linux/amd64
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/alarm-server-docker-image.yml
+++ b/.github/workflows/alarm-server-docker-image.yml
@@ -2,7 +2,7 @@ name: Alarm Server Docker Image CI
 
 on:
   push:
-    branches: [ "CSSTUDIO-2989" ]
+    branches: [ "master" ]
     paths: services/alarm-server/**
     tags:
       - '**'

--- a/services/alarm-server/Dockerfile
+++ b/services/alarm-server/Dockerfile
@@ -2,6 +2,6 @@ FROM eclipse-temurin:17-jre
 
 # deployment unit
 COPY target/service-alarm-server-*.jar /alarmserver/service-alarm-server-*.jar
-COPY target/lib/** /alarmserver/lib
+COPY target/lib /alarmserver/lib
 
 CMD ["java", "-jar", "/alarmserver/service-alarm-server-*.jar"]

--- a/services/alarm-server/Dockerfile
+++ b/services/alarm-server/Dockerfile
@@ -2,5 +2,6 @@ FROM eclipse-temurin:17-jre
 
 # deployment unit
 COPY target/service-alarm-server-*.jar /alarmserver/service-alarm-server-*.jar
+COPY target/lib/** /alarmserver/lib
 
 CMD ["java", "-jar", "/alarmserver/service-alarm-server-*.jar"]

--- a/services/alarm-server/Dockerfile
+++ b/services/alarm-server/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:17-jre
+
+# deployment unit
+COPY target/service-alarm-server-*.jar /alarmserver/service-alarm-server-*.jar
+
+CMD ["java", "-jar", "/alarmserver/service-alarm-server-*.jar"]

--- a/services/alarm-server/README.md
+++ b/services/alarm-server/README.md
@@ -47,3 +47,64 @@ some useful startup arguments include
 -import   config.xml        - Import alarm configruation from file
 -logging logging.properties - Load log settings
 ```
+
+## Docker
+
+Docker compose files are provided for convenience.
+
+### Launch only Kafka
+
+``docker-compose-kafka.yml`` 
+
+This is used to start the Kafka message broker (in Zookeeper mode). Typical use case: launch alarm
+server manually.
+
+Usage:
+
+```
+>docker compose -f docker-compose-kafka.yml --env-file /path/to/environment/file
+```
+
+where ``/path/to/environment/file`` is a file defining a ``HOSTNAME`` variable, e.g.
+```
+HOSTNAME=foo.bar.com
+```
+When launching the alarm server, the ``-server`` argument must match the value of ``HOSTNAME``.
+
+### Launch Kafka and alarm server for import
+
+``docker-compose-alarm-server-for-import.yml``
+
+This is used to start the full stack for the purpose of importing an alarm configuration file.
+
+Usage:
+
+```
+>docker compose -f docker-compose-alarm-server-for-import.yml --env-file /path/to/environment/file
+```
+
+Here the ``/path/to/environment/file`` file *must* list:
+```
+HOSTNAME=foo.bar.com
+CONFIG_FILE=/path/to/Accelerator.xml
+```
+In other words, this imports an alarm configuration for the default topic ``Accelerator``.
+
+### Launch Kafka and alarm server
+
+``docker-compose-alarm-server-for-import.yml``
+
+This is used to start the full stack for running the alarm server and listen to EPICS alarms.
+
+Usage:
+
+```
+>docker compose -f docker-compose-alarm-server.yml --env-file /path/to/environment/file
+```
+
+Here the ``/path/to/environment/file`` file *must* list:
+```
+HOSTNAME=foo.bar.com
+```
+
+Note that in all cases ``HOSTNAME`` *can not* be set to ``localhost``.

--- a/services/alarm-server/docker-compose-alarm-server-for-import.yml
+++ b/services/alarm-server/docker-compose-alarm-server-for-import.yml
@@ -45,4 +45,4 @@ services:
       - /home:/home
     command: >
       /bin/bash -c "
-      java -jar /alarmserver/service-alarm-server-*.jar -server ${HOSTNAME}:9092"
+      java -jar /alarmserver/service-alarm-server-*.jar -import ${CONFIG_FILE} -server ${HOSTNAME}:9092"

--- a/services/alarm-server/docker-compose-alarm-server.yml
+++ b/services/alarm-server/docker-compose-alarm-server.yml
@@ -1,0 +1,45 @@
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper
+    healthcheck:
+      test: nc -z localhost 2181 || exit -1
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - 2181:2181
+
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    hostname: ${HOSTNAME} 
+    ports:
+      - 9092:9092
+    depends_on:
+      - zookeeper
+    healthcheck:
+      test: kafka-topics --bootstrap-server broker:9092 --list
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9094,OUTSIDE://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://:9094,OUTSIDE://:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+
+  alarmserver:
+    image: ghcr.io/controlsystemstudio/phoebus/service-alarm-server:csstudio-2989
+    depends_on:
+      - kafka
+    command: >
+      /bin/bash -c "
+        java -jar /alarmserver/service-alarm-server-*.jar"
+

--- a/services/alarm-server/docker-compose-kafka.yml
+++ b/services/alarm-server/docker-compose-kafka.yml
@@ -35,14 +35,3 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,OUTSIDE:PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
-
-  alarmserver:
-    image: ghcr.io/controlsystemstudio/phoebus/service-alarm-server:master
-    depends_on:
-      kafka:
-        condition: service_healthy
-    volumes:
-      - /home:/home
-    command: >
-      /bin/bash -c "
-      java -jar /alarmserver/service-alarm-server-*.jar -server ${HOSTNAME}:9092"


### PR DESCRIPTION
After som trials and errors.... Docker for the alarm service comes with some limitations. I have created three files to cover the use cases:

- Run only Zookeeper and Kafka. Saves user from downloading and configuring Kafka.
- Run the entire stack to import a configuration, only for default topic "Accelerator"
- Run the entire stack in "normal mode", only for default topic "Accelerator"

Peer testing and feed-back appreciated.