### PR TITLE
Update logbook clients to use server side managed "levels"

### DIFF
--- a/app/logbook/inmemory/src/main/java/org/phoebus/applications/logbook/InMemoryLogClient.java
+++ b/app/logbook/inmemory/src/main/java/org/phoebus/applications/logbook/InMemoryLogClient.java
@@ -1,14 +1,28 @@
 package org.phoebus.applications.logbook;
 
+import org.phoebus.logbook.Attachment;
+import org.phoebus.logbook.AttachmentImpl;
+import org.phoebus.logbook.LogClient;
+import org.phoebus.logbook.LogEntry;
+import org.phoebus.logbook.LogEntryImpl;
+import org.phoebus.logbook.LogEntryImpl.LogEntryBuilder;
+import org.phoebus.logbook.LogEntryLevel;
+import org.phoebus.logbook.Logbook;
+import org.phoebus.logbook.LogbookException;
+import org.phoebus.logbook.LogbookImpl;
+import org.phoebus.logbook.Property;
+import org.phoebus.logbook.PropertyImpl;
+import org.phoebus.logbook.SearchResult;
+import org.phoebus.logbook.Tag;
+import org.phoebus.logbook.TagImpl;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
@@ -23,21 +37,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.phoebus.logbook.Attachment;
-import org.phoebus.logbook.AttachmentImpl;
-import org.phoebus.logbook.LogClient;
-import org.phoebus.logbook.LogEntry;
-import org.phoebus.logbook.LogEntryImpl;
-import org.phoebus.logbook.LogEntryImpl.LogEntryBuilder;
-import org.phoebus.logbook.Logbook;
-import org.phoebus.logbook.LogbookException;
-import org.phoebus.logbook.LogbookImpl;
-import org.phoebus.logbook.Property;
-import org.phoebus.logbook.PropertyImpl;
-import org.phoebus.logbook.SearchResult;
-import org.phoebus.logbook.Tag;
-import org.phoebus.logbook.TagImpl;
-
 /**
  * A logbook which maintains logentries in memory. It is mainly for testing and debugging purpose.
  */
@@ -47,16 +46,16 @@ public class InMemoryLogClient implements LogClient {
     private final Map<Long, LogEntry> logEntries;
 
     private final Collection<Logbook> logbooks = Arrays.asList(LogbookImpl.of("Controls"),
-                                                               LogbookImpl.of("Commissioning"),
-                                                               LogbookImpl.of("Scratch Pad"));
+            LogbookImpl.of("Commissioning"),
+            LogbookImpl.of("Scratch Pad"));
     private final Collection<Tag> tags = Arrays.asList(TagImpl.of("Operations"),
-                                                       TagImpl.of("Alarm"),
-                                                       TagImpl.of("Example"));
+            TagImpl.of("Alarm"),
+            TagImpl.of("Example"));
     private final List<String> levels = Arrays.asList("Urgent", "Suggestion", "Info", "Request", "Problem");
 
     private static List<Property> inMemoryProperties() {
         Map<String, String> tracAttributes = new HashMap<>();
-        Property track = PropertyImpl.of("Track",tracAttributes);
+        Property track = PropertyImpl.of("Track", tracAttributes);
         Map<String, String> experimentAttributes = new HashMap<>();
         Property experimentProperty = PropertyImpl.of("Experiment", experimentAttributes);
         Map<String, String> resourceAttributes = new HashMap<>();
@@ -80,8 +79,8 @@ public class InMemoryLogClient implements LogClient {
     }
 
     @Override
-    public Collection<String> listLevels() {
-        return levels;
+    public Collection<LogEntryLevel> listLevels() {
+        return levels.stream().map(l -> new LogEntryLevel(l, false)).toList();
     }
 
     @Override
@@ -110,6 +109,7 @@ public class InMemoryLogClient implements LogClient {
     }
 
     String prefix = "phoebus_tmp_file";
+
     @Override
     public LogEntry set(LogEntry log) {
         long id = logIdCounter.incrementAndGet();
@@ -155,12 +155,12 @@ public class InMemoryLogClient implements LogClient {
     @Override
     public List<LogEntry> findLogs(Map<String, String> map) {
         Stream<LogEntry> searchStream = logEntries.values().stream();
-        if(map.containsKey("start")) {
+        if (map.containsKey("start")) {
             searchStream = searchStream.filter(log -> {
                 return log.getCreatedDate().isAfter(Instant.ofEpochSecond(Long.valueOf(map.get("start"))));
             });
         }
-        if(map.containsKey("end")) {
+        if (map.containsKey("end")) {
             searchStream = searchStream.filter(log -> {
                 return log.getCreatedDate().isBefore(Instant.ofEpochSecond(Long.valueOf(map.get("end"))));
             });
@@ -169,7 +169,7 @@ public class InMemoryLogClient implements LogClient {
             final String searchString = map.get("search").replaceAll("\\*", "");
             if (!searchString.isEmpty()) {
                 searchStream = searchStream.filter(log -> {
-                    return log.getDescription().contains(searchString)||log.getTitle().contains(searchString);
+                    return log.getDescription().contains(searchString) || log.getTitle().contains(searchString);
                 });
             }
         }

--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -546,6 +547,24 @@ public class OlogHttpClient implements LogClient {
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to submit template, got client exception", e);
             throw new LogbookException(e);
+        }
+    }
+
+    @Override
+    public Collection<org.phoebus.logbook.Level> getLevels(){
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(Preferences.olog_url + "/levels"))
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            return OlogObjectMappers.logEntryDeserializer.readValue(
+                    response.body(), new TypeReference<Set<org.phoebus.logbook.Level>>() {
+                    });
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Unable to get templates from service", e);
+            return Collections.emptySet();
         }
     }
 }

--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
@@ -13,6 +13,7 @@ import org.phoebus.logbook.Attachment;
 import org.phoebus.logbook.LogClient;
 import org.phoebus.logbook.LogEntry;
 import org.phoebus.logbook.LogEntryChangeHandler;
+import org.phoebus.logbook.LogEntryLevel;
 import org.phoebus.logbook.LogTemplate;
 import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.LogbookException;
@@ -551,7 +552,7 @@ public class OlogHttpClient implements LogClient {
     }
 
     @Override
-    public Collection<org.phoebus.logbook.Level> getLevels(){
+    public Collection<LogEntryLevel> getLogEntryLevels(){
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(Preferences.olog_url + "/levels"))
                 .GET()
@@ -560,7 +561,7 @@ public class OlogHttpClient implements LogClient {
         try {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             return OlogObjectMappers.logEntryDeserializer.readValue(
-                    response.body(), new TypeReference<Set<org.phoebus.logbook.Level>>() {
+                    response.body(), new TypeReference<Set<LogEntryLevel>>() {
                     });
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to get templates from service", e);

--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
@@ -552,7 +552,7 @@ public class OlogHttpClient implements LogClient {
     }
 
     @Override
-    public Collection<LogEntryLevel> getLogEntryLevels(){
+    public Collection<LogEntryLevel> listLevels(){
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(Preferences.olog_url + "/levels"))
                 .GET()

--- a/app/logbook/olog/client/src/main/java/org/phoebus/olog/api/OlogClient.java
+++ b/app/logbook/olog/client/src/main/java/org/phoebus/olog/api/OlogClient.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.phoebus.logbook.Attachment;
 import org.phoebus.logbook.LogClient;
 import org.phoebus.logbook.LogEntry;
+import org.phoebus.logbook.LogEntryLevel;
 import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.LogbookException;
 import org.phoebus.logbook.Messages;
@@ -197,13 +198,12 @@ public class OlogClient implements LogClient {
 
     }
 
-
     // A predefined set of levels supported by olog
     private final List<String> levels = Arrays.asList("Urgent", "Suggestion", "Info", "Request", "Problem");
 
     @Override
-    public Collection<String> listLevels() {
-        return levels;
+    public Collection<LogEntryLevel> listLevels() {
+        return levels.stream().map(l -> new LogEntryLevel(l, false)).toList();
     }
 
     @Override

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AdvancedSearchViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AdvancedSearchViewController.java
@@ -20,33 +20,43 @@ package org.phoebus.logbook.olog.ui;
 
 import javafx.application.Platform;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.geometry.Pos;
+import javafx.geometry.Side;
 import javafx.scene.control.Button;
-import javafx.scene.control.ComboBox;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.CustomMenuItem;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import org.phoebus.logbook.LogEntryLevel;
 import org.phoebus.logbook.LogClient;
 import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.Tag;
-import org.phoebus.olog.es.api.Preferences;
 import org.phoebus.ui.dialog.ListSelectionPopOver;
 import org.phoebus.ui.dialog.PopOver;
+import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.time.TimeRelativeIntervalPane;
 import org.phoebus.util.text.Strings;
 import org.phoebus.util.time.TimeParser;
 import org.phoebus.util.time.TimeRelativeInterval;
 import org.phoebus.util.time.TimestampFormats;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -85,30 +95,47 @@ public class AdvancedSearchViewController {
     ListSelectionPopOver logbookSearchPopover;
 
     @FXML
-    ComboBox<String> levelSelector;
-
-    @FXML
     TextField searchTags;
     ListSelectionPopOver tagSearchPopover;
 
     private final LogClient logClient;
 
+    @SuppressWarnings("unused")
     @FXML
     private AnchorPane advancedSearchPane;
 
+    @SuppressWarnings("unused")
     @FXML
     private RadioButton sortDescRadioButton;
 
+    @SuppressWarnings("unused")
     @FXML
     private RadioButton sortAscRadioButton;
 
+    @SuppressWarnings("unused")
     @FXML
     private TextField attachmentTypes;
+
+    @SuppressWarnings("unused")
+    @FXML
+    private TextField selectedLevelsField;
+
+    @SuppressWarnings("unused")
+    @FXML
+    private ToggleButton levelsToggleButton;
+
+    @SuppressWarnings("unused")
+    @FXML
+    private GridPane gridPane;
+
+    private final ContextMenu levelsContextMenu = new ContextMenu();
 
     private final SearchParameters searchParameters;
 
     private final SimpleBooleanProperty sortAscending = new SimpleBooleanProperty(false);
-    private final SimpleBooleanProperty requireAttachments = new SimpleBooleanProperty(false);
+    private final ObservableList<LevelSelection> levelSelections = FXCollections.observableArrayList();
+    private final SimpleStringProperty selectedLevelsString = new SimpleStringProperty();
+    private final List<String> levelsList = new ArrayList<>();
 
     private Runnable searchCallback = () -> {
         throw new IllegalStateException("Search callback is not set on AdvancedSearchViewController!");
@@ -133,8 +160,18 @@ public class AdvancedSearchViewController {
         searchText.setOnKeyReleased(this::searchOnEnter);
         searchAuthor.textProperty().bindBidirectional(this.searchParameters.authorProperty());
         searchAuthor.setOnKeyReleased(this::searchOnEnter);
-        levelSelector.valueProperty().bindBidirectional(this.searchParameters.levelProperty());
-        levelSelector.setOnAction(e -> searchCallback.run());
+        selectedLevelsField.textProperty().bind(selectedLevelsString);
+        levelsToggleButton.setGraphic(new ImageView(ImageCache.getImage(AdvancedSearchViewController.class, "/icons/down_triangle.png")));
+        levelsToggleButton.focusedProperty().addListener((changeListener, oldVal, newVal) ->
+        {
+            if (!newVal && !levelsContextMenu.isShowing())
+                levelsToggleButton.setSelected(false);
+        });
+
+        selectedLevelsString.addListener((obs, o, n) -> {
+            this.searchParameters.levelsProperty().setValue(selectedLevelsString.get());
+            searchCallback.run();
+        });
         searchTags.textProperty().bindBidirectional(this.searchParameters.tagsProperty());
         searchParameters.tagsProperty().addListener(searchOnTextChange);
         searchLogbooks.textProperty().bindBidirectional(this.searchParameters.logbooksProperty());
@@ -170,24 +207,22 @@ public class AdvancedSearchViewController {
         Button apply = new Button();
         apply.setText(Messages.Apply);
         apply.setPrefWidth(80);
-        apply.setOnAction((event) -> {
-            Platform.runLater(() -> {
-                TimeRelativeInterval interval = timeSelectionPane.getInterval();
-                if (interval.isStartAbsolute()) {
-                    searchParameters.startTimeProperty().setValue(TimestampFormats.MILLI_FORMAT.format(interval.getAbsoluteStart().get()));
-                } else {
-                    searchParameters.startTimeProperty().setValue(TimeParser.format(interval.getRelativeStart().get()));
-                }
-                if (interval.isEndAbsolute()) {
-                    searchParameters.endTimeProperty().setValue(TimestampFormats.MILLI_FORMAT.format(interval.getAbsoluteEnd().get()));
-                } else {
-                    searchParameters.endTimeProperty().setValue(TimeParser.format(interval.getRelativeEnd().get()));
-                }
-                if (timeSearchPopover.isShowing())
-                    timeSearchPopover.hide();
-                searchCallback.run();
-            });
-        });
+        apply.setOnAction((event) -> Platform.runLater(() -> {
+            TimeRelativeInterval interval = timeSelectionPane.getInterval();
+            if (interval.isStartAbsolute()) {
+                searchParameters.startTimeProperty().setValue(TimestampFormats.MILLI_FORMAT.format(interval.getAbsoluteStart().get()));
+            } else {
+                searchParameters.startTimeProperty().setValue(TimeParser.format(interval.getRelativeStart().get()));
+            }
+            if (interval.isEndAbsolute()) {
+                searchParameters.endTimeProperty().setValue(TimestampFormats.MILLI_FORMAT.format(interval.getAbsoluteEnd().get()));
+            } else {
+                searchParameters.endTimeProperty().setValue(TimeParser.format(interval.getRelativeEnd().get()));
+            }
+            if (timeSearchPopover.isShowing())
+                timeSearchPopover.hide();
+            searchCallback.run();
+        }));
         Button cancel = new Button();
         cancel.setText("Cancel");
         cancel.setPrefWidth(80);
@@ -283,9 +318,19 @@ public class AdvancedSearchViewController {
             }
         });
 
-        List<String> levelList = Arrays.stream(Preferences.levels).toList();
-        levelSelector.getItems().add("");
-        levelSelector.getItems().addAll(levelList);
+        levelsList.addAll(logClient.getLogEntryLevels().stream().map(LogEntryLevel::name).sorted().toList());
+        levelsList.forEach(level -> {
+            LevelSelection levelSelection = new LevelSelection(level, false);
+            levelSelections.add(levelSelection);
+            CheckBox checkBox = new CheckBox(level);
+            LevelSelectionMenuItem levelSelectionMenuItem = new LevelSelectionMenuItem(checkBox);
+            levelSelectionMenuItem.setHideOnClick(false);
+            checkBox.selectedProperty().addListener((observable, oldValue, newValue) -> {
+                levelSelection.selected = newValue;
+                setSelectedLevelsString();
+            });
+            levelsContextMenu.getItems().add(levelSelectionMenuItem);
+        });
 
         sortAscending.addListener((observable, oldValue, newValue) -> {
             sortDescRadioButton.selectedProperty().set(!newValue);
@@ -295,6 +340,11 @@ public class AdvancedSearchViewController {
         sortDescRadioButton.setOnAction(ae -> sortAscending.set(false));
 
         sortAscRadioButton.setOnAction(ae -> sortAscending.set(true));
+
+        gridPane.setOnMouseClicked(e -> levelsToggleButton.setSelected(false));
+
+        // Make sure controls are updated based on search string entered by user
+        updateControls(searchParameters.getValue());
     }
 
     public AnchorPane getPane() {
@@ -308,23 +358,30 @@ public class AdvancedSearchViewController {
      */
     private void updateControls(String queryString) {
         Map<String, String> queryStringParameters = LogbookQueryUtil.parseHumanReadableQueryString(queryString);
-        queryStringParameters.entrySet().stream().forEach(entry -> {
+        queryStringParameters.entrySet().forEach(entry -> {
             Keys keys = Keys.findKey(entry.getKey());
             if (keys != null) {
                 if (keys.equals(Keys.LEVEL)) {
-                    List<String> levels = Arrays.stream(Preferences.levels).toList();
-                    if (levels.contains(entry.getValue())) {
-                        searchParameters.levelProperty().setValue(entry.getValue());
+                    List<String> validatedLevels = getValidatedLevelsSelection(entry.getValue());
+                    if (validatedLevels.isEmpty()) {
+                        searchParameters.levelsProperty().setValue(null);
                     } else {
-                        searchParameters.levelProperty().setValue(null);
+                        String selectedLevels =
+                                String.join(",", validatedLevels);
+                        searchParameters.levelsProperty().setValue(selectedLevels);
                     }
+                    levelsContextMenu.getItems().forEach(mi -> {
+                        LevelSelectionMenuItem levelSelectionMenuItem =
+                                (LevelSelectionMenuItem) mi;
+                        levelSelectionMenuItem.setSelected(validatedLevels.contains(levelSelectionMenuItem.getCheckBox().getText()));
+                    });
                 } else if (keys.equals(Keys.LOGBOOKS)) {
                     List<String> validatedLogbookNames = getValidatedLogbooksSelection(entry.getValue());
                     if (validatedLogbookNames.isEmpty()) {
                         searchParameters.logbooksProperty().setValue(null);
                     } else {
                         String selectedLogbooks =
-                                validatedLogbookNames.stream().collect(Collectors.joining(","));
+                                String.join(",", validatedLogbookNames);
                         searchParameters.logbooksProperty().setValue(selectedLogbooks);
                     }
                     logbookSearchPopover.setSelected(validatedLogbookNames);
@@ -333,7 +390,7 @@ public class AdvancedSearchViewController {
                     if (validatedTagsNames.isEmpty()) {
                         searchParameters.tagsProperty().setValue(null);
                     } else {
-                        String selectedTags = validatedTagsNames.stream().collect(Collectors.joining(","));
+                        String selectedTags = String.join(",", validatedTagsNames);
                         searchParameters.tagsProperty().setValue(selectedTags);
                     }
                     tagSearchPopover.setSelected(validatedTagsNames);
@@ -347,12 +404,10 @@ public class AdvancedSearchViewController {
             return Collections.emptyList();
         }
         List<String> validLogbookNames =
-                logClient.listLogbooks().stream().map(Logbook::getName).sorted().collect(Collectors.toList());
+                logClient.listLogbooks().stream().map(Logbook::getName).sorted().toList();
         List<String> logbooksFromQueryString =
-                Arrays.stream(logbooks.split(",")).map(s -> s.trim()).collect(Collectors.toList());
-        List<String> validatedLogbookNames =
-                logbooksFromQueryString.stream().filter(logbookName -> validLogbookNames.contains(logbookName)).collect(Collectors.toList());
-        return validatedLogbookNames;
+                Arrays.stream(logbooks.split(",")).map(String::trim).toList();
+        return logbooksFromQueryString.stream().filter(validLogbookNames::contains).collect(Collectors.toList());
     }
 
     protected List<String> getValidatedTagsSelection(String tags) {
@@ -360,12 +415,19 @@ public class AdvancedSearchViewController {
             return Collections.emptyList();
         }
         List<String> validTagsNames =
-                logClient.listTags().stream().map(Tag::getName).sorted().collect(Collectors.toList());
+                logClient.listTags().stream().map(Tag::getName).sorted().toList();
         List<String> logbooksFromQueryString =
-                Arrays.stream(tags.split(",")).map(s -> s.trim()).collect(Collectors.toList());
-        List<String> validatedLogbookNames =
-                logbooksFromQueryString.stream().filter(logbookName -> validTagsNames.contains(logbookName)).collect(Collectors.toList());
-        return validatedLogbookNames;
+                Arrays.stream(tags.split(",")).map(String::trim).toList();
+        return logbooksFromQueryString.stream().filter(validTagsNames::contains).collect(Collectors.toList());
+    }
+
+    protected List<String> getValidatedLevelsSelection(String levels) {
+        if (Strings.isNullOrEmpty(levels)) {
+            return Collections.emptyList();
+        }
+        List<String> levelsFromQueryString =
+                Arrays.stream(levels.split(",")).map(String::trim).toList();
+        return levelsFromQueryString.stream().filter(levelsList::contains).collect(Collectors.toList());
     }
 
     public SimpleBooleanProperty getSortAscending() {
@@ -378,12 +440,64 @@ public class AdvancedSearchViewController {
         }
     }
 
-    private final ChangeListener<? super String> searchOnTextChange = (options, oldValue, newValue) -> {
-        searchCallback.run();
-    };
+    private final ChangeListener<? super String> searchOnTextChange = (options, oldValue, newValue) -> searchCallback.run();
 
-    private final ChangeListener<? super Boolean> searchOnSortChange = (options, oldValue, newValue) -> {
-        searchCallback.run();
-    };
+    private final ChangeListener<? super Boolean> searchOnSortChange = (options, oldValue, newValue) -> searchCallback.run();
+
+    private void setSelectedLevelsString() {
+        selectedLevelsString.set(levelSelections.stream().filter(LevelSelection::isSelected)
+                .map(LevelSelection::getName).collect(Collectors.joining(",")));
+    }
+
+    @SuppressWarnings("unused")
+    @FXML
+    public void selectLevels() {
+        if (levelsToggleButton.isSelected()) {
+            levelsContextMenu.show(selectedLevelsField, Side.BOTTOM, 0, 0);
+        } else {
+            levelsContextMenu.hide();
+        }
+    }
+
+    /**
+     * Encapsulates data needed to construct the level selection context menu.
+     */
+    private static class LevelSelection {
+        private final String name;
+        private boolean selected;
+
+        public LevelSelection(String name, boolean selected) {
+            this.name = name;
+            this.selected = selected;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean isSelected() {
+            return selected;
+        }
+    }
+
+    /**
+     * Encapsulates items needed to maintain the level selection context menu.
+     */
+    private static class LevelSelectionMenuItem extends CustomMenuItem {
+        private final CheckBox checkBox;
+
+        public LevelSelectionMenuItem(CheckBox checkBox) {
+            super(checkBox);
+            this.checkBox = checkBox;
+        }
+
+        public void setSelected(boolean selected) {
+            checkBox.setSelected(selected);
+        }
+
+        public CheckBox getCheckBox() {
+            return checkBox;
+        }
+    }
 
 }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AdvancedSearchViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AdvancedSearchViewController.java
@@ -180,9 +180,7 @@ public class AdvancedSearchViewController {
         startTime.setOnKeyReleased(this::searchOnEnter);
         endTime.textProperty().bindBidirectional(this.searchParameters.endTimeProperty());
         endTime.setOnKeyReleased(this::searchOnEnter);
-        searchParameters.addListener((observable, oldValue, newValue) -> {
-            updateControls(newValue);
-        });
+        searchParameters.addListener((observable, oldValue, newValue) -> updateControls(newValue));
         sortAscending.addListener(searchOnSortChange);
 
         attachmentTypes.textProperty().bindBidirectional(this.searchParameters.attachmentsProperty());
@@ -318,7 +316,7 @@ public class AdvancedSearchViewController {
             }
         });
 
-        levelsList.addAll(logClient.getLogEntryLevels().stream().map(LogEntryLevel::name).sorted().toList());
+        levelsList.addAll(logClient.listLevels().stream().map(LogEntryLevel::name).sorted().toList());
         levelsList.forEach(level -> {
             LevelSelection levelSelection = new LevelSelection(level, false);
             levelSelections.add(levelSelection);

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -165,7 +165,9 @@ public class LogEntryTableViewController extends LogbookSearchController {
         configureComboBox();
         ologQueries.setAll(ologQueryManager.getQueries());
 
-        searchParameters.addListener((observable, oldValue, newValue) -> query.getEditor().setText(newValue));
+        searchParameters.addListener((observable, oldValue, newValue) -> {
+            query.getEditor().setText(newValue);
+        });
 
         tableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SearchParameters.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SearchParameters.java
@@ -43,7 +43,7 @@ public class SearchParameters implements ObservableValue<String> {
     private SimpleStringProperty title = new SimpleStringProperty();
     private SimpleStringProperty text = new SimpleStringProperty();
     private SimpleStringProperty author = new SimpleStringProperty();
-    private SimpleStringProperty level = new SimpleStringProperty();
+    private SimpleStringProperty levels = new SimpleStringProperty();
     private SimpleStringProperty tags = new SimpleStringProperty();
     private SimpleStringProperty logbooks = new SimpleStringProperty();
     private SimpleStringProperty startTime = new SimpleStringProperty();
@@ -74,7 +74,7 @@ public class SearchParameters implements ObservableValue<String> {
             updateMap(Keys.OWNER, newValue);
             notifyListeners();
         });
-        level.addListener((observable, oldValue, newValue) -> {
+        levels.addListener((observable, oldValue, newValue) -> {
             updateMap(Keys.LEVEL, newValue);
             notifyListeners();
         });
@@ -106,7 +106,7 @@ public class SearchParameters implements ObservableValue<String> {
         } else {
             searchParameters.put(key, newValue);
         }
-        notifyListeners();
+        //notifyListeners();
     }
 
     public void addListener(InvalidationListener listener) {
@@ -149,8 +149,8 @@ public class SearchParameters implements ObservableValue<String> {
         return author;
     }
 
-    public SimpleStringProperty levelProperty() {
-        return level;
+    public SimpleStringProperty levelsProperty() {
+        return levels;
     }
 
     public SimpleStringProperty tagsProperty() {
@@ -203,9 +203,9 @@ public class SearchParameters implements ObservableValue<String> {
             textProperty().setValue(null);
         }
         if (map.containsKey(Keys.LEVEL.getName())) {
-            levelProperty().setValue(map.get(Keys.LEVEL.getName()));
+            levelsProperty().setValue(map.get(Keys.LEVEL.getName()));
         } else {
-            levelProperty().setValue(null);
+            levelsProperty().setValue(null);
         }
         if (map.containsKey(Keys.TAGS.getName())) {
             tagsProperty().setValue(map.get(Keys.TAGS.getName()));

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
@@ -61,6 +61,7 @@ import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.logbook.LogClient;
 import org.phoebus.logbook.LogEntry;
+import org.phoebus.logbook.LogEntryLevel;
 import org.phoebus.logbook.LogFactory;
 import org.phoebus.logbook.LogService;
 import org.phoebus.logbook.LogTemplate;
@@ -824,9 +825,9 @@ public class LogEntryEditorController {
 
             templatesProperty.setAll(logClient.getTemplates().stream().toList());
 
-            Collection<org.phoebus.logbook.Level> levels = logClient.getLevels();
-            availableLevels.setAll(levels.stream().map(org.phoebus.logbook.Level::name).sorted().toList());
-            Optional<org.phoebus.logbook.Level> optionalLevel = levels.stream().filter(org.phoebus.logbook.Level::defaultLevel).findFirst();
+            Collection<LogEntryLevel> levels = logClient.getLogEntryLevels();
+            availableLevels.setAll(levels.stream().map(LogEntryLevel::name).sorted().toList());
+            Optional<LogEntryLevel> optionalLevel = levels.stream().filter(LogEntryLevel::defaultLevel).findFirst();
             String defaultLevel = null;
             if(optionalLevel.isPresent()){
                 // One level value should be the default level
@@ -906,7 +907,7 @@ public class LogEntryEditorController {
      * Loads template to configure UI elements.
      *
      * @param logTemplate A {@link LogTemplate} selected by user. If <code>null</code>, all log entry elements
-     *                    will be cleared, except the Level selector, which will be set to the top-most item.
+     *                    will be cleared, except the LogEntryLevel selector, which will be set to the top-most item.
      */
     private void loadTemplate(LogTemplate logTemplate) {
         if (logTemplate != null) {

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
@@ -341,15 +341,8 @@ public class LogEntryEditorController {
         }
 
         levelLabel.setText(LogbookUIPreferences.level_field_name);
-        // Sites may wish to define a different meaning and name for the "level" field.
-        String[] levelList = org.phoebus.olog.es.api.Preferences.levels;
-        availableLevels.addAll(Arrays.asList(levelList));
         levelSelector.setItems(availableLevels);
-        selectedLevelProperty.set(logEntry.getLevel() != null ? logEntry.getLevel() : availableLevels.get(0));
-
-        levelSelector.getSelectionModel().select(selectedLevelProperty.get());
         dateField.setText(TimestampFormats.DATE_FORMAT.format(Instant.now()));
-
 
         titleField.textProperty().bindBidirectional(titleProperty);
         titleProperty.addListener((changeListener, oldVal, newVal) ->
@@ -830,6 +823,17 @@ public class LogEntryEditorController {
             }
 
             templatesProperty.setAll(logClient.getTemplates().stream().toList());
+
+            Collection<org.phoebus.logbook.Level> levels = logClient.getLevels();
+            availableLevels.setAll(levels.stream().map(org.phoebus.logbook.Level::name).sorted().toList());
+            Optional<org.phoebus.logbook.Level> optionalLevel = levels.stream().filter(org.phoebus.logbook.Level::defaultLevel).findFirst();
+            String defaultLevel = null;
+            if(optionalLevel.isPresent()){
+                // One level value should be the default level
+               defaultLevel = optionalLevel.get().name();
+            }
+            selectedLevelProperty.set(logEntry.getLevel() != null ? logEntry.getLevel() : defaultLevel);
+            levelSelector.getSelectionModel().select(selectedLevelProperty.get());
         });
     }
 

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
@@ -825,7 +825,7 @@ public class LogEntryEditorController {
 
             templatesProperty.setAll(logClient.getTemplates().stream().toList());
 
-            Collection<LogEntryLevel> levels = logClient.getLogEntryLevels();
+            Collection<LogEntryLevel> levels = logClient.listLevels();
             availableLevels.setAll(levels.stream().map(LogEntryLevel::name).sorted().toList());
             Optional<LogEntryLevel> optionalLevel = levels.stream().filter(LogEntryLevel::defaultLevel).findFirst();
             String defaultLevel = null;

--- a/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
+++ b/app/logbook/olog/ui/src/main/resources/log_olog_ui_preferences.properties
@@ -11,7 +11,7 @@ default_logbook_query=desc=*&start=12 hours&end=now
 # Stylesheet for the items in the log calendar view
 calendar_view_item_stylesheet=Agenda.css
 
-# Text to render for the "Level" field of a log entry. Sites may wish to customize this with respect to
+# Text to render for the "LogEntryLevel" field of a log entry. Sites may wish to customize this with respect to
 # its wording and its implied purpose.
 level_field_name=Level:
 

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/AdvancedSearchView.fxml
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/AdvancedSearchView.fxml
@@ -23,10 +23,10 @@
   ~  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
   -->
 
-<AnchorPane fx:id="advancedSearchPane" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.phoebus.logbook.olog.ui.AdvancedSearchViewController">
+<AnchorPane fx:id="advancedSearchPane" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.phoebus.logbook.olog.ui.AdvancedSearchViewController">
 
         <children>
-            <GridPane layoutX="18.0" layoutY="95.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <GridPane fx:id="gridPane" layoutX="18.0" layoutY="95.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                 <columnConstraints>
                     <ColumnConstraints hgrow="NEVER" minWidth="10.0" prefWidth="100.0" />
                     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
@@ -67,7 +67,16 @@
                     <Label text="%Text" GridPane.rowIndex="3" />
                     <TextField fx:id="searchText" GridPane.columnSpan="2" GridPane.rowIndex="4" />
                     <Label fx:id="levelLabel" text="Level:" GridPane.rowIndex="5" />
-                    <ComboBox fx:id="levelSelector" prefWidth="150.0" GridPane.columnSpan="2" GridPane.rowIndex="6" />
+                    <!--<ComboBox fx:id="levelSelector" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.columnSpan="2" GridPane.rowIndex="6" />-->
+                    <HBox maxWidth="1.7976931348623157E308" GridPane.columnSpan="2" GridPane.rowIndex="6">
+                        <children>
+                            <TextField fx:id="selectedLevelsField" editable="false" HBox.hgrow="ALWAYS">
+                     <HBox.margin>
+                        <Insets right="5.0" />
+                     </HBox.margin></TextField>
+                            <ToggleButton fx:id="levelsToggleButton" onAction="#selectLevels" />
+                        </children>
+                    </HBox>
                     <Label text="%Logbooks" GridPane.rowIndex="7" />
                     <TextField fx:id="searchLogbooks" editable="false" GridPane.columnSpan="2" GridPane.rowIndex="8" />
                     <Label text="%Tags" GridPane.rowIndex="9" />

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/AdvancedSearchViewController.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/AdvancedSearchViewController.java
@@ -35,6 +35,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import org.phoebus.logbook.LogClient;
+import org.phoebus.logbook.LogEntryLevel;
 import org.phoebus.logbook.Logbook;
 import org.phoebus.logbook.Tag;
 import org.phoebus.logbook.ui.LogbookQueryUtil.Keys;
@@ -261,7 +262,7 @@ public class AdvancedSearchViewController {
             searchParameters.put(Keys.TITLE, newValue);
         });
 
-        List<String> levelList = logClient.listLevels().stream().collect(Collectors.toList());
+        List<String> levelList = logClient.listLevels().stream().map(LogEntryLevel::name).toList();
         levelSelector.getItems().add("");
         levelSelector.getItems().addAll(levelList);
 

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/write/LogEntryModel.java
@@ -21,6 +21,7 @@ import org.phoebus.logbook.AttachmentImpl;
 import org.phoebus.logbook.LogClient;
 import org.phoebus.logbook.LogEntry;
 import org.phoebus.logbook.LogEntryImpl.LogEntryBuilder;
+import org.phoebus.logbook.LogEntryLevel;
 import org.phoebus.logbook.LogFactory;
 import org.phoebus.logbook.LogService;
 import org.phoebus.logbook.Logbook;
@@ -46,7 +47,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import static org.phoebus.ui.application.PhoebusApplication.logger;
 
@@ -579,7 +579,7 @@ public class LogEntryModel {
             {
                 LogClient logClient = logFactory.getLogClient();
 
-                List<String> levelList = logClient.listLevels().stream().collect(Collectors.toList());
+                List<String> levelList = logClient.listLevels().stream().map(LogEntryLevel::name).toList();
 
                 // Certain views have listeners to these observable lists. So, when they change, the call backs need to execute on the FX Application thread.
                 Platform.runLater(() ->

--- a/app/logbook/ui/src/main/resources/log_ui_preferences.properties
+++ b/app/logbook/ui/src/main/resources/log_ui_preferences.properties
@@ -11,6 +11,6 @@ default_logbook_query=search=*&start=12 hours&end=now
 # Stylesheet for the items in the log calendar view
 calendar_view_item_stylesheet=Agenda.css
 
-# Text to render for the "Level" field of a log entry. Sites may wish to customize this with respect to
+# Text to render for the "LogEntryLevel" field of a log entry. Sites may wish to customize this with respect to
 # its wording and its implied purpose.
 level_field_name=Level:

--- a/core/logbook/src/main/java/org/phoebus/logbook/Level.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/Level.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2025 European Spallation Source ERIC.
+ */
+
+package org.phoebus.logbook;
+
+/**
+ * Encapsulates &quot;level&quot; data managed on the server side.
+ * @param name The name, presented in UI and contained on a log entry
+ * @param defaultLevel Indicates if the instantiated object is the
+ *                     default level. Server will ensure only one single
+ *                     level is maintained as the default level.
+ */
+public record Level(String name, boolean defaultLevel) {
+}

--- a/core/logbook/src/main/java/org/phoebus/logbook/LogClient.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/LogClient.java
@@ -92,11 +92,9 @@ public interface LogClient {
     }
 
     /**
-     * List the supported log levels
-     *
-     * @return a list of supported levels
+     * @return List of {@link LogEntryLevel}s maintained in the service
      */
-    default Collection<String> listLevels() {
+    default Collection<LogEntryLevel> listLevels() {
         return Collections.emptyList();
     }
 
@@ -528,12 +526,5 @@ public interface LogClient {
      */
     default LogTemplate saveTemplate(LogTemplate logTemplate) throws LogbookException{
         return null;
-    }
-
-    /**
-     * @return List of {@link LogEntryLevel}s maintained in the service
-     */
-    default Collection<LogEntryLevel> getLogEntryLevels(){
-        return Collections.emptySet();
     }
 }

--- a/core/logbook/src/main/java/org/phoebus/logbook/LogClient.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/LogClient.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Eric Berryman taken from shroffk
@@ -528,5 +529,9 @@ public interface LogClient {
      */
     default LogTemplate saveTemplate(LogTemplate logTemplate) throws LogbookException{
         return null;
+    }
+
+    default Collection<Level> getLevels(){
+        return Collections.emptySet();
     }
 }

--- a/core/logbook/src/main/java/org/phoebus/logbook/LogClient.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/LogClient.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Eric Berryman taken from shroffk
@@ -531,7 +530,10 @@ public interface LogClient {
         return null;
     }
 
-    default Collection<Level> getLevels(){
+    /**
+     * @return List of {@link LogEntryLevel}s maintained in the service
+     */
+    default Collection<LogEntryLevel> getLogEntryLevels(){
         return Collections.emptySet();
     }
 }

--- a/core/logbook/src/main/java/org/phoebus/logbook/LogEntryLevel.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/LogEntryLevel.java
@@ -11,5 +11,5 @@ package org.phoebus.logbook;
  *                     default level. Server will ensure only one single
  *                     level is maintained as the default level.
  */
-public record Level(String name, boolean defaultLevel) {
+public record LogEntryLevel(String name, boolean defaultLevel) {
 }


### PR DESCRIPTION
The Olog web browser client has already been updated.

Requires Olog backend supporting the ``/levels``` endpoint.