### PR TITLE
Add INVALID severity to alarm datasource

### DIFF
--- a/app/alarm/datasource/src/main/java/org/phoebus/pv/alarm/AlarmPV.java
+++ b/app/alarm/datasource/src/main/java/org/phoebus/pv/alarm/AlarmPV.java
@@ -143,6 +143,8 @@ public class AlarmPV extends PV
                     return Alarm.of(AlarmSeverity.MINOR, AlarmStatus.UNDEFINED, state.toString());
                 case MAJOR:
                     return Alarm.of(AlarmSeverity.MAJOR, AlarmStatus.UNDEFINED, state.toString());
+                case INVALID:
+                    return Alarm.of(AlarmSeverity.INVALID, AlarmStatus.UNDEFINED, state.toString());
                 case UNDEFINED:
                     return Alarm.of(AlarmSeverity.UNDEFINED, AlarmStatus.UNDEFINED, state.toString());
                 default:


### PR DESCRIPTION
Right now the alarm datasource doesn't correctly show the severity when the tree is in invalid state:

![Image](https://github.com/user-attachments/assets/fdb55e1a-841b-4239-9b30-59e19fa42e7f)


P.S. We didn't know about this feature until the spring EPICS meeting... it is great!