### PR TITLE
Fix annotation moving to the left when X axis PV changes

### DIFF
--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AnnotationImpl.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/AnnotationImpl.java
@@ -179,7 +179,7 @@ public class AnnotationImpl<XTYPE extends Comparable<XTYPE>> extends Annotation<
             throw new TimeoutException("Cannot update annotation, no lock on " + data);
         try
         {
-            final int index = search.findSampleLessOrEqual(data, location);
+            final int index = search.findClosestSample(data, location);
             if (index < 0)
                 return false;
             final PlotDataItem<XTYPE> sample = data.get(index);


### PR DESCRIPTION
When on plot the X axis PV changes the way that here is no anymore the same x value, the annotation was choosing the last index before. We found the issue while using NTPVs on X and Y axis, which was recalculated every time in the IOC - so we never could find the same sample.

When X axis PV is changing every time, it was causing the issue that annotation was slowly going to the left and finally ending at the beginning.

Before:
<img width="2649" height="979" alt="image" src="https://github.com/user-attachments/assets/abb51296-7b75-4040-9f78-3d454dc7647b" />

Finding the closest sample instead should fix the issue (or at least limit it).
