### PR TITLE
Add 'in' operator for scan server scripts

### DIFF
--- a/app/scan/model/src/main/java/org/csstudio/scan/command/Comparison.java
+++ b/app/scan/model/src/main/java/org/csstudio/scan/command/Comparison.java
@@ -43,7 +43,13 @@ public enum Comparison
     INCREASE_BY("to increase by"),
 
     /** Value has decreased by some amount */
-    DECREASE_BY("to decrease by");
+    DECREASE_BY("to decrease by"),
+
+    /** (Discrete) value has to be included in some list (only for TextValueConditions) */
+    IN("in"),
+
+    /** (Discrete) value has to NOT be included in some list (only for TextValueConditions) */
+    NOT_IN("not in");
 
     final private String label;
 

--- a/app/scan/model/src/main/java/org/csstudio/scan/command/WaitCommand.java
+++ b/app/scan/model/src/main/java/org/csstudio/scan/command/WaitCommand.java
@@ -195,7 +195,6 @@ public class WaitCommand extends ScanCommand
     public void readXML(final Element element) throws Exception
     {
         setDeviceName(XMLUtil.getChildString(element, ScanCommandProperty.TAG_DEVICE).orElse(""));
-        setDesiredValue(StringOrDouble.parse(XMLUtil.getChildString(element, ScanCommandProperty.TAG_VALUE).orElse("0")));
         try
         {
             setComparison(Comparison.valueOf(XMLUtil.getChildString(element, "comparison").orElse(Comparison.EQUALS.toString())));
@@ -203,6 +202,14 @@ public class WaitCommand extends ScanCommand
         catch (Throwable ex)
         {
             setComparison(Comparison.EQUALS);
+        }
+        if (getComparison() == Comparison.IN || getComparison() == Comparison.NOT_IN) {
+            // don't remove string quotes!
+            // must be parsed later to an array of values using Strings.parseStringList!
+            setDesiredValue(XMLUtil.getChildString(element, ScanCommandProperty.TAG_VALUE).orElse("0"));
+        }
+        else {
+            setDesiredValue(StringOrDouble.parse(XMLUtil.getChildString(element, ScanCommandProperty.TAG_VALUE).orElse("0")));
         }
         setTolerance(XMLUtil.getChildDouble(element, ScanCommandProperty.TAG_TOLERANCE).orElse(0.1));
         setTimeout(XMLUtil.getChildDouble(element, ScanCommandProperty.TAG_TIMEOUT).orElse(0.0));

--- a/core/util/src/main/java/org/phoebus/util/text/Strings.java
+++ b/core/util/src/main/java/org/phoebus/util/text/Strings.java
@@ -1,5 +1,7 @@
 package org.phoebus.util.text;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class Strings {
@@ -16,5 +18,107 @@ public class Strings {
         } else {
             return false;
         }
+    }
+
+    public static List<String> parseStringList(String text) {
+        final List<String> result = new ArrayList<>();
+        if (text == null || text.isEmpty()) {
+            return result;
+        }
+
+        final StringBuilder current = new StringBuilder();
+        Character quote = null;
+
+        for (int i = 0; i < text.length(); i++) {
+            final char c = text.charAt(i);
+
+            if (quote == null) {
+                if (Character.isWhitespace(c) && current.isEmpty()) {
+                    // skip non-quoted whitespace character at the start of unquoted string
+                }
+                else if (c == '\"' || c == '\'') {
+                    // start quoted string, assert that current StringBuilder is empty
+                    if (!current.isEmpty()) {
+                        // string contained non-whitespace, characters so it was of the form
+                        // "input 'start quote', next element"
+                        // which is invalid
+                        throw new RuntimeException("Unexpected quote in non-quoted string: " + current + c);
+                    }
+                    quote = c;
+                }
+                else if (c == ',') {
+                    // end unquoted string, add trimmed value and reset
+                    result.add(current.toString().trim());
+                    current.setLength(0);
+                }
+                else {
+                    // other character, just add to the current value
+                    current.append(c);
+                }
+            }
+            else {
+                if (c == quote) {
+                    // end quoted string, expect whitespace then comma
+                    String elt = current.toString();
+                    result.add(elt);
+                    current.setLength(0);
+
+                    // also reset quote
+                    quote = null;
+
+                    while (true) {
+                        i++;
+                        if (i >= text.length()) {
+                            // end of string, no more elements after this
+                            return result;
+                        }
+                        final char k = text.charAt(i);
+                        if (k == ',') {
+                            // start next element
+                            break;
+                        }
+                        if (Character.isWhitespace(k)) {
+                            // skip whitespace character in search for comma
+                            continue;
+                        }
+                        // non-whitespace, non-comma character, BAD!
+                        throw new RuntimeException(
+                                "Expected whitespace after string list element " + elt + " got " + k
+                        );
+                    }
+                }
+                else if (c == '\\') {
+                    // escaped quote?
+                    // we might want to support more escape sequences
+                    if (i + 1 < text.length() && text.charAt(i + i) == quote) {
+                        current.append(quote);
+                        i++;
+                    }
+                    else {
+                        // just a backslash...
+                        current.append(c);
+                    }
+                }
+                else {
+                    // other character, don't do anything special
+                    current.append(c);
+                }
+            }
+        }
+
+        // last element may still be in here
+        if (!current.isEmpty()) {
+            if (quote != null) {
+                throw new RuntimeException(
+                        "Unexpected end of string while scanning quoted string " + quote + current
+                );
+            }
+            else {
+                // non-quoted, just add trimmed value
+                result.add(current.toString().trim());
+            }
+        }
+
+        return result;
     }
 }

--- a/core/util/src/test/java/org/phoebus/util/text/StringsTest.java
+++ b/core/util/src/test/java/org/phoebus/util/text/StringsTest.java
@@ -18,8 +18,9 @@ package org.phoebus.util.text;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit test for {@link Strings}.
@@ -36,4 +37,35 @@ public class StringsTest {
     assertFalse(Strings.isNullOrEmpty("a"));
   }
 
+  @Test
+  void testParseStringList() {
+    assertEquals(
+            List.of("A", "B", "C"),
+            Strings.parseStringList("A, B, C")
+    );
+    assertEquals(
+            List.of("An apple", "an orange", "banana"),
+            Strings.parseStringList("An apple, an orange, banana")
+    );
+
+    assertEquals(
+            List.of("An apple", "an orange", "banana"),
+            Strings.parseStringList("'An apple', an orange, banana")
+    );
+
+    assertEquals(
+            List.of("INVALID", "ERROR"),
+            Strings.parseStringList("\"INVALID\", \"ERROR\"")
+    );
+
+    assertEquals(
+            List.of("    item with leading and trailing spaces that are not removed    "),
+            Strings.parseStringList("'    item with leading and trailing spaces that are not removed    '")
+    );
+
+    assertEquals(
+            List.of("Hello, Dolly", "Goodbye, cruel world"),
+            Strings.parseStringList("\"Hello, Dolly\", \"Goodbye, cruel world\"")
+    );
+  }
 }

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/condition/TextValueCondition.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/condition/TextValueCondition.java
@@ -16,6 +16,7 @@
 package org.csstudio.scan.server.condition;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 
 import org.csstudio.scan.command.Comparison;
@@ -119,6 +120,12 @@ public class TextValueCondition implements DeviceCondition, DeviceListener
         }
     }
 
+    private boolean containsValue(String value) {
+        return Arrays.stream(desired_value.split(",")).anyMatch(
+                v -> v.strip().equals(value.strip())  // strip input value just to be sure
+        );
+    }
+
     /** Determine if the condition is currently met
      *  @return <code>true</code> if condition is met
      *  @throws Exception on error reading from the device
@@ -140,6 +147,10 @@ public class TextValueCondition implements DeviceCondition, DeviceListener
             return value.compareTo(desired_value) <= 0;
         case BELOW:
             return value.compareTo(desired_value) < 0;
+        case IN:
+            return containsValue(value);
+        case NOT_IN:
+            return !containsValue(value);
         default:
             throw new Error("Condition not implemented for strings: " + comparison);
         }

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/condition/TextValueCondition.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/condition/TextValueCondition.java
@@ -24,6 +24,7 @@ import org.csstudio.scan.server.device.Device;
 import org.csstudio.scan.server.device.DeviceListener;
 
 import org.phoebus.core.vtypes.VTypeHelper;
+import org.phoebus.util.text.Strings;
 
 /** Condition that waits for a Device to reach a certain string value.
  *
@@ -121,8 +122,8 @@ public class TextValueCondition implements DeviceCondition, DeviceListener
     }
 
     private boolean containsValue(String value) {
-        return Arrays.stream(desired_value.split(",")).anyMatch(
-                v -> v.strip().equals(value.strip())  // strip input value just to be sure
+        return Strings.parseStringList(desired_value).stream().anyMatch(
+                v -> v.equals(value) || v.equals(value.strip())  // strip input value just to be sure
         );
     }
 


### PR DESCRIPTION
We want to use the scan server to run some procedures, in which we want to wait for a state (a discrete value) to be any of a specific set of values (or not any of a specific set of values). Since this was not really possible with the scan server as it is now, we decided to implement it. There may be better ways of doing this though, as I am currently not super happy about the comma separated value. Perhaps someone here has a better idea, but I couldn't think of a nicer way of doing this, without implementing a completely new command or causing big changes to the current wait command implementation. Feedback is welcome, but perhaps this is already fine as it is.