### PR TITLE
PVA search monitor column sizing

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/server/PVASearchMonitorMain.java
+++ b/core/pva/src/main/java/org/epics/pva/server/PVASearchMonitorMain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022-2023 Oak Ridge National Laboratory.
+ * Copyright (c) 2022-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -164,14 +164,22 @@ public class PVASearchMonitorMain
                 System.out.println("Run 'pvget QUIT' to stop");
             while (! done.await(update_period, TimeUnit.SECONDS))
             {
-                System.out.println("\nCount Name                 Last Client                                Age");
+                int max_name = 10, max_client = 10;
+                for (SearchInfo info : searches.values())
+                {
+                    max_name   = Math.max(max_name,   info.name.length());
+                    max_client = Math.max(max_client, info.client.toString().length());
+                }
+
+                System.out.format("\nCount %-" + max_name + "s %-" + max_client + "s    Age\n", "Name", "Last Client");
+                final String format = "%5d %-" + max_name + "s %-" + max_client + "s %6d sec\n";
                 final Instant now = Instant.now();
                 searches.values()
                         .stream()
                         .sorted()
                         .forEach(info ->
                 {
-                    System.out.format("%5d %-20s %-35s %6d sec\n",
+                    System.out.format(format,
                                       info.count.get(),
                                       info.name,
                                       info.client.toString(),


### PR DESCRIPTION
PVXS's `CERT:STATUS:...` PVs are quite long.
Auto-size the PV and client columns to keep the table readable