### PR TITLE
Update table cell rendering in snapshot view

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -51,6 +51,7 @@ import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 import javafx.util.converter.DoubleStringConverter;
 import org.epics.vtype.Alarm;
+import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.Display;
 import org.epics.vtype.Time;
 import org.epics.vtype.VEnum;
@@ -272,6 +273,12 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
     protected TableColumn<TableEntry, ?> baseSnapshotColumn;
 
     @FXML
+    private TableColumn<TableEntry, AlarmSeverity> storedSeverityColumn;
+
+    @FXML
+    private TableColumn<TableEntry, AlarmSeverity> liveSeverityColumn;
+
+    @FXML
     protected TooltipTableColumn<VType> baseSnapshotValueColumn;
 
     @FXML
@@ -357,7 +364,6 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
     }
 
 
-
     @FXML
     public void initialize() {
 
@@ -396,7 +402,7 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
 
         saveSnapshotButton.disableProperty().bind(Bindings.createBooleanBinding(() ->
                         // TODO: support save (=update) a composite snapshot from the snapshot view. In the meanwhile, disable save button.
-                                snapshotDataDirty.not().get() ||
+                        snapshotDataDirty.not().get() ||
                                 snapshotNameProperty.isEmpty().get() ||
                                 snapshotCommentProperty.isEmpty().get() ||
                                 userIdentity.isNull().get(),
@@ -468,7 +474,7 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
 
         showLiveReadbackButton.setGraphic(new ImageView(new Image(getClass().getResourceAsStream("/icons/show_live_readback_column.png"))));
         showLiveReadbackButton.selectedProperty()
-                .addListener((a, o, n) ->{
+                .addListener((a, o, n) -> {
                     this.showReadbacks.set(n);
                     actionResultReadbackColumn.visibleProperty().setValue(actionResultReadbackColumn.getGraphic() != null);
                 });
@@ -668,6 +674,9 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
         storedReadbackColumn.setCellFactory(e -> new VTypeCellEditor<>());
         readbackColumn.visibleProperty().bind(showReadbacks);
 
+        liveSeverityColumn.setCellFactory(a -> new AlarmSeverityCell());
+        storedSeverityColumn.setCellFactory(a -> new AlarmSeverityCell());
+
         timeColumn.visibleProperty().bind(compareViewEnabled.not());
         firstDividerColumn.visibleProperty().bind(compareViewEnabled);
         statusColumn.visibleProperty().bind(compareViewEnabled.not());
@@ -763,7 +772,7 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
      * Restores snapshot meta-data properties to indicate that the UI
      * is not showing persisted {@link Snapshot} data.
      */
-    private void resetMetaData(){
+    private void resetMetaData() {
         tabTitleProperty.setValue(Messages.unnamedSnapshot);
         snapshotNameProperty.setValue(null);
         snapshotCommentProperty.setValue(null);
@@ -1141,7 +1150,7 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
                 break;
             }
         }
-        for(SnapshotItem snapshotItem : snapshotItems){
+        for (SnapshotItem snapshotItem : snapshotItems) {
             if (snapshotItem.getConfigPv().getReadbackPvName() != null && snapshotItem.getReadbackValue() != null &&
                     snapshotItem.getReadbackValue().equals(VDisconnectedData.INSTANCE)) {
                 disconnectedReadbackPvEncountered.set(true);
@@ -1155,7 +1164,7 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
             if (!disconnectedPvEncountered.get()) {
                 actionResultColumn.setGraphic(new ImageView(ImageCache.getImage(SnapshotController.class, "/icons/ok.png")));
             }
-            if(!disconnectedReadbackPvEncountered.get()){
+            if (!disconnectedReadbackPvEncountered.get()) {
                 actionResultReadbackColumn.setGraphic(new ImageView(ImageCache.getImage(SnapshotController.class, "/icons/ok.png")));
             }
         });
@@ -1329,8 +1338,7 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
         Platform.runLater(() -> {
             if (!disconnectedPvEncountered.get()) {
                 actionResultColumn.setGraphic(new ImageView(ImageCache.getImage(SnapshotController.class, "/icons/ok.png")));
-            }
-            else{
+            } else {
                 actionResultColumn.setGraphic(new ImageView(ImageCache.getImage(SnapshotController.class, "/icons/error.png")));
             }
         });
@@ -1508,15 +1516,13 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
             tableEntry.setStoredReadbackValue(entry.getReadbackValue(), 0);
             if (entry.getValue() == null || entry.getValue().equals(VDisconnectedData.INSTANCE)) {
                 tableEntry.setActionResult(ActionResult.FAILED);
-            }
-            else {
+            } else {
                 tableEntry.setActionResult(ActionResult.OK);
             }
-            if (entry.getConfigPv().getReadbackPvName() != null){
-                if(entry.getReadbackValue() == null || entry.getReadbackValue().equals(VDisconnectedData.INSTANCE)) {
+            if (entry.getConfigPv().getReadbackPvName() != null) {
+                if (entry.getReadbackValue() == null || entry.getReadbackValue().equals(VDisconnectedData.INSTANCE)) {
                     tableEntry.setActionResultReadback(ActionResult.FAILED);
-                }
-                else{
+                } else {
                     tableEntry.setActionResultReadback(ActionResult.OK);
                 }
             }
@@ -1590,22 +1596,20 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
     }
 
     /**
-     *
      * @param configurationData {@link ConfigurationData} obejct of a {@link org.phoebus.applications.saveandrestore.model.Configuration}
      * @return <code>true</code> if any if the {@link ConfigPv} items in {@link ConfigurationData#getPvList()} defines a non-null read-back
      * PV name, otherwise <code>false</code>.
      */
-    private boolean configurationHasReadbackPvs(ConfigurationData configurationData){
+    private boolean configurationHasReadbackPvs(ConfigurationData configurationData) {
         return configurationData.getPvList().stream().anyMatch(cp -> cp.getReadbackPvName() != null);
     }
 
     /**
-     *
      * @param snapshotData {@link SnapshotData} obejct of a {@link org.phoebus.applications.saveandrestore.model.Snapshot}
      * @return <code>true</code> if any if the {@link ConfigPv} items in {@link SnapshotData#getSnapshotItems()} defines a non-null read-back
      * PV name, otherwise <code>false</code>.
      */
-    private boolean configurationHasReadbackPvs(SnapshotData snapshotData){
+    private boolean configurationHasReadbackPvs(SnapshotData snapshotData) {
         return snapshotData.getSnapshotItems().stream().anyMatch(si -> si.getConfigPv().getReadbackPvName() != null);
     }
 
@@ -1658,6 +1662,34 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
                             setGraphic(new ImageView(ImageCache.getImage(SnapshotController.class, "/icons/error.png")));
                 }
             }
+        }
+    }
+
+    /**
+     * {@link TableCell} customized for the alarm severity column such that alarm information is
+     * decorated in the same manner as in other applications.
+     */
+    private static class AlarmSeverityCell extends TableCell<TableEntry, AlarmSeverity> {
+
+        @Override
+        public void updateItem(AlarmSeverity alarmSeverity, boolean empty) {
+            if (empty) {
+                setText(null);
+                setStyle(TableCellColors.REGULAR_CELL_STYLE);
+            } else if (alarmSeverity == null) {
+                setText("---");
+                setStyle(TableCellColors.REGULAR_CELL_STYLE);
+            } else {
+                setText(alarmSeverity.toString());
+                switch (alarmSeverity) {
+                    case NONE -> setStyle(TableCellColors.ALARM_NONE_STYLE);
+                    case UNDEFINED -> setStyle(TableCellColors.ALARM_UNDEFINED_STYLE);
+                    case MINOR -> setStyle(TableCellColors.ALARM_MINOR_STYLE);
+                    case MAJOR -> setStyle(TableCellColors.ALARM_MAJOR_STYLE);
+                    case INVALID -> setStyle(TableCellColors.ALARM_INVALID_STYLE);
+                }
+            }
+
         }
     }
 }

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/TableCellColors.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/TableCellColors.java
@@ -5,7 +5,6 @@
 package org.phoebus.applications.saveandrestore.ui.snapshot;
 
 import javafx.scene.paint.Color;
-import javafx.scene.paint.Paint;
 import org.phoebus.ui.Preferences;
 import org.phoebus.ui.javafx.Brightness;
 import org.phoebus.ui.javafx.JFXUtil;
@@ -16,34 +15,111 @@ import org.phoebus.ui.javafx.JFXUtil;
  */
 public class TableCellColors {
 
-    public static final Color DISCONNECTED_COLOR = Color.rgb(Preferences.undefined_severity_background_color[0],
+    private static final Color DISCONNECTED_COLOR = Color.rgb(Preferences.undefined_severity_background_color[0],
             Preferences.undefined_severity_background_color[1],
             Preferences.undefined_severity_background_color[2]);
+    private static final Color ALARM_NONE_COLOR = Color.rgb(Preferences.alarm_area_panel_ok_severity_background_color[0],
+            Preferences.alarm_area_panel_ok_severity_background_color[1],
+            Preferences.alarm_area_panel_ok_severity_background_color[2]);
+    private static final Color ALARM_MINOR_COLOR = Color.rgb(Preferences.alarm_area_panel_minor_severity_background_color[0],
+            Preferences.alarm_area_panel_minor_severity_background_color[1],
+            Preferences.alarm_area_panel_minor_severity_background_color[2]);
+    private static final Color ALARM_MAJOR_COLOR = Color.rgb(Preferences.alarm_area_panel_major_severity_background_color[0],
+            Preferences.alarm_area_panel_major_severity_background_color[1],
+            Preferences.alarm_area_panel_major_severity_background_color[2]);
+    private static final Color ALARM_UNDEFINED_COLOR = Color.rgb(Preferences.alarm_area_panel_undefined_severity_background_color[0],
+            Preferences.alarm_area_panel_major_severity_background_color[1],
+            Preferences.alarm_area_panel_major_severity_background_color[2]);
+    private static final Color ALARM_INVALID_COLOR = Color.rgb(Preferences.alarm_area_panel_invalid_severity_background_color[0],
+            Preferences.alarm_area_panel_invalid_severity_background_color[1],
+            Preferences.alarm_area_panel_invalid_severity_background_color[2]);
 
-    public static final Paint DISCONNECTED_PAINT;
     private static final Color DISCONNECTED_TEXT_COLOR;
-    private static final Color DISCONNECTED_BORDER_COLOR;
+    private static final Color ALARM_NONE_TEXT_COLOR;
+    private static final Color ALARM_MINOR_TEXT_COLOR;
+    private static final Color ALARM_MAJOR_TEXT_COLOR;
+    private static final Color ALARM_UNDEFINED_TEXT_COLOR;
+    private static final Color ALARM_INVALID_TEXT_COLOR;
     public static final String REGULAR_CELL_STYLE = "-fx-text-fill: black;  -fx-background-color: transparent";
     public static final String DISCONNECTED_STYLE;
-    public static final String DISCONNECTED_STYLE_SMALL;
+    public static final String ALARM_NONE_STYLE;
+    public static final String ALARM_MINOR_STYLE;
+    public static final String ALARM_MAJOR_STYLE;
+    public static final String ALARM_UNDEFINED_STYLE;
+    public static final String ALARM_INVALID_STYLE;
 
     static {
-        DISCONNECTED_PAINT = Paint.valueOf(JFXUtil.webRGB(DISCONNECTED_COLOR));
         if (Brightness.of(DISCONNECTED_COLOR) < Brightness.BRIGHT_THRESHOLD) {
             DISCONNECTED_TEXT_COLOR = Color.WHITE;
-            DISCONNECTED_BORDER_COLOR = Color.WHITE;
-        } else {
+        }
+        else {
             DISCONNECTED_TEXT_COLOR = Color.BLACK;
-            DISCONNECTED_BORDER_COLOR = Color.GRAY;
+        }
+
+        if(Brightness.of(ALARM_NONE_COLOR) < Brightness.BRIGHT_THRESHOLD){
+            ALARM_NONE_TEXT_COLOR = Color.WHITE;
+        }
+        else{
+            ALARM_NONE_TEXT_COLOR = Color.BLACK;
+        }
+
+        if(Brightness.of(ALARM_MINOR_COLOR) < Brightness.BRIGHT_THRESHOLD){
+            ALARM_MINOR_TEXT_COLOR = Color.WHITE;
+        }
+        else{
+            ALARM_MINOR_TEXT_COLOR = Color.BLACK;
+        }
+
+        if(Brightness.of(ALARM_MAJOR_COLOR) < Brightness.BRIGHT_THRESHOLD){
+            ALARM_MAJOR_TEXT_COLOR = Color.WHITE;
+        }
+        else{
+            ALARM_MAJOR_TEXT_COLOR = Color.BLACK;
+        }
+
+        if(Brightness.of(ALARM_UNDEFINED_COLOR) < Brightness.BRIGHT_THRESHOLD){
+            ALARM_UNDEFINED_TEXT_COLOR = Color.WHITE;
+        }
+        else{
+            ALARM_UNDEFINED_TEXT_COLOR = Color.BLACK;
+        }
+
+        if(Brightness.of(ALARM_INVALID_COLOR) < Brightness.BRIGHT_THRESHOLD){
+            ALARM_INVALID_TEXT_COLOR = Color.WHITE;
+        }
+        else{
+            ALARM_INVALID_TEXT_COLOR = Color.BLACK;
         }
 
 
-        DISCONNECTED_STYLE = "-fx-border-color: transparent; -fx-border-width: 2 0 2 0; -fx-background-insets: 2 0 2 0; -fx-text-fill: " +
+        DISCONNECTED_STYLE = "-fx-background-insets: 2 2 2 2; -fx-text-fill: " +
                 JFXUtil.webRGB(DISCONNECTED_TEXT_COLOR) +
                 ";  -fx-background-color: " +
                 JFXUtil.webRGB(DISCONNECTED_COLOR);
-        DISCONNECTED_STYLE_SMALL = "-fx-border-color: " + JFXUtil.webRGB(DISCONNECTED_BORDER_COLOR) +"; -fx-border-width: 2 2 2 2;" +
-                " -fx-background-color: " +
-                JFXUtil.webRGB(DISCONNECTED_COLOR);
+
+        ALARM_NONE_STYLE = "-fx-background-insets: 2 2 2 2; -fx-text-fill: " +
+                JFXUtil.webRGB(ALARM_NONE_TEXT_COLOR) +
+                ";  -fx-background-color: " +
+                JFXUtil.webRGB(ALARM_NONE_COLOR);
+
+        ALARM_MINOR_STYLE = "-fx-background-insets: 2 2 2 2; -fx-text-fill: " +
+                JFXUtil.webRGB(ALARM_MINOR_TEXT_COLOR) +
+                ";  -fx-background-color: " +
+                JFXUtil.webRGB(ALARM_MINOR_COLOR);
+
+        ALARM_MAJOR_STYLE = "-fx-background-insets: 2 2 2 2; -fx-text-fill: " +
+                JFXUtil.webRGB(ALARM_MAJOR_TEXT_COLOR) +
+                ";  -fx-background-color: " +
+                JFXUtil.webRGB(ALARM_MAJOR_COLOR);
+
+        ALARM_UNDEFINED_STYLE = "-fx-background-insets: 2 2 2 2; -fx-text-fill: " +
+                JFXUtil.webRGB(ALARM_UNDEFINED_TEXT_COLOR) +
+                ";  -fx-background-color: " +
+                JFXUtil.webRGB(ALARM_UNDEFINED_COLOR);
+
+        ALARM_INVALID_STYLE = "-fx-background-insets: 2 2 2 2; -fx-text-fill: " +
+                JFXUtil.webRGB(ALARM_INVALID_TEXT_COLOR) +
+                ";  -fx-background-color: " +
+                JFXUtil.webRGB(ALARM_INVALID_COLOR);
     }
 }

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/TableEntry.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/TableEntry.java
@@ -61,8 +61,8 @@ public class TableEntry {
     private final ObjectProperty<Instant> timestamp = new SimpleObjectProperty<>(this, "timestamp");
     private final StringProperty liveStatus = new SimpleStringProperty(this, "liveStatus", "---");
     private final StringProperty storedStatus = new SimpleStringProperty(this, "storedStatus", PVAAlarm.AlarmStatus.UNDEFINED.name());
-    private final StringProperty liveSeverity = new SimpleStringProperty(this, "liveSeverity", "---");
-    private final StringProperty storedSeverity = new SimpleStringProperty(this, "storedSeverity", AlarmSeverity.UNDEFINED.toString());
+    private final ObjectProperty<AlarmSeverity> liveSeverity = new SimpleObjectProperty<>(this, "liveSeverity", null);
+    private final ObjectProperty<AlarmSeverity> storedSeverity = new SimpleObjectProperty<>(this, "storedSeverity", null);
     /**
      * Snapshot value set either when user takes snapshot, or when snapshot data is loaded from remote service. Note that this
      * can be modified if user chooses to use a multiplier before triggering a restore operation, or if the value is
@@ -185,7 +185,7 @@ public class TableEntry {
      * @return the property providing the alarm severity of the PV value
      */
     @SuppressWarnings("unused")
-    public StringProperty liveSeverityProperty() {
+    public ObjectProperty<AlarmSeverity> liveSeverityProperty() {
         return liveSeverity;
     }
 
@@ -254,7 +254,7 @@ public class TableEntry {
     }
 
     @SuppressWarnings("unused")
-    public StringProperty storedSeverityProperty() {
+    public ObjectProperty<AlarmSeverity> storedSeverityProperty() {
         return storedSeverity;
     }
 
@@ -294,27 +294,27 @@ public class TableEntry {
         if (index == 0) {
             if (val instanceof VNumber) {
                 storedStatus.set(((VNumber) val).getAlarm().getStatus().name());
-                storedSeverity.set(((VNumber) val).getAlarm().getSeverity().toString());
+                storedSeverity.set(((VNumber) val).getAlarm().getSeverity());
                 timestamp.set(((VNumber) val).getTime().getTimestamp());
             } else if (val instanceof VNumberArray) {
                 storedStatus.set(((VNumberArray) val).getAlarm().getStatus().name());
-                storedSeverity.set(((VNumberArray) val).getAlarm().getSeverity().toString());
+                storedSeverity.set(((VNumberArray) val).getAlarm().getSeverity());
                 timestamp.set(((VNumberArray) val).getTime().getTimestamp());
             } else if (val instanceof VEnum) {
                 storedStatus.set(((VEnum) val).getAlarm().getStatus().name());
-                storedSeverity.set(((VEnum) val).getAlarm().getSeverity().toString());
+                storedSeverity.set(((VEnum) val).getAlarm().getSeverity());
                 timestamp.set(((VEnum) val).getTime().getTimestamp());
             } else if (val instanceof VEnumArray) {
                 storedStatus.set(((VEnumArray) val).getAlarm().getStatus().name());
-                storedSeverity.set(((VEnumArray) val).getAlarm().getSeverity().toString());
+                storedSeverity.set(((VEnumArray) val).getAlarm().getSeverity());
                 timestamp.set(((VEnumArray) val).getTime().getTimestamp());
             } else if (val instanceof VNoData) {
                 storedStatus.set("---");
-                storedSeverity.set("---");
+                storedSeverity.set(null);
                 timestamp.set(null);
             } else {
                 storedStatus.set(AlarmSeverity.NONE.toString());
-                storedSeverity.set("---");
+                storedSeverity.set(null);
                 timestamp.set(null);
             }
             snapshotVal.set(val);
@@ -388,26 +388,26 @@ public class TableEntry {
         liveStoredEqual.set(Utilities.areValuesEqual(val, stored, threshold));
         if (val instanceof VNumber) {
             liveStatus.set(((VNumber) val).getAlarm().getStatus().name());
-            liveSeverity.set(((VNumber) val).getAlarm().getSeverity().toString());
+            liveSeverity.set(((VNumber) val).getAlarm().getSeverity());
             timestamp.set(((VNumber) val).getTime().getTimestamp());
         } else if (val instanceof VNumberArray) {
             liveStatus.set(((VNumberArray) val).getAlarm().getStatus().name());
-            liveSeverity.set(((VNumberArray) val).getAlarm().getSeverity().toString());
+            liveSeverity.set(((VNumberArray) val).getAlarm().getSeverity());
             timestamp.set(((VNumberArray) val).getTime().getTimestamp());
         } else if (val instanceof VEnum) {
             liveStatus.set(((VEnum) val).getAlarm().getStatus().name());
-            liveSeverity.set(((VEnum) val).getAlarm().getSeverity().toString());
+            liveSeverity.set(((VEnum) val).getAlarm().getSeverity());
             timestamp.set(((VEnum) val).getTime().getTimestamp());
         } else if (val instanceof VEnumArray) {
             liveStatus.set(((VEnumArray) val).getAlarm().getStatus().name());
-            liveSeverity.set(((VEnumArray) val).getAlarm().getSeverity().toString());
+            liveSeverity.set(((VEnumArray) val).getAlarm().getSeverity());
             timestamp.set(((VEnumArray) val).getTime().getTimestamp());
         } else if (val instanceof VDisconnectedData) {
-            liveSeverity.set("---");
+            liveSeverity.set(AlarmSeverity.UNDEFINED);
             liveStatus.set("---");
             timestamp.set(null);
         } else {
-            liveSeverity.set(AlarmSeverity.NONE.toString());
+            liveSeverity.set(null);
             liveStatus.set("---");
             timestamp.set(null);
         }

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/VDeltaCellEditor.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/VDeltaCellEditor.java
@@ -19,19 +19,11 @@
 
 package org.phoebus.applications.saveandrestore.ui.snapshot;
 
-import javafx.geometry.Insets;
 import javafx.scene.control.Tooltip;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.scene.layout.Background;
-import javafx.scene.layout.BackgroundFill;
-import javafx.scene.layout.CornerRadii;
-import javafx.scene.paint.Color;
-import org.phoebus.saveandrestore.util.Utilities;
-import org.phoebus.saveandrestore.util.VNoData;
 import org.phoebus.applications.saveandrestore.ui.VTypePair;
 import org.phoebus.core.vtypes.VDisconnectedData;
-import org.phoebus.ui.Preferences;
+import org.phoebus.saveandrestore.util.Utilities;
+import org.phoebus.saveandrestore.util.VNoData;
 
 import java.util.Formatter;
 
@@ -44,8 +36,6 @@ import java.util.Formatter;
  */
 public class VDeltaCellEditor<T> extends VTypeCellEditor<T> {
 
-    private static final Image WARNING_IMAGE = new Image(
-            SnapshotController.class.getResourceAsStream("/icons/hprio_tsk.png"));
     private final Tooltip tooltip = new Tooltip();
 
     private boolean showDeltaPercentage = false;
@@ -92,10 +82,9 @@ public class VDeltaCellEditor<T> extends VTypeCellEditor<T> {
                         setText(vtc.getString());
                     }
                     if (!vtc.isWithinThreshold()) {
-                        setGraphic(new ImageView(WARNING_IMAGE));
+                        setStyle(TableCellColors.ALARM_MAJOR_STYLE);
                     }
                 }
-
                 tooltip.setText(item.toString());
                 setTooltip(tooltip);
             }

--- a/app/save-and-restore/app/src/main/resources/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotView.fxml
+++ b/app/save-and-restore/app/src/main/resources/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotView.fxml
@@ -232,12 +232,12 @@ save-and-restore UI, this fxml does not make use of TabPane and Tab elements.
 
                     <TableColumn fx:id="severityColumn" minWidth="140.0" prefWidth="200.0" sortable="false" styleClass="snapshot-table-centered" text="%tableColumnAlarmSeverity">
                         <columns>
-                            <TooltipTableColumn labelText="%tableColumnStored" minWidth="70.0" prefWidth="100.0" styleClass="snapshot-table-left-aligned" tooltip="%toolTipTableColumnStoredAlarmSeverity">
+                            <TooltipTableColumn fx:id="storedSeverityColumn" labelText="%tableColumnStored" minWidth="70.0" prefWidth="100.0" styleClass="snapshot-table-left-aligned" tooltip="%toolTipTableColumnStoredAlarmSeverity">
                                 <cellValueFactory>
                                     <PropertyValueFactory property="storedSeverity" />
                                 </cellValueFactory>
                             </TooltipTableColumn>
-                            <TooltipTableColumn labelText="%tableColumnLive" minWidth="70.0" prefWidth="100.0" styleClass="snapshot-table-left-aligned" tooltip="%toolTipTableColumnLiveAlarmSeverity">
+                            <TooltipTableColumn fx:id="liveSeverityColumn" labelText="%tableColumnLive" minWidth="70.0" prefWidth="100.0" styleClass="snapshot-table-left-aligned" tooltip="%toolTipTableColumnLiveAlarmSeverity">
                                 <cellValueFactory>
                                     <PropertyValueFactory property="liveSeverity" />
                                 </cellValueFactory>


### PR DESCRIPTION
As per user request:

Exclamation mark icon in delta column of the save&restore snapshot view considered insufficient, colored background preferred, so changed to same color as major alarm color (icon removed).

Also: update the columns related to alarm severity to use same colors as alarm related information in other applications.

NOTE: in most cases (?) live (and stored) alarm severity should be NONE (=green background) for all rows. At the same time, when looking at a saved snapshot, the delta column may show many rows with a non-zero delta. The table then becomes very colorful. If in addition some PVs in a snapshot were saved with an alarm severity other than NONE, then additional cells would be rendered with non-transparent color.

All in all, this PR is to be seen as a proposal. Check screen shots for examples, but keep in mind some of them are not really "real" use cases but taken from my test runs.

<img width="1851" height="416" alt="Screenshot 2025-08-18 at 15 07 49" src="https://github.com/user-attachments/assets/61094319-d25f-4994-b699-51ac1c5e9ed0" />
<img width="1987" height="718" alt="Screenshot 2025-08-18 at 15 07 57" src="https://github.com/user-attachments/assets/f316c33a-29bb-4579-89a8-946677d9ce74" />
<img width="1988" height="392" alt="Screenshot 2025-08-18 at 15 08 17" src="https://github.com/user-attachments/assets/a05a8e98-3ef4-4676-9bd2-3683bf2f976e" />
