### PR TITLE
Implement user defined runtime zoom factor

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/Preferences.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/Preferences.java
@@ -33,6 +33,8 @@ public class Preferences
     @Preference public static String probe_display;
     /** Preference setting */
     public static final List<TextPatch> pv_name_patches = new ArrayList<>();
+    /** Preference setting */
+    @Preference public static int default_zoom_factor;
 
     static
     {

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ZoomAction.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ZoomAction.java
@@ -8,6 +8,9 @@
 package org.csstudio.display.builder.runtime.app;
 
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
+import org.phoebus.framework.preferences.AnnotatedPreferences;
+import org.phoebus.framework.preferences.PreferencesReader;
+import org.phoebus.framework.preferences.Preference;
 
 import javafx.application.Platform;
 import javafx.scene.control.ComboBox;
@@ -19,13 +22,19 @@ public class ZoomAction extends ComboBox<String>
 {
     private boolean updating = false;
 
+    @Preference public static double default_zoom_factor;
+
+    static
+    {
+        AnnotatedPreferences.initialize(ZoomAction.class, "/zoom_preferences.properties");
+    }
+
     /** @param instance {@link DisplayRuntimeInstance} */
     public ZoomAction(final DisplayRuntimeInstance instance)
     {
         setEditable(true);
         setPrefWidth(100.0);
         getItems().addAll(JFXRepresentation.ZOOM_LEVELS);
-        setValue(JFXRepresentation.DEFAULT_ZOOM_LEVEL);
         // For Ctrl-Wheel zoom gesture
         instance.getRepresentation().setZoomListener(txt ->
         {
@@ -33,6 +42,13 @@ public class ZoomAction extends ComboBox<String>
             getEditor().setText(txt);
         });
         setOnAction(event -> zoom(instance.getRepresentation()));
+
+        // Add the zoom action into a queue
+        Platform.runLater(() ->
+        {
+            String zoom = String.format("%d %%", (int)(default_zoom_factor * 100));
+            setValue(zoom);
+        });
     }
 
     private void zoom(final JFXRepresentation representation)

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ZoomAction.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ZoomAction.java
@@ -49,6 +49,8 @@ public class ZoomAction extends ComboBox<String>
         {
             String zoom = String.format("%d %%", default_zoom_factor);
             setValue(zoom);
+            // Invoke zoom changed handler
+            getOnAction().handle(null);
         });
     }
 

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ZoomAction.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ZoomAction.java
@@ -22,7 +22,7 @@ public class ZoomAction extends ComboBox<String>
 {
     private boolean updating = false;
 
-    @Preference public static double default_zoom_factor;
+    @Preference public static int default_zoom_factor;
 
     static
     {
@@ -35,6 +35,7 @@ public class ZoomAction extends ComboBox<String>
         setEditable(true);
         setPrefWidth(100.0);
         getItems().addAll(JFXRepresentation.ZOOM_LEVELS);
+        setValue(JFXRepresentation.DEFAULT_ZOOM_LEVEL);
         // For Ctrl-Wheel zoom gesture
         instance.getRepresentation().setZoomListener(txt ->
         {
@@ -43,10 +44,10 @@ public class ZoomAction extends ComboBox<String>
         });
         setOnAction(event -> zoom(instance.getRepresentation()));
 
-        // Add the zoom action into a queue
+        // Apply default zoom factor from settings.ini
         Platform.runLater(() ->
         {
-            String zoom = String.format("%d %%", (int)(default_zoom_factor * 100));
+            String zoom = String.format("%d %%", default_zoom_factor);
             setValue(zoom);
         });
     }

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ZoomAction.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ZoomAction.java
@@ -8,9 +8,7 @@
 package org.csstudio.display.builder.runtime.app;
 
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
-import org.phoebus.framework.preferences.AnnotatedPreferences;
-import org.phoebus.framework.preferences.PreferencesReader;
-import org.phoebus.framework.preferences.Preference;
+import org.csstudio.display.builder.runtime.Preferences;
 
 import javafx.application.Platform;
 import javafx.scene.control.ComboBox;
@@ -21,13 +19,6 @@ import javafx.scene.control.ComboBox;
 public class ZoomAction extends ComboBox<String>
 {
     private boolean updating = false;
-
-    @Preference public static int default_zoom_factor;
-
-    static
-    {
-        AnnotatedPreferences.initialize(ZoomAction.class, "/zoom_preferences.properties");
-    }
 
     /** @param instance {@link DisplayRuntimeInstance} */
     public ZoomAction(final DisplayRuntimeInstance instance)
@@ -47,7 +38,7 @@ public class ZoomAction extends ComboBox<String>
         // Apply default zoom factor from settings.ini
         Platform.runLater(() ->
         {
-            String zoom = String.format("%d %%", default_zoom_factor);
+            String zoom = String.format("%d %%", Preferences.default_zoom_factor);
             setValue(zoom);
             // Invoke zoom changed handler
             getOnAction().handle(null);

--- a/app/display/runtime/src/main/resources/display_runtime_preferences.properties
+++ b/app/display/runtime/src/main/resources/display_runtime_preferences.properties
@@ -46,3 +46,6 @@ update_throttle=250
 # When left empty, the "Probe Display"
 # context menu entry is disabled.
 probe_display=examples:/probe.bob
+
+# Default zoom factor (percentage) of display runtime window
+default_zoom_factor=100

--- a/app/display/runtime/src/main/resources/zoom_preferences.properties
+++ b/app/display/runtime/src/main/resources/zoom_preferences.properties
@@ -1,6 +1,0 @@
-# ----------------------
-# Package org.csstudio.display.builder.runtime.app
-# ----------------------
-
-# Default zoom factor (percentage) of display runtime window
-default_zoom_factor=100

--- a/app/display/runtime/src/main/resources/zoom_preferences.properties
+++ b/app/display/runtime/src/main/resources/zoom_preferences.properties
@@ -1,0 +1,6 @@
+# ----------------------
+# Package org.csstudio.display.builder.runtime.app
+# ----------------------
+
+# Defualt zoom factor(double) of display runtime window
+default_zoom_factor=1.00

--- a/app/display/runtime/src/main/resources/zoom_preferences.properties
+++ b/app/display/runtime/src/main/resources/zoom_preferences.properties
@@ -2,5 +2,5 @@
 # Package org.csstudio.display.builder.runtime.app
 # ----------------------
 
-# Defualt zoom factor(double) of display runtime window
-default_zoom_factor=1.00
+# Default zoom factor (percentage) of display runtime window
+default_zoom_factor=100


### PR DESCRIPTION
Add a mechanism to apply a custom zoom factor for the runtime window. 

The desired zoom factor can be set in settings.ini as:
```
org.csstudio.display.builder.runtime.app/default_zoom_factor=1.23
```

Refers to #3366 