### PR TITLE
Fix documentation for jca configuration

### DIFF
--- a/services/save-and-restore/doc/index.rst
+++ b/services/save-and-restore/doc/index.rst
@@ -20,7 +20,7 @@ Server-side IOC communication
 The service exposes endpoints for reading and writing PVs, i.e. to create or restore snapshots. Depending on the
 setup this server-side IOC communication may need some configuration:
 
-For ca (channel access) the service must be started with the ``-Dca.use_env=true`` Java option, and the list of
+For ca (channel access) the service must be started with the ``-Djca.use_env=true`` Java option, and the list of
 gateways - if any - must be set as a system environment named ``EPICS_CA_ADDR_LIST``.
 
 For pva (pv access) the service must be started with the ``-DdefaultProtocol=pva`` Java option, and the list of


### PR DESCRIPTION
Fix documentation instruction for save and restore service .
channel access configuration use -Djca.use_env=true and not -Dca.use_env=true