### PR TITLE
PVA: Handle client's connection to server in receive thread

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/common/TCPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -63,10 +62,15 @@ abstract public class TCPHandler
 
     /** TCP socket to PVA peer
      *
+     *  Server got this client socket from `accept`.
+     *  Client needs to create the socket and connect to server's address.
+     *
      *  Reading and writing is handled by receive and send threads,
      *  but 'protected' so that derived classes may peek at socket properties.
+     *
+     *  @see {@link #initializeSocket()}
      */
-    protected final Socket socket;
+    protected Socket socket = null;
 
     /** Flag to indicate that 'close' was called to close the 'socket' */
     protected volatile boolean running = true;
@@ -117,13 +121,11 @@ abstract public class TCPHandler
      *  but will only start sending them when the
      *  send thread is running
      *
-     *  @param socket Socket to read/write
      *  @param client_mode Is this the client, expecting to receive messages from server?
      *  @see #startSender()
      */
-    public TCPHandler(final Socket socket, final boolean client_mode)
+    public TCPHandler(final boolean client_mode)
     {
-        this.socket = Objects.requireNonNull(socket);
         this.client_mode = client_mode;
 
         // Receive buffer byte order is set based on header flag of each received message.
@@ -132,6 +134,13 @@ abstract public class TCPHandler
         // For client, order is updated during connection validation (PVAHeader.CTRL_SET_BYTE_ORDER)
         send_buffer.order(ByteOrder.nativeOrder());
     }
+
+    /** Initialize the {@link #socket}. Called by receiver.
+     *
+     *  Server received socket from `accept` during construction and this may be a NOP.
+     *  Client will have to create socket and connect to server's address in here
+     */
+    abstract protected void initializeSocket() throws Exception;
 
     /** Start receiving data
      *  To be called by Client/ServerTCPHandler when fully constructed
@@ -260,6 +269,8 @@ abstract public class TCPHandler
     {
         try
         {
+            Thread.currentThread().setName("TCP receiver");
+            initializeSocket();
             Thread.currentThread().setName("TCP receiver " + socket.getLocalSocketAddress());
             logger.log(Level.FINER, () -> Thread.currentThread().getName() + " started for " + socket.getRemoteSocketAddress());
             logger.log(Level.FINER, "Native byte order " + receive_buffer.order());

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2023 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,7 +62,9 @@ class ServerTCPHandler extends TCPHandler
 
     public ServerTCPHandler(final PVAServer server, final Socket client, final TLSHandshakeInfo tls_info) throws Exception
     {
-        super(client, false);
+        super(false);
+        // Server received the client socket from `accept`
+        this.socket = Objects.requireNonNull(client);
         this.server = Objects.requireNonNull(server);
         this.tls_info = tls_info;
 
@@ -111,6 +113,12 @@ class ServerTCPHandler extends TCPHandler
 
             buffer.putInt(size_offset, buffer.position() - payload_start);
         });
+    }
+
+    @Override
+    protected void initializeSocket() throws Exception
+    {
+        // Nothing to do, received client socket on construction
     }
 
     PVAServer getServer()

--- a/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/server/ServerTCPHandler.java
@@ -116,9 +116,10 @@ class ServerTCPHandler extends TCPHandler
     }
 
     @Override
-    protected void initializeSocket() throws Exception
+    protected boolean initializeSocket()
     {
         // Nothing to do, received client socket on construction
+        return true;
     }
 
     PVAServer getServer()


### PR DESCRIPTION
Solves the original issue of #3348, #3338 :

The ClientTCPHandler now performs the TCP connection at the start of its receiver thread.
We no longer hang in the TCP connection setup when the ClientTCPHandler is created.
Nor do we need to create a new short-lived thread for the ClientTCPHandler.