### PR TITLE
docs: switch to Read the Docs theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,7 +91,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,10 +8,9 @@ Welcome to the CS-Studio/Phoebus Documentation!
 
 .. image:: splash.png
 
-User Documentation:
-
 .. toctree::
    :maxdepth: 1
+   :caption: User Documentation
 
    intro
    running
@@ -24,10 +23,9 @@ User Documentation:
    services
    services_architecture
 
-Developer Documentation:
-
 .. toctree::
    :maxdepth: 1
+   :caption: Developer Documentation
 
    develop
    phoebus_product
@@ -41,11 +39,3 @@ Developer Documentation:
    trouble_shooting
    eclipse_debugging
    gui_testing
-
-Appendix
-========
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-


### PR DESCRIPTION
Fixes #3160.

This switches the documentation from the "default" theme to the "Read the Docs" theme, which provides a sidebar that is consistent across all pages, which makes it easier to navigate, and easier to grasp the structure of the documentation.

There are other Sphinx themes, which you can see here: https://sphinx-themes.org/
but the RTD theme is very popular, and well designed, in my opinion.