### PR TITLE
CSSTUDIO-3164 Bugfix: reset 'pv_value' when the PV name changes.

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PVWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/PVWidget.java
@@ -82,6 +82,7 @@ public class PVWidget extends VisibleWidget
     {
         super.defineProperties(properties);
         properties.add(pv_name = propPVName.createProperty(this, ""));
+        pv_name.addPropertyListener((property, oldValue, newValue) -> pv_value.setValue(null));
         properties.add(pv_value = runtimePropPVValue.createProperty(this, null));
         properties.add(alarm_border = propBorderAlarmSensitive.createProperty(this, true));
     }


### PR DESCRIPTION
This pull request fixes a bug that can be reproduced in the following way:

1. Create a TextUpdate widget and connect it to a PV `PV1`.
2. At runtime of the OPI:
    2.a. Change the TextUpdate widget's PV to a non-existent PV `PV2`, causing the TextUpdate widget to display `<PV2>` and a disconnected status.
    2.b. Change the TextUpdate widget's PV back to the original PV `PV1`. Instead of displaying the value of the original PV, the TextUpdate widget now disiplays `<PV2>`. (But it no longer displays the disconnected status.)

The reason for this behavior is an optimization in the class `PropertyChangeHandler`, which doesn't notify listeners if the value of a property remains unchanged:

https://github.com/ControlSystemStudio/phoebus/blob/8ba09238126cf5666067535eed7b250189b4263a/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/PropertyChangeHandler.java#L167-L169

When the PV name was changed in step 2.a above, the property `pv_value` in the class `PVWidget` remained unchanged, since `PV2` didn't exist. In step 2.b, when the PV name was changed back to `PV1`, the optimization in `PropertyChangeHandler` prevented the notification of the TextUpdate widget, and the displayed text was not updated from `<PV2>` to the value of `PV1`.

This pull request adds a `WidgetPropertyListener` to the property `pv_name` that resets the property `pv_value` to `null` whenever `pv_name` is updated.