### PR TITLE
Fix missing context menu for certain controls widgets

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.runtime.app;
 
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propConfirmDialog;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propConfirmDialogOptions;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPassword;
 
 import javafx.collections.ObservableList;
@@ -21,6 +22,7 @@ import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
+import org.csstudio.display.builder.model.properties.ConfirmDialog;
 import org.csstudio.display.builder.model.spi.ActionInfo;
 import org.csstudio.display.builder.representation.ToolkitListener;
 import org.csstudio.display.builder.representation.javafx.widgets.JFXBaseRepresentation;
@@ -134,8 +136,17 @@ class ContextMenuSupport {
         // because in here we would invoke actions without those constraints
         final Optional<WidgetProperty<String>> pass = widget.checkProperty(propPassword);
         final Optional<WidgetProperty<Boolean>> prompt = widget.checkProperty(propConfirmDialog);
+        final Optional<WidgetProperty<ConfirmDialog>> promptOptions = widget.checkProperty(propConfirmDialogOptions);
+        Boolean promptBool = false;
+        if (promptOptions.get().getValue() instanceof ConfirmDialog) {
+            if (((ConfirmDialog) promptOptions.get().getValue()) != ConfirmDialog.NONE) {
+                promptBool = true;
+            }
+        } else {
+            promptBool = prompt.get().getValue();
+        }
         final boolean need_dialog = (pass.isPresent()  &&  !pass.get().getValue().isBlank())  ||
-                                  (prompt.isPresent()  &&   prompt.get().getValue());
+                                  (prompt.isPresent()  &&  promptBool );
 
         if (! need_dialog)
             for (ActionInfo info : widget.propActions().getValue().getActions()) {

--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/ContextMenuSupport.java
@@ -138,12 +138,14 @@ class ContextMenuSupport {
         final Optional<WidgetProperty<Boolean>> prompt = widget.checkProperty(propConfirmDialog);
         final Optional<WidgetProperty<ConfirmDialog>> promptOptions = widget.checkProperty(propConfirmDialogOptions);
         Boolean promptBool = false;
-        if (promptOptions.get().getValue() instanceof ConfirmDialog) {
-            if (((ConfirmDialog) promptOptions.get().getValue()) != ConfirmDialog.NONE) {
-                promptBool = true;
+        if (prompt.isPresent() && promptOptions.isPresent()) {
+            if (promptOptions.get().getValue() instanceof ConfirmDialog) {
+                if (((ConfirmDialog) promptOptions.get().getValue()) != ConfirmDialog.NONE) {
+                    promptBool = true;
+                }
+            } else {
+                promptBool = prompt.get().getValue();
             }
-        } else {
-            promptBool = prompt.get().getValue();
         }
         final boolean need_dialog = (pass.isPresent()  &&  !pass.get().getValue().isBlank())  ||
                                   (prompt.isPresent()  &&  promptBool );


### PR DESCRIPTION
Any widget that uses an 'option' for their Confirmation Dialog (e.g. None, On both, on set, etc) is throwing an exception when you right click to display the context menu. This is because this property value cannot be converted to a Boolean. 

See ISSUE [3407](https://github.com/ControlSystemStudio/phoebus/issues/3407) for full details.

I have fixed this by also obtaining the `propConfirmDialogOptions` property and checking whether it is of type `ConfirmDialog`. If it is then I use logic to convert the enum to a boolean. If it is not then we are in the original case where the Confirmation Dialog is just true/false so we can obtain the value from that. A boolean cannot be converted to a `ConfirmDialog` enum and a `ConfirmDialog` enum cannot be converted to a boolean so I think the only way to check this is to grab both property values.