### PR TITLE
CSSTUDIO-3113 PVAClient: Accept TCP connections on a separate thread.

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
@@ -250,32 +250,35 @@ public class PVAClient implements AutoCloseable
         channel.setState(ClientChannelState.FOUND);
         logger.log(Level.FINE, () -> "Reply for " + channel + " from " + (tls ? "TLS " : "TCP ") + server + " " + guid);
 
-        final ClientTCPHandler tcp = tcp_handlers.computeIfAbsent(server, addr ->
-        {
-            try
+        Thread thread = new Thread(() -> {
+            final ClientTCPHandler tcp = tcp_handlers.computeIfAbsent(server, addr ->
             {
-                return new ClientTCPHandler(this, addr, guid, tls);
+                try
+                {
+                    return new ClientTCPHandler(this, addr, guid, tls);
+                }
+                catch (Exception ex)
+                {
+                    logger.log(Level.WARNING, "Cannot connect to TCP " + addr, ex);
+                }
+                return null;
+            });
+            // In case of connection errors, tcp will be null
+            if (tcp == null)
+            {   // Cannot connect to server on provided port? Likely a server or firewall problem.
+                // On the next search, that same server might reply and then we fail the same way on connect.
+                // Still, no way around re-registering the search so we succeed once the server is fixed.
+                search.register(channel, false /* not "now" but eventually */);
             }
-            catch (Exception ex)
+            else
             {
-                logger.log(Level.WARNING, "Cannot connect to TCP " + addr, ex);
-            }
-            return null;
-        });
-        // In case of connection errors, tcp will be null
-        if (tcp == null)
-        {   // Cannot connect to server on provided port? Likely a server or firewall problem.
-            // On the next search, that same server might reply and then we fail the same way on connect.
-            // Still, no way around re-registering the search so we succeed once the server is fixed.
-            search.register(channel, false /* not "now" but eventually */);
-        }
-        else
-        {
-            if (tcp.updateGuid(guid))
-                logger.log(Level.FINE, "Search-only TCP handler received GUID, now " + tcp);
+                if (tcp.updateGuid(guid))
+                    logger.log(Level.FINE, "Search-only TCP handler received GUID, now " + tcp);
 
-            channel.registerWithServer(tcp);
-        }
+                channel.registerWithServer(tcp);
+            }
+        });
+        thread.start();
     }
 
     /** Called by {@link ClientTCPHandler} when connection is lost or closed because unused


### PR DESCRIPTION
We have encountered an issue where with an IOC that accepts UDP but drops TCP packets: when loading an OPI that contains a PV on the IOC in question, any PVs that have not been connected to yet show as being disconnected.

It appears that the reason is that the code that connects over TCP after receiving a UDP response to a search query gets stuck waiting for the TCP connection to be established. It appears that this code runs on a single thread, and that as a consequence the TCP connections to subsequent IOCs are not established.

This pull request calls the code to establish the TCP connection on a separate thread. Please note that I do not know this code base, and that this pull request is meant as a starting point for a discussion and perhaps as inspiration for a real fix. In particular, I don't know which parts of the code are thread-safe and in which way. This has to be considered carefully.

I can reproduce the issue by the following steps:
1. Running a few soft IOCs locally
2. Creating an OPI with Text Update widgets displaying them
3. Configuring the firewall to drop TCP packets on the port of one of the soft IOCs
4. Refreshing the OPI.

@kasemir, I would like to ask whether you think that this looks like a plausible fix for the error that we have observed?