### PR TITLE
Implement dynamic window title management based on active dock tabs

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXStageRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXStageRepresentation.java
@@ -49,7 +49,6 @@ public class JFXStageRepresentation extends JFXRepresentation
     public Parent configureStage(final DisplayModel model, final Consumer<DisplayModel> close_request_handler)
     {
         final String name = model.getDisplayName();
-        stage.setTitle(name);
 
         //  The following trick is necessary because keys cannot be longer than 80 characters.
         final String hexName = Integer.toHexString(name.hashCode()).toLowerCase();

--- a/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/Messages.java
@@ -184,6 +184,7 @@ public class Messages
     public static String WebBrowser;
     public static String Welcome;
     public static String Window;
+    public static String WindowTitleFormat;
 
     static
     {

--- a/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/PhoebusApplication.java
@@ -80,11 +80,7 @@ import org.phoebus.ui.application.MenuEntryService.MenuTreeNode;
 import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.dialog.ListPickerDialog;
 import org.phoebus.ui.dialog.OpenFileDialog;
-import org.phoebus.ui.docking.DockItem;
-import org.phoebus.ui.docking.DockItemWithInput;
-import org.phoebus.ui.docking.DockPane;
-import org.phoebus.ui.docking.DockPaneListener;
-import org.phoebus.ui.docking.DockStage;
+import org.phoebus.ui.docking.*;
 import org.phoebus.ui.help.OpenAbout;
 import org.phoebus.ui.help.OpenHelp;
 import org.phoebus.ui.internal.MementoHelper;
@@ -546,6 +542,8 @@ public class PhoebusApplication extends Application {
             // .. but schedule preparation to close
             closeMainStage();
         });
+
+        StageTitleManager.bindStageTitlesToActiveTabs(main_stage);
 
         DockPane.addListener(dock_pane_listener);
         DockPane.setActiveDockPane(DockStage.getDockPanes(main_stage).get(0));

--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockStage.java
@@ -164,7 +164,6 @@ public class DockStage
 
         final Scene scene = new Scene(layout, geometry.width, geometry.height);
         stage.setScene(scene);
-        stage.setTitle(Messages.FixedTitle);
         // Set position
         stage.setX(geometry.x);
         stage.setY(geometry.y);

--- a/core/ui/src/main/java/org/phoebus/ui/docking/StageTitleManager.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/StageTitleManager.java
@@ -1,0 +1,68 @@
+package org.phoebus.ui.docking;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.StringExpression;
+import javafx.stage.Stage;
+import org.phoebus.ui.application.Messages;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Helper class to manage the window title.
+ */
+public class StageTitleManager {
+
+    private static final DockPaneListener listener = StageTitleManager::setStageTitleToTabTitle;
+
+    // This class is only a static utility, so it should not be instantiated.
+    private StageTitleManager() {}
+
+    public static void bindStageTitlesToActiveTabs(Stage mainStage) {
+        // this will listen to all tab focus events and set the stage title
+        // of the stage in which the tab is located to the formatted title.
+        DockPane.addListener(listener);
+
+        // This listener is passed down to all child panes when a split occurs,
+        // so it fires when any pane in the main stage becomes empty.
+        // Therefore, we have to check if all panes are empty.
+        DockStage.getDockPanes(mainStage).get(0).addDockPaneEmptyListener(() -> {
+            List<DockPane> panes = DockStage.getDockPanes(mainStage);
+            for (DockPane pane : panes) {
+                if (!pane.getDockItems().isEmpty()) {
+                    // If any pane has items, we don't need to set the title to default
+                    return;
+                }
+            }
+            // If all panes are empty, set the stage title to the default
+            mainStage.titleProperty().unbind();
+            setStageTitleToDefault(mainStage);
+        });
+    }
+
+    private static void setStageTitleToTabTitle(DockItem dockItem) {
+        if (dockItem == null) {
+            return;
+        }
+        DockPane pane = dockItem.getDockPane();
+        // I don't think this is ever true,
+        // but better to have it and not need it than the other way around
+        if (pane == null) {
+            return;
+        }
+        pane.deferUntilInScene(scene -> {
+            if (scene.getWindow() instanceof Stage stage) {
+                if (DockPane.getActiveDockPane() != pane) {
+                    // If the dock pane is not active, don't do anything
+                    return;
+                }
+                StringExpression exp = Bindings.format(Messages.WindowTitleFormat, dockItem.labelTextProperty());
+                stage.titleProperty().bind(exp);
+            }
+        });
+    }
+
+    private static void setStageTitleToDefault(Stage stage) {
+        stage.setTitle(Messages.FixedTitle);
+    }
+}

--- a/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
+++ b/core/ui/src/main/resources/org/phoebus/ui/application/messages.properties
@@ -170,3 +170,4 @@ UnsavedChanges_wouldYouLikeToSaveAnyChangesBeforeReplacingTheLayout=Would you li
 WebBrowser=Web Browser
 Welcome=Welcome
 Window=Window
+WindowTitleFormat=CS-Studio: %s

--- a/core/ui/src/main/resources/org/phoebus/ui/application/messages_fr.properties
+++ b/core/ui/src/main/resources/org/phoebus/ui/application/messages_fr.properties
@@ -168,3 +168,4 @@ UnsavedChanges_wouldYouLikeToSaveAnyChangesBeforeReplacingTheLayout=Voulez-vous 
 WebBrowser=Navigateur Web
 Welcome=Bienvenue
 Window=Fen\u00EAtre
+WindowTitleFormat=CS-Studio: %s


### PR DESCRIPTION
As discussed, this pull request resolves #3480.

It adds a class that sets up listeners that listen to to tab focus events, which update the window title to include the focused tab. 
The format of the window title is configurable with the message resource `WindowTitleFormat=CS-Studio: %s`, with %s being replaced by the active tab name. In the edge case where the main window has no active tabs, it falls back to `FixedTitle`. 

It also slightly improves the logic determining which panel is currently active when splitting and merging them, as before it could lead to situations where a tab that no longer existed would still be deemed the "active tab".