### PR TITLE
Support search for referenced snapshots

### DIFF
--- a/app/save-and-restore/app/doc/index.rst
+++ b/app/save-and-restore/app/doc/index.rst
@@ -88,7 +88,8 @@ Brief description of all items in the context menu (details on actions are outli
 * Restore from client - restore a snapshot or composite snapshot from the client application.
 * Restore from service - restore a snapshot or composite snapshot from the service.
 * Edit - edit a configuration.
-* Rename - rename a folder or configuration.
+* Find references - locates composite snapshot nodes referencing the selected node.
+* Rename - rename a folder.
 * Copy - put selected items on clipboard.
 * Paste - paste items from clipboard.
 * Delete - delete selected items.

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
@@ -86,6 +86,7 @@ import org.phoebus.applications.saveandrestore.ui.contextmenu.CopyUniqueIdToClip
 import org.phoebus.applications.saveandrestore.ui.contextmenu.CreateSnapshotMenuItem;
 import org.phoebus.applications.saveandrestore.ui.contextmenu.EditCompositeMenuItem;
 import org.phoebus.applications.saveandrestore.ui.contextmenu.ExportToCSVMenuItem;
+import org.phoebus.applications.saveandrestore.ui.contextmenu.FindReferencesMenuItem;
 import org.phoebus.applications.saveandrestore.ui.contextmenu.ImportFromCSVMenuItem;
 import org.phoebus.applications.saveandrestore.ui.contextmenu.LoginMenuItem;
 import org.phoebus.applications.saveandrestore.ui.contextmenu.NewCompositeSnapshotMenuItem;
@@ -232,6 +233,7 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
                     }),
             new SeparatorMenuItem(),
             new EditCompositeMenuItem(this, selectedItemsProperty, this::editCompositeSnapshot),
+            new FindReferencesMenuItem(this, selectedItemsProperty, this::findReferences),
             new RenameFolderMenuItem(this, selectedItemsProperty, this::renameNode),
             copyMenuItem,
             pasteMenuItem,
@@ -525,7 +527,7 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
     /**
      * Opens a new snapshot view tab associated with the selected configuration.
      */
-    public void openConfigurationForSnapshot() {
+    private void openConfigurationForSnapshot() {
         TreeItem<Node> treeItem = browserSelectionModel.getSelectedItems().get(0);
         SnapshotTab tab = new SnapshotTab(treeItem.getValue(), saveAndRestoreService);
         tab.newSnapshot(treeItem.getValue());
@@ -634,7 +636,7 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
      * Launches the composite snapshot editor view. Note that a tab showing this view uses the "edit_" prefix
      * for the id since it would otherwise clash with a restore view of a composite snapshot.
      */
-    public void editCompositeSnapshot() {
+    private void editCompositeSnapshot() {
         Node compositeSnapshotNode = browserSelectionModel.getSelectedItem().getValue();
         editCompositeSnapshot(compositeSnapshotNode, Collections.emptyList());
     }
@@ -709,11 +711,11 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
     /**
      * Creates a new configuration in the selected tree node.
      */
-    public void createNewConfiguration() {
+    private void createNewConfiguration() {
         launchTabForNewConfiguration(browserSelectionModel.getSelectedItems().get(0).getValue());
     }
 
-    public void createNewCompositeSnapshot() {
+    private void createNewCompositeSnapshot() {
         launchTabForNewCompositeSnapshot(browserSelectionModel.getSelectedItems().get(0).getValue(),
                 Collections.emptyList());
     }
@@ -1505,5 +1507,10 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
             }
         }
         return true;
+    }
+
+    private void findReferences(){
+        SearchAndFilterTab searchAndFilterTab = openSearchWindow();
+        searchAndFilterTab.getController().findReferencesForSnapshot(treeView.getSelectionModel().getSelectedItems().get(0).getValue().getUniqueId());
     }
 }

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/contextmenu/FindReferencesMenuItem.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/contextmenu/FindReferencesMenuItem.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 European Spallation Source ERIC.
+ */
+
+package org.phoebus.applications.saveandrestore.ui.contextmenu;
+
+import javafx.collections.ObservableList;
+import org.phoebus.applications.saveandrestore.Messages;
+import org.phoebus.applications.saveandrestore.model.Node;
+import org.phoebus.applications.saveandrestore.model.NodeType;
+import org.phoebus.applications.saveandrestore.ui.SaveAndRestoreBaseController;
+import org.phoebus.ui.javafx.ImageCache;
+
+/**
+ * {@link javafx.scene.control.MenuItem} for finding references of a snapshot or composite snapshot.
+ */
+public class FindReferencesMenuItem extends SaveAndRestoreMenuItem {
+
+    public FindReferencesMenuItem(SaveAndRestoreBaseController saveAndRestoreController,
+                                  ObservableList<Node> selectedItemsProperty,
+                                  Runnable onAction) {
+        super(saveAndRestoreController, selectedItemsProperty, onAction);
+        setGraphic(ImageCache.getImageView(ImageCache.class, "/icons/sar-search_18x18.png"));
+        setText(Messages.findSnapshotReferences);
+    }
+
+    @Override
+    public void configure() {
+        visibleProperty().set(selectedItemsProperty.size() == 1 &&
+                (selectedItemsProperty.get(0).getNodeType().equals(NodeType.SNAPSHOT) ||
+                        selectedItemsProperty.get(0).getNodeType().equals(NodeType.COMPOSITE_SNAPSHOT)));
+    }
+}

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/search/SearchAndFilterTab.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/search/SearchAndFilterTab.java
@@ -25,7 +25,6 @@ import javafx.scene.image.ImageView;
 import org.phoebus.applications.saveandrestore.Messages;
 import org.phoebus.applications.saveandrestore.SaveAndRestoreApplication;
 import org.phoebus.applications.saveandrestore.ui.SaveAndRestoreController;
-import org.phoebus.applications.saveandrestore.ui.SaveAndRestoreService;
 import org.phoebus.applications.saveandrestore.ui.SaveAndRestoreTab;
 import org.phoebus.framework.nls.NLS;
 import org.phoebus.ui.javafx.ImageCache;
@@ -65,7 +64,7 @@ public class SearchAndFilterTab extends SaveAndRestoreTab {
             Node node = loader.load();
             controller = loader.getController();
             setContent(node);
-            setOnCloseRequest(event -> ((SearchAndFilterViewController)controller).handleSaveAndFilterTabClosed());
+            setOnCloseRequest(event -> ((SearchAndFilterViewController) controller).handleSaveAndFilterTabClosed());
         } catch (IOException e) {
             Logger.getLogger(SearchAndFilterTab.class.getName())
                     .log(Level.SEVERE, "Unable to load search tab content fxml", e);
@@ -74,5 +73,9 @@ public class SearchAndFilterTab extends SaveAndRestoreTab {
 
         setText(Messages.search);
         setGraphic(new ImageView(ImageCache.getImage(ImageCache.class, "/icons/sar-search_18x18.png")));
+    }
+
+    public SearchAndFilterViewController getController() {
+        return (SearchAndFilterViewController) controller;
     }
 }

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/search/SearchAndFilterViewController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/search/SearchAndFilterViewController.java
@@ -208,6 +208,8 @@ public class SearchAndFilterViewController extends SaveAndRestoreBaseController
 
     private final SimpleBooleanProperty goldenOnlyProperty = new SimpleBooleanProperty();
 
+    private final SimpleStringProperty referencedProperty = new SimpleStringProperty();
+
     private static final Logger LOGGER = Logger.getLogger(SearchAndFilterViewController.class.getName());
 
     private final SimpleBooleanProperty disableUi = new SimpleBooleanProperty();
@@ -534,6 +536,9 @@ public class SearchAndFilterViewController extends SaveAndRestoreBaseController
                 map.put(Keys.TAGS.getName(), tags + "," + Tag.GOLDEN);
             }
         }
+        if (referencedProperty.get() != null && !referencedProperty.get().trim().isEmpty()) {
+            map.put(Keys.REFERENCED.getName(), referencedProperty.get());
+        }
         return SearchQueryUtil.toQueryString(map);
     }
 
@@ -649,12 +654,17 @@ public class SearchAndFilterViewController extends SaveAndRestoreBaseController
     }
 
     @Override
-    public void handleTabClosed(){
+    public void handleTabClosed() {
         webSocketClientService.removeWebSocketMessageHandler(this);
     }
 
     @Override
-    public boolean doCloseCheck(){
+    public boolean doCloseCheck() {
         return true;
+    }
+
+    public void findReferencesForSnapshot(String nodeId) {
+        referencedProperty.setValue(nodeId);
+        updateParametersAndSearch();
     }
 }

--- a/app/save-and-restore/model/src/main/java/org/phoebus/applications/saveandrestore/model/search/SearchQueryUtil.java
+++ b/app/save-and-restore/model/src/main/java/org/phoebus/applications/saveandrestore/model/search/SearchQueryUtil.java
@@ -41,7 +41,8 @@ public class SearchQueryUtil {
         FROM("from"),
         SIZE("size"),
         GOLDEN("golden"),
-        PVS("pvs");
+        PVS("pvs"),
+        REFERENCED("referenced");
 
         private final String name;
 
@@ -58,7 +59,7 @@ public class SearchQueryUtil {
             return getName();
         }
 
-        protected static final Map<String, Keys> lookupTable = new HashMap<>();
+        private static final Map<String, Keys> lookupTable = new HashMap<>();
 
         static {
             lookupTable.put("name", Keys.NAME);
@@ -70,6 +71,7 @@ public class SearchQueryUtil {
             lookupTable.put("type", Keys.TYPE);
             lookupTable.put("golden", Keys.GOLDEN);
             lookupTable.put("pvs", Keys.PVS);
+            lookupTable.put("referenced", Keys.REFERENCED);
         }
 
         public static Keys findKey(String keyName) {

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/NodeDAO.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/NodeDAO.java
@@ -63,12 +63,6 @@ public interface NodeDAO {
      */
     List<Node> getNodes(List<String> uniqueNodeIds);
 
-    /**
-     * This is deprecated, use {@link #deleteNodes} instead.
-     *
-     * @param nodeId The unique id of the node to delete.
-     */
-    void deleteNode(String nodeId);
 
     /**
      * Checks that each of the node ids passed to this method exist, and that none of them

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/CompositeSnapshotDataRepository.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/CompositeSnapshotDataRepository.java
@@ -22,7 +22,6 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.Result;
 import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
-import co.elastic.clients.elasticsearch._types.query_dsl.MatchPhraseQuery;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.CountResponse;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
@@ -37,10 +36,11 @@ import co.elastic.clients.elasticsearch.core.IndexResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
-import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.phoebus.applications.saveandrestore.model.CompositeSnapshot;
 import org.phoebus.applications.saveandrestore.model.CompositeSnapshotData;
+import org.phoebus.applications.saveandrestore.model.Node;
+import org.phoebus.applications.saveandrestore.model.search.SearchResult;
 import org.phoebus.service.saveandrestore.model.ESTreeNode;
 import org.phoebus.service.saveandrestore.search.SearchUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,6 +69,9 @@ public class CompositeSnapshotDataRepository implements CrudRepository<Composite
     @SuppressWarnings("unused")
     @Value("${elasticsearch.composite_snapshot_node.index:saveandrestore_composite_snapshot}")
     private String ES_COMPOSITE_SNAPSHOT_INDEX;
+
+    @Autowired
+    private ElasticsearchTreeRepository elasticsearchTreeRepository;
 
     @Autowired
     @Qualifier("client")
@@ -145,19 +148,20 @@ public class CompositeSnapshotDataRepository implements CrudRepository<Composite
      * Retrieves all {@link CompositeSnapshotData} documents. Note that to work around the limits in
      * Elasticsearch (e.g. max 10000 documents in a search request), the implementation uses paginated search to repeatedly
      * query for next round of hits. A page size of 100 is used for each query.
+     *
      * @return An {@link Iterable} of {@link CompositeSnapshotData} objects, potentially empty.
      */
     @Override
-    public Iterable<CompositeSnapshotData>  findAll() {
+    public Iterable<CompositeSnapshotData> findAll() {
         List<CompositeSnapshotData> result = new ArrayList<>();
         int pageSize = 100;
         int from = 0;
-        while(true){
+        while (true) {
             try {
                 SearchResponse<CompositeSnapshotData> searchResponse = runPagedMatchAll(pageSize, from);
                 result.addAll(searchResponse.hits().hits().stream().map(Hit::source).collect(Collectors.toList()));
                 from += searchResponse.hits().hits().size();
-                if(searchResponse.hits().hits().size() < pageSize){
+                if (searchResponse.hits().hits().size() < pageSize) {
                     break;
                 }
             } catch (IOException e) {
@@ -168,13 +172,13 @@ public class CompositeSnapshotDataRepository implements CrudRepository<Composite
         return result;
     }
 
-    private SearchResponse<CompositeSnapshotData> runPagedMatchAll(int pageSize, int from) throws IOException{
+    private SearchResponse<CompositeSnapshotData> runPagedMatchAll(int pageSize, int from) throws IOException {
         SearchRequest searchRequest =
                 SearchRequest.of(s ->
-                    s.index(ES_COMPOSITE_SNAPSHOT_INDEX)
-                            .query(new MatchAllQuery.Builder().build()._toQuery())
-                            .size(pageSize)
-                            .from(from));
+                        s.index(ES_COMPOSITE_SNAPSHOT_INDEX)
+                                .query(new MatchAllQuery.Builder().build()._toQuery())
+                                .size(pageSize)
+                                .from(from));
         return client.search(searchRequest, CompositeSnapshotData.class);
     }
 
@@ -185,14 +189,13 @@ public class CompositeSnapshotDataRepository implements CrudRepository<Composite
 
     @Override
     public long count() {
-        try{
+        try {
             CountRequest countRequest = CountRequest.of(c ->
                     c.index(ES_COMPOSITE_SNAPSHOT_INDEX));
             CountResponse countResponse = client.count(countRequest);
             return countResponse.count();
-        }
-        catch(Exception e){
-            logger.log(Level.SEVERE, "Failed to count CompositeSnapshot objects" , e);
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Failed to count CompositeSnapshot objects", e);
             throw new RuntimeException(e);
         }
     }
@@ -203,10 +206,9 @@ public class CompositeSnapshotDataRepository implements CrudRepository<Composite
             DeleteRequest deleteRequest = DeleteRequest.of(d ->
                     d.index(ES_COMPOSITE_SNAPSHOT_INDEX).id(s).refresh(Refresh.True));
             DeleteResponse deleteResponse = client.delete(deleteRequest);
-            if(deleteResponse.result().equals(Result.Deleted)){
+            if (deleteResponse.result().equals(Result.Deleted)) {
                 logger.log(Level.WARNING, "Composite snapshot with id " + s + " deleted.");
-            }
-            else{
+            } else {
                 logger.log(Level.WARNING, "Composite snapshot with id " + s + " NOT deleted.");
             }
         } catch (IOException e) {
@@ -243,12 +245,24 @@ public class CompositeSnapshotDataRepository implements CrudRepository<Composite
         }
     }
 
-    public List<CompositeSnapshotData> containedIn(MultiValueMap<String, String> searchParameters){
+    /**
+     * Finds {@link Node}s of type {@link org.phoebus.applications.saveandrestore.model.NodeType#COMPOSITE_SNAPSHOT} referencing
+     * the node id present in the search parameters.
+     *
+     * @param searchParameters {@link MultiValueMap} that should contain an element keyed &quot;referenced&quot;
+     * @return A potentially empty {@link SearchResult}
+     */
+    public SearchResult referenced(MultiValueMap<String, String> searchParameters) {
 
         SearchRequest searchRequest = searchUtil.buildSearchRequest(searchParameters);
         try {
             SearchResponse<CompositeSnapshotData> response = client.search(searchRequest, CompositeSnapshotData.class);
-            return response.hits().hits().stream().map(Hit::source).collect(Collectors.toList());
+            HitsMetadata<CompositeSnapshotData> hitsMetadata = response.hits();
+            List<CompositeSnapshotData> compositeSnapshotDataList = hitsMetadata.hits().stream().map(Hit::source).toList();
+            Iterable<ESTreeNode> esTreeNodes = elasticsearchTreeRepository.findAllById(compositeSnapshotDataList.stream().map(CompositeSnapshotData::getUniqueId).toList());
+            List<Node> list = new ArrayList<>();
+            esTreeNodes.iterator().forEachRemaining(es -> list.add(es.getNode()));
+            return new SearchResult((int) hitsMetadata.total().value(), list);
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Failed to search for referenced snapshot nodes", e);
             throw new RuntimeException(e);

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ConfigurationDataRepository.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ConfigurationDataRepository.java
@@ -26,6 +26,7 @@ import co.elastic.clients.elasticsearch.core.*;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
 import org.phoebus.applications.saveandrestore.model.ConfigurationData;
+import org.phoebus.applications.saveandrestore.model.Node;
 import org.phoebus.service.saveandrestore.search.SearchUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -212,6 +213,5 @@ public class ConfigurationDataRepository implements CrudRepository<Configuration
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-
     }
 }

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchDAO.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchDAO.java
@@ -1289,4 +1289,16 @@ public class ElasticsearchDAO implements NodeDAO {
             return index1 - index2;
         }
     }
+
+    public List<Node> containedInCompositeSnapshot(MultiValueMap<String, String> searchParameters){
+        List<CompositeSnapshotData> compositeSnapshotDataList = compositeSnapshotDataRepository.containedIn(searchParameters);
+        List<String> compositeSnapshotIds = compositeSnapshotDataList.stream().map(CompositeSnapshotData::getUniqueId).toList();
+
+        Iterable<ESTreeNode> esTreeNodes = elasticsearchTreeRepository.findAllById(compositeSnapshotIds);
+
+        List<Node> list = new ArrayList<>();
+        esTreeNodes.iterator().forEachRemaining(es -> list.add(es.getNode()));
+
+        return list;
+    }
 }

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/search/SearchUtil.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/search/SearchUtil.java
@@ -3,14 +3,24 @@ package org.phoebus.service.saveandrestore.search;
 import co.elastic.clients.elasticsearch._types.FieldSort;
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
-import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery.Builder;
+import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.DisMaxQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.FuzzyQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.IdsQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchPhraseQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.WildcardQuery;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import org.phoebus.applications.saveandrestore.model.Tag;
-import org.phoebus.applications.saveandrestore.model.search.SearchQueryUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
-import org.springframework.ldap.core.support.AbstractContextSource;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -18,12 +28,14 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A utility class for creating a search query for log entries based on time,
@@ -94,10 +106,9 @@ public class SearchUtil {
                         for (String pattern : getSearchTerms(value)) {
                             String term = pattern.trim().toLowerCase();
                             // Quoted strings will be mapped to a phrase query
-                            if(term.startsWith("\"") && term.endsWith("\"")){
+                            if (term.startsWith("\"") && term.endsWith("\"")) {
                                 nodeNamePhraseTerms.add(term.substring(1, term.length() - 1));
-                            }
-                            else{
+                            } else {
                                 // add wildcards inorder to search for sub-strings
                                 nodeNameTerms.add("*" + term + "*");
                             }
@@ -178,10 +189,9 @@ public class SearchUtil {
                             BoolQuery.Builder bqb = new BoolQuery.Builder();
                             // This handles a special case where search is done on name only, e.g. tags=golden
                             if (tagsSearchFields[0] != null && !tagsSearchFields[0].isEmpty() && (tagsSearchFields[1] == null || tagsSearchFields[1].isEmpty())) {
-                                if(!tagsSearchFields[0].equalsIgnoreCase(Tag.GOLDEN)){
+                                if (!tagsSearchFields[0].equalsIgnoreCase(Tag.GOLDEN)) {
                                     bqb.must(WildcardQuery.of(w -> w.caseInsensitive(true).field("node.tags.name").value(tagsSearchFields[0].trim().toLowerCase()))._toQuery());
-                                }
-                                else{
+                                } else {
                                     MatchQuery matchQuery = MatchQuery.of(m -> m.field("node.tags.name").query(Tag.GOLDEN));
                                     NestedQuery innerNestedQuery = NestedQuery.of(n1 -> n1.path("node.tags").query(matchQuery._toQuery()));
                                     NestedQuery outerNestedQuery = NestedQuery.of(n2 -> n2.path("node").query(innerNestedQuery._toQuery()));
@@ -198,7 +208,7 @@ public class SearchUtil {
                         }
                     }
                     DisMaxQuery disMaxQuery = tagsQuery.build();
-                    if(!disMaxQuery.queries().isEmpty()){
+                    if (!disMaxQuery.queries().isEmpty()) {
                         boolQueryBuilder.must(disMaxQuery._toQuery());
                     }
                     break;
@@ -215,7 +225,7 @@ public class SearchUtil {
                         from = Integer.parseInt(maxFrom.get());
                     }
                     break;
-                case "containedin":
+                case "referenced":
                     return buildSearchRequestForContainedIn(searchParameters);
                 default:
                     // Unsupported search parameters ignored
@@ -266,7 +276,7 @@ public class SearchUtil {
         }
 
         // Add uniqueId query
-        if(!uniqueIdTerms.isEmpty()){
+        if (!uniqueIdTerms.isEmpty()) {
             boolQueryBuilder.must(IdsQuery.of(id -> id.values(uniqueIdTerms))._toQuery());
         }
 
@@ -330,6 +340,7 @@ public class SearchUtil {
     /**
      * Builds a query on the configuration index to find {@link org.phoebus.applications.saveandrestore.model.ConfigurationData}
      * documents containing any of the PV names passed to this method. Both setpoint and readback PV names are considered.
+     *
      * @param pvNames List of PV names. Query will user or-strategy.
      * @return A {@link SearchRequest} object, no limit on result size except maximum Elastic limit.
      */
@@ -394,19 +405,20 @@ public class SearchUtil {
 
     /**
      * Constructs a {@link SearchRequest} search for composite snapshots containing a node id.
+     *
      * @param searchParameters Map of search parameters where key &quot;containedin&quot; must be present and
      *                         contain at least one value. Note however that only first value is considered.
      *                         If no value is specified, an {@link IllegalArgumentException} is thrown.
      * @return A suitable {@link SearchRequest}
      */
-    private SearchRequest buildSearchRequestForContainedIn(MultiValueMap<String, String> searchParameters){
-        List<String> value = searchParameters.get("containedin");
-        if(value.isEmpty()){
-            throw new IllegalArgumentException("At least one value must be specified for 'containedin'");
+    private SearchRequest buildSearchRequestForContainedIn(MultiValueMap<String, String> searchParameters) {
+        List<String> value = searchParameters.get("referenced");
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException("At least one value must be specified for 'referenced'");
         }
         int from = 0;
         List<String> parameter = searchParameters.get("from");
-        if(parameter != null){
+        if (parameter != null) {
             Optional<String> maxFrom = parameter.stream().max(Comparator.comparing(Integer::valueOf));
             if (maxFrom.isPresent()) {
                 from = Integer.parseInt(maxFrom.get());
@@ -414,7 +426,7 @@ public class SearchUtil {
         }
         int size = maxSearchSize;
         parameter = searchParameters.get("size");
-        if(parameter != null){
+        if (parameter != null) {
             Optional<String> maxFrom = parameter.stream().max(Comparator.comparing(Integer::valueOf));
             if (maxFrom.isPresent()) {
                 size = Integer.parseInt(maxFrom.get());

--- a/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/persistence/dao/impl/DAOTestIT.java
+++ b/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/persistence/dao/impl/DAOTestIT.java
@@ -163,7 +163,7 @@ public class DAOTestIT {
         config = nodeDAO.createNode(topLevelFolderNode.getUniqueId(), config);
         Node snapshot = nodeDAO.createNode(config.getUniqueId(), Node.builder().name("node").nodeType(NodeType.SNAPSHOT).build());
 
-        nodeDAO.deleteNode(topLevelFolderNode.getUniqueId());
+        nodeDAO.deleteNodes(List.of(topLevelFolderNode.getUniqueId()));
 
         try {
             nodeDAO.getNode(config.getUniqueId());
@@ -211,7 +211,7 @@ public class DAOTestIT {
         Node config = nodeDAO.createNode(folder1.getUniqueId(),
                 Node.builder().nodeType(NodeType.CONFIGURATION).name("Config").build());
 
-        nodeDAO.deleteNode(folder1.getUniqueId());
+        nodeDAO.deleteNodes(List.of(folder1.getUniqueId()));
         root = nodeDAO.getNode(rootNode.getUniqueId());
         assertTrue(root.getLastModified().getTime() > rootLastModified.getTime());
         try {
@@ -230,7 +230,7 @@ public class DAOTestIT {
 
     @Test
     public void testDeleteRootFolder() {
-        assertThrows(IllegalArgumentException.class, () -> nodeDAO.deleteNode(nodeDAO.getRootNode().getUniqueId()));
+        assertThrows(IllegalArgumentException.class, () -> nodeDAO.deleteNodes(List.of(nodeDAO.getRootNode().getUniqueId())));
     }
 
     @Test
@@ -320,9 +320,9 @@ public class DAOTestIT {
 
         compositeSnapshot = nodeDAO.createCompositeSnapshot(topLevelFolderNode.getUniqueId(), compositeSnapshot);
 
-        assertThrows(RuntimeException.class, () -> nodeDAO.deleteNode(snapshotNode.getUniqueId()));
+        assertThrows(RuntimeException.class, () -> nodeDAO.deleteNodes(List.of(snapshotNode.getUniqueId())));
 
-        nodeDAO.deleteNode(compositeSnapshot.getCompositeSnapshotNode().getUniqueId());
+        nodeDAO.deleteNodes(List.of((compositeSnapshot.getCompositeSnapshotNode().getUniqueId())));
     }
 
     @Test
@@ -402,7 +402,7 @@ public class DAOTestIT {
         assertEquals("Updated description", compositeSnapshot.getCompositeSnapshotNode().getDescription());
         assertEquals(2, compositeSnapshot.getCompositeSnapshotData().getReferencedSnapshotNodes().size());
 
-        nodeDAO.deleteNode(compositeSnapshot.getCompositeSnapshotNode().getUniqueId());
+        nodeDAO.deleteNodes(List.of(compositeSnapshot.getCompositeSnapshotNode().getUniqueId()));
 
     }
 
@@ -455,7 +455,7 @@ public class DAOTestIT {
 
         assertEquals(20, all.size());
 
-        compositeSnapshotNodeIds.forEach(id -> nodeDAO.deleteNode(id));
+        compositeSnapshotNodeIds.forEach(id -> nodeDAO.deleteNodes(List.of(id)));
 
     }
 
@@ -502,7 +502,7 @@ public class DAOTestIT {
         List<Node> snapshots = nodeDAO.getSnapshots(config.getUniqueId());
         assertEquals(1, snapshots.size());
 
-        nodeDAO.deleteNode(snapshot.getSnapshotNode().getUniqueId());
+        nodeDAO.deleteNodes(List.of(snapshot.getSnapshotNode().getUniqueId()));
 
         snapshots = nodeDAO.getSnapshots(config.getUniqueId());
         assertTrue(snapshots.isEmpty());
@@ -1584,8 +1584,8 @@ public class DAOTestIT {
         // Make sure referenced nodes have been copied to copied composite snapshot
         assertEquals(1, nodeDAO.getCompositeSnapshotData(childNodes.get(0).getUniqueId()).getReferencedSnapshotNodes().size());
 
-        nodeDAO.deleteNode(childNodes.get(0).getUniqueId());
-        nodeDAO.deleteNode(compositeSnapshot.getCompositeSnapshotNode().getUniqueId());
+        nodeDAO.deleteNodes(List.of(childNodes.get(0).getUniqueId()));
+        nodeDAO.deleteNodes(List.of(compositeSnapshot.getCompositeSnapshotNode().getUniqueId()));
     }
 
     @Test
@@ -1648,7 +1648,7 @@ public class DAOTestIT {
         assertThrows(IllegalArgumentException.class,
                 () -> nodeDAO.copyNodes(List.of(compositeSnapshotId), config2Id, "user"));
 
-        nodeDAO.deleteNode(compositeSnapshot.getCompositeSnapshotNode().getUniqueId());
+        nodeDAO.deleteNodes(List.of(compositeSnapshot.getCompositeSnapshotNode().getUniqueId()));
     }
 
     @Test
@@ -1660,14 +1660,14 @@ public class DAOTestIT {
         folderNode.setNodeType(NodeType.FOLDER);
         folderNode = nodeDAO.createNode(rootNode.getUniqueId(), folderNode);
 
-        nodeDAO.deleteNode(folderNode.getUniqueId());
+        nodeDAO.deleteNodes(List.of(folderNode.getUniqueId()));
         assertTrue(nodeDAO.getChildNodes(rootNode.getUniqueId()).isEmpty());
     }
 
     @Test
     public void testDeleteNodeInvalid() {
         assertThrows(NodeNotFoundException.class,
-                () -> nodeDAO.deleteNode("invalid"));
+                () -> nodeDAO.deleteNodes(List.of("invalid")));
     }
 
     @Test
@@ -1684,7 +1684,7 @@ public class DAOTestIT {
         folderNode2.setNodeType(NodeType.FOLDER);
         nodeDAO.createNode(folderNode.getUniqueId(), folderNode2);
 
-        nodeDAO.deleteNode(folderNode.getUniqueId());
+        nodeDAO.deleteNodes(List.of(folderNode.getUniqueId()));
         assertTrue(nodeDAO.getChildNodes(rootNode.getUniqueId()).isEmpty());
     }
 
@@ -1986,7 +1986,7 @@ public class DAOTestIT {
         assertEquals(1, duplicates.size());
         assertEquals("pv1", duplicates.get(0));
 
-        nodeDAO.deleteNode(compositeSnapshotNode.getUniqueId());
+        nodeDAO.deleteNodes(List.of(compositeSnapshotNode.getUniqueId()));
     }
 
     @Test
@@ -2152,7 +2152,7 @@ public class DAOTestIT {
 
         assertEquals(4, snapshotItems.size());
 
-        nodeDAO.deleteNode(compositeSnapshotNode.getUniqueId());
+        nodeDAO.deleteNodes(List.of(compositeSnapshotNode.getUniqueId()));
     }
 
     @Test
@@ -2268,7 +2268,7 @@ public class DAOTestIT {
     }
 
     @Test
-    public void testSnapshotContainedInCompositeSnapshot() throws Exception{
+    public void testSnapshotContainedInCompositeSnapshot(){
         Node rootNode = nodeDAO.getRootNode();
         Node folderNode =
                 Node.builder().name("folder").build();
@@ -2339,17 +2339,17 @@ public class DAOTestIT {
                 snapshot2.getSnapshotNode().getUniqueId()));
         compositeSnapshot.setCompositeSnapshotData(compositeSnapshotData);
 
-        compositeSnapshot = nodeDAO.createCompositeSnapshot(folderNode.getUniqueId(), compositeSnapshot);
+        nodeDAO.createCompositeSnapshot(folderNode.getUniqueId(), compositeSnapshot);
         //************  End create composite snapshot ************/
 
         MultiValueMap<String, String> searchParameters = new LinkedMultiValueMap<>();
-        searchParameters.put("containedin", List.of(newSnapshot1.getUniqueId()));
+        searchParameters.put("referenced", List.of(newSnapshot1.getUniqueId()));
         searchParameters.put("from", List.of("0"));
         searchParameters.put("size", List.of("100"));
 
-        List<Node> nodes = nodeDAO.containedInCompositeSnapshot(searchParameters);
+        List<Node> nodes = nodeDAO.search(searchParameters).getNodes();
 
-        assertEquals(nodes.size(), 1);
+        assertEquals( 1, nodes.size());
 
         //************  Create another composite snapshot ************/
         Node compositeSnapshotNode2 = Node.builder().name("My composite snapshot 2").nodeType(NodeType.COMPOSITE_SNAPSHOT).build();
@@ -2367,21 +2367,22 @@ public class DAOTestIT {
         nodeDAO.createCompositeSnapshot(folderNode.getUniqueId(), compositeSnapshot2);
         //************  End create another composite snapshot ************/
 
-        nodes = nodeDAO.containedInCompositeSnapshot(searchParameters);
+        nodes = nodeDAO.search(searchParameters).getNodes();
 
-        assertEquals(nodes.size(), 2);
+        assertEquals(2, nodes.size());
 
-        searchParameters.put("containedin", List.of("non-existing"));
+        searchParameters.put("referenced", List.of("non-existing"));
 
-        nodes = nodeDAO.containedInCompositeSnapshot(searchParameters);
+        nodes = nodeDAO.search(searchParameters).getNodes();
 
-        assertEquals(nodes.size(), 0);
+        assertEquals(0, nodes.size());
 
-        searchParameters.put("containedin", Collections.emptyList());
+        searchParameters.put("referenced", Collections.emptyList());
+        nodes = nodeDAO.search(searchParameters).getNodes();
 
-        assertThrows(IllegalArgumentException.class, () -> nodeDAO.containedInCompositeSnapshot(searchParameters));
+        assertTrue(nodes.isEmpty());
 
-        nodeDAO.deleteNode(compositeSnapshotNode.getUniqueId());
-        nodeDAO.deleteNode(compositeSnapshotNode2.getUniqueId());
+        nodeDAO.deleteNodes(List.of(compositeSnapshotNode.getUniqueId()));
+        nodeDAO.deleteNodes(List.of(compositeSnapshotNode2.getUniqueId()));
     }
 }

--- a/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/web/controllers/ComparisonControllerTestIT.java
+++ b/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/web/controllers/ComparisonControllerTestIT.java
@@ -107,12 +107,12 @@ public class ComparisonControllerTestIT {
 
         } finally {
             if(compositeSnapshot1 != null && compositeSnapshot1.getCompositeSnapshotNode() != null && compositeSnapshot1.getCompositeSnapshotNode().getUniqueId() != null){
-                nodeDAO.deleteNode(compositeSnapshot1.getCompositeSnapshotNode().getUniqueId());
+                nodeDAO.deleteNodes(List.of(compositeSnapshot1.getCompositeSnapshotNode().getUniqueId()));
             }
             if(compositeSnapshot2 != null && compositeSnapshot2.getCompositeSnapshotNode() != null && compositeSnapshot2.getCompositeSnapshotNode().getUniqueId() != null){
-                nodeDAO.deleteNode(compositeSnapshot2.getCompositeSnapshotNode().getUniqueId());
+                nodeDAO.deleteNodes(List.of(compositeSnapshot2.getCompositeSnapshotNode().getUniqueId()));
             }
-            nodeDAO.deleteNode(topLevelFolder.getUniqueId());
+            nodeDAO.deleteNodes(List.of(topLevelFolder.getUniqueId()));
         }
     }
 }


### PR DESCRIPTION
As per user request: provide a tool for finding composite snapshot referencing a snapshot or other composite snapshot. 

This has been implemented as a context menu item (see screen shot) which based on the selected node opens the search and filter view to perform a search. The search result list will reveal in what composite snapshots the slected node has been found.

Server side hence supports a new type of query: referenced=<node id>.

<img width="328" height="527" alt="Screenshot 2025-09-10 at 14 16 55" src="https://github.com/user-attachments/assets/98a688e1-75eb-4ef0-9aa4-845b4378cf9c" />
