### PR TITLE
Allow opening folder nodes in SaR

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
@@ -1348,10 +1348,6 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
                 });
                 return;
             }
-            if (node.getNodeType().equals(NodeType.FOLDER)) {
-                logger.log(Level.WARNING, "Requested to open node, but node must not be folder node");
-                return;
-            }
             Stack<Node> copiedStack = new Stack<>();
             Platform.runLater(() -> {
                 DirectoryUtilities.CreateLocationStringAndNodeStack(node, false).getValue().forEach(copiedStack::push);


### PR DESCRIPTION
I am not sure why this check was added, it works just fine (and as I would expect). Basically, I want to be able to navigate to SaR folders from a display file, and not just to a specific configuration / snapshot. Removing this opens the SaR app and expands the selected folder node, and highlights it as well. 