### PR TITLE
NavTabs: Better handling of invalid active_tab

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/NavigationTabsWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/NavigationTabsWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2023 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,6 @@ import org.phoebus.framework.macros.Macros;
 /** Widget with tabs to select amongst several embedded displays
  *  @author Kay Kasemir
  */
-@SuppressWarnings("nls")
 public class NavigationTabsWidget extends VisibleWidget
 {
     /** Widget descriptor */
@@ -210,7 +209,7 @@ public class NavigationTabsWidget extends VisibleWidget
     {
         final Macros base = super.getEffectiveMacros();
         // Join macros of active tab
-        final int index;
+        int index;
 
         // To fetch the effective macros, we want to add those of the selected tab.
         // But if we get the tab index via active.getValue(), AND 'active' itself contains macros,
@@ -228,7 +227,13 @@ public class NavigationTabsWidget extends VisibleWidget
             return base;
         }
 
-        if (index >= 0  &&  index < tabs.size())
+        if (index >= tabs.size())
+        {
+            logger.log(Level.WARNING, this + " active tab " + index + " needs to be within 0 ... " + (tabs.size() - 1));
+            index = tabs.size()-1;
+        }
+
+        if (index >= 0)
             try
             {
                 final Macros selected = tabs.getElement(index).macros().getValue();

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2017-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,13 +51,16 @@ import javafx.scene.layout.Pane;
  *
  *  @author Kay Kasemir
  */
-@SuppressWarnings("nls")
 public class NavigationTabsRepresentation extends RegionBaseRepresentation<NavigationTabs, NavigationTabsWidget>
 {
     private final DirtyFlag dirty_sizes = new DirtyFlag();
     private final DirtyFlag dirty_tabs = new DirtyFlag();
     private final DirtyFlag dirty_tab_look = new DirtyFlag();
     private final DirtyFlag dirty_active_tab = new DirtyFlag();
+
+    // Track the "active tab" of navigation tabs _inside_ this one.
+    // As user toggles between tabs, this will allow restoring the active tab
+    // of nested instances, which would otherwise start over at their default tab
     private class SelectedNavigationTabs extends MutablePair<Integer, HashMap<Pair<Integer, String>, HashMap<String, SelectedNavigationTabs>>> {
         public SelectedNavigationTabs(int activeTab) {
             left = activeTab;
@@ -244,9 +247,10 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
                 });
                 checkCompletion(model_widget, completion, "timeout representing new content");
 
-                int tabNumber = model_widget.propActiveTab().getValue();
-                String tabName = model_widget.propTabs().getValue().get(model_widget.propActiveTab().getValue()).name().getValue();
-                Pair<Integer, String> tabNumberAndTabName = new Pair<>(tabNumber, tabName);
+                final List<TabProperty> tabs = model_widget.propTabs().getValue();
+                final int tabNumber = Math.min(model_widget.propActiveTab().getValue(), tabs.size()-1);
+                final String tabName = tabs.get(tabNumber).name().getValue();
+                final Pair<Integer, String> tabNumberAndTabName = new Pair<>(tabNumber, tabName);
 
                 if (!selectedNavigationTabs.right.containsKey(tabNumberAndTabName)) {
                     selectedNavigationTabs.right.put(tabNumberAndTabName, new HashMap<>());


### PR DESCRIPTION
If the active tab is outside of the range of defined tabs, it would show disfunctional tab content (no macros) and log an ArrayIndexOutOfBounds exception.
Now it will log something like "Widget 'XXXX' (navtabs) active tab 5 needs to be within 0 ... 4" and fall back to the highest valid tab index.