### PR TITLE
Add explicit check for response code when downloading attachments for http olog. 

### DIFF
--- a/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
+++ b/app/logbook/olog/client-es/src/main/java/org/phoebus/olog/es/api/OlogHttpClient.java
@@ -469,6 +469,10 @@ public class OlogHttpClient implements LogClient {
                     .GET()
                     .build();
             HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if(response.statusCode() >= 300) {
+                LOGGER.log(Level.WARNING, "failed to obtain attachment: " + new String(response.body().readAllBytes()));
+                return null;
+            }
             return response.body();
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "failed to obtain attachment", e);

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/AttachmentsViewController.java
@@ -278,7 +278,7 @@ public class AttachmentsViewController {
      * @param attachment The image {@link Attachment} selected by user.
      */
     private void showImagePreview(Attachment attachment) {
-        if (attachment.getFile() != null) {
+        if (attachment.getFile() != null && attachment.getFile().exists()) {
             // Load image data off UI thread...
             JobManager.schedule("Show image attachment", monitor -> {
                 try {

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SingleLogEntryDisplayController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/SingleLogEntryDisplayController.java
@@ -33,6 +33,7 @@ import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.ui.web.HyperLinkRedirectListener;
 
 import java.io.File;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.text.MessageFormat;
@@ -260,8 +261,11 @@ public class SingleLogEntryDisplayController extends HtmlAwareController {
 
                 File attachmentFile = new File(attachmentsDirectory, attachment.getId() + fileExtension);
                 if (!attachmentFile.exists()) {
-                    Files.copy(logClient.getAttachment(logEntry.getId(), attachment.getName()), attachmentFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                    attachmentFile.deleteOnExit();
+                    InputStream stream = logClient.getAttachment(logEntry.getId(), attachment.getName());
+                    if(stream != null) {
+                        Files.copy(stream, attachmentFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                        attachmentFile.deleteOnExit();
+                    }
                 }
                 fileAttachment.setFile(attachmentFile);
                 attachmentList.add(fileAttachment);


### PR DESCRIPTION
Currently, the olog http client does not check the response code from the server when downloading attachments, this results in the saved images sometimes containing non image data. This can happen if attachments are deleted from the olog database for example. This pr is an attempt to improve the error handling and logging of this.