### PR TITLE
CSSTUDIO-3341 (1) Bugfix: fix zooming (2) Improve zooming: avoid hiding of OPI-elements behind scrollbars

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -461,7 +461,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
      */
     private double setZoom(final double zoom)
     {
-        final double zoom_to_set;
+        final double zoomToSet;
         if (zoom <= 0.0)
         {   // Determine zoom to fit outline of display into available space.
             // In order to determine the actual bounds within which an OPI
@@ -475,8 +475,8 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
             double hHcrollbarHeight = 0.0;
             {
                 List<ScrollBar> scrollbars = model_root.lookupAll(".scroll-bar").stream().filter(node -> node instanceof ScrollBar).map(node -> (ScrollBar) node).collect(Collectors.toUnmodifiableList());
-                List<ScrollBar> model_root_scrollbars = scrollbars.stream().filter(scrollbar -> scrollbar.getParent() == model_root).collect(Collectors.toUnmodifiableList());
-                for (ScrollBar scrollBar : model_root_scrollbars) {
+                List<ScrollBar> modelRootScrollbars = scrollbars.stream().filter(scrollbar -> scrollbar.getParent() == model_root).collect(Collectors.toUnmodifiableList());
+                for (ScrollBar scrollBar : modelRootScrollbars) {
                     if (scrollBar.getOrientation() == Orientation.HORIZONTAL) {
                         hScrollbarVisible = scrollBar.isVisible();
                         hHcrollbarHeight = scrollBar.getLayoutBounds().getHeight();
@@ -498,10 +498,10 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
                     Math.max(0.0, viewportBounds.getWidth() - (vScrollbarVisible ? 0.0 : vScrollbarWidth)),
                     Math.max(0.0, viewportBounds.getHeight() - (hScrollbarVisible ? 0.0 : hHcrollbarHeight)));
 
-            final double zoom_x_with_scrollbars_rounded;
-            final double zoom_x_without_scrollbars_rounded;
-            final double zoom_y_with_scrollbars_rounded;
-            final double zoom_y_without_scrollbars_rounded;
+            final double zoomXWithScrollbarsRounded;
+            final double zoomXWithoutScrollbarsRounded;
+            final double zoomYWithScrollbarsRounded;
+            final double zoomYWithoutScrollbarsRounded;
 
             {
                 final Bounds outline = widget_pane.getLayoutBounds();
@@ -514,84 +514,84 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
                 // to zoom 'in'.
                 // This requires displays to be created with
                 // correct width/height properties.
-                final double zoom_x_without_scrollbars, zoom_y_without_scrollbars;
-                final double zoom_x_with_scrollbars, zoom_y_with_scrollbars;
+                final double zoomXWithoutScrollbars, zoomYWithoutScrollbars;
+                final double zoomXWithScrollbars, zoomYWithScrollbars;
                 if (outline.getWidth() > layoutBoundsWithScrollbars.getWidth()) {
-                    zoom_x_without_scrollbars = layoutBoundsWithoutScrollbars.getWidth() / outline.getWidth();
-                    zoom_x_with_scrollbars = layoutBoundsWithScrollbars.getWidth() / outline.getWidth();
+                    zoomXWithoutScrollbars = layoutBoundsWithoutScrollbars.getWidth() / outline.getWidth();
+                    zoomXWithScrollbars = layoutBoundsWithScrollbars.getWidth() / outline.getWidth();
                 }
                 else if (model.propWidth().getValue() > 0) {
-                    zoom_x_without_scrollbars = layoutBoundsWithoutScrollbars.getWidth() / model.propWidth().getValue();
-                    zoom_x_with_scrollbars = layoutBoundsWithScrollbars.getWidth() / model.propWidth().getValue();
+                    zoomXWithoutScrollbars = layoutBoundsWithoutScrollbars.getWidth() / model.propWidth().getValue();
+                    zoomXWithScrollbars = layoutBoundsWithScrollbars.getWidth() / model.propWidth().getValue();
                 }
                 else {
-                    zoom_x_without_scrollbars = 1.0;
-                    zoom_x_with_scrollbars = 1.0;
+                    zoomXWithoutScrollbars = 1.0;
+                    zoomXWithScrollbars = 1.0;
                 }
 
                 if (outline.getHeight() > layoutBoundsWithScrollbars.getHeight()) {
-                    zoom_y_without_scrollbars = layoutBoundsWithoutScrollbars.getHeight() / outline.getHeight();
-                    zoom_y_with_scrollbars = layoutBoundsWithScrollbars.getHeight() / outline.getHeight();
+                    zoomYWithoutScrollbars = layoutBoundsWithoutScrollbars.getHeight() / outline.getHeight();
+                    zoomYWithScrollbars = layoutBoundsWithScrollbars.getHeight() / outline.getHeight();
                 }
                 else if (model.propHeight().getValue() > 0) {
-                    zoom_y_without_scrollbars =layoutBoundsWithoutScrollbars.getHeight() / model.propHeight().getValue();
-                    zoom_y_with_scrollbars = layoutBoundsWithScrollbars.getHeight() / model.propHeight().getValue();
+                    zoomYWithoutScrollbars =layoutBoundsWithoutScrollbars.getHeight() / model.propHeight().getValue();
+                    zoomYWithScrollbars = layoutBoundsWithScrollbars.getHeight() / model.propHeight().getValue();
                 }
                 else {
-                    zoom_y_without_scrollbars = 1.0;
-                    zoom_y_with_scrollbars = 1.0;
+                    zoomYWithoutScrollbars = 1.0;
+                    zoomYWithScrollbars = 1.0;
                 }
 
                 // Round down the zoom-level in order to avoid situations where the
                 // zoom-level is instead being rounded up, causing a scrollbar to
                 // be displayed when a scrollbar is not needed.
-                zoom_x_with_scrollbars_rounded = Math.floor(zoom_x_with_scrollbars * 1000.0) / 1000.0;
-                zoom_x_without_scrollbars_rounded = Math.floor(zoom_x_without_scrollbars * 1000.0) / 1000.0;
-                zoom_y_with_scrollbars_rounded = Math.floor(zoom_y_with_scrollbars * 1000.0) / 1000.0;
-                zoom_y_without_scrollbars_rounded = Math.floor(zoom_y_without_scrollbars * 1000.0) / 1000.0;
+                zoomXWithScrollbarsRounded = Math.floor(zoomXWithScrollbars * 1000.0) / 1000.0;
+                zoomXWithoutScrollbarsRounded = Math.floor(zoomXWithoutScrollbars * 1000.0) / 1000.0;
+                zoomYWithScrollbarsRounded = Math.floor(zoomYWithScrollbars * 1000.0) / 1000.0;
+                zoomYWithoutScrollbarsRounded = Math.floor(zoomYWithoutScrollbars * 1000.0) / 1000.0;
             }
 
             if (zoom == ZOOM_WIDTH) {
-                if (zoom_x_without_scrollbars_rounded * model.propHeight().getValue() > layoutBoundsWithoutScrollbars.getHeight()) {
-                    // Setting zoom_to_set to 'zoom_x_without_scrollbars_rounded'
+                if (zoomXWithoutScrollbarsRounded * model.propHeight().getValue() > layoutBoundsWithoutScrollbars.getHeight()) {
+                    // Setting zoomToSet to 'zoomXWithoutScrollbarsRounded'
                     // would result in the horizontal scrollbar being shown.
-                    // Therefore, set zoom_to_set = zoom_x_with_scrollbars_rounded
-                    zoom_to_set = zoom_x_with_scrollbars_rounded;
+                    // Therefore, set zoomToSet = zoomXWithScrollbarsRounded
+                    zoomToSet = zoomXWithScrollbarsRounded;
                 }
                 else {
-                    zoom_to_set = zoom_x_without_scrollbars_rounded;
+                    zoomToSet = zoomXWithoutScrollbarsRounded;
                 }
             }
             else if (zoom == ZOOM_HEIGHT) {
-                if (zoom_y_without_scrollbars_rounded * model.propWidth().getValue() > layoutBoundsWithoutScrollbars.getWidth()) {
-                    // Setting zoom_to_set to 'zoom_y_without_scrollbars_rounded'
+                if (zoomYWithoutScrollbarsRounded * model.propWidth().getValue() > layoutBoundsWithoutScrollbars.getWidth()) {
+                    // Setting zoomToSet to 'zoomYWithoutScrollbarsRounded'
                     // would result in the vertical scrollbar being shown.
-                    // Therefore, set zoom_to_set = zoom_y_with_scrollbars_rounded:
-                    zoom_to_set = zoom_y_with_scrollbars_rounded;
+                    // Therefore, set zoomToSet = zoomYWithScrollbarsRounded:
+                    zoomToSet = zoomYWithScrollbarsRounded;
                 }
                 else {
-                    zoom_to_set = zoom_y_without_scrollbars_rounded;
+                    zoomToSet = zoomYWithoutScrollbarsRounded;
                 }
             }
             else {
                 // Assume ZOOM_ALL
-                if (zoom_y_without_scrollbars_rounded * model.propWidth().getValue() > layoutBoundsWithoutScrollbars.getWidth() ||
-                        zoom_x_without_scrollbars_rounded * model.propHeight().getValue() > layoutBoundsWithoutScrollbars.getHeight()) {
-                    // Setting zoom_to_set to 'Math.min(zoom_x_without_scrollbars_rounded, zoom_y_with_scrollbars_rounded)'
+                if (zoomYWithoutScrollbarsRounded * model.propWidth().getValue() > layoutBoundsWithoutScrollbars.getWidth() ||
+                        zoomXWithoutScrollbarsRounded * model.propHeight().getValue() > layoutBoundsWithoutScrollbars.getHeight()) {
+                    // Setting zoomToSet to 'Math.min(zoomXWithoutScrollbarsRounded, zoomYWithScrollbarsRounded)'
                     // would result in at least either the vertical or the horizontal scrollbar being shown.
-                    // Therefore, set zoom_to_set = Math.min(zoom_x_without_scrollbars_rounded, zoom_y_without_scrollbars_rounded):
-                    zoom_to_set = Math.min(zoom_x_with_scrollbars_rounded, zoom_y_with_scrollbars_rounded); // Assume ZOOM_ALL
+                    // Therefore, set zoomToSet = Math.min(zoomXWithoutScrollbarsRounded, zoomYWithoutScrollbarsRounded):
+                    zoomToSet = Math.min(zoomXWithScrollbarsRounded, zoomYWithScrollbarsRounded); // Assume ZOOM_ALL
                 }
                 else {
-                    zoom_to_set = Math.min(zoom_x_without_scrollbars_rounded, zoom_y_without_scrollbars_rounded);
+                    zoomToSet = Math.min(zoomXWithoutScrollbarsRounded, zoomYWithoutScrollbarsRounded);
                 }
             }
         }
         else {
-            zoom_to_set = zoom;
+            zoomToSet = zoom;
         }
 
-        widget_pane.getTransforms().setAll(new Scale(zoom_to_set, zoom_to_set));
+        widget_pane.getTransforms().setAll(new Scale(zoomToSet, zoomToSet));
         // Appears similar to using this API:
         //     widget_parent.setScaleX(zoom);
         //     widget_parent.setScaleY(zoom);
@@ -605,7 +605,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         if (isEditMode())
             updateModelSizeIndicators();
 
-        return zoom_to_set;
+        return zoomToSet;
     }
 
     /** @return Zoom factor, 1.0 for 1:1 */


### PR DESCRIPTION
This pull request contains one bugfix and one improvement:

1. The bugfix fixes the zooming issue described in https://github.com/ControlSystemStudio/phoebus/pull/3193#issuecomment-3083347202. This bugfix is implemented in the (1-line) commit https://github.com/ControlSystemStudio/phoebus/commit/f96efe1740b0542f297bb6153436c6e3eeb5797c. I am not sure that the bugfix is "correct" or not (since I do not understand the changes in https://github.com/ControlSystemStudio/phoebus/pull/3193), but it looks to me that https://github.com/ControlSystemStudio/phoebus/pull/3193 added `widget_pane` and that operations that were previously done through methods on `widget_parent` were changed to be done through methods on `widget_pane` instead, and therefore it seems plausible that the fix is "correct".
2. The improvement concerns the behavior of zooming using `WIDTH`, `HEIGHT`, and `ALL`, and fixes an issue where sometimes OPI UI-elements would be hidden behind scrollbars. With this improvement, they should no longer be hidden behind a scrollbar. I think the solution works well in general; please note, however, that in some corner cases, there may be a small gap between the edge of the zoomed-in OPI and the side of the window. The improvement is implemented in the commit https://github.com/ControlSystemStudio/phoebus/commit/253f1a0a2fbbb498aff6936bf378726552d3138a.