### PR TITLE
Fix ScaledSlider becoming non selectable in edit mode when disabled

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
@@ -408,7 +408,7 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
     {
         super.updateChanges();
         if (dirty_enablement.checkAndClear())
-            jfx_node.setDisable(! enabled);
+            slider.setDisable(!enabled);
         if (dirty_layout.checkAndClear())
         {
             final boolean horizontal = model_widget.propHorizontal().getValue();


### PR DESCRIPTION
We found an annoyance in which, if you disable a ScaledSlider, the element can not be selected by left clicking on it in the editor but is needed to use the widget list on the left.

This seems to be related to the ScaledSlider code for disabling the widget that would disabled the jfx_node instead of the slider only creating this issue. It can be reproduced easily just by creating a ScaledSlider widget, disabling it, deselecting and then trying to select it again.

This is a minimal change to just disable the slider instead of the whole node so it can still be selected in the Edit View and enabled when needed.