### PR TITLE
Add a suggestion's list to TextEntry Widget

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextEntryWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/TextEntryWidget.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015-2020 Oak Ridge National Laboratory.
+ * Copyright (c) 2025 Thales.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,22 +10,32 @@ package org.csstudio.display.builder.model.widgets;
 
 import static org.csstudio.display.builder.model.ModelPlugin.logger;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newBooleanPropertyDescriptor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newIntegerPropertyDescriptor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newPVNamePropertyDescriptor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newStringPropertyDescriptor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propConfirmDialog;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propConfirmMessage;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propEnabled;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFormat;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propHorizontalAlignment;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propItemsFromPV;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPassword;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPrecision;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propShowUnits;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propVerticalAlignment;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propWrapWords;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
 
+import java.util.stream.Collectors;
 import org.csstudio.display.builder.model.MacroizedWidgetProperty;
 import org.csstudio.display.builder.model.Messages;
 import org.csstudio.display.builder.model.Version;
@@ -76,6 +87,46 @@ public class TextEntryWidget extends WritablePVWidget
     /** 'multi_line' */
     public static final WidgetPropertyDescriptor<Boolean> propMultiLine =
         newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "multi_line", Messages.WidgetProperties_MultiLine);
+
+
+
+    /**
+     * 'items' property: list of items (string properties) for auto-completion
+     */
+    public static final WidgetPropertyDescriptor<String> propItems =
+        newPVNamePropertyDescriptor(WidgetPropertyCategory.BEHAVIOR, "autocompleteitems", "Suggestions");
+
+    /**
+     * 'min_chars' property: minimum characters to trigger autocomplete
+     */
+    private static final WidgetPropertyDescriptor<Integer> propMinCharacters =
+        newIntegerPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR, "min_characters", "Min Characters");
+
+    /**
+     * 'case_sensitive' property: whether matching is case sensitive
+     */
+    private static final WidgetPropertyDescriptor<Boolean> propCaseSensitive =
+        newBooleanPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR, "case_sensitive", "Case Sensitive");
+
+    /**
+     * 'placeholder' property: placeholder text when empty
+     */
+    private static final WidgetPropertyDescriptor<String> propPlaceholder =
+        newStringPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "placeholder", "Placeholder Text");
+
+    /**
+     * 'allowcustom' property: allow custom values
+     */
+    private static final WidgetPropertyDescriptor<Boolean> propCustom =
+        newBooleanPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR, "allow_custom",
+            "Allow custom values");
+
+    /**
+     * 'filter_mode' property: how to filter suggestions (starts_with, contains, fuzzy)
+     */
+    private static final WidgetPropertyDescriptor<String> propFilterMode =
+        newStringPropertyDescriptor(WidgetPropertyCategory.BEHAVIOR, "filter_mode", "Filter Mode");
+
 
     private static class CustomWidgetConfigurator extends WidgetConfigurator
     {
@@ -282,6 +333,17 @@ public class TextEntryWidget extends WritablePVWidget
     private volatile WidgetProperty<Boolean> multi_line;
     private volatile WidgetProperty<HorizontalAlignment> horizontal_alignment;
     private volatile WidgetProperty<VerticalAlignment> vertical_alignment;
+    private volatile WidgetProperty<String> items;
+    private volatile WidgetProperty<Boolean> items_from_pv;
+    private volatile WidgetProperty<Boolean> confirm_dialog;
+    private volatile WidgetProperty<String> confirm_message;
+    private volatile WidgetProperty<String> password;
+    private volatile WidgetProperty<Integer> min_characters;
+    private volatile WidgetProperty<Boolean> case_sensitive;
+    private volatile WidgetProperty<String> placeholder;
+    private volatile WidgetProperty<String> filter_mode;
+    private volatile WidgetProperty<Boolean> allow_custom;
+    private volatile List<String> itemsList = List.of();
 
     /** Constructor */
     public TextEntryWidget()
@@ -317,6 +379,18 @@ public class TextEntryWidget extends WritablePVWidget
         properties.add(wrap_words = propWrapWords.createProperty(this, false));
         properties.add(multi_line = propMultiLine.createProperty(this, false));
         BorderSupport.addBorderProperties(this, properties);
+
+        properties.add(items = propItems.createProperty(this, ""));
+        properties.add(items_from_pv = propItemsFromPV.createProperty(this, false));
+        properties.add(min_characters = propMinCharacters.createProperty(this, 1));
+        properties.add(case_sensitive = propCaseSensitive.createProperty(this, false));
+        properties.add(placeholder = propPlaceholder.createProperty(this, "Type to search..."));
+        properties.add(filter_mode = propFilterMode.createProperty(this, "fuzzy"));
+        properties.add(allow_custom = propCustom.createProperty(this, false));
+
+        properties.add(confirm_dialog = propConfirmDialog.createProperty(this, false));
+        properties.add(confirm_message = propConfirmMessage.createProperty(this, "Are you sure you want to do this?"));
+        properties.add(password = propPassword.createProperty(this, ""));
     }
 
     /** @return 'foreground_color' property */
@@ -383,5 +457,140 @@ public class TextEntryWidget extends WritablePVWidget
     public WidgetProperty<VerticalAlignment> propVerticalAlignment()
     {
         return vertical_alignment;
+    }
+
+    /**
+     * @return 'items' property
+     */
+    public WidgetProperty<String> propItems() {
+        return items;
+    }
+
+    /**
+     * Convenience routine for script to fetch items
+     *
+     * @return Items currently available for auto-completion
+     */
+    public Collection<String> getItems() {
+        return itemsList;
+    }
+
+    /**
+     * Set the items list for auto-completion
+     *
+     * @param items List of items to set
+     */
+    public void setItems(List<String> items) {
+        this.itemsList = Objects.requireNonNullElseGet(items, List::of);
+    }
+
+    /**
+     * @return 'items_from_PV' property
+     */
+    public WidgetProperty<Boolean> propItemsFromPV() {
+        return items_from_pv;
+    }
+
+    /**
+     * @return 'confirm_dialog' property
+     */
+    public WidgetProperty<Boolean> propConfirmDialog() {
+        return confirm_dialog;
+    }
+
+    /**
+     * @return 'confirm_message' property
+     */
+    public WidgetProperty<String> propConfirmMessage() {
+        return confirm_message;
+    }
+
+    /**
+     * @return 'password' property
+     */
+    public WidgetProperty<String> propPassword() {
+        return password;
+    }
+
+    /**
+     * @return 'min_characters' property
+     */
+    public WidgetProperty<Integer> propMinCharacters() {
+        return min_characters;
+    }
+
+    /**
+     * @return 'case_sensitive' property
+     */
+    public WidgetProperty<Boolean> propCaseSensitive() {
+        return case_sensitive;
+    }
+
+    /**
+     * @return 'placeholder' property
+     */
+    public WidgetProperty<String> propPlaceholder() {
+        return placeholder;
+    }
+
+    /**
+     * @return 'filter_mode' property
+     */
+    public WidgetProperty<String> propFilterMode() {
+        return filter_mode;
+    }
+
+    /**
+     * @return 'allow_custom' property
+     */
+    public WidgetProperty<Boolean> propCustom() {
+        return allow_custom;
+    }
+
+    /**
+     * Filter items based on input text and return top N matches
+     *
+     * @param inputText Text to filter by
+     * @return List of filtered suggestions (max N items)
+     */
+    public List<String> getFilteredSuggestions(final String inputText) {
+        if (inputText == null || inputText.length() < min_characters.getValue()) {
+            return List.of();
+        }
+
+        final String searchText = case_sensitive.getValue() ? inputText : inputText.toLowerCase();
+        final String mode = filter_mode.getValue();
+
+        return getItems().stream()
+            .filter(item -> {
+                final String itemText = case_sensitive.getValue() ? item : item.toLowerCase();
+                return switch (mode) {
+                    case "starts_with" -> itemText.startsWith(searchText);
+                    case "fuzzy" -> fuzzyMatch(itemText, searchText);
+                    default -> itemText.contains(searchText);
+                };
+            })
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Simple fuzzy matching algorithm for filtering option.
+     *
+     * @param text    Text to search in
+     * @param pattern Pattern to search for
+     * @return true if pattern fuzzy matches text
+     */
+    private boolean fuzzyMatch(final String text, final String pattern) {
+        int textIndex = 0;
+        int patternIndex = 0;
+
+        while (textIndex < text.length() && patternIndex < pattern.length()) {
+            if (text.charAt(textIndex) == pattern.charAt(patternIndex)) {
+                patternIndex++;
+            }
+            textIndex++;
+        }
+
+        return patternIndex == pattern.length();
     }
 }

--- a/app/display/model/src/main/resources/examples/01_main.bob
+++ b/app/display/model/src/main/resources/examples/01_main.bob
@@ -15,7 +15,7 @@
 Note you can also navigate between buttons via &lt;Tab&gt; key or &lt;Shift&gt; and cursor keys,
 then press &lt;SPACE&gt; to activate button.</text>
     <x>10</x>
-    <y>490</y>
+    <y>520</y>
     <width>640</width>
     <height>80</height>
     <font use_class="true">
@@ -23,7 +23,7 @@ then press &lt;SPACE&gt; to activate button.</text>
       </font>
     </font>
     <foreground_color use_class="true">
-      <color name="Text" red="0" green="0" blue="0">
+      <color name="Text" red="204" green="204" blue="204">
       </color>
     </foreground_color>
     <transparent use_class="true">true</transparent>
@@ -42,7 +42,7 @@ then press &lt;SPACE&gt; to activate button.</text>
       </font>
     </font>
     <foreground_color use_class="true">
-      <color name="Text" red="0" green="0" blue="0">
+      <color name="Text" red="204" green="204" blue="204">
       </color>
     </foreground_color>
     <transparent use_class="true">true</transparent>
@@ -62,9 +62,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button</name>
     <actions>
       <action type="open_display">
+        <description>Introduction</description>
         <file>02_intro.bob</file>
         <target>replace</target>
-        <description>Introduction</description>
       </action>
     </actions>
     <y>80</y>
@@ -76,9 +76,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_7</name>
     <actions>
       <action type="open_display">
+        <description>Properties</description>
         <file>03_properties.bob</file>
         <target>replace</target>
-        <description>Properties</description>
       </action>
     </actions>
     <y>120</y>
@@ -90,9 +90,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_25</name>
     <actions>
       <action type="open_display">
+        <description>Classes</description>
         <file>use_classes.bob</file>
         <target>replace</target>
-        <description>Classes</description>
       </action>
     </actions>
     <y>160</y>
@@ -104,9 +104,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_9</name>
     <actions>
       <action type="open_display">
+        <description>Macros</description>
         <file>04_macros.bob</file>
         <target>replace</target>
-        <description>Macros</description>
       </action>
     </actions>
     <y>200</y>
@@ -118,9 +118,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_10</name>
     <actions>
       <action type="open_display">
+        <description>Actions</description>
         <file>05_actions.bob</file>
         <target>replace</target>
-        <description>Actions</description>
       </action>
     </actions>
     <y>240</y>
@@ -132,9 +132,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_37</name>
     <actions>
       <action type="open_display">
+        <description>Rules</description>
         <file>09_rules.bob</file>
         <target>replace</target>
-        <description>Rules</description>
       </action>
     </actions>
     <y>280</y>
@@ -146,9 +146,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_6</name>
     <actions>
       <action type="open_display">
+        <description>Scripts</description>
         <file>10_scripts.bob</file>
         <target>replace</target>
-        <description>Scripts</description>
       </action>
     </actions>
     <y>320</y>
@@ -160,9 +160,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_40</name>
     <actions>
       <action type="open_display">
+        <description>Datasources</description>
         <file>11_datasources.bob</file>
         <target>replace</target>
-        <description>Datasources</description>
       </action>
     </actions>
     <y>360</y>
@@ -174,9 +174,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_41</name>
     <actions>
       <action type="open_display">
+        <description>Formulas</description>
         <file>12_formulas.bob</file>
         <target>replace</target>
-        <description>Formulas</description>
       </action>
     </actions>
     <y>400</y>
@@ -188,9 +188,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_26</name>
     <actions>
       <action type="open_display">
+        <description>Enablement</description>
         <file>enablement.bob</file>
         <target>replace</target>
-        <description>Enablement</description>
       </action>
     </actions>
     <y>440</y>
@@ -226,9 +226,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_1</name>
     <actions>
       <action type="open_display">
+        <description>Label</description>
         <file>graphics_label.bob</file>
         <target>replace</target>
-        <description>Label</description>
       </action>
     </actions>
     <x>190</x>
@@ -241,9 +241,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_8</name>
     <actions>
       <action type="open_display">
+        <description>Picture</description>
         <file>graphics_picture.bob</file>
         <target>replace</target>
-        <description>Picture</description>
       </action>
     </actions>
     <x>190</x>
@@ -256,9 +256,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_17</name>
     <actions>
       <action type="open_display">
+        <description>Rectangle</description>
         <file>graphics_rect.bob</file>
         <target>replace</target>
-        <description>Rectangle</description>
       </action>
     </actions>
     <x>190</x>
@@ -271,9 +271,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_38</name>
     <actions>
       <action type="open_display">
+        <description>Arc</description>
         <file>graphics_arc.bob</file>
         <target>replace</target>
-        <description>Arc</description>
       </action>
     </actions>
     <x>190</x>
@@ -286,9 +286,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_39</name>
     <actions>
       <action type="open_display">
+        <description>Polygon/line</description>
         <file>graphics_poly.bob</file>
         <target>replace</target>
-        <description>Polygon/line</description>
       </action>
     </actions>
     <x>190</x>
@@ -313,9 +313,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_2</name>
     <actions>
       <action type="open_display">
+        <description>Text Update</description>
         <file>monitors_textupdate.bob</file>
         <target>replace</target>
-        <description>Text Update</description>
       </action>
     </actions>
     <x>330</x>
@@ -328,9 +328,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_3</name>
     <actions>
       <action type="open_display">
+        <description>LED</description>
         <file>monitors_led.bob</file>
         <target>replace</target>
-        <description>LED</description>
       </action>
     </actions>
     <x>330</x>
@@ -343,9 +343,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_20</name>
     <actions>
       <action type="open_display">
+        <description>Byte Monitor</description>
         <file>monitors_bytemonitor.bob</file>
         <target>replace</target>
-        <description>Byte Monitor</description>
       </action>
     </actions>
     <x>330</x>
@@ -358,9 +358,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_34</name>
     <actions>
       <action type="open_display">
+        <description>Tank</description>
         <file>monitors_tank.bob</file>
         <target>replace</target>
-        <description>Tank</description>
       </action>
     </actions>
     <x>330</x>
@@ -373,9 +373,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_35</name>
     <actions>
       <action type="open_display">
+        <description>Table</description>
         <file>monitors_table.bob</file>
         <target>replace</target>
-        <description>Table</description>
       </action>
     </actions>
     <x>330</x>
@@ -388,9 +388,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_27</name>
     <actions>
       <action type="open_display">
+        <description>Gauges</description>
         <file>monitors_gauge.bob</file>
         <target>replace</target>
-        <description>Gauges</description>
       </action>
     </actions>
     <x>330</x>
@@ -408,9 +408,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_28</name>
     <actions>
       <action type="open_display">
+        <description>Meters</description>
         <file>monitors_meter.bob</file>
         <target>replace</target>
-        <description>Meters</description>
       </action>
     </actions>
     <x>330</x>
@@ -428,9 +428,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_32</name>
     <actions>
       <action type="open_display">
+        <description>Symbols</description>
         <file>monitors_symbols.bob</file>
         <target>replace</target>
-        <description>Symbols</description>
       </action>
     </actions>
     <x>330</x>
@@ -455,9 +455,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_14</name>
     <actions>
       <action type="open_display">
+        <description>Text Entry</description>
         <file>controls_textentry.bob</file>
         <target>replace</target>
-        <description>Text Entry</description>
       </action>
     </actions>
     <x>470</x>
@@ -470,9 +470,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_15</name>
     <actions>
       <action type="open_display">
+        <description>Toggle Buttons</description>
         <file>controls_toggle_buttons.bob</file>
         <target>replace</target>
-        <description>Toggle Buttons</description>
       </action>
     </actions>
     <x>470</x>
@@ -485,9 +485,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_16</name>
     <actions>
       <action type="open_display">
+        <description>Action Buttons</description>
         <file>controls_action_buttons.bob</file>
         <target>replace</target>
-        <description>Action Buttons</description>
       </action>
     </actions>
     <x>470</x>
@@ -500,9 +500,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_18</name>
     <actions>
       <action type="open_display">
+        <description>Incr. Controls</description>
         <file>controls_spinner_slider_scrollbar.bob</file>
         <target>replace</target>
-        <description>Incr. Controls</description>
       </action>
     </actions>
     <x>470</x>
@@ -515,9 +515,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_19</name>
     <actions>
       <action type="open_display">
+        <description>Combo Box</description>
         <file>controls_combo.bob</file>
         <target>replace</target>
-        <description>Combo Box</description>
       </action>
     </actions>
     <x>470</x>
@@ -530,9 +530,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_36</name>
     <actions>
       <action type="open_display">
+        <description>Check Boxes</description>
         <file>controls_checkboxes_slidebuttons.bob</file>
         <target>replace</target>
-        <description>Check Boxes</description>
       </action>
     </actions>
     <x>470</x>
@@ -545,9 +545,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_23</name>
     <actions>
       <action type="open_display">
+        <description>Radio Button</description>
         <file>controls_radio.bob</file>
         <target>replace</target>
-        <description>Radio Button</description>
       </action>
     </actions>
     <x>470</x>
@@ -560,9 +560,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_22</name>
     <actions>
       <action type="open_display">
+        <description>File Selector</description>
         <file>controls_fileselector.bob</file>
         <target>replace</target>
-        <description>File Selector</description>
       </action>
     </actions>
     <x>470</x>
@@ -572,12 +572,32 @@ then press &lt;SPACE&gt; to activate button.</text>
     <tooltip>$(actions)</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
+    <name>Action Button_33</name>
+    <actions>
+      <action type="open_display">
+        <description>Knob</description>
+        <file>controls_knob.bob</file>
+        <target>replace</target>
+      </action>
+    </actions>
+    <x>470</x>
+    <y>440</y>
+    <width>120</width>
+    <height>26</height>
+    <scripts>
+      <script file="scripts/disable_missing.py">
+        <pv_name>loc://knob("knob")</pv_name>
+      </script>
+    </scripts>
+    <tooltip>$(actions)</tooltip>
+  </widget>
+  <widget type="action_button" version="3.0.0">
     <name>Action Button_34</name>
     <actions>
       <action type="open_display">
+        <description>Thumb Wheel</description>
         <file>controls_thumbwheel.bob</file>
         <target>replace</target>
-        <description>Thumb Wheel</description>
       </action>
     </actions>
     <x>470</x>
@@ -607,9 +627,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>XY</name>
     <actions>
       <action type="open_display">
+        <description>X/Y Plot</description>
         <file>plots_xy.bob</file>
         <target>replace</target>
-        <description>X/Y Plot</description>
       </action>
     </actions>
     <x>610</x>
@@ -622,9 +642,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Strip</name>
     <actions>
       <action type="open_display">
+        <description>Strip Chart</description>
         <file>plots_strip.bob</file>
         <target>replace</target>
-        <description>Strip Chart</description>
       </action>
     </actions>
     <x>610</x>
@@ -637,9 +657,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>DB</name>
     <actions>
       <action type="open_display">
+        <description>Data Browser</description>
         <file>plots_databrowser.bob</file>
         <target>replace</target>
-        <description>Data Browser</description>
       </action>
     </actions>
     <x>610</x>
@@ -652,9 +672,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Image</name>
     <actions>
       <action type="open_display">
+        <description>Image</description>
         <file>plots_image.bob</file>
         <target>replace</target>
-        <description>Image</description>
       </action>
     </actions>
     <x>610</x>
@@ -679,9 +699,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_13</name>
     <actions>
       <action type="open_display">
+        <description>Group</description>
         <file>structure_group.bob</file>
         <target>replace</target>
-        <description>Group</description>
       </action>
     </actions>
     <x>750</x>
@@ -694,9 +714,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_11</name>
     <actions>
       <action type="open_display">
+        <description>Embedded</description>
         <file>embedded/structure_embedded.bob</file>
         <target>replace</target>
-        <description>Embedded</description>
       </action>
     </actions>
     <x>750</x>
@@ -709,9 +729,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_12</name>
     <actions>
       <action type="open_display">
+        <description>Tabs</description>
         <file>structure_tabs.bob</file>
         <target>replace</target>
-        <description>Tabs</description>
       </action>
     </actions>
     <x>750</x>
@@ -724,9 +744,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_31</name>
     <actions>
       <action type="open_display">
+        <description>Navigation Tabs</description>
         <file>structure_navtabs.bob</file>
         <target>replace</target>
-        <description>Navigation Tabs</description>
       </action>
     </actions>
     <x>750</x>
@@ -739,9 +759,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_30</name>
     <actions>
       <action type="open_display">
+        <description>Array</description>
         <file>structure_array.bob</file>
         <target>replace</target>
-        <description>Array</description>
       </action>
     </actions>
     <x>750</x>
@@ -754,9 +774,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_21</name>
     <actions>
       <action type="open_display">
+        <description>Template &amp; Inst.</description>
         <file>template_and_instance/example.bob</file>
         <target>replace</target>
-        <description>Template &amp; Inst.</description>
       </action>
     </actions>
     <x>750</x>
@@ -781,9 +801,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_20</name>
     <actions>
       <action type="open_display">
+        <description>Web Browser</description>
         <file>misc_webbrowser.bob</file>
         <target>replace</target>
-        <description>Web Browser</description>
       </action>
     </actions>
     <x>890</x>
@@ -796,9 +816,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_24</name>
     <actions>
       <action type="open_display">
+        <description>Clocks</description>
         <file>misc_clock.bob</file>
         <target>replace</target>
-        <description>Clocks</description>
       </action>
     </actions>
     <x>890</x>
@@ -816,9 +836,9 @@ then press &lt;SPACE&gt; to activate button.</text>
     <name>Action Button_29</name>
     <actions>
       <action type="open_display">
+        <description>Fishtank</description>
         <file>fishtank/heater.bob</file>
         <target>replace</target>
-        <description>Fishtank</description>
       </action>
     </actions>
     <x>890</x>

--- a/app/display/model/src/main/resources/examples/controls_textentry.bob
+++ b/app/display/model/src/main/resources/examples/controls_textentry.bob
@@ -15,7 +15,7 @@
       </font>
     </font>
     <foreground_color use_class="true">
-      <color name="Text" red="0" green="0" blue="0">
+      <color name="Text" red="204" green="204" blue="204">
       </color>
     </foreground_color>
     <transparent use_class="true">true</transparent>
@@ -118,7 +118,7 @@
     <width>250</width>
     <height>70</height>
     <font>
-      <font name="Oddball" family="PakTypeNaqsh" style="REGULAR" size="40.0">
+      <font name="Oddball" family="Comic Sans MS" style="REGULAR" size="40.0">
       </font>
     </font>
     <background_color>
@@ -148,7 +148,7 @@ Pressing 'Enter' confirms editing and writes the entered value to the PV.</text>
       </font>
     </font>
     <foreground_color use_class="true">
-      <color name="Text" red="0" green="0" blue="0">
+      <color name="Text" red="204" green="204" blue="204">
       </color>
     </foreground_color>
     <transparent use_class="true">true</transparent>
@@ -200,7 +200,7 @@ To cancel editing and revert to the original value, press 'Escape'.
       </font>
     </font>
     <foreground_color use_class="true">
-      <color name="Text" red="0" green="0" blue="0">
+      <color name="Text" red="204" green="204" blue="204">
       </color>
     </foreground_color>
     <transparent use_class="true">true</transparent>
@@ -228,7 +228,286 @@ Press 'Escape', 'Tab', or click elsewhere to abort.</text>
       </font>
     </font>
     <foreground_color use_class="true">
-      <color name="Text" red="0" green="0" blue="0">
+      <color name="Text" red="204" green="204" blue="204">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <wrap_words use_class="true">true</wrap_words>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_5</name>
+    <text>A Text Entry can have suggestions.</text>
+    <x>850</x>
+    <y>71</y>
+    <width>481</width>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Text Entry_7</name>
+    <pv_name>loc://suggestions_test&lt;VString&gt;</pv_name>
+    <x>850</x>
+    <y>101</y>
+    <width>220</width>
+    <autocompleteitems>a suggestion
+something
+something else
+possibly
+nothing</autocompleteitems>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_14</name>
+    <text>Like a Combo Box, suggestions can be based on PV value.</text>
+    <x>850</x>
+    <y>131</y>
+    <width>481</width>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Text Entry_8</name>
+    <pv_name>loc://suggestions_test1&lt;VEnum&gt;(0, "NORTH", "SOUTH", "EAST", "WEST")</pv_name>
+    <x>850</x>
+    <y>161</y>
+    <width>220</width>
+    <autocompleteitems>a suggestion
+something
+something else
+possibly
+nothing</autocompleteitems>
+    <items_from_pv>true</items_from_pv>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_16</name>
+    <text>Suggestions</text>
+    <x>850</x>
+    <y>31</y>
+    <width>201</width>
+    <font>
+      <font name="Header 3" family="Liberation Sans" style="BOLD" size="16.0">
+      </font>
+    </font>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_17</name>
+    <text>Miscellaneous options:</text>
+    <x>850</x>
+    <y>201</y>
+    <width>481</width>
+    <height>30</height>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Text Entry_10</name>
+    <pv_name>loc://suggestions_test2&lt;VEnum&gt;(0, "NORTH", "SOUTH", "EAST", "WEST")</pv_name>
+    <x>1000</x>
+    <y>230</y>
+    <width>220</width>
+    <autocompleteitems>a suggestion
+something
+something else
+possibly
+nothing</autocompleteitems>
+    <items_from_pv>true</items_from_pv>
+    <show_confirm_dialog>true</show_confirm_dialog>
+    <password>test</password>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_18</name>
+    <text>Password:</text>
+    <x>850</x>
+    <y>231</y>
+    <width>80</width>
+    <height>30</height>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Text Entry_11</name>
+    <pv_name>loc://suggestions_test3&lt;VEnum&gt;(0, "NORTH", "SOUTH", "EAST", "WEST")</pv_name>
+    <x>1000</x>
+    <y>261</y>
+    <width>220</width>
+    <autocompleteitems>a suggestion
+something
+something else
+possibly
+nothing</autocompleteitems>
+    <items_from_pv>true</items_from_pv>
+    <case_sensitive>true</case_sensitive>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_19</name>
+    <text>Case sensitive:</text>
+    <x>850</x>
+    <y>262</y>
+    <width>150</width>
+    <height>30</height>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Text Entry_12</name>
+    <pv_name>loc://suggestions_test4&lt;VEnum&gt;(0, "NORTH", "SOUTH", "EAST", "WEST")</pv_name>
+    <x>1000</x>
+    <y>292</y>
+    <width>220</width>
+    <autocompleteitems>a suggestion
+something
+something else
+possibly
+nothing</autocompleteitems>
+    <items_from_pv>true</items_from_pv>
+    <min_characters>3</min_characters>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_20</name>
+    <text>Minimum characters:</text>
+    <x>850</x>
+    <y>293</y>
+    <width>150</width>
+    <height>30</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_22</name>
+    <text>Pattern matching:</text>
+    <x>850</x>
+    <y>323</y>
+    <width>481</width>
+    <height>30</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_23</name>
+    <text>fuzzy*:</text>
+    <x>850</x>
+    <y>353</y>
+    <width>201</width>
+    <height>18</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_24</name>
+    <class>COMMENT</class>
+    <text>*Fuzzy string searching (or approximate string matching):
+It is the technique of finding strings that match a pattern approximately</text>
+    <x>850</x>
+    <y>410</y>
+    <width>370</width>
+    <height>80</height>
+    <font use_class="true">
+      <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="204" green="204" blue="204">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <wrap_words use_class="true">true</wrap_words>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Text Entry_14</name>
+    <pv_name>loc://suggestions_test5&lt;VString&gt;</pv_name>
+    <x>850</x>
+    <y>371</y>
+    <width>220</width>
+    <autocompleteitems>banana
+strawberry
+raspberry
+blueberry
+apple
+pineapple
+pear
+kiwi
+blackberry
+lemon
+orange
+apricot
+mango
+avocado
+cherry
+bilberry
+peach
+satsuma
+persimmon</autocompleteitems>
+    <items_from_pv>true</items_from_pv>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Text Entry_15</name>
+    <pv_name>loc://suggestions_test5&lt;VString&gt;</pv_name>
+    <x>1080</x>
+    <y>371</y>
+    <width>220</width>
+    <autocompleteitems>banana
+strawberry
+raspberry
+blueberry
+apple
+pineapple
+pear
+kiwi
+blackberry
+lemon
+orange
+apricot
+mango
+avocado
+cherry
+bilberry
+peach
+satsuma
+persimmon</autocompleteitems>
+    <items_from_pv>true</items_from_pv>
+    <filter_mode>starts_with</filter_mode>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Text Entry_16</name>
+    <pv_name>loc://suggestions_test5&lt;VString&gt;</pv_name>
+    <x>1310</x>
+    <y>371</y>
+    <width>220</width>
+    <autocompleteitems>banana
+strawberry
+raspberry
+blueberry
+apple
+pineapple
+pear
+kiwi
+blackberry
+lemon
+orange
+apricot
+mango
+avocado
+cherry
+bilberry
+peach
+satsuma
+persimmon</autocompleteitems>
+    <items_from_pv>true</items_from_pv>
+    <filter_mode>contains</filter_mode>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_25</name>
+    <text>starts_with*:</text>
+    <x>1080</x>
+    <y>353</y>
+    <width>201</width>
+    <height>18</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_26</name>
+    <text>contains*:</text>
+    <x>1310</x>
+    <y>353</y>
+    <width>201</width>
+    <height>18</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_27</name>
+    <class>COMMENT</class>
+    <text>Unlike a Combobox, the suggestion system has no limits on the number of suggestions it can make.</text>
+    <x>850</x>
+    <y>500</y>
+    <width>370</width>
+    <height>80</height>
+    <font use_class="true">
+      <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="204" green="204" blue="204">
       </color>
     </foreground_color>
     <transparent use_class="true">true</transparent>

--- a/app/display/model/src/test/java/org/csstudio/display/builder/model/widgets/TextEntryWidgetTest.java
+++ b/app/display/model/src/test/java/org/csstudio/display/builder/model/widgets/TextEntryWidgetTest.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Thales.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.csstudio.display.builder.model.widgets;
+
+import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.Widget;
+import org.csstudio.display.builder.model.persist.ModelReader;
+import org.csstudio.display.builder.model.persist.ModelWriter;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+/**
+ * JUnit test suite for TextEntryWidget functionality.
+ * This test class validates the TextEntryWidget's filtering and suggestion
+ * capabilities, including various search modes, case sensitivity options,
+ * minimum character requirements, and XML serialization/deserialization.
+ */
+@SuppressWarnings("nls")
+public class TextEntryWidgetTest
+{
+    /**
+     * Creates a new TextEntryWidget instance with the specified suggestion items.
+     *
+     * @param items the list of suggestion items to set on the widget
+     * @return a new TextEntryWidget configured with the provided items
+     */
+    private TextEntryWidget newWidgetWithItems(List<String> items)
+    {
+        final TextEntryWidget w = new TextEntryWidget();
+        w.setItems(items);
+        return w;
+    }
+
+    /**
+     * Tests case-insensitive substring matching functionality.
+     * Verifies that the widget correctly filters suggestions using case-insensitive
+     * "contains" mode. The test ensures that partial matches are found regardless
+     * of character case in both the input and the suggestion items.
+     */
+    @Test
+    public void testContainsCaseInsensitive()
+    {
+        final TextEntryWidget w = newWidgetWithItems(List.of("Alpha", "beta", "ALPHABET", "gamma"));
+
+        w.propMinCharacters().setValue(2);
+        w.propCaseSensitive().setValue(false);
+        w.propFilterMode().setValue("contains");
+
+        final List<String> result = w.getFilteredSuggestions("ha");
+        assertThat(result, equalTo(List.of("Alpha", "ALPHABET")));
+    }
+
+    /**
+     * Tests case-sensitive prefix matching functionality.
+     * Verifies that the widget correctly filters suggestions using case-sensitive
+     * "starts with" mode. Only items that begin with the exact case-matched
+     * input string should be included in the results.
+     */
+    @Test
+    public void testStartsWithCaseSensitive()
+    {
+        final TextEntryWidget w = newWidgetWithItems(List.of("Foo", "Foobar", "foo", "FOO", "bar"));
+
+        w.propMinCharacters().setValue(1);
+        w.propCaseSensitive().setValue(true);
+        w.propFilterMode().setValue("starts_with");
+
+        final List<String> result = w.getFilteredSuggestions("Fo");
+        assertThat(result, equalTo(List.of("Foo", "Foobar")));
+    }
+
+    /**
+     * Tests fuzzy matching functionality.
+     * Verifies that the widget correctly performs fuzzy matching where input
+     * characters can match non-consecutive characters in suggestion items.
+     * The fuzzy algorithm should find items containing all input characters
+     * in the correct order, but not necessarily consecutively.
+     */
+    @Test
+    public void testFuzzyMatching()
+    {
+        final TextEntryWidget w = newWidgetWithItems(List.of("cartwheel", "carthorse", "cow", "chart"));
+
+        w.propMinCharacters().setValue(3);
+        w.propCaseSensitive().setValue(false);
+        w.propFilterMode().setValue("fuzzy");
+
+        final List<String> result = w.getFilteredSuggestions("crt");
+        assertThat(result, equalTo(List.of("cartwheel", "carthorse", "chart")));
+    }
+
+    /**
+     * Tests minimum character requirement enforcement.
+     * Verifies that the widget respects the minimum character setting and
+     * returns no suggestions when the input length is below the configured
+     * minimum threshold.
+     */
+    @Test
+    public void testMinCharactersBlocksShortInput()
+    {
+        final TextEntryWidget w = newWidgetWithItems(List.of("one", "two", "three"));
+
+        w.propMinCharacters().setValue(3);
+        w.propCaseSensitive().setValue(false);
+        w.propFilterMode().setValue("contains");
+
+        final List<String> result = w.getFilteredSuggestions("ab");
+        assertThat(result, equalTo(List.of()));
+    }
+
+    /**
+     * Tests XML serialization and deserialization round-trip to ensure all
+     * key TextEntryWidget properties are correctly preserved.
+     * This test:
+     * - Creates a TextEntryWidget with custom property values including
+     *   suggestion items, filtering options, and UI settings
+     * - Serializes it to XML using ModelWriter
+     * - Deserializes it back using ModelReader
+     * - Verifies that all critical properties retain their values after
+     *   the round-trip operation
+     * The test covers persistence of suggestion items, minimum character
+     * requirements, case sensitivity, filter mode, placeholder text,
+     * and custom input settings.
+     */
+    @Test
+    public void testXMLRoundtripPreservesKeyProperties() throws Exception
+    {
+        TextEntryWidget w = new TextEntryWidget();
+        w.setItems(List.of("one", "Two", "three"));
+        w.propItems().setValue("one\nTwo\nthree");
+        w.propMinCharacters().setValue(2);
+        w.propCaseSensitive().setValue(true);
+        w.propFilterMode().setValue("starts_with");
+        w.propPlaceholder().setValue("Enter value…");
+        w.propCustom().setValue(true);
+
+        final String xml = ModelWriter.getXML(List.of(w));
+
+        final DisplayModel model = ModelReader.parseXML(xml);
+        final List<Widget> widgets = model.getChildren();
+        assertThat(widgets.size(), equalTo(1));
+        assertThat(widgets.get(0), instanceOf(TextEntryWidget.class));
+
+        w = (TextEntryWidget) widgets.get(0);
+
+        assertThat(w.propItems().getValue(), equalTo("one\nTwo\nthree"));
+        assertThat(w.propMinCharacters().getValue(), equalTo(2));
+        assertThat(w.propCaseSensitive().getValue(), equalTo(true));
+        assertThat(w.propFilterMode().getValue(), equalTo("starts_with"));
+        assertThat(w.propPlaceholder().getValue(), equalTo("Enter value…"));
+        assertThat(w.propCustom().getValue(), equalTo(true));
+    }
+}

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseWidgetRepresentations.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseWidgetRepresentations.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2017-2021 Oak Ridge National Laboratory.
+ * Copyright (c) 2025 Thales.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
As previously discussed, this PR aims to provide a list of suggestions based on what the user types in a TextEntry Widget.

- The PV is only written when pressing the key (same behavior than before) or when a suggestion is selected
- Possibility to allow or disallow values outside the list of suggestions (via an option)
- Different search algorithms (startswith, fuzzy, contains)
- A more comprehensive example page detailing all the options

Here's the demo page from Home menu :
<img width="1218" height="710" alt="472009784-8e934e5a-9359-4a49-bdc3-3baa1f3eda0f" src="https://github.com/user-attachments/assets/a2550490-01c3-4ff9-b5b1-caf42a44313b" />
