### PR TITLE
CSSTUDIO-3325 Bugfix: Make labels of Byte Monitor widget visible when placed alongside a Label widget inside of a tab of a Navigation Tabs widget

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
@@ -138,14 +138,12 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
             {
             case NONE:
                 jfx_node.setPrefSize(width, height);
-                jfx_node.setMinSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.setMaxSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 if (was_ever_transformed)
                     jfx_node.getTransforms().clear();
                 break;
             case NINETY:
                 jfx_node.setPrefSize(height, width);
-                jfx_node.setMinSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.setMaxSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()),
                                                 new Translate(-height, 0));
@@ -153,7 +151,6 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
                 break;
             case ONEEIGHTY:
                 jfx_node.setPrefSize(width, height);
-                jfx_node.setMinSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.setMaxSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()),
                                                 new Translate(-width, -height));
@@ -161,7 +158,6 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
                                break;
             case MINUS_NINETY:
                 jfx_node.setPrefSize(height, width);
-                jfx_node.setMinSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.setMaxSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()),
                                                 new Translate(0, -width));


### PR DESCRIPTION
This pull request fixes a bug that can be reproduced as follows:

1. Create an OPI ("OPI A") containing: a Label widget and a Byte Monitor widget _with labels_. It is important that the Label widget is placed into the OPI _before_ the Byte Monitor widget is placed into the OPI.
2. Create a second OPI ("OPI B") containing a Navigation Tabs widget, one tab of which embeds OPI A.

The bug is: when running OPI B, the labels of the Byte Array widget are not visible when opening the tab that contains OPI A.

I don't have an explanation for this bug. Through testing, I have determined that this bug was introduced in https://github.com/ControlSystemStudio/phoebus/pull/3354. In particular, it is the call `jfx_node.setMinSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE)` in `LabelRepresentation.updateChanges()` that causes the issue: the bug doesn't occur when commenting out this call.

Since the goal of the pull request https://github.com/ControlSystemStudio/phoebus/pull/3354 was to prevent the Label widget from _increasing_ its size when the font was larger than the widget, the call to `jfx_node.setMinSize()` is actually unnecessary to implement the goal: the call to `jfx_node.setMaxSize()` already implements this goal. Therefore, I propose to work around this bug by simply removing the call to `jfx_node.setMinSize()`. Do you think this is acceptable, @rjwills28? (Unfortunately, I cannot assign you as a reviewer to this pull request for some reason, @rjwills28.)