### PR TITLE
CSSTUDIO-3410 Add check for and annunciation of disconnection from the Alarm Server to the Annunciator

### DIFF
--- a/app/alarm/model/src/main/java/org/phoebus/applications/alarm/talk/TalkClient.java
+++ b/app/alarm/model/src/main/java/org/phoebus/applications/alarm/talk/TalkClient.java
@@ -9,6 +9,7 @@ package org.phoebus.applications.alarm.talk;
 
 import static java.lang.Thread.sleep;
 import static org.phoebus.applications.alarm.AlarmSystem.logger;
+import static org.phoebus.applications.alarm.AlarmSystem.nag_period_ms;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -194,7 +195,12 @@ public class TalkClient
                     } catch (final Exception ex) {
                         logger.log(Level.WARNING, "Talk error for " + SeverityLevel.UNDEFINED + ", " + "Alarm Server Disconnected", ex);
                     }
-                    nextDisconnectedAnnunciation = Optional.of(now.plus(disconnectionAnnunciationPeriod));
+                    if (nag_period_ms > 0) {
+                        nextDisconnectedAnnunciation = Optional.of(now.plus(disconnectionAnnunciationPeriod)); // Annunciate disconnect again after nag period_ms
+                    }
+                    else {
+                        nextDisconnectedAnnunciation = Optional.of(Instant.MAX); // When nag_period_ms == 0, don't annunciate the disconnection again.
+                    }
                 }
             } else {
                 nextDisconnectedAnnunciation = Optional.empty(); // Connection to the Alarm Server exists.


### PR DESCRIPTION
This pull request adds a check for disconnections from the Alarm Server to the Annunciator. If a disconnection is detected, the annunciator announces the disconnect. If the disconnections persists, the disconnection is annunciated periodically with the period configured in the option `org.phoebus.applications.alarm/nag_period`.

The implemented mechanism is based on the existing mechanism used for detecting disconnections in `AlarmClient`. The Alarm Server is configured to send at least one message every `org.phoebus.applications.alarm/heartbeat_secs` seconds on the `config_name` topic (_not_ the `config_name + AlarmSystem.TALK_TOPIC_SUFFIX` topic!), and if no messages have been received for three times this period, then a disconnection has been detected.

The implementation runs in two threads:
1. Thread 1 subscribes to updates on the topic `config_name` and it polls the Alarm Server every second, and if there are new messages, the timestamp is saved.
2. Thread 2 checks once every second whether the latest timestamp received is within three times the configured heartbeat interval. If it isn't, it annunciates a disconnection.

I run the polling on a separate thread from the logic to check and annunciate disconnections because there seem to be situations where polling the Kafka server is blocking: if I start the Annunciator with the Alarm Server _not running_, then the polling seems to be blocking, and the check for disconnections would not run if it were called on the same thread.

Since the Alarm Server only implements the heartbeat functionality for the topic `config_name` and _not_ for the topic `config_name + AlarmSystem.TALK_TOPIC_SUFFIX`, the polling is made for the topic `config_name`.