### PR TITLE
use Maven CI friendly versions

### DIFF
--- a/app/3d-viewer/pom.xml
+++ b/app/3d-viewer/pom.xml
@@ -3,19 +3,19 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-3d-viewer</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/app/alarm/audio-annunciator/pom.xml
+++ b/app/alarm/audio-annunciator/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.phoebus</groupId>
         <artifactId>app-alarm</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>app-alarm-audio-annunciator</artifactId>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-alarm-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>

--- a/app/alarm/datasource/pom.xml
+++ b/app/alarm/datasource/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-alarm</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-alarm-datasouce</artifactId>
   <dependencies>
@@ -22,32 +22,32 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-alarm-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
         <groupId>net.sf.sociaal</groupId>

--- a/app/alarm/freetts-annunciator/pom.xml
+++ b/app/alarm/freetts-annunciator/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.phoebus</groupId>
         <artifactId>app-alarm</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>app-alarm-freetts-annunciator</artifactId>
 
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-alarm-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/app/alarm/logging-ui/pom.xml
+++ b/app/alarm/logging-ui/pom.xml
@@ -3,39 +3,39 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-alarm</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-alarm-logging-ui</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-alarm-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-alarm-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/app/alarm/model/pom.xml
+++ b/app/alarm/model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-alarm</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-alarm-model</artifactId>
   <dependencies>
@@ -47,12 +47,12 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/alarm/pom.xml
+++ b/app/alarm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modules>
     <module>model</module>

--- a/app/alarm/ui/pom.xml
+++ b/app/alarm/ui/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-alarm</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-alarm-ui</artifactId>
   <dependencies>
@@ -22,27 +22,27 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-alarm-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
   </dependencies>

--- a/app/channel/channelfinder/pom.xml
+++ b/app/channel/channelfinder/pom.xml
@@ -3,24 +3,24 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-channel</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-channel-channelfinder</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-security</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/app/channel/pom.xml
+++ b/app/channel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-channel</artifactId>
   <packaging>pom</packaging>

--- a/app/channel/utility/pom.xml
+++ b/app/channel/utility/pom.xml
@@ -3,34 +3,34 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-channel</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-channel-utility</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-channel-channelfinder</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/channel/views/pom.xml
+++ b/app/channel/views/pom.xml
@@ -3,39 +3,39 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-channel</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-channel-views</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-channel-channelfinder</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-channel-utility</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/console/pom.xml
+++ b/app/console/pom.xml
@@ -4,18 +4,18 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/credentials-management/pom.xml
+++ b/app/credentials-management/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>app</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-security</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 </project>

--- a/app/databrowser-json/pom.xml
+++ b/app/databrowser-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-databrowser-json</artifactId>
   <dependencies>
@@ -24,13 +24,13 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-databrowser</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>

--- a/app/databrowser-timescale/pom.xml
+++ b/app/databrowser-timescale/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-databrowser-timescale</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-databrowser</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/databrowser/pom.xml
+++ b/app/databrowser/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-databrowser</artifactId>
   <dependencies>
@@ -27,42 +27,42 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-formula</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-trends-archive-reader</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-rtplot</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.epics</groupId>

--- a/app/diag/pom.xml
+++ b/app/diag/pom.xml
@@ -4,18 +4,18 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/app/display/actions/pom.xml
+++ b/app/display/actions/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.phoebus</groupId>
         <artifactId>app-display</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>app-display-actions</artifactId>
@@ -24,12 +24,12 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-representation-javafx</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
            <groupId>org.phoebus</groupId>
            <artifactId>app-display-model</artifactId>
-           <version>4.7.4-SNAPSHOT</version>
+           <version>${revision}</version>
        </dependency>
     </dependencies>
 </project>

--- a/app/display/adapters/pom.xml
+++ b/app/display/adapters/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>app-display</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -12,17 +12,17 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-email-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-logbook</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-runtime</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/app/display/convert-edm/pom.xml
+++ b/app/display/convert-edm/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-display</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-display-convert-edm</artifactId>
   <dependencies>
@@ -22,27 +22,27 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-formula</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-editor</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-actions</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/display/convert-medm/pom.xml
+++ b/app/display/convert-medm/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-display</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-display-convert-medm</artifactId>
   <dependencies>
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-actions</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/display/editor/pom.xml
+++ b/app/display/editor/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-display</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-display-editor</artifactId>
   <dependencies>
@@ -22,22 +22,22 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-representation-javafx</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/display/fonts/pom.xml
+++ b/app/display/fonts/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-display</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-display-fonts</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/display/linearmeter/pom.xml
+++ b/app/display/linearmeter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>app-display</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -20,19 +20,19 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-model</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-representation</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-representation-javafx</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/app/display/model/pom.xml
+++ b/app/display/model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-display</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-display-model</artifactId>
   <dependencies>
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/display/navigation/pom.xml
+++ b/app/display/navigation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>app-display</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -13,32 +13,32 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-framework</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-util</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-model</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-actions</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-representation-javafx</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/app/display/pom.xml
+++ b/app/display/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modules>
     <module>model</module>

--- a/app/display/representation-javafx/pom.xml
+++ b/app/display/representation-javafx/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-display</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-display-representation-javafx</artifactId>
   <dependencies>
@@ -51,37 +51,37 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-rtplot</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-representation</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-databrowser</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-3d-viewer</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <!--<dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-actions</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>-->
   </dependencies>
 </project>

--- a/app/display/representation/pom.xml
+++ b/app/display/representation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-display</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-display-representation</artifactId>
   <dependencies>
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/display/runtime/pom.xml
+++ b/app/display/runtime/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-display</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-display-runtime</artifactId>
   <dependencies>
@@ -37,27 +37,27 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-representation-javafx</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-display-actions</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/display/thumbwheel/pom.xml
+++ b/app/display/thumbwheel/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>app-display</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,19 +17,19 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-model</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-representation</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-representation-javafx</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/app/email/pom.xml
+++ b/app/email/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-email</artifactId>
   <packaging>pom</packaging>

--- a/app/email/ui/pom.xml
+++ b/app/email/ui/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.phoebus</groupId>
         <artifactId>app-email</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>app-email-ui</artifactId>
@@ -11,17 +11,17 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-util</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-email</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
     <build>

--- a/app/errlog/pom.xml
+++ b/app/errlog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -16,12 +16,12 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/eslog/pom.xml
+++ b/app/eslog/pom.xml
@@ -4,18 +4,18 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.activemq/activemq-client -->
     <dependency>

--- a/app/filebrowser/pom.xml
+++ b/app/filebrowser/pom.xml
@@ -4,23 +4,23 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/imageviewer/pom.xml
+++ b/app/imageviewer/pom.xml
@@ -4,18 +4,18 @@
     <parent>
         <groupId>org.phoebus</groupId>
         <artifactId>app</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <dependencies>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-framework</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>

--- a/app/log-configuration/pom.xml
+++ b/app/log-configuration/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
   </dependencies>

--- a/app/logbook/elog/pom.xml
+++ b/app/logbook/elog/pom.xml
@@ -3,19 +3,19 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-logbook</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-logbook-elog</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-logbook</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
       <dependency>
           <groupId>org.phoebus</groupId>
           <artifactId>core-security</artifactId>
-          <version>4.7.4-SNAPSHOT</version>
+          <version>${revision}</version>
       </dependency>
     <dependency>
         <groupId>net.dongliu</groupId>

--- a/app/logbook/inmemory/pom.xml
+++ b/app/logbook/inmemory/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-logbook</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-logbook-inmemory</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-logbook</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/logbook/olog/client-es/pom.xml
+++ b/app/logbook/olog/client-es/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>app-logbook-olog</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -40,22 +40,22 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-logbook</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-framework</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-util</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-security</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/app/logbook/olog/client/pom.xml
+++ b/app/logbook/olog/client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>app-logbook-olog</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -13,17 +13,17 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-logbook</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-security</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-util</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/app/logbook/olog/pom.xml
+++ b/app/logbook/olog/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-logbook</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-logbook-olog</artifactId>
 </project>

--- a/app/logbook/olog/ui/pom.xml
+++ b/app/logbook/olog/ui/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>app-logbook-olog</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -13,32 +13,32 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-framework</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-util</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-logbook</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-security</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-logbook-olog-client-es</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.jfxtras</groupId>

--- a/app/logbook/pom.xml
+++ b/app/logbook/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modules>
     <module>inmemory</module>

--- a/app/logbook/ui/pom.xml
+++ b/app/logbook/ui/pom.xml
@@ -3,34 +3,34 @@
     <parent>
         <groupId>org.phoebus</groupId>
         <artifactId>app-logbook</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>app-logbook-ui</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-framework</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-util</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-logbook</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-security</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.jfxtras</groupId>

--- a/app/pace/pom.xml
+++ b/app/pace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -22,22 +22,22 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-logbook-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/perfmon/pom.xml
+++ b/app/perfmon/pom.xml
@@ -3,19 +3,19 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-perfmon</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>parent</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modules>
     <module>diag</module>

--- a/app/probe/pom.xml
+++ b/app/probe/pom.xml
@@ -4,23 +4,23 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/pvtable/pom.xml
+++ b/app/pvtable/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -22,27 +22,27 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-security</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/pvtree/pom.xml
+++ b/app/pvtree/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -22,22 +22,22 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/rtplot/pom.xml
+++ b/app/rtplot/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-rtplot</artifactId>
   <dependencies>
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/save-and-restore/app/pom.xml
+++ b/app/save-and-restore/app/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.phoebus</groupId>
 		<artifactId>app-save-and-restore</artifactId>
-		<version>4.7.4-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>save-and-restore</artifactId>
@@ -18,33 +18,33 @@
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>core-ui</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>core-logbook</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 		  <groupId>org.phoebus</groupId>
 		  <artifactId>save-and-restore-model</artifactId>
-		  <version>4.7.4-SNAPSHOT</version>
+		  <version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>save-and-restore-util</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>app-display-model</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>app-trends-archive-datasource</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>

--- a/app/save-and-restore/logging/pom.xml
+++ b/app/save-and-restore/logging/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.phoebus</groupId>
 		<artifactId>app-save-and-restore</artifactId>
-		<version>4.7.4-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>save-and-restore-logging</artifactId>
@@ -12,17 +12,17 @@
 		<dependency>
 		  <groupId>org.phoebus</groupId>
 		  <artifactId>save-and-restore-model</artifactId>
-		  <version>4.7.4-SNAPSHOT</version>
+		  <version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>core-framework</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>core-logbook</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openjfx</groupId>
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>core-security</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 	
 		<!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/app/save-and-restore/model/pom.xml
+++ b/app/save-and-restore/model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.phoebus</groupId>
 		<artifactId>app-save-and-restore</artifactId>
-		<version>4.7.4-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>save-and-restore-model</artifactId>
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>core-framework</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>

--- a/app/save-and-restore/pom.xml
+++ b/app/save-and-restore/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modules>
     <module>model</module>

--- a/app/save-and-restore/util/pom.xml
+++ b/app/save-and-restore/util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.phoebus</groupId>
         <artifactId>app-save-and-restore</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,18 +20,18 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>save-and-restore-model</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-pv</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-vtype</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>

--- a/app/scan/client/pom.xml
+++ b/app/scan/client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-scan</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-scan-client</artifactId>
   <dependencies>
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-scan-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/scan/model/pom.xml
+++ b/app/scan/model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-scan</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-scan-model</artifactId>
   <dependencies>
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/scan/pom.xml
+++ b/app/scan/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modules>
     <module>model</module>

--- a/app/scan/ui/pom.xml
+++ b/app/scan/ui/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-scan</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-scan-ui</artifactId>
   <dependencies>
@@ -22,27 +22,27 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-rtplot</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-scan-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-scan-client</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/trends/archive-datasource/pom.xml
+++ b/app/trends/archive-datasource/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>app-trends</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>app-trends-archive-datasource</artifactId>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-trends-archive-reader</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 </project>

--- a/app/trends/archive-reader/pom.xml
+++ b/app/trends/archive-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>app-trends</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-pv</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-types</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-util</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/app/trends/pom.xml
+++ b/app/trends/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modules>
     <module>rich-adapters</module>

--- a/app/trends/rich-adapters/pom.xml
+++ b/app/trends/rich-adapters/pom.xml
@@ -3,29 +3,29 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-trends</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-trends-rich-adapters</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-databrowser</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-email-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-logbook</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/app/trends/simple-adapters/pom.xml
+++ b/app/trends/simple-adapters/pom.xml
@@ -3,29 +3,29 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app-trends</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>app-trends-simple-adapters</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-databrowser</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-email-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-logbook</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/update/pom.xml
+++ b/app/update/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>app</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>javax.jms</groupId>

--- a/app/utility/pom.xml
+++ b/app/utility/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.phoebus</groupId>
         <artifactId>app</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/app/utility/preference-manager/pom.xml
+++ b/app/utility/preference-manager/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>app-utility</artifactId>
         <groupId>org.phoebus</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -12,12 +12,12 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-framework</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 </project>

--- a/core/email/pom.xml
+++ b/core/email/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>core-email</artifactId>
   <dependencies>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/formula/pom.xml
+++ b/core/formula/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
    <!-- epics-util -->
@@ -16,12 +16,12 @@
    <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-vtype</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
       <dependency>
           <groupId>org.junit.jupiter</groupId>
@@ -38,7 +38,7 @@
       <dependency>
           <groupId>org.phoebus</groupId>
           <artifactId>core-util</artifactId>
-          <version>4.7.4-SNAPSHOT</version>
+          <version>${revision}</version>
           <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/core/framework/pom.xml
+++ b/core/framework/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-formula</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/core/launcher/pom.xml
+++ b/core/launcher/pom.xml
@@ -3,19 +3,19 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>core-launcher</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-ui</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/logbook/pom.xml
+++ b/core/logbook/pom.xml
@@ -3,19 +3,19 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>core-logbook</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,6 +25,6 @@
   <parent>
    <groupId>org.phoebus</groupId>
    <artifactId>parent</artifactId>
-   <version>4.7.4-SNAPSHOT</version>
+   <version>${revision}</version>
   </parent>
 </project>

--- a/core/pv-ca/pom.xml
+++ b/core/pv-ca/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -36,13 +36,13 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/pv-jackie/pom.xml
+++ b/core/pv-jackie/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>

--- a/core/pv-mqtt/pom.xml
+++ b/core/pv-mqtt/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -22,13 +22,13 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>

--- a/core/pv-opva/pom.xml
+++ b/core/pv-opva/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/pv-pva/pom.xml
+++ b/core/pv-pva/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -43,19 +43,19 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pva</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/pv-tango/pom.xml
+++ b/core/pv-tango/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>

--- a/core/pv/pom.xml
+++ b/core/pv/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -40,17 +40,17 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-formula</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/pva/pom.xml
+++ b/core/pva/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>

--- a/core/security/pom.xml
+++ b/core/security/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>core-security</artifactId>
   <dependencies>
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/types/pom.xml
+++ b/core/types/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/ui/pom.xml
+++ b/core/ui/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>core-ui</artifactId>
   <dependencies>
@@ -59,27 +59,27 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-types</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-security</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <!-- Support for SVG -->

--- a/core/util/pom.xml
+++ b/core/util/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>core-util</artifactId>
   <dependencies>

--- a/core/vtype/pom.xml
+++ b/core/vtype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>core</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pva</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/dependencies/install-jars/pom.xml
+++ b/dependencies/install-jars/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>install-jars</artifactId>
 

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>phoebus-target</artifactId>
 
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>install-jars</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>parent</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modules>
     <module>install-jars</module>

--- a/phoebus-product/pom.xml
+++ b/phoebus-product/pom.xml
@@ -11,271 +11,271 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-launcher</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-pv-ca</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-pv-mqtt</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-pv-opva</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-pv-pva</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-pv-tango</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-diag</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-filebrowser</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-probe</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-logbook-inmemory</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-logbook-olog-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-logbook-elog</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-logbook-olog-client</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-logbook-olog-client-es</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-pvtable</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-pvtree</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-log-configuration</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-email-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-errlog</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-rtplot</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-databrowser</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-trends-archive-reader</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-databrowser-json</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-databrowser-timescale</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-representation-javafx</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-fonts</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-runtime</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-thumbwheel</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-linearmeter</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-editor</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-navigation</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-adapters</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-convert-medm</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-display-convert-edm</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-scan-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-alarm-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-alarm-freetts-annunciator</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-alarm-logging-ui</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-alarm-datasouce</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-update</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-3d-viewer</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-perfmon</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-console</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-imageviewer</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-eslog</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
 
         <!-- A default implementation of contribututions db context menu -->
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-trends-rich-adapters</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-trends-archive-datasource</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-channel-views</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-channel-channelfinder</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>save-and-restore</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>save-and-restore-logging</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>app-credentials-management</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -285,7 +285,7 @@
         <dependency>
             <groupId>org.phoebus</groupId>
             <artifactId>core-pv-jackie</artifactId>
-            <version>4.7.4-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
     <build>
@@ -360,7 +360,7 @@
     <parent>
         <groupId>org.phoebus</groupId>
         <artifactId>parent</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <!-- Package the phoebus product with dependencies, run scripts, and sources.
     Generate tar.gz for mac and linux, zip for Windows -->

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.phoebus</groupId>
   <artifactId>parent</artifactId>
-  <version>4.7.4-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <name>phoebus (parent)</name>
   <description>A framework and set of tools to monitor and operate large scale control systems, such as the ones in the accelerator community.</description>
@@ -64,6 +64,7 @@
   </distributionManagement>
 
   <properties>
+    <revision>4.7.4-SNAPSHOT</revision>
     <project.build.outputTimestamp>2024-01-10T19:23:58Z</project.build.outputTimestamp>
     <epics.version>7.0.10</epics.version>
     <epics.util.version>1.0.7</epics.util.version>

--- a/services/alarm-config-logger/pom.xml
+++ b/services/alarm-config-logger/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>services</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <properties>
     <spring.boot-version>2.7.3</spring.boot-version>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-alarm-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/services/alarm-logger/pom.xml
+++ b/services/alarm-logger/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>services</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <properties>
     <java.version>1.11</java.version>
@@ -95,12 +95,12 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-alarm-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <!--log4j2 to slf4j adapter-->

--- a/services/alarm-server/pom.xml
+++ b/services/alarm-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>services</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>service-alarm-server</artifactId>
@@ -24,43 +24,43 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv-ca</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv-pva</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-formula</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-email</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-alarm-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <!--JUL bindings for sfl4j-->
     <dependency> 

--- a/services/archive-engine/pom.xml
+++ b/services/archive-engine/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>services</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>service-archive-engine</artifactId>
 
@@ -82,27 +82,27 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv-ca</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv-pva</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>parent</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modules>
     <module>alarm-server</module>

--- a/services/save-and-restore/pom.xml
+++ b/services/save-and-restore/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.phoebus</groupId>
 		<artifactId>services</artifactId>
-		<version>4.7.4-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 
 	<groupId>org.phoebus</groupId>
 	<artifactId>service-save-and-restore</artifactId>
-	<version>4.7.4-SNAPSHOT</version>
+	<version>${revision}</version>
 
 	<properties>
 		<spring.boot.version>2.7.3</spring.boot.version>
@@ -61,24 +61,24 @@
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>save-and-restore-model</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>save-and-restore-util</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>core-pv-pva</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.phoebus</groupId>
 			<artifactId>core-pv-ca</artifactId>
-			<version>4.7.4-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>

--- a/services/scan-server/pom.xml
+++ b/services/scan-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.phoebus</groupId>
     <artifactId>services</artifactId>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>service-scan-server</artifactId>
   <dependencies>
@@ -66,32 +66,32 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-framework</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-util</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv-ca</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv-pva</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>app-scan-model</artifactId>
-      <version>4.7.4-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This is a proposition to centralize the Phoebus version in the root `pom.xml`, in the `revision` property. This is an official Maven workflow, specified here: https://maven.apache.org/guides/mini/guide-maven-ci-friendly.html

This enables downstream users to make their own versions, by specifying `-Drevision=4.7.4-42-SNAPSHOT` in the Maven command-line.

This also should make the Maven release plugin unnecessary, since the version is specified in a central place, according to: https://stackoverflow.com/a/67012045

Tested with the command `mvn package -DskipTests -Drevision=4.7.4-42-SNAPSHOT`