### PR TITLE
Fix no_write cursor not showing for multi-line TextEntry widget

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
@@ -9,6 +9,7 @@ package org.csstudio.display.builder.representation.javafx.widgets;
 
 import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -51,6 +52,8 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
      */
     private boolean active = false;
     private volatile boolean enabled = true;
+    private static final String NODE_ID = UUID.randomUUID().toString();;
+
 
     private final DirtyFlag dirty_size = new DirtyFlag();
     private final DirtyFlag dirty_style = new DirtyFlag();
@@ -101,6 +104,7 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
             text = new TextField();
         text.setMinSize(Region.USE_PREF_SIZE, Region.USE_PREF_SIZE);
         text.getStyleClass().add("text_entry");
+        text.setId(NODE_ID);
 
         if (! toolkit.isEditMode())
         {
@@ -425,6 +429,12 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
                 String alignment = model_widget.propHorizontalAlignment().getValue().toString().toLowerCase();
                 PseudoClass alignmentClass = PseudoClass.getPseudoClass(alignment);
                 jfx_node.pseudoClassStateChanged(alignmentClass, true);
+                
+                if (jfx_node.getScene() != null) {
+                    // Need to get the TextArea 'content' node to set the cursor
+                    // for the whole widget otherwise it will only show on the borders.
+                    jfx_node.getScene().lookup("#"+NODE_ID+" .content").setCursor(Cursors.NO_WRITE);
+                }
             }
         }
         if (! active)


### PR DESCRIPTION
PR to fix the case where a disabled `TextEntry` widget with 'multi-line' enabled does not show the 'no-write' cursor over the whole widget - see https://github.com/ControlSystemStudio/phoebus/issues/3502.

A fix for this is to set the cursor for the `TextArea` `content` node. To do this I have set a unique ID for each text entry widget and use this to get the content node from the scene and then set the cursor on that node. 