### PR TITLE
Fix import of save&restore legacy csv

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/filehandler/csv/CSVParser.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/filehandler/csv/CSVParser.java
@@ -187,17 +187,19 @@ public class CSVParser extends CSVCommon {
 
                     csvParser.getTags().add(tag);
                 }
-            } else if (!line.startsWith(COMMENT_PREFIX) && csvParser.getColumnHeaders().isEmpty()) {
-                csvParser.analyzeColumnHeader(line);
-            } else {
-                String[] columns = csvParser.split(line);
-
-                Map<String, String> entry = new HashMap<>();
-                for (int index = 0; index < columns.length; index++) {
-                    entry.put(csvParser.getColumnHeaders().get(index), columns[index]);
+            } else if (!line.startsWith(COMMENT_PREFIX)) {
+                if(csvParser.getColumnHeaders().isEmpty()){
+                    csvParser.analyzeColumnHeader(line);
                 }
+                else {
+                    String[] columns = csvParser.split(line);
 
-                csvParser.getEntries().add(entry);
+                    Map<String, String> entry = new HashMap<>();
+                    for (int index = 0; index < columns.length; index++) {
+                        entry.put(csvParser.getColumnHeaders().get(index), columns[index]);
+                    }
+                    csvParser.getEntries().add(entry);
+                }
             }
         }
 


### PR DESCRIPTION
This fixes a bug in csv import in save&restore. 
Apparently import is not used much as the bug has been around for ~5 years.