### PR TITLE
CSSTUDIO-3374 Set border of `model_root` in Display Editor when it is focused directly using CSS

### DIFF
--- a/app/display/editor/src/main/java/org/csstudio/display/builder/editor/DisplayEditor.java
+++ b/app/display/editor/src/main/java/org/csstudio/display/builder/editor/DisplayEditor.java
@@ -199,7 +199,7 @@ public class DisplayEditor
     public Parent create ()
     {
         model_root = toolkit.createModelRoot();
-        model_root.getStyleClass().add("widget_pane_unfocused");
+        model_root.getStyleClass().add("widget_pane");
         autoScrollHandler = new AutoScrollHandler(model_root);
 
         final Group scroll_body = (Group) model_root.getContent();
@@ -225,13 +225,6 @@ public class DisplayEditor
         setSnap(prefs.getBoolean(SNAP_WIDGETS, true));
         setCoords(prefs.getBoolean(SHOW_COORDS, true));
 
-        model_root.focusedProperty().addListener((observableValue, aBoolean, focused) -> {
-            if (focused) {
-                model_root.getStyleClass().add("widget_pane_focused");
-            } else {
-                model_root.getStyleClass().remove("widget_pane_focused");
-            }
-        });
         return root;
     }
 

--- a/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/opieditor.css
+++ b/app/display/editor/src/main/resources/org/csstudio/display/builder/editor/opieditor.css
@@ -180,11 +180,11 @@
 	-fx-snap-to-pixel: false
 }
 
-.widget_pane_unfocused{
+.widget_pane{
     -fx-border-color: #F4F4F4;
 }
 
-.widget_pane_focused{
+.widget_pane:focused{
     -fx-border-color: #00A0D8;
 }
 


### PR DESCRIPTION
This pull request implements the setting of the blue border when Display Editor is focused directly using CSS instead of using an event handler to manually add and remove a style class.

The background for this pull request is that I am currently developing a new widget for Phoebus that displays a Waterfall Plot. When selecting an instance of the new Waterfall Plot Widget and then clicks on the background of the OPI (so that `model_root` is selected), the CPU usage goes constantly to over 100%. Through debugging, I have concluded that the cause is the event handler on `model_root` that adds and removes the CSS style class that sets the border of `model_root` in order to indicate that it is selected.

This pull request removes the event handler and replaces it with a CSS implementation of `widget_pane:focused`. I think this is an improvement over the implementation using an event handler, while it at the same time solves the performance issue I encounter.