### PR TITLE
Support delta value sorting on string PVs

### DIFF
--- a/app/save-and-restore/util/src/main/java/org/phoebus/saveandrestore/util/Utilities.java
+++ b/app/save-and-restore/util/src/main/java/org/phoebus/saveandrestore/util/Utilities.java
@@ -663,11 +663,10 @@ public final class Utilities {
             int diff = b == null ? (c == null ? 0 : 1) : (c == null ? -1 : b.compareTo(c));
             return new VTypeComparison(str, diff, diff == 0);
         } else if (value instanceof VString && baseValue instanceof VString) {
-            String str = valueToString(value);
             String b = ((VString) value).getValue();
             String c = ((VString) baseValue).getValue();
             int diff = b == null ? (c == null ? 0 : 1) : (c == null ? -1 : b.compareTo(c));
-            return new VTypeComparison(str, diff, diff == 0);
+            return new VTypeComparison(b, diff,diff == 0, Math.abs(diff));
         } else if (value instanceof VNumberArray && baseValue instanceof VNumberArray) {
             String sb = valueToString(value);
             boolean equal = areValuesEqual(value, baseValue, Optional.empty());
@@ -873,11 +872,10 @@ public final class Utilities {
             int diff = b == null ? (c == null ? 0 : 1) : (c == null ? -1 : b.compareTo(c));
             return new VTypeComparison(str, diff, diff == 0);
         } else if (value instanceof VString && baseValue instanceof VString) {
-            String str = valueToString(value);
             String b = ((VString) value).getValue();
             String c = ((VString) baseValue).getValue();
             int diff = b == null ? (c == null ? 0 : 1) : (c == null ? -1 : b.compareTo(c));
-            return new VTypeComparison(str, diff, diff == 0);
+            return new VTypeComparison(b, diff, diff == 0, Math.abs(diff));
         } else if (value instanceof VNumberArray && baseValue instanceof VNumberArray) {
             boolean equal = areValuesEqual(value, baseValue, Optional.empty());
             return new VTypeComparison(equal ? "---" : "NOT EQUAL", equal ? 0 : 1, equal);

--- a/app/save-and-restore/util/src/test/java/org/phoebus/saveandrestore/util/UtilitiesTest.java
+++ b/app/save-and-restore/util/src/test/java/org/phoebus/saveandrestore/util/UtilitiesTest.java
@@ -702,7 +702,8 @@ public class UtilitiesTest {
         assertEquals("a", result.getString());
         assertTrue(result.getValuesEqual() < 0);
         assertFalse(result.isWithinThreshold());
-        assertEquals(0, result.getAbsoluteDelta(), 0.0);
+        int delta = ((VString) val1).getValue().compareTo(((VString) val2).getValue());
+        assertEquals(Math.abs(delta), result.getAbsoluteDelta(), 0.0);
     }
 
     /**


### PR DESCRIPTION
In the save&restore snapshot view, the delta columns supported sorting only on numeric scalar types. Deltas on string PVs where evaluated as zero diff even though they were treated as non-equal.

This PR enhances sorting to consider deltas for string scalar types. 