### PR TITLE
JavaFX update to 21.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <epics.version>7.0.10</epics.version>
     <epics.util.version>1.0.7</epics.util.version>
     <vtype.version>1.0.7</vtype.version>
-    <openjfx.version>21.0.3</openjfx.version>
+    <openjfx.version>21.0.7</openjfx.version>
     <jackson.version>2.12.3</jackson.version>
     <batik.version>1.17</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
Fixes (at least) one apparent bug: new-line chars in source shown in ```WebView``` rendered as "unknown" chars (rectangles):

Before:
<img width="484" alt="Screenshot 2025-04-21 at 09 46 18" src="https://github.com/user-attachments/assets/c0e4c5ce-33d7-407a-a991-0804b4e17f9b" />

After:
<img width="479" alt="Screenshot 2025-04-21 at 09 46 29" src="https://github.com/user-attachments/assets/867a8523-2ed5-40e2-a8d7-9e8f63ddcf67" />
