### PR TITLE
Wrap Elog plain text inside <p> tag

### DIFF
--- a/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogApi.java
+++ b/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogApi.java
@@ -198,7 +198,13 @@ public class ElogApi {
         attributes.put( data[0], data[1] );
       }
     }
-    attributes.put( "Text", String.join("\n", returned_msg.subList( delimiter_idx + 1, returned_msg.size() ) ) );
+
+    // Wrap text inside <p> tag if Encoding is "plain"
+    String textContent = String.join("\n", returned_msg.subList(delimiter_idx + 1, returned_msg.size()));
+    if( "plain".equalsIgnoreCase(attributes.get("Encoding")) ) {
+        textContent = "<p style=\"white-space: pre-wrap;\">" + textContent + "</p>";
+    }
+    attributes.put("Text", textContent);
 
     return new ElogEntry( attributes, attachments );
   }


### PR DESCRIPTION
It seems that the previous PR https://github.com/ControlSystemStudio/phoebus/pull/3413 affects the behavior of Olog, and the approach is not appropriate. So this PR takes a different approach.

For Elog, there are three kind of encodings as follows,

**plain**
![image](https://github.com/user-attachments/assets/1f751ec5-8313-467a-8081-28039bbf89e0)

**ELCode**
![image](https://github.com/user-attachments/assets/6f3cba98-8010-4138-9fbf-b9b96b44375a)

**HTML**
![image](https://github.com/user-attachments/assets/27888186-d0d1-432b-9829-104c279e22f2)

For `HTML` encoding, the newline is controlled by the `<p>` tag and whitespace by `&nbsp;`, so there is no problem when displayed on Olog UI.

For `plain` encoding, this PR wraps the Elog text inside `<p style="white-space: pre-wrap;"></p>` tag in order to preserve whitespaces.


