### PR TITLE
Copy snapshot data node ID over in sanitization like for configuration nodes

### DIFF
--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchDAO.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchDAO.java
@@ -671,7 +671,6 @@ public class ElasticsearchDAO implements NodeDAO {
 
     @Override
     public Configuration createConfiguration(String parentNodeId, Configuration configuration) {
-
         ConfigurationData sanitizedConfigurationData = removeDuplicatePVNames(configuration.getConfigurationData());
         configuration.setConfigurationData(sanitizedConfigurationData);
 
@@ -901,6 +900,7 @@ public class ElasticsearchDAO implements NodeDAO {
         SnapshotData sanitizedSnapshotData = new SnapshotData();
         List<SnapshotItem> sanitizedList = new ArrayList<>(sanitizedMap.values());
         sanitizedSnapshotData.setSnapshotItems(sanitizedList);
+        sanitizedSnapshotData.setUniqueId(snapshotData.getUniqueId());
         return sanitizedSnapshotData;
     }
 


### PR DESCRIPTION
While working on the SaR service (and trying to populate it automatically through the REST interface), I ran into the following problem: my snapshots weren't updating properly, and I was getting responses with empty uniqueIds in the snapshotData nodes. It turns out the sanitization step was not copying over the original UUID (which is forced to be the same as the snapshotNode ID), and it was also auto-generating bogus ids in ElasticSearch. I just made sure the UUID is copied over to the sanitzed snapshot data, and it seems to work properly for me now.