### PR TITLE
Add a pref to make symbols with transparent regions clickable

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXPreferences.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXPreferences.java
@@ -22,6 +22,8 @@ public class JFXPreferences
     @Preference public static int tooltip_delay_ms;
     /** Tooltip duration */
     @Preference public static int tooltip_display_sec;
+    /** make the transparent parts of symbols clickable */
+    @Preference public static boolean pick_on_bounds;
 
     static
     {

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -41,6 +41,7 @@ import org.csstudio.display.builder.model.util.ModelResourceUtil;
 import org.csstudio.display.builder.model.util.ModelThreadPool;
 import org.csstudio.display.builder.model.widgets.PVWidget;
 import org.csstudio.display.builder.model.widgets.SymbolWidget;
+import org.csstudio.display.builder.representation.javafx.JFXPreferences;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.csstudio.display.builder.representation.javafx.SVGHelper;
 import org.epics.util.array.ListNumber;
@@ -477,6 +478,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
     private void enableRunActionsOnMouseClick() {
         imageView.focusTraversableProperty().set(true);
         imageView.setStyle("-fx-cursor: hand;");
+        imageView.setPickOnBounds(JFXPreferences.pick_on_bounds);
 
         ColorAdjust[] clickEffect = { null }; // Values are wrapped in arrays as a workaround of the fact that Java doesn't allow non-final variables to be captured by closures.
         DropShadow[] focusEffect = { null };

--- a/app/display/representation-javafx/src/main/resources/jfx_repr_preferences.properties
+++ b/app/display/representation-javafx/src/main/resources/jfx_repr_preferences.properties
@@ -17,3 +17,8 @@ tooltip_display_sec=30
 # Note that for historic reasons tool tips are also influenced
 # by the property `org.csstudio.display.builder.disable_tooltips`.
 # When `true`, tool tips are disabled.
+
+# Determines whether the mouse can interact with the bounds
+# of the symbol widget. If false, interaction is
+# limited to the visible area of the element.
+pick_on_bounds=false


### PR DESCRIPTION
@DenSinH implementing the final conclusion from this PR #3319