### PR TITLE
Add check for HEIC file attachments

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/Messages.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/Messages.java
@@ -40,6 +40,7 @@ public class Messages
             GroupingFailed,
             GroupSelectedEntries,
             JumpToLogEntry,
+            HeicFilesNotSupported,
             Level,
             Logbook,
             LogbookNotSupported,

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/AttachmentsEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/AttachmentsEditorController.java
@@ -291,9 +291,16 @@ public class AttachmentsEditorController {
         this.textArea = textArea;
     }
 
+    /**
+     * Add
+     * @param files
+     */
     private void addFiles(List<File> files) {
         Platform.runLater(() -> sizesErrorMessage.set(null));
         if (!checkFileSizes(files)) {
+            return;
+        }
+        if(!checkForHeicFiles(files)){
             return;
         }
         MimetypesFileTypeMap fileTypeMap = new MimetypesFileTypeMap();
@@ -402,5 +409,32 @@ public class AttachmentsEditorController {
      */
     public void clearAttachments(){
         getAttachments().clear();
+    }
+
+    /**
+     * Checks if any of the attached files uses extension heic or heics, which are unsupported. If a heic file
+     * is detected, an error dialog is shown.
+     * @param files List of {@link File}s to check.
+     * @return <code>true</code> if all is well, i.e. no heic files deyected, otherwise <code>false</code>.
+     */
+    private boolean checkForHeicFiles(List<File> files){
+        if(hasHeicFiles(files)){
+            Alert alert = new Alert(AlertType.ERROR);
+            alert.setHeaderText(Messages.HeicFilesNotSupported);
+            DialogHelper.positionDialog(alert, textArea, -200, -100);
+            alert.show();
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Checks for heic(s) file extension. Ideally Apache Tika should be used to detect heic content.
+     * @param files List of {@link File}s to check.
+     * @return <code>true</code> if all is well, i.e. no heic files deyected, otherwise <code>false</code>.
+     */
+    private boolean hasHeicFiles(List<File> files){
+        return files.stream().filter(f ->
+                (f.getName().toLowerCase().endsWith(".heic") || f.getName().toLowerCase().endsWith(".heics"))).findFirst().isPresent();
     }
 }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/EmbedImageDialogController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/EmbedImageDialogController.java
@@ -45,6 +45,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 import java.util.ResourceBundle;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -55,26 +56,37 @@ import java.util.logging.Logger;
  */
 public class EmbedImageDialogController implements Initializable{
 
+    @SuppressWarnings("unused")
     @FXML
     private DialogPane dialogPane;
+    @SuppressWarnings("unused")
     @FXML
     private Label fileLabel;
+    @SuppressWarnings("unused")
     @FXML
     private Label widthLabel;
+    @SuppressWarnings("unused")
     @FXML
     private Label heightLabel;
+    @SuppressWarnings("unused")
     @FXML
     private Button browseButton;
+    @SuppressWarnings("unused")
     @FXML
     private Button clipboardButton;
+    @SuppressWarnings("unused")
     @FXML
     private TextField fileName;
+    @SuppressWarnings("unused")
     @FXML
     private TextField width;
+    @SuppressWarnings("unused")
     @FXML
     private TextField height;
+    @SuppressWarnings("unused")
     @FXML
     private Label scaleLabel;
+    @SuppressWarnings("unused")
     @FXML
     private TextField scale;
 
@@ -82,22 +94,22 @@ public class EmbedImageDialogController implements Initializable{
      * This is set when image is selected from file or clipboard. It is not bound to
      * a UI component.
      */
-    private IntegerProperty widthProperty = new SimpleIntegerProperty();
+    private final IntegerProperty widthProperty = new SimpleIntegerProperty();
     /**
      * This is the computed width value rendered in the UI component.
      */
-    private IntegerProperty scaledWidthProperty = new SimpleIntegerProperty();
+    private final IntegerProperty scaledWidthProperty = new SimpleIntegerProperty();
     /**
      * This is set when image is selected from file or clipboard. It is not bound to
      * a UI component.
      */
-    private IntegerProperty heightProperty = new SimpleIntegerProperty();
+    private final IntegerProperty heightProperty = new SimpleIntegerProperty();
     /**
      * This is the computed width value rendered in the UI component.
      */
-    private IntegerProperty scaledHeightProperty = new SimpleIntegerProperty();
-    private SimpleStringProperty filenameProperty = new SimpleStringProperty();
-    private DoubleProperty scaleProperty = new SimpleDoubleProperty(1.0);
+    private final IntegerProperty scaledHeightProperty = new SimpleIntegerProperty();
+    private final SimpleStringProperty filenameProperty = new SimpleStringProperty();
+    private final DoubleProperty scaleProperty = new SimpleDoubleProperty(1.0);
 
     private String id;
 
@@ -127,13 +139,14 @@ public class EmbedImageDialogController implements Initializable{
         dialogPane.lookupButton(ButtonType.OK).disableProperty().bind(okButtonBinding);
     }
 
+    @SuppressWarnings("unused")
     @FXML
     public void browse(){
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle(Messages.SelectFile);
         fileChooser.getExtensionFilters().addAll(
-                new FileChooser.ExtensionFilter("Image files (jpg, png, gif)", "*.jpg", "*.png", "*.gif"),
-                new FileChooser.ExtensionFilter("All files", "*.*")
+                new FileChooser.ExtensionFilter("Image files (jpg, jpeg, png, gif)", "*.jpg", "*.jpeg", "*.png", "*.gif")
+
         );
 
         File file = fileChooser.showOpenDialog(dialogPane.getScene().getWindow());
@@ -152,6 +165,7 @@ public class EmbedImageDialogController implements Initializable{
         }
     }
 
+    @SuppressWarnings("unused")
     @FXML
     public void pasteClipboard(){
         image = Clipboard.getSystemClipboard().getImage();

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/messages.properties
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/messages.properties
@@ -57,6 +57,7 @@ HitsPerPage=Hits per page:
 ImageWidth=Width
 ImageHeight=Height
 JumpToLogEntry=Jump to Log Entry: 
+HeicFilesNotSupported=HEIC file attachments not supported
 Level=Level
 Logbook=Logbook
 Logbooks=Logbooks:


### PR DESCRIPTION
HEIC may be the default iOS file format for images. We have seen users attaching such files to Olog, but since HEIC is not supported in JavaFX, and only in Safari browser, it makes sense to disallow HEIC attachments.

This PR adds a check on file extension. If HEIC file is encountered, the attach file(s) operation aborts with an error dialog:

![Screenshot 2025-07-04 at 14 19 31](https://github.com/user-attachments/assets/cedf006e-6fe9-4c43-937d-90124cb8d132)

On the Olog service side a similar check will be added. 

HEIC to JPG conversion has been evaluated as an option. Only to find that it is not: needs either third party app (ImageMagic) or a closed source lib at $1600 per/year.