### PR TITLE
CSSTDUIO-3408 Bugfix: Add null-check for `value_prop` before calling `value_prop.getValue()`

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/RegionBaseRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/RegionBaseRepresentation.java
@@ -255,14 +255,19 @@ abstract public class RegionBaseRepresentation<JFX extends Region, MW extends Vi
         AlarmSeverity severity = AlarmSeverity.NONE;
 
         // Ignore custom border and value of primary PV, show disconnected
-        final VType value = value_prop.getValue();
-        final Alarm alarm = Alarm.alarmOf(value);
-        if (! model_widget.runtimePropConnected().getValue() || alarm.equals(Alarm.disconnected()))
+        if (!model_widget.runtimePropConnected().getValue()) {
             severity = AlarmSeverity.UNDEFINED;
-        else
-        {   // Reflect severity of primary PV's value
-            if (value_prop != null  && alarm_sensitive_border_prop.getValue())
-            {
+        }
+        else if (value_prop != null && alarm_sensitive_border_prop.getValue())
+        {
+            // Reflect severity of primary PV's value
+            final VType value = value_prop.getValue();
+            final Alarm alarm = Alarm.alarmOf(value);
+
+            if (alarm.equals(Alarm.disconnected())) {
+                severity = AlarmSeverity.UNDEFINED;
+            }
+            else {
                 if (alarm != null  &&  alarm.getSeverity() != AlarmSeverity.NONE)
                     // Have alarm info
                     severity = alarm.getSeverity();


### PR DESCRIPTION
This pull request fixes the issue described by @kasemir in https://github.com/ControlSystemStudio/phoebus/pull/3474#issuecomment-3234557173 by checking whether `value_prop` is not equal to `null` before calling `value_prop.getValue()`.