### PR TITLE
CSSTUDIO-3336 Bugfix: Remove logging of warning when 'resource_name' is not a URL and clarify comment.

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/util/ModelResourceUtil.java
@@ -304,8 +304,7 @@ public class ModelResourceUtil
         return null;
     }
 
-    /** Check if a resource doesn't just look like a URL
-     *  but can actually be opened
+    /** Check if a resource can be opened as a URL
      *  @param resource_name Path to resource, presumably "http://.."
      *  @return <code>true</code> if indeed an exiting URL
      */
@@ -327,7 +326,6 @@ public class ModelResourceUtil
         }
 
         if (! isURL(resource_name)) {
-            logger.log(Level.WARNING, "URL {0} is not a URL", new Object[] { resource_name });
             return false;
         }
 


### PR DESCRIPTION
This pull request removes the logging of the warning when `resource_name` is not a URL in the function `canOpenUrl()`. It also clarifies the comment describing the function `canOpenUrl()`.

The logging of this warning was introduced in the pull request https://github.com/ControlSystemStudio/phoebus/pull/3246. It logs a warning when a resource is not a URL. However, `canOpenUrl()` is called in the function `doResolveResource()` in order to determine _whether_ a given resource is specified as a URL or not, and it is not an error if it is not a URL. If the resource is not a URL, `canOpenUrl()` returns `false`, and an attempt is made to load the given resource as a file instead.

If the resource is also not a file path, then the function `doResolveResource()` logs a warning of the form `"<resource> is not resolved"`.