### PR TITLE
Fix conversion of OPI actions to execute scripts/commands into BOB

### DIFF
--- a/app/display/actions/pom.xml
+++ b/app/display/actions/pom.xml
@@ -31,5 +31,11 @@
            <artifactId>app-display-model</artifactId>
            <version>4.7.4-SNAPSHOT</version>
        </dependency>
+       <dependency>
+	      <groupId>org.junit.jupiter</groupId>
+	      <artifactId>junit-jupiter</artifactId>
+	      <version>${junit.version}</version>
+	      <scope>test</scope>
+       </dependency>
     </dependencies>
 </project>

--- a/app/display/actions/src/main/java/org/csstudio/display/actions/ExecuteCommandAction.java
+++ b/app/display/actions/src/main/java/org/csstudio/display/actions/ExecuteCommandAction.java
@@ -93,7 +93,7 @@ public class ExecuteCommandAction extends ActionInfoBase {
     @Override
     public boolean matchesAction(String actionId) {
         return actionId.equalsIgnoreCase(EXECUTE_COMMAND) ||
-                "EXECUTE_CMD".equalsIgnoreCase(type);
+                actionId.equalsIgnoreCase("EXECUTE_CMD");
     }
 
     public String getCommand() {

--- a/app/display/actions/src/main/java/org/csstudio/display/actions/ExecuteScriptAction.java
+++ b/app/display/actions/src/main/java/org/csstudio/display/actions/ExecuteScriptAction.java
@@ -58,6 +58,7 @@ public class ExecuteScriptAction extends ActionInfoBase {
 
     @Override
     public void readFromXML(ModelReader modelReader, Element actionXml) throws Exception {
+        String type = actionXml.getAttribute(XMLTags.TYPE);
         if (type.equalsIgnoreCase(EXECUTE_SCRIPT)) {
             // <script file="EmbeddedPy">
             //   <text>  the embedded text  </text>
@@ -105,10 +106,10 @@ public class ExecuteScriptAction extends ActionInfoBase {
         writer.writeAttribute(XMLTags.TYPE, EXECUTE_SCRIPT);
         writeDescriptionToXML(writer, description);
         writer.writeStartElement(XMLTags.SCRIPT);
-        writer.writeAttribute(XMLTags.FILE, path);
+        writer.writeAttribute(XMLTags.FILE, scriptInfo.getPath());
         // The controller updates the text and path not the scriptInfo
-        if (this.path.equals(ScriptInfo.EMBEDDED_PYTHON) ||
-                this.path.equals(ScriptInfo.EMBEDDED_JAVASCRIPT)) {
+        if (scriptInfo.getPath().equals(ScriptInfo.EMBEDDED_PYTHON) ||
+                scriptInfo.getPath().equals(ScriptInfo.EMBEDDED_JAVASCRIPT)) {
             final String text = this.text;
             if (text != null) {
                 writer.writeStartElement(XMLTags.TEXT);
@@ -119,6 +120,13 @@ public class ExecuteScriptAction extends ActionInfoBase {
         writer.writeEndElement();
     }
 
+    @Override
+    public boolean matchesAction(String actionId) {
+        return actionId.equalsIgnoreCase(EXECUTE_SCRIPT) ||
+                actionId.equalsIgnoreCase(EXECUTE_PYTHONSCRIPT) ||
+                actionId.equalsIgnoreCase(EXECUTE_JAVASCRIPT);
+    }
+    
     public ScriptInfo getScriptInfo() {
         return scriptInfo;
     }

--- a/app/display/actions/src/test/java/org/csstudio/display/actions/ExecuteCommandTest.java
+++ b/app/display/actions/src/test/java/org/csstudio/display/actions/ExecuteCommandTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 European Spallation Source ERIC.
+ */
+package org.csstudio.display.actions;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.persist.ModelReader;
+import org.csstudio.display.builder.model.persist.ModelWriter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test Execute Script actions
+ * 
+ * @author Becky Auger-Williams
+ */
+public class ExecuteCommandTest {
+    
+    private static final String TMP_OUTFILE = "/tmp/outfile.bob";
+
+    @Test
+    public void execute_command() {
+        String xml = "<display typeId=\"org.csstudio.opibuilder.Display\" version=\"1.0.0\">"
+                + "<widget typeId=\"org.csstudio.opibuilder.widgets.ActionButton\" version=\"2.0.0\">"
+                + "<actions hook=\"false\" hook_all=\"true\"><action type=\"EXECUTE_CMD\">"
+                + "<command>echo hello</command><command_directory>$(user.home)</command_directory>"
+                + "<wait_time>10</wait_time><description></description></action></actions>"
+                + "</widget></display>";
+
+        InputStream stream = new ByteArrayInputStream(xml.getBytes(Charset.forName("UTF-8")));
+        try (FileOutputStream outStream = new FileOutputStream(TMP_OUTFILE);
+             ModelWriter writer = new ModelWriter(outStream);) {
+
+            ModelReader reader = new ModelReader(stream);
+            DisplayModel model = reader.readModel();
+            assertTrue(model.isClean());
+
+            writer.writeModel(model);
+
+            // Check the model gets written correctly
+            String file_content = Files.readString(Path.of(TMP_OUTFILE)).strip();
+            assertTrue(file_content.contains("<command>echo hello</command>"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Exception thrown" + e.getLocalizedMessage());
+        }
+        // Test clean up
+        File tmpfile = new File(TMP_OUTFILE); 
+        tmpfile.delete();
+    }
+}

--- a/app/display/actions/src/test/java/org/csstudio/display/actions/ExecuteScriptTest.java
+++ b/app/display/actions/src/test/java/org/csstudio/display/actions/ExecuteScriptTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 European Spallation Source ERIC.
+ */
+package org.csstudio.display.actions;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.persist.ModelReader;
+import org.csstudio.display.builder.model.persist.ModelWriter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test Execute Script actions
+ * 
+ * @author Becky Auger-Williams
+ */
+public class ExecuteScriptTest {
+    
+    private static final String TMP_OUTFILE = "/tmp/outfile.bob";
+
+    @Test
+    public void execute_embedded_javascript() {
+        String xml = "<display typeId=\"org.csstudio.opibuilder.Display\" version=\"1.0.0\">"
+                + "<widget typeId=\"org.csstudio.opibuilder.widgets.ActionButton\" version=\"2.0.0\">"
+                + "<actions hook=\"false\" hook_all=\"true\"><action type=\"EXECUTE_JAVASCRIPT\"><path></path>"
+                + "<scriptText><![CDATA[importPackage(Packages.org.csstudio.opibuilder.scriptUtil);]]></scriptText>"
+                + "<embedded>true</embedded><description></description></action></actions>"
+                + "</widget></display>";
+
+        InputStream stream = new ByteArrayInputStream(xml.getBytes(Charset.forName("UTF-8")));
+        try (FileOutputStream outStream = new FileOutputStream(TMP_OUTFILE);
+             ModelWriter writer = new ModelWriter(outStream);) {
+
+            ModelReader reader = new ModelReader(stream);
+            DisplayModel model = reader.readModel();
+            assertTrue(model.isClean());
+
+            writer.writeModel(model);
+
+            // Check the model gets written correctly
+            String file_content = Files.readString(Path.of(TMP_OUTFILE)).strip();
+            assertTrue(file_content.contains("<text><![CDATA[importPackage(Packages.org.csstudio.opibuilder.scriptUtil);]]></text>"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Exception thrown" + e.getLocalizedMessage());
+        }
+        // Test clean up
+        File tmpfile = new File(TMP_OUTFILE); 
+        tmpfile.delete();
+    }
+    
+    @Test
+    public void execute_embedded_pythonscript() {
+        String xml = "<display typeId=\"org.csstudio.opibuilder.Display\" version=\"1.0.0\">"
+                + "<widget typeId=\"org.csstudio.opibuilder.widgets.ActionButton\" version=\"2.0.0\">"
+                + "<actions hook=\"false\" hook_all=\"true\"><action type=\"EXECUTE_PYTHONSCRIPT\"><path></path>"
+                + "<scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil\n"
+                + "]]></scriptText>"
+                + "<embedded>true</embedded><description></description></action></actions>"
+                + "</widget></display>";
+
+        InputStream stream = new ByteArrayInputStream(xml.getBytes(Charset.forName("UTF-8")));
+        try (FileOutputStream outStream = new FileOutputStream(TMP_OUTFILE);
+             ModelWriter writer = new ModelWriter(outStream);) {
+
+            ModelReader reader = new ModelReader(stream);
+            DisplayModel model = reader.readModel();
+            assertTrue(model.isClean());
+
+            writer.writeModel(model);
+            
+            // Check the model gets written correctly
+            String file_content = Files.readString(Path.of(TMP_OUTFILE)).strip();
+            assertTrue(file_content.contains("<text><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil\n"
+                    + "]]></text>"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Exception thrown" + e.getLocalizedMessage());
+        }
+        // Test clean up
+        File tmpfile = new File(TMP_OUTFILE); 
+        tmpfile.delete();
+    }
+}

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/Converter.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/Converter.java
@@ -175,7 +175,6 @@ public class Converter {
 				final ModelReader reader = new ModelReader(new FileInputStream(infile));
 				DisplayModel model = reader.readModel();
 				writer.writeModel(model);
-				writer.close();
 			} catch (Exception e) {
 				throw e;
 			}


### PR DESCRIPTION
I found a few issues during the conversion of OPI to BOB when the widgets contained an action to EXECUTE_CMD, EXECUTE_PYTHONSCRIPT or EXECUTE_JAVASCRIPT. These are detailed in https://github.com/ControlSystemStudio/phoebus/issues/3340.

This PR fixes the 3 issues detailed in the issue ticket above and also adds 2 Java unit tests to test this functionality to ensure we don't miss an regression to converter in the future.