### PR TITLE
Fix macro test following change to the default EXAMPLE_MACRO

### DIFF
--- a/app/display/model/src/test/java/org/csstudio/display/builder/model/macros/MacroHierarchyUnitTest.java
+++ b/app/display/model/src/test/java/org/csstudio/display/builder/model/macros/MacroHierarchyUnitTest.java
@@ -83,7 +83,7 @@ public class MacroHierarchyUnitTest
         model.expandMacros(Preferences.getMacros());
 
         MacroValueProvider macros = model.getEffectiveMacros();
-        assertThat(macros.getValue("EXAMPLE_MACRO"), equalTo("Value from Preferences"));
+        assertThat(macros.getValue("EXAMPLE_MACRO"), nullValue());
 
         // Can also fall back to widget properties
         assertThat(macros.getValue("type"), nullValue());


### PR DESCRIPTION
As noticed by @georgweiss (https://github.com/ControlSystemStudio/phoebus/pull/3475#issuecomment-3204479772) a previous [change](https://github.com/ControlSystemStudio/phoebus/pull/3475) to remove the default `EXAMPLE_MACRO` broke one of the Java unit tests.

I have fixed the test to reflect the new state of the EXAMPLE_MACRO.

Thanks for catching this!