### PR TITLE
Add 'pick_on_bounds' property to symbolwidgets for clicking intricate symbols

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/Messages.java
@@ -273,6 +273,7 @@ public class Messages
                          WidgetProperties_Rotation,
                          WidgetProperties_Rules,
                          WidgetProperties_RunActionsOnMouseClick,
+                         WidgetProperties_PickOnBounds,
                          WidgetProperties_Running,
                          WidgetProperties_ScaleFactor,
                          WidgetProperties_ScaleFormat,

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/SymbolWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/SymbolWidget.java
@@ -88,6 +88,10 @@ public class SymbolWidget extends PVWidget {
     /** Property */
     public static final WidgetPropertyDescriptor<String>                        propFallbackSymbol = newFilenamePropertyDescriptor (WidgetPropertyCategory.BEHAVIOR, "fallback_symbol", Messages.WidgetProperties_FallbackSymbol);
     public static final WidgetPropertyDescriptor<Boolean>                       propRunActionsOnMouseClick = newBooleanPropertyDescriptor (WidgetPropertyCategory.BEHAVIOR, "run_actions_on_mouse_click", Messages.WidgetProperties_RunActionsOnMouseClick);
+
+    /** 'pick_on_bounds' */
+    public static final WidgetPropertyDescriptor<Boolean>                       propPickOnBounds = newBooleanPropertyDescriptor (WidgetPropertyCategory.BEHAVIOR, "pick_on_bounds", Messages.WidgetProperties_PickOnBounds);
+
     /** 'svg_rendering_resolution_factor': */
     public static final WidgetPropertyDescriptor<Double> propSVGRenderingResolutionFactor = newDoublePropertyDescriptor(WidgetPropertyCategory.DISPLAY, "svg_rendering_resolution_factor", Messages.WidgetProperties_SVGRenderingResolutionFactor);
 
@@ -125,6 +129,7 @@ public class SymbolWidget extends PVWidget {
     private volatile WidgetProperty<String>                      fallbackSymbol;
     private volatile WidgetProperty<WidgetColor>                 disconnectOverlayColor;
     private volatile WidgetProperty<Boolean>                     run_actions_on_mouse_click;
+    private volatile WidgetProperty<Boolean>                     pick_on_bounds;
     private volatile WidgetProperty<Double>                      svgRenderingResolutionFactor;
 
     /** Returns 'symbol' property: element for list of 'symbols' property */
@@ -230,6 +235,11 @@ public class SymbolWidget extends PVWidget {
         return run_actions_on_mouse_click;
     }
 
+    /** @return property */
+    public WidgetProperty<Boolean> propPickOnBounds() {
+        return pick_on_bounds;
+    }
+
     /** @return 'svgRenderingResolutionFactor' property */
     public WidgetProperty<Double> propSVGRenderingResolutionFactor() {
         return svgRenderingResolutionFactor;
@@ -268,6 +278,7 @@ public class SymbolWidget extends PVWidget {
             int indexOfPropActions = properties.indexOf(propActions());
             run_actions_on_mouse_click = propRunActionsOnMouseClick.createProperty(this, false);
             properties.add(indexOfPropActions + 1, run_actions_on_mouse_click);
+            properties.add(indexOfPropActions + 2, pick_on_bounds = propPickOnBounds.createProperty(this, false));
         }
 
     }

--- a/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
+++ b/app/display/model/src/main/resources/org/csstudio/display/builder/model/messages.properties
@@ -258,6 +258,7 @@ WidgetProperties_RingWidth=Ring Width
 WidgetProperties_Rotation=Rotation
 WidgetProperties_Rules=Rules
 WidgetProperties_RunActionsOnMouseClick=Run Actions on Mouse Click
+WidgetProperties_PickOnBounds=Pick on Bounds
 WidgetProperties_Running=Running
 WidgetProperties_ScaleFactor=Scale Factor
 WidgetProperties_ScaleFormat=Scale Format

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -477,6 +477,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
     private void enableRunActionsOnMouseClick() {
         imageView.focusTraversableProperty().set(true);
         imageView.setStyle("-fx-cursor: hand;");
+        imageView.setPickOnBounds(model_widget.propPickOnBounds().getValue());
 
         ColorAdjust[] clickEffect = { null }; // Values are wrapped in arrays as a workaround of the fact that Java doesn't allow non-final variables to be captured by closures.
         DropShadow[] focusEffect = { null };


### PR DESCRIPTION
We have some intricate symbols with transparency, but clicking them can be quite annoying, as the mouse might hover over a small transparent region of the image, which makes it not register the hover state / makes it unclickable. We added a property named after the corresponding JavaFX ImageView property "pick on bounds", which makes the entire image bounds clickable, regardless of transparency. For backwards compatibility, it is false by default. 