### PR TITLE
EDM converter: Create output path folders

### DIFF
--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-202 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/ConverterPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-202 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -66,6 +66,7 @@ public class ConverterPreferences
             logger.log(Level.WARNING, "Cannot parse font_mappings", ex);
         }
 
+        edm_paths_config = edm_paths_config.strip();
         if (! edm_paths_config.isEmpty())
             try
             {
@@ -76,8 +77,8 @@ public class ConverterPreferences
                 logger.log(Level.WARNING, "Cannot parse paths from " + edm_paths_config, ex);
             }
 
-        final String dir = prefs.get("auto_converter_dir");
-        if (dir.isBlank())
+        final String dir = prefs.get("auto_converter_dir").strip();
+        if (dir.isEmpty())
             auto_converter_dir = null;
         else
         {

--- a/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/EdmAutoConverter.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/display/converter/edm/EdmAutoConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2019-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@ package org.csstudio.display.converter.edm;
 import static org.csstudio.display.converter.edm.Converter.logger;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.logging.Level;
@@ -142,7 +143,11 @@ public class EdmAutoConverter implements DisplayAutoConverter
         // Convert EDM input
         logger.log(Level.INFO, "Converting " + input + " into " + output);
         locator.setPrefix(new File(display_file).getParent());
-        new EdmConverter(input, locator).write(output);
+        final EdmConverter converter = new EdmConverter(input, locator);
+
+        // Save EDM file to potentially new folder
+        Files.createDirectories(output.getParentFile().toPath());
+        converter.write(output);
 
         // Return DisplayModel of the converted file
         return ModelLoader.loadModel(output.getPath());


### PR DESCRIPTION
When EDM files are arranged in a directory tree, the auto-converted files will now create a mirror of that structure instead of failing when the folder structure hadn't been created ahead of time