### PR TITLE
Table helpers

### DIFF
--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTable.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.phoebus.framework.nls.NLS;
+import org.phoebus.framework.persistence.Memento;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.ui.docking.DockItem;
@@ -86,5 +87,17 @@ public class AlarmLogTable implements AppInstance {
 
         controller.setSearchString(parsedQuery);
         controller.setIsNodeTable(true);
+    }
+
+    @Override
+    public void restore(final Memento memento)
+    {
+        controller.restore(memento);
+    }
+
+    @Override
+    public void save(final Memento memento)
+    {
+        controller.save(memento);
     }
 }

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -42,9 +42,12 @@ import org.phoebus.applications.alarm.logging.ui.AlarmLogTableQueryUtil.Keys;
 import org.phoebus.applications.alarm.model.SeverityLevel;
 import org.phoebus.applications.alarm.model.json.JsonModelReader;
 import org.phoebus.applications.alarm.ui.AlarmUI;
+import org.phoebus.applications.alarm.ui.table.AlarmInfoRow;
 import org.phoebus.framework.jobs.Job;
+import org.phoebus.framework.persistence.Memento;
 import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.ui.application.ContextMenuHelper;
+import org.phoebus.ui.application.TableHelper;
 import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.FocusUtil;
 import org.phoebus.ui.javafx.ImageCache;
@@ -607,7 +610,7 @@ public class AlarmLogTableController {
         // search for other context menu actions registered for AlarmLogTableType
         SelectionService.getInstance().setSelection("AlarmLogTable", tableView.getSelectionModel().getSelectedItems());
 
-        if (ContextMenuHelper.addColumnVisibilityEntries(tableView, contextMenu))
+        if (TableHelper.addContextMenuColumnVisibilityEntries(tableView, contextMenu))
             contextMenu.getItems().add(new SeparatorMenuItem());
 
         ContextMenuHelper.addSupportedEntries(FocusUtil.setFocusOn(tableView), contextMenu);
@@ -662,5 +665,13 @@ public class AlarmLogTableController {
         } else {
             configsContextMenu.hide();
         }
+    }
+
+    void save(final Memento memento) {
+        TableHelper.saveColumnVisibilities(tableView, memento, (col, idx) -> "COL" + idx + "vis");
+    }
+
+    void restore(final Memento memento) {
+        TableHelper.restoreColumnVisibilities(tableView, memento, (col, idx) -> "COL" + idx + "vis");
     }
 }

--- a/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
+++ b/app/alarm/logging-ui/src/main/java/org/phoebus/applications/alarm/logging/ui/AlarmLogTableController.java
@@ -607,6 +607,9 @@ public class AlarmLogTableController {
         // search for other context menu actions registered for AlarmLogTableType
         SelectionService.getInstance().setSelection("AlarmLogTable", tableView.getSelectionModel().getSelectedItems());
 
+        if (ContextMenuHelper.addColumnVisibilityEntries(tableView, contextMenu))
+            contextMenu.getItems().add(new SeparatorMenuItem());
+
         ContextMenuHelper.addSupportedEntries(FocusUtil.setFocusOn(tableView), contextMenu);
 
         tableView.setContextMenu(contextMenu);

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmContextMenuHelper.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/AlarmContextMenuHelper.java
@@ -58,12 +58,13 @@ public class AlarmContextMenuHelper
      *  @param menu Menu to extend
      *  @param selection Selected alarm tree items
      */
-    public void addSupportedEntries(final Node node,
+    public boolean addSupportedEntries(final Node node,
                                     final AlarmClient model,
                                     final ContextMenu menu,
                                     final List<AlarmTreeItem<?>> selection)
     {
         final List<MenuItem> menu_items = menu.getItems();
+        final int itemsBefore = menu_items.size();
         final List<AlarmTreeItem<?>> active = new ArrayList<>();
         final List<AlarmTreeItem<?>> acked = new ArrayList<>();
         final List<ProcessVariable> pvnames = new ArrayList<>();
@@ -140,6 +141,7 @@ public class AlarmContextMenuHelper
             SelectionService.getInstance().setSelection("AlarmUI", selection);
             ContextMenuHelper.addSupportedEntries(FocusUtil.setFocusOn(node), menu);
         }
+        return itemsBefore != menu_items.size();
     }
 
     private static MenuItem createSkippedEntriesHint(final Node node, final String type)

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -39,6 +39,7 @@ import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.ui.application.ContextMenuHelper;
 import org.phoebus.ui.application.ContextMenuService;
 import org.phoebus.ui.application.SaveSnapshotAction;
+import org.phoebus.ui.application.TableHelper;
 import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 import org.phoebus.ui.javafx.Brightness;
 import org.phoebus.ui.javafx.ClearingTextField;
@@ -540,7 +541,7 @@ public class AlarmTableUI extends BorderPane
             final ObservableList<MenuItem> menu_items = menu.getItems();
             menu_items.clear();
 
-            if (ContextMenuHelper.addColumnVisibilityEntries(table, menu)) {
+            if (TableHelper.addContextMenuColumnVisibilityEntries(table, menu)) {
                 menu_items.add(new SeparatorMenuItem());
             }
 
@@ -610,6 +611,9 @@ public class AlarmTableUI extends BorderPane
         for (TableColumn<AlarmInfoRow, ?> col : active.getColumns())
             memento.getNumber("COL" + i++).ifPresent(wid -> col.setPrefWidth(wid.doubleValue()));
 
+        // visibility is linked to other table, no need to also save/restore other table
+        TableHelper.restoreColumnVisibilities(active, memento, (col, idx) -> "COL" + idx + "vis");
+
         i = memento.getNumber("SORT").orElse(-1).intValue();
         if (i >= 0)
         {
@@ -626,6 +630,9 @@ public class AlarmTableUI extends BorderPane
         int i = 0;
         for (TableColumn<AlarmInfoRow, ?> col : active.getColumns())
             memento.setNumber("COL" + i++, col.getWidth());
+
+        // visibility is linked to other table, no need to also save/restore other table
+        TableHelper.saveColumnVisibilities(active, memento, (col, idx) -> "COL" + idx + "vis");
 
         final List<TableColumn<AlarmInfoRow, ?>> sorted = active.getSortOrder();
         if (sorted.size() == 1)

--- a/app/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
+++ b/app/pvtable/src/main/java/org/phoebus/applications/pvtable/PVTableInstance.java
@@ -23,6 +23,7 @@ import org.phoebus.applications.pvtable.persistence.PVTablePersistence;
 import org.phoebus.applications.pvtable.ui.PVTable;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.jobs.JobMonitor;
+import org.phoebus.framework.persistence.Memento;
 import org.phoebus.framework.spi.AppDescriptor;
 import org.phoebus.framework.spi.AppInstance;
 import org.phoebus.framework.util.ResourceParser;
@@ -41,13 +42,14 @@ public class PVTableInstance implements AppInstance
     final private AppDescriptor app;
     final private DockItemWithInput dock_item;
 
-    private PVTableModel model = new PVTableModel();
+    private final PVTableModel model = new PVTableModel();
+    private final PVTable table;
 
     PVTableInstance(final AppDescriptor app)
     {
         this.app = app;
 
-        final PVTable table = new PVTable(model);
+        table = new PVTable(model);
 
         dock_item = new DockItemWithInput(this, table, null, PVTableApplication.file_extensions, this::doSave);
         DockPane.getActiveDockPane().addTab(dock_item);
@@ -146,5 +148,17 @@ public class PVTableInstance implements AppInstance
     {
         logger.log(Level.INFO, "Stopping PV Table...");
         model.dispose();
+    }
+
+    @Override
+    public void restore(final Memento memento)
+    {
+        table.restore(memento);
+    }
+
+    @Override
+    public void save(final Memento memento)
+    {
+        table.save(memento);
     }
 }

--- a/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
+++ b/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
@@ -740,6 +740,9 @@ public class PVTable extends VBox
             menu.getItems().clear();
             menu.getItems().addAll(info, new SeparatorMenuItem());
 
+            if (ContextMenuHelper.addColumnVisibilityEntries(table, menu))
+                menu.getItems().add(new SeparatorMenuItem());
+
             if (model.isSaveRestoreEnabled())
                 menu.getItems().addAll(save, restore, new SeparatorMenuItem());
 

--- a/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
+++ b/app/pvtable/src/main/java/org/phoebus/applications/pvtable/ui/PVTable.java
@@ -27,12 +27,14 @@ import org.phoebus.applications.pvtable.model.PVTableModel;
 import org.phoebus.applications.pvtable.model.PVTableModelListener;
 import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.core.vtypes.VTypeHelper;
+import org.phoebus.framework.persistence.Memento;
 import org.phoebus.framework.selection.Selection;
 import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.security.authorization.AuthorizationService;
 import org.phoebus.ui.application.ContextMenuHelper;
 import org.phoebus.ui.application.ContextMenuService;
 import org.phoebus.ui.application.SaveSnapshotAction;
+import org.phoebus.ui.application.TableHelper;
 import org.phoebus.ui.autocomplete.PVAutocompleteMenu;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.dialog.NumericInputDialog;
@@ -740,7 +742,7 @@ public class PVTable extends VBox
             menu.getItems().clear();
             menu.getItems().addAll(info, new SeparatorMenuItem());
 
-            if (ContextMenuHelper.addColumnVisibilityEntries(table, menu))
+            if (TableHelper.addContextMenuColumnVisibilityEntries(table, menu))
                 menu.getItems().add(new SeparatorMenuItem());
 
             if (model.isSaveRestoreEnabled())
@@ -1049,5 +1051,13 @@ public class PVTable extends VBox
         for (String pv : pvs)
             if (! pv.isEmpty())
                 model.addItemAbove(existing, pv);
+    }
+
+    public void save(final Memento memento) {
+        TableHelper.saveColumnVisibilities(table, memento, (col, idx) -> "COL" + idx + "vis");
+    }
+
+    public void restore(final Memento memento) {
+        TableHelper.restoreColumnVisibilities(table, memento, (col, idx) -> "COL" + idx + "vis");
     }
 }

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScanMonitor.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScanMonitor.java
@@ -169,23 +169,13 @@ public class ScanMonitor implements AppInstance
     @Override
     public void restore(final Memento memento)
     {
-        final List<TableColumn<ScanInfoProxy, ?>> columns = scans.getTableColumns();
-        // Don't restore width of the last column, the "Error",
-        // because its pref.width is bound to a computation from table width
-        // and sum of other columns
-        for (int i=0; i<columns.size()-1; ++i)
-        {
-            final TableColumn<?, ?> col = columns.get(i);
-            memento.getNumber("COL" + i).ifPresent(wid -> col.setPrefWidth(wid.doubleValue()));
-        }
+        scans.restore(memento);
     }
 
     @Override
     public void save(final Memento memento)
     {
-        int i = 0;
-        for (TableColumn<?,?> col : scans.getTableColumns())
-            memento.setNumber("COL" + i++, col.getWidth());
+        scans.save(memento);
     }
 
     private void dispose()

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScansTable.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScansTable.java
@@ -21,6 +21,7 @@ import org.csstudio.scan.info.ScanState;
 import org.csstudio.scan.ui.ScanUIPreferences;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.jobs.JobMonitor;
+import org.phoebus.ui.application.ContextMenuHelper;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.util.time.TimestampFormats;
@@ -298,6 +299,8 @@ public class ScansTable extends VBox
             // Start with benign, "read only" commands, then end with commands that
             // do something like re-submit, abort, remove
             menu.getItems().setAll(server_info, new SeparatorMenuItem());
+            if (ContextMenuHelper.addColumnVisibilityEntries(scan_table, menu))
+                menu.getItems().add(new SeparatorMenuItem());
 
             final List<ScanInfo> selection = scan_table.getSelectionModel().getSelectedItems().stream().map(proxy -> proxy.info).collect(Collectors.toList());
             if (selection.size() == 1)

--- a/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScansTable.java
+++ b/app/scan/ui/src/main/java/org/csstudio/scan/ui/monitor/ScansTable.java
@@ -21,7 +21,9 @@ import org.csstudio.scan.info.ScanState;
 import org.csstudio.scan.ui.ScanUIPreferences;
 import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.jobs.JobMonitor;
+import org.phoebus.framework.persistence.Memento;
 import org.phoebus.ui.application.ContextMenuHelper;
+import org.phoebus.ui.application.TableHelper;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.util.time.TimestampFormats;
@@ -299,7 +301,7 @@ public class ScansTable extends VBox
             // Start with benign, "read only" commands, then end with commands that
             // do something like re-submit, abort, remove
             menu.getItems().setAll(server_info, new SeparatorMenuItem());
-            if (ContextMenuHelper.addColumnVisibilityEntries(scan_table, menu))
+            if (TableHelper.addContextMenuColumnVisibilityEntries(scan_table, menu))
                 menu.getItems().add(new SeparatorMenuItem());
 
             final List<ScanInfo> selection = scan_table.getSelectionModel().getSelectedItems().stream().map(proxy -> proxy.info).collect(Collectors.toList());
@@ -475,5 +477,25 @@ public class ScansTable extends VBox
     private boolean isStatusbarVisible()
     {
         return getChildren().size() > 1;
+    }
+
+    void save(final Memento memento) {
+        int i = 0;
+        for (TableColumn<?,?> col : getTableColumns())
+            memento.setNumber("COL" + i++, col.getWidth());
+        TableHelper.saveColumnVisibilities(scan_table, memento, (col, idx) -> "COL" + idx + "vis");
+    }
+
+    void restore(final Memento memento) {
+        final List<TableColumn<ScanInfoProxy, ?>> columns = getTableColumns();
+        // Don't restore width of the last column, the "Error",
+        // because its pref.width is bound to a computation from table width
+        // and sum of other columns
+        for (int i=0; i<columns.size()-1; ++i)
+        {
+            final TableColumn<?, ?> col = columns.get(i);
+            memento.getNumber("COL" + i).ifPresent(wid -> col.setPrefWidth(wid.doubleValue()));
+        }
+        TableHelper.restoreColumnVisibilities(scan_table, memento, (col, idx) -> "COL" + idx + "vis");
     }
 }

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
@@ -80,19 +80,4 @@ public class ContextMenuHelper
 
         return true;
     }
-
-    /** Add context menu entries for showing / hiding columns
-     *
-     * */
-    public static boolean addColumnVisibilityEntries(final TableView<?> table, final ContextMenu menu) {
-        for (TableColumn<?, ?> col : table.getColumns()) {
-            if (col.getText().isEmpty()) continue;
-            CheckMenuItem item = new CheckMenuItem("Show " + col.getText());
-//            col.visibleProperty().bindBidirectional(item.selectedProperty());
-            item.selectedProperty().bindBidirectional(col.visibleProperty());
-            menu.getItems().add(item);
-        }
-        return !table.getColumns().isEmpty();
-    }
-
 }

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuHelper.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 
+import javafx.scene.control.*;
 import org.phoebus.framework.adapter.AdapterService;
 import org.phoebus.framework.selection.Selection;
 import org.phoebus.framework.selection.SelectionService;
@@ -22,8 +23,6 @@ import org.phoebus.ui.docking.DockStage;
 import org.phoebus.ui.spi.ContextMenuEntry;
 
 import javafx.scene.Node;
-import javafx.scene.control.ContextMenu;
-import javafx.scene.control.MenuItem;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.stage.Stage;
@@ -81,4 +80,19 @@ public class ContextMenuHelper
 
         return true;
     }
+
+    /** Add context menu entries for showing / hiding columns
+     *
+     * */
+    public static boolean addColumnVisibilityEntries(final TableView<?> table, final ContextMenu menu) {
+        for (TableColumn<?, ?> col : table.getColumns()) {
+            if (col.getText().isEmpty()) continue;
+            CheckMenuItem item = new CheckMenuItem("Show " + col.getText());
+//            col.visibleProperty().bindBidirectional(item.selectedProperty());
+            item.selectedProperty().bindBidirectional(col.visibleProperty());
+            menu.getItems().add(item);
+        }
+        return !table.getColumns().isEmpty();
+    }
+
 }

--- a/core/ui/src/main/java/org/phoebus/ui/application/TableHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/TableHelper.java
@@ -1,0 +1,60 @@
+package org.phoebus.ui.application;
+
+import javafx.collections.ObservableList;
+import javafx.scene.control.CheckMenuItem;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import org.phoebus.framework.persistence.Memento;
+
+import java.util.function.BiFunction;
+
+public class TableHelper {
+
+    /** Add context menu entries for showing / hiding columns
+     * */
+    public static boolean addContextMenuColumnVisibilityEntries(final TableView<?> table, final ContextMenu menu) {
+        boolean added_item = false;
+        for (TableColumn<?, ?> col : table.getColumns()) {
+            if (col.getText().isEmpty()) continue;
+            CheckMenuItem item = new CheckMenuItem("Show " + col.getText());
+            item.selectedProperty().bindBidirectional(col.visibleProperty());
+            menu.getItems().add(item);
+            added_item = true;
+        }
+        return added_item;
+    }
+
+
+    /** Save column visibilities to a memento
+     * */
+    public static <T> void saveColumnVisibilities(
+            final TableView<T> table,
+            final Memento memento,
+            BiFunction<TableColumn<T, ?>, Integer, String> key
+    ) {
+        ObservableList<TableColumn<T, ?>> columns = table.getColumns();
+        for (int i = 0; i < columns.size(); i++) {
+            TableColumn<T, ?> col = columns.get(i);
+            if (col.getText().isEmpty()) continue;
+            String k = key.apply(col, i);
+            memento.setBoolean(k, col.isVisible());
+        }
+    }
+
+    /** Restore column visibilities from a memento
+     * */
+    public static <T> void restoreColumnVisibilities(
+            final TableView<T> table,
+            final Memento memento,
+            BiFunction<TableColumn<T, ?>, Integer, String> key
+    ) {
+        ObservableList<TableColumn<T, ?>> columns = table.getColumns();
+        for (int i = 0; i < columns.size(); i++) {
+            TableColumn<T, ?> col = columns.get(i);
+            if (col.getText().isEmpty()) continue;
+            String k = key.apply(col, i);
+            memento.getBoolean(k).ifPresent(col::setVisible);
+        }
+    }
+}


### PR DESCRIPTION
Add 'Show <column.Text()>' context menu items, with persistency to certain commonly used tables:
- Scan table
- PV table
- Alarm log
- Alarm table
One idea that I had is that perhaps the column width may also stored generically through the TableHelper save / restore methods.