### PR TITLE
CSSTUDIO-3270 Add Layout: Move existing instance of DisplayRuntime to the layout that is added.

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
+++ b/core/ui/src/main/java/org/phoebus/ui/internal/MementoHelper.java
@@ -309,6 +309,7 @@ public class MementoHelper
                     instance = existing.getApplication();
                     existing.getDockPane().getTabs().remove(existing);
                     pane.getTabs().add(existing);
+                    existing.select();
                 }
                 else {
                     instance = ((AppResourceDescriptor) app).create(inputURI);


### PR DESCRIPTION
This pull request implements the functionality that "Add Layout" locates existing instances of running OPIs, and if it finds them, it moves the existing instance to the layout that is added. Before this pull request, if an OPI in a layout was already loaded when adding the layout, the OPI would not be included in the added layout.

The motivation for the change is that when adding a layout, one intuitively expects the full layout to be loaded as specified. The functionality is limited to `DisplayRuntime` since it covers the majority of use cases.