### PR TITLE
Databrowser export: Add tab to header

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/ExportJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/ExportJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -87,7 +87,7 @@ abstract public class ExportJob implements JobRunnable
         }
     }
 
-    /** @param comment Comment prefix ('#' for most ASCII, '%' for Matlab, ...)
+    /** @param comment Comment prefix ('#\t' for most ASCII, '%' for Matlab, ...)
      *  @param model Model with data
      *  @param start Start time
      *  @param end End time

--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/PlainExportJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/export/PlainExportJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,8 +45,10 @@ public class PlainExportJob extends ExportJob
             final String filename,
             final Consumer<Exception> error_handler,
             final boolean unixTimeStamp)
-    {
-        super("# ", model, start, end, source, optimize_parameter, filename, error_handler, unixTimeStamp);
+    {   // MS Excel fails to recognize tab-separated data columns
+    	// unless the initial header rows also contain at least one tab per row,
+    	// so add that to comment
+        super("#\t", model, start, end, source, optimize_parameter, filename, error_handler, unixTimeStamp);
         this.formatter = formatter;
     }
 


### PR DESCRIPTION
As of early 2025, MS Excel fails to recognize tab-separated data columns unless the initial header rows also contain at least one tab per row, so add that to comment.

In this example, note how "Tab" has been selected as the "Delimiter", but the preview still shows only the timestamp column, ignoring the following tab-separated data column:

![image](https://github.com/user-attachments/assets/bd6e052c-8320-4af1-af27-272a659a63ee)


When the initial header rows include at least one tab per row, in this example right after the '#', the data columns are correctly detected:

![image](https://github.com/user-attachments/assets/69130598-0edf-4349-a0f8-7258cec0fde3)


Looks like the number of tabs in the header doesn't  need to match the number of data columns, but the header rows need to contain at least one Tab to then enable tab separation for the data columns.

Ideally this should be fixed in MS Excel, but I don't have enough MS stock to trigger such updates.