### PR TITLE
Manage Illegal pattern Exception on a new Snapshot

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTableViewController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTableViewController.java
@@ -247,8 +247,14 @@ public class SnapshotTableViewController extends BaseSnapshotTableViewController
             snapshot.setSnapshotData(snapshotData);
             showSnapshotInTable(snapshot);
             if (!Preferences.default_snapshot_name_date_format.isEmpty()) {
-                SimpleDateFormat formatter = new SimpleDateFormat(Preferences.default_snapshot_name_date_format);
-                snapshot.getSnapshotNode().setName(formatter.format(new Date()));
+                try {
+                    //The format could be not correct
+                    SimpleDateFormat formatter = new SimpleDateFormat(Preferences.default_snapshot_name_date_format);
+                    snapshot.getSnapshotNode().setName(formatter.format(new Date()));
+                }
+                catch (Exception e) {
+                    // Do not manage date format
+                }
             }
             consumer.accept(Optional.of(snapshot));
         });

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTableViewController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotTableViewController.java
@@ -247,13 +247,14 @@ public class SnapshotTableViewController extends BaseSnapshotTableViewController
             snapshot.setSnapshotData(snapshotData);
             showSnapshotInTable(snapshot);
             if (!Preferences.default_snapshot_name_date_format.isEmpty()) {
+                String dateFormat = Preferences.default_snapshot_name_date_format;
                 try {
                     //The format could be not correct
-                    SimpleDateFormat formatter = new SimpleDateFormat(Preferences.default_snapshot_name_date_format);
+                    SimpleDateFormat formatter = new SimpleDateFormat(dateFormat);
                     snapshot.getSnapshotNode().setName(formatter.format(new Date()));
                 }
                 catch (Exception e) {
-                    // Do not manage date format
+                    LOGGER.log(Level.WARNING, dateFormat + " is not a valid date format please check 'default_snapshot_name_date_format' preference ", e);
                 }
             }
             consumer.accept(Optional.of(snapshot));

--- a/app/save-and-restore/util/src/main/resources/save_and_restore_util_preferences.properties
+++ b/app/save-and-restore/util/src/main/resources/save_and_restore_util_preferences.properties
@@ -1,5 +1,5 @@
 # -----------------------------------------------
-# Package org.phoebus.applications.saveandrestore
+# Package org.phoebus.saveandrestore.util
 # -----------------------------------------------
 
 # connection timeout (in ms) when taking snapshot


### PR DESCRIPTION
Manage a java.lang.IllegalArgumentException: Illegal pattern 
when default_snapshot_name_date_format preference is set to a wrong format

In the previous version default_snapshot_name_date_format was a flag true or false.
Now, it can be a Date format.

Our user receive this error and the application is freezing :
```
2025-03-10 09:54:58 WARNING [[org.phoebus.framework.jobs](http://org.phoebus.framework.jobs/)] Job 'Take snapshot' failed
java.lang.IllegalArgumentException: Illegal pattern character 't'
    at java.base/java.text.SimpleDateFormat.compile(SimpleDateFormat.java:849)
    at java.base/java.text.SimpleDateFormat.initialize(SimpleDateFormat.java:657)
    at java.base/java.text.SimpleDateFormat.<init>(SimpleDateFormat.java:628)
    at java.base/java.text.SimpleDateFormat.<init>(SimpleDateFormat.java:603)
    at org.phoebus.applications.saveandrestore.ui.snapshot.SnapshotTableViewController.lambda$takeSnapshot$24(SnapshotTableViewController.java:250)
    at [org.phoebus.framework.jobs.Job.execute](http://org.phoebus.framework.jobs.job.execute/)(Job.java:50)
    at [org.phoebus.framework.jobs.JobManager.execute](http://org.phoebus.framework.jobs.jobmanager.execute/)(JobManager.java:54)
    at [org.phoebus.framework.jobs.JobManager.lambda](http://org.phoebus.framework.jobs.jobmanager.lambda/)$schedule$0(JobManager.java:45)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.base/java.lang.Thread.run(Thread.java:842)
```

In addition, the preferences defined in save_and_restore_preferences.properties are not generated in the preferences list in the documentation https://control-system-studio.readthedocs.io/en/latest/preference_properties.html#saveandrestore .
This list is generated by https://github.com/ControlSystemStudio/phoebus/blob/master/docs/source/conf.py , I suppose that the script does not manage 2 preferences files in the same package.

The missing preferences are detected since PR https://github.com/ControlSystemStudio/phoebus/pull/2927