### PR TITLE
github: add a Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+
+<!-- ^^^ Describe your changes here ^^^ -->
+
+## Checklist
+
+<!--
+    Check all that apply.
+
+    Note that these are not all required,
+    but serves as information for reviewers.
+-->
+
+- Testing:
+    - [ ] The feature has automated tests
+    - [ ] Tests were run
+    - If not, explain how you tested your changes
+
+- Documentation:
+    - [ ] The feature is documented
+    - [ ] The documentation is up to date
+    - Release notes:
+        - [ ] Added an entry if the change is breaking or significant
+        - [ ] Added an entry when adding a new feature


### PR DESCRIPTION
This is intended to serve as a reminder for contributors, and hopefully should help keeping the documentation and release notes up-to-date.

This should also save time for reviewers by automatically asking common questions to contributors.

I've only included some common generic questions in the checklist. The PR template doesn't start with a title because GitHub automatically prepend the PR template with the commit message body (so the title would be after that).