### PR TITLE
CSSTUDIO-3364 Bugfix: Restore Zoom-level when restoring a layout.

### DIFF
--- a/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
+++ b/app/display/runtime/src/main/java/org/csstudio/display/builder/runtime/app/DisplayRuntimeInstance.java
@@ -249,8 +249,10 @@ public class DisplayRuntimeInstance implements AppInstance
                 //
                 // Run this inside Platform.runLater(), since
                 // the constructor of ZoomAction also sets the zoom-
-                // level (to 100%) using Platform.runLater().
-                // When restoring an instance of Display Runtime,
+                // level (to the value set by the option
+                // 'default_zoom_factor', which by default is set
+                // to 100%) using Platform.runLater(). When
+                // restoring an instance of Display Runtime,
                 // DisplayRuntime.restore() is called _after_
                 // the constructor of ZoomAction is called and
                 // Platform.runLater() preserves the relative


### PR DESCRIPTION
This pull request fixes a bug introduced by https://github.com/ControlSystemStudio/phoebus/pull/3369: when restoring a layout (using either the "Load Layout" or the "Add Layout" functionality), the zoom-level would not be set to the saved value.