### PR TITLE
Preserve whitespaces on detail log webview

### DIFF
--- a/app/logbook/olog/ui/src/main/resources/detail_log_webview.css
+++ b/app/logbook/olog/ui/src/main/resources/detail_log_webview.css
@@ -42,6 +42,7 @@ blockquote{
 
 p{
     margin-top: 5px;
+    white-space: pre-wrap;
 }
 
 .olog-table {


### PR DESCRIPTION
For PSI Elog, if log is submitted as plain text and retrieved using Phoebus client, whitespaces and newlines in description will be collapsed as single whitespace. 

For example, 
333   | 444   | 555
ccd   | ddd   | eee

will be displayed as,
333 | 444 | 555 ccd | ddd | eee

This PR adds one line CSS style in order to preserve the whitespaces.