### PR TITLE
step1 for fixing tcp connections delays, based on the discussion #3338

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
@@ -160,12 +160,18 @@ public class SecureSockets
     public static Socket createClientSocket(final InetSocketAddress address, final boolean tls) throws Exception
     {
         initialize();
-        if (! tls)
-            return new Socket(address.getAddress(), address.getPort());
+        int connection_timeout = Math.max(1, PVASettings.EPICS_PVA_CONN_TMO) * 1000; // Use EPICS_PVA_CONN_TMO for socket connection timeout, but at least 1 second
+
+        if (!tls) {
+            Socket socket = new Socket();
+            socket.connect(address, connection_timeout);
+            return socket;
+        }
 
         if (tls_client_sockets == null)
             throw new Exception("TLS is not supported. Configure EPICS_PVA_TLS_KEYCHAIN");
-        final SSLSocket socket = (SSLSocket) tls_client_sockets.createSocket(address.getAddress(), address.getPort());
+        final SSLSocket socket = (SSLSocket) tls_client_sockets.createSocket();
+        socket.connect(address, connection_timeout);
         socket.setEnabledProtocols(PROTOCOLS);
         // Handshake starts when first writing, but that might delay SSL errors, so force handshake before we use the socket
         socket.startHandshake();


### PR DESCRIPTION
I have used an existing setting/preference 

```
    /** Connection timeout [seconds]
     *
     * <p>When approaching this time without having received a new value,
     * an 'Echo' request is sent. If still no reply, the channel is disconnected.
     */
    public static int EPICS_PVA_CONN_TMO = 30;
```

I had to change to code to first create a unconnected socket and then try connect with a timeout. Previously we were using constructors which both created *and* connected to the address... but these constructors did not support configuring a timeout.

A @kasemir through review would be appreciated. @abrahamwolk can you test this branch with a reduced timeout to see what impact it has on your Phoebus behaviour.