### PR TITLE
ISSUE-3368: Fix display/beahviour of 'not_enabled' control widgets

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
@@ -166,9 +166,17 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
             final Button button = new Button();
             button.setOnAction(event -> confirm(() -> handleActions(actions.getActions())));
             result = button;
+            if (actions.getActions().size() == 1) {
+                // If the ActionButton only has a single action and that is to 
+                // write to a PV then is_writePV should be true.
+                // This means that if the PV is non-writable then the
+                // ActionButton will be disabled.
+                if (actions.getActions().get(0).getType().equals("write_pv"))
+                    is_writePV = true;
+            }
         } else {
             // If there is at least one non-WritePVAction then is_writePV should be false
-            is_writePV = !has_non_writePVAction;
+            is_writePV = has_non_writePVAction;
 
             final MenuButton button = new MenuButton();
 
@@ -461,11 +469,7 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
             // Don't disable the widget, because that would also remove the
             // tooltip
             // Just apply a style that matches the disabled look.
-            Styles.update(base, Styles.NOT_ENABLED, !enabled);
-            // Apply the cursor to the pane and not to the button
-            if (!toolkit.isEditMode()) {
-                jfx_node.setCursor(enabled ? Cursor.HAND : Cursors.NO_WRITE);
-            }
+            setDisabledLook(enabled, jfx_node.getChildren());
         }
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
@@ -83,6 +83,7 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<Pane, Boo
     private volatile String value_label;
     private volatile ImageView[] state_images;
     private volatile ImageView value_image;
+    protected volatile boolean enabled = true;
 
     private final UntypedWidgetPropertyListener imagesChangedListener = this::imagesChanged;
     private final UntypedWidgetPropertyListener representationChangedListener = this::representationChanged;
@@ -138,8 +139,10 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<Pane, Boo
      */
     private void handlePress(final boolean pressed)
     {
-        logger.log(Level.FINE, "{0} pressed", model_widget);
-        Platform.runLater(() -> confirm(pressed));
+        if (enabled) {
+            logger.log(Level.FINE, "{0} pressed", model_widget);
+            Platform.runLater(() -> confirm(pressed));
+        }
     }
 
     /** Check for confirmation, then perform the button action
@@ -403,10 +406,9 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<Pane, Boo
         }
         if (dirty_enablement.checkAndClear())
         {
-            final boolean enabled = model_widget.propEnabled().getValue()  &&
+            enabled = model_widget.propEnabled().getValue()  &&
                                     model_widget.runtimePropPVWritable().getValue();
-            button.setDisable(! enabled);
-            Styles.update(button, Styles.NOT_ENABLED, !enabled);
+            setDisabledLook(enabled, jfx_node.getChildren());        
         }
         if (update_value)
         {

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
@@ -229,7 +229,7 @@ public class CheckBoxRepresentation extends RegionBaseRepresentation<CheckBox, C
             // Just apply a style that matches the disabled look.
             enabled = model_widget.propEnabled().getValue() &&
                       model_widget.runtimePropPVWritable().getValue();
-            Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
+            setDisabledLook(enabled, jfx_node.getChildrenUnmodifiable());
             if (model_widget.propAutoSize().getValue())
                 sizeChanged(null, null, null);
         }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ChoiceButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ChoiceButtonRepresentation.java
@@ -181,6 +181,14 @@ public class ChoiceButtonRepresentation extends RegionBaseRepresentation<TilePan
             {
                 active = false;
             }
+        } 
+        else if (!enabled && newval == null) 
+        {
+            // If the choice button is not enabled (no write allowed)
+            // we still have to ensure the 'oldval' stays selected
+            // as otherwise clicking on the same value will set an 
+            // unselected look on the ChoiceButton.
+        	toggle.selectToggle(oldval);
         }
     }
 
@@ -332,8 +340,7 @@ public class ChoiceButtonRepresentation extends RegionBaseRepresentation<TilePan
             // Just apply a style that matches the disabled look.
             enabled = model_widget.propEnabled().getValue() &&
                       model_widget.runtimePropPVWritable().getValue();
-            Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
-            jfx_node.setCursor(enabled ? Cursor.DEFAULT : Cursors.NO_WRITE);
+            setDisabledLook(enabled, jfx_node.getChildren());
             for (Node node : jfx_node.getChildren())
             {
                 final ButtonBase b = (ButtonBase) node;

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
@@ -296,8 +296,7 @@ public class ComboRepresentation extends RegionBaseRepresentation<ComboBox<Strin
             // and the cursor will be ignored
             //  jfx_node.setDisable(! enabled);
             // So keep enabled, but indicate that trying to operate the widget is futile
-            Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
-            jfx_node.setCursor(enabled ? Cursor.DEFAULT : Cursors.NO_WRITE);
+            setDisabledLook(enabled, jfx_node.getChildrenUnmodifiable());
             if (model_widget.propEditable().getValue())
             {
                 jfx_node.getEditor().setEditable(enabled ? model_widget.propEditable().getValue() : false);

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -26,14 +26,17 @@ import org.csstudio.display.builder.model.widgets.GroupWidget;
 import org.csstudio.display.builder.model.widgets.TabsWidget;
 import org.csstudio.display.builder.model.widgets.TabsWidget.TabItemProperty;
 import org.csstudio.display.builder.representation.WidgetRepresentation;
+import org.csstudio.display.builder.representation.javafx.Cursors;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
 
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
+import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import org.phoebus.core.types.ProcessVariable;
 import org.phoebus.ui.dnd.DataFormats;
+import org.phoebus.ui.javafx.Styles;
 
 /** Base class for all JavaFX widget representations
  *  @param <JFX> JFX Widget
@@ -354,6 +357,24 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
             // Cannot use Collections.swap() because it results in an IllegalArgumentException: Children: duplicate children added
             JFXRepresentation.getChildren(parent).remove(jfx_node);
             addToParent(parent);
+        }
+    }
+
+    /**
+     * We do not want to disable widgets if they cannot be written to as this
+     * removes the context menu. Instead we replicate the disabled look from Java FX
+     * and set the cursor to the 'NO_WRITE' cursor to indicate this.
+     * 
+     * @param enabled  boolean as to whether widget interaction is allowed
+     * @param children list of children nodes under the parent widget
+     */
+    public void setDisabledLook(Boolean enabled, ObservableList<Node> children) {
+        jfx_node.setCursor(enabled ? Cursor.DEFAULT : Cursors.NO_WRITE);
+        if (children != null) {
+            for (Node node : children)
+            {
+                Styles.update(node, Styles.NOT_ENABLED, !enabled);
+            }   
         }
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/RadioRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/RadioRepresentation.java
@@ -299,7 +299,7 @@ public class RadioRepresentation extends JFXBaseRepresentation<TilePane, RadioWi
             // Just apply a style that matches the disabled look.
             enabled = model_widget.propEnabled().getValue() &&
                       model_widget.runtimePropPVWritable().getValue();
-            Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
+            setDisabledLook(enabled, jfx_node.getChildren());
             for (Node rb_node : jfx_node.getChildren())
             {
                 final RadioButton rb = (RadioButton) rb_node;

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
@@ -407,8 +407,11 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
     public void updateChanges()
     {
         super.updateChanges();
-        if (dirty_enablement.checkAndClear())
+        if (dirty_enablement.checkAndClear()) {
             slider.setDisable(!enabled);
+            setDisabledLook(enabled, jfx_node.getChildrenUnmodifiable());
+        }
+
         if (dirty_layout.checkAndClear())
         {
             final boolean horizontal = model_widget.propHorizontal().getValue();

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScrollBarRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScrollBarRepresentation.java
@@ -335,8 +335,7 @@ public class ScrollBarRepresentation extends RegionBaseRepresentation<ScrollBar,
             // Don't disable the widget, because that would also remove the
             // context menu etc.
             // Just apply a style that matches the disabled look.
-            Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
-            jfx_node.setCursor(enabled ? Cursor.DEFAULT : Cursors.NO_WRITE);
+            setDisabledLook(enabled, jfx_node.getChildrenUnmodifiable());
         }
         if (dirty_size.checkAndClear())
         {

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
@@ -99,7 +99,7 @@ public class SlideButtonRepresentation extends RegionBaseRepresentation<HBox, Sl
             // Just apply a style that matches the disabled look.
             enabled = model_widget.propEnabled().getValue() && model_widget.runtimePropPVWritable().getValue();
 
-            Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
+            setDisabledLook(enabled, jfx_node.getChildren());
 
             // Since jfx_node.isManaged() == false, need to trigger layout
             jfx_node.layout();

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
@@ -49,6 +49,7 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
      *  but also read when receiving new value
      */
     private boolean active = false;
+    private volatile boolean enabled = true;
 
     private final DirtyFlag dirty_size = new DirtyFlag();
     private final DirtyFlag dirty_style = new DirtyFlag();
@@ -236,35 +237,37 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
     /** Submit value entered by user */
     private void submit()
     {
-        // Strip 'units' etc. from text
-        final String text = jfx_node.getText();
-
-        final Object value = FormatOptionHandler.parse(model_widget.runtimePropValue().getValue(), text,
-                                                       model_widget.propFormat().getValue());
-        logger.log(Level.FINE, "Writing '" + text + "' as " + value + " (" + value.getClass().getName() + ")");
-        toolkit.fireWrite(model_widget, value);
-
-        // Wrote value. Expected is either
-        // a) PV receives that value, PV updates to
-        //    submitted value or maybe a 'clamped' value
-        // --> We'll receive contentChanged() and display PV's latest.
-        // b) PV doesn't receive the value and never sends
-        //    an update. JFX control is stuck with the 'text'
-        //    the user entered, not reflecting the actual PV
-        // --> Request an update to the last known 'value_text'.
-        //
-        // This could result in a little flicker:
-        // User enters "new_value".
-        // We send that, but restore "old_value" to handle case b)
-        // PV finally sends "new_value", and we show that.
-        //
-        // In practice, this rarely happens because we only schedule an update.
-        // By the time it executes, we already have case a.
-        // If it does turn into a problem, could introduce toolkit.scheduleDelayedUpdate()
-        // so that case b) only restores the old 'value_text' after some delay,
-        // increasing the chance of a) to happen.
-        dirty_content.mark();
-        toolkit.scheduleUpdate(this);
+        if (enabled) {
+            // Strip 'units' etc. from text
+            final String text = jfx_node.getText();
+    
+            final Object value = FormatOptionHandler.parse(model_widget.runtimePropValue().getValue(), text,
+                                                           model_widget.propFormat().getValue());
+            logger.log(Level.FINE, "Writing '" + text + "' as " + value + " (" + value.getClass().getName() + ")");
+            toolkit.fireWrite(model_widget, value);
+    
+            // Wrote value. Expected is either
+            // a) PV receives that value, PV updates to
+            //    submitted value or maybe a 'clamped' value
+            // --> We'll receive contentChanged() and display PV's latest.
+            // b) PV doesn't receive the value and never sends
+            //    an update. JFX control is stuck with the 'text'
+            //    the user entered, not reflecting the actual PV
+            // --> Request an update to the last known 'value_text'.
+            //
+            // This could result in a little flicker:
+            // User enters "new_value".
+            // We send that, but restore "old_value" to handle case b)
+            // PV finally sends "new_value", and we show that.
+            //
+            // In practice, this rarely happens because we only schedule an update.
+            // By the time it executes, we already have case a.
+            // If it does turn into a problem, could introduce toolkit.scheduleDelayedUpdate()
+            // so that case b) only restores the old 'value_text' after some delay,
+            // increasing the chance of a) to happen.
+            dirty_content.mark();
+            toolkit.scheduleUpdate(this);
+        }
     }
 
     @Override
@@ -399,14 +402,14 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
             jfx_node.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
 
             // Enable if enabled by user and there's write access
-            final boolean enabled = model_widget.propEnabled().getValue()  &&
+            enabled = model_widget.propEnabled().getValue()  &&
                                     model_widget.runtimePropPVWritable().getValue();
             // Don't disable the widget, because that would also remove the
             // context menu etc.
             // Just apply a style that matches the disabled look.
             jfx_node.setEditable(enabled);
-            Styles.update(jfx_node, Styles.NOT_ENABLED, !enabled);
-            jfx_node.setCursor(enabled ? Cursor.DEFAULT : Cursors.NO_WRITE);
+            setDisabledLook(enabled, jfx_node.getChildrenUnmodifiable());
+
 
             if(jfx_node instanceof TextField){
                 ((TextField)jfx_node).setAlignment(pos);

--- a/app/display/thumbwheel/src/main/java/org/csstudio/display/widget/ThumbwheelWidgetRepresentation.java
+++ b/app/display/thumbwheel/src/main/java/org/csstudio/display/widget/ThumbwheelWidgetRepresentation.java
@@ -109,7 +109,7 @@ public class ThumbwheelWidgetRepresentation extends RegionBaseRepresentation<Thu
     public void updateChanges() {
         super.updateChanges();
         if (dirty_enablement.checkAndClear()) {
-            jfx_node.setDisable(!enabled);
+            setDisabledLook(enabled, jfx_node.getChildren());
         }
         if (dirty_style.checkAndClear()) {
 
@@ -150,7 +150,8 @@ public class ThumbwheelWidgetRepresentation extends RegionBaseRepresentation<Thu
     // decrementing the values via buttons
     private void writeValueToPV(final Number new_value)
     {
-        toolkit.fireWrite(model_widget, new_value);
+        if (enabled)
+            toolkit.fireWrite(model_widget, new_value);
     }
 
     // Value change is triggered when the PV value changes

--- a/core/ui/src/main/resources/org/phoebus/ui/javafx/csstudio.css
+++ b/core/ui/src/main/resources/org/phoebus/ui/javafx/csstudio.css
@@ -17,6 +17,9 @@
 .not_enabled
 {
     -fx-opacity: 0.4;
+    -fx-background-insets: 0;
+    -fx-color: -fx-base;
+    -fx-focus-color: -fx-base;
 }
 
 /** Tracker */


### PR DESCRIPTION
This PR addresses issues that were discovered while testing the 'not_enabled' behaviour of control widgets when relating to a PV which has the 'no-write' property. Please see https://github.com/ControlSystemStudio/phoebus/issues/3368 for a full list of issues and discussion.

Summary of changes:
- I have created a generic method to apply the 'not_enabled' style and mouse cursor that can be called from all control widgets to make the behaviour consistent across widgets (`setDisabledLook(...)`).
- An ActionButton will be shown as 'not_enabled' if it has a single action to write to a no-write PV. This is the only case where this will be true as if an ActionButton has multiple actions then it should still be shown as enabled even if one of those actions is to write to a no-write PV.
- Don't use the .setDisable(true) as this removes the context menu from the widget. 
- Check the `enabled` status before trying to write to a PV to stop exceptions being thrown in the logs.
- Update the `.not_enabled` css class so that widgets do not show hover-over or click color changes when they should look 'disabled' - see video of interactions with a ChoiceButton in issue https://github.com/ControlSystemStudio/phoebus/issues/3368 