### PR TITLE
PVA client: Fix ConcurrentModificationException in search

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -343,7 +343,6 @@ class ChannelSearch
     }
 
     /** Invoked by timer: Check searched channels for the next one to handle */
-    @SuppressWarnings("unchecked")
     private void runSearches()
     {
         // Determine current search bucket

--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -342,9 +342,6 @@ class ChannelSearch
         }
     }
 
-    /** List of channels to search, re-used within runSearches */
-    private final ArrayList<PVAChannel> to_search = new ArrayList<>();
-
     /** Invoked by timer: Check searched channels for the next one to handle */
     @SuppressWarnings("unchecked")
     private void runSearches()
@@ -352,7 +349,7 @@ class ChannelSearch
         // Determine current search bucket
         final int current = current_search_bucket.getAndUpdate(i -> (i + 1) % search_buckets.size());
         // Collect channels to be searched while sync'ed
-        to_search.clear();
+        final ArrayList<SearchRequest.Channel> to_search = new ArrayList<>();
         synchronized (this)
         {
             final Set<SearchedChannel> bucket = search_buckets.get(current);
@@ -406,7 +403,7 @@ class ChannelSearch
             int count = 0;
             while (start + count < to_search.size()  &&  count < Short.MAX_VALUE-1)
             {
-                final PVAChannel channel = to_search.get(start + count);
+                final SearchRequest.Channel channel = to_search.get(start + count);
                 int size = 4 + PVAString.getEncodedSize(channel.getName());
                 if (payload + size < MAX_SEARCH_PAYLOAD)
                 {
@@ -428,9 +425,9 @@ class ChannelSearch
             if (count == 0)
                 break;
 
-            final List<PVAChannel> batch = to_search.subList(start, start + count);
-            // PVAChannel extends SearchRequest.Channel, so use List<PVAChannel> as Collection<SR.Channel>
-            search((Collection<SearchRequest.Channel>) (List<? extends SearchRequest.Channel>)batch);
+            // Submit one batch from 'to_search'
+            final List<SearchRequest.Channel> batch = to_search.subList(start, start + count);
+            search(batch);
             start += count;
         }
     }


### PR DESCRIPTION
`ChannelSearch.runSearches` used to re-use one `to_search` array list.
By the time the submitted searches encode the channels from that list,
it might get cleared and re-populated, resulting in a ConcurrentModificationException.
This happens to be more likely with TCP-based searches (EPICS_PVA_NAME_SERVERS).

Need to create a new `to_search` array in each `runSearches` call.

At same time removed some unnecessary casts.