### PR TITLE
Implement opening File Browser from Top Resources

### DIFF
--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowser.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowser.java
@@ -55,19 +55,50 @@ public class FileBrowser implements AppInstance
             content = new Label("Cannot load UI");
         }
 
+        // final DockItem tab = new DockItem(this, content);
+        // DockPane.getActiveDockPane().addTab(tab);
+
+        // if (controller != null  &&  file != null){
+        //     if(file.isDirectory()){
+        //         controller.setRoot(file);
+        //     }
+        //     else{
+        //         controller.setRootAndHighlight(file);
+        //     }
+        // }
+
+        // tab.addClosedNotification(controller::shutdown);
         final DockItem tab = new DockItem(this, content);
         DockPane.getActiveDockPane().addTab(tab);
 
-        if (controller != null  &&  file != null){
-            if(file.isDirectory()){
-                controller.setRoot(file);
-            }
-            else{
-                controller.setRootAndHighlight(file);
-            }
+        // Initial title
+        if (file != null)
+        {
+            String folderName = file.getName().isEmpty() ? file.getPath() : file.getName();
+            tab.setLabel(app.getDisplayName() + " \\" + folderName);
         }
 
-        tab.addClosedNotification(controller::shutdown);
+        // When the user navigates, update the tab name dynamically
+        if (controller != null)
+        {
+            controller.addRootChangeListener(newRoot -> {
+                if (newRoot != null)
+                {
+                    String folderName = newRoot.getName().isEmpty() ? newRoot.getPath() : newRoot.getName();
+                    tab.setLabel(app.getDisplayName() + " \\" + folderName);
+                }
+            });
+
+            if (file != null)
+            {
+                if (file.isDirectory())
+                    controller.setRoot(file);
+                else
+                    controller.setRootAndHighlight(file);
+            }
+
+            tab.addClosedNotification(controller::shutdown);
+        }
     }
 
     @Override

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowser.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowser.java
@@ -55,19 +55,6 @@ public class FileBrowser implements AppInstance
             content = new Label("Cannot load UI");
         }
 
-        // final DockItem tab = new DockItem(this, content);
-        // DockPane.getActiveDockPane().addTab(tab);
-
-        // if (controller != null  &&  file != null){
-        //     if(file.isDirectory()){
-        //         controller.setRoot(file);
-        //     }
-        //     else{
-        //         controller.setRootAndHighlight(file);
-        //     }
-        // }
-
-        // tab.addClosedNotification(controller::shutdown);
         final DockItem tab = new DockItem(this, content);
         DockPane.getActiveDockPane().addTab(tab);
 

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowser.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowser.java
@@ -58,11 +58,11 @@ public class FileBrowser implements AppInstance
         final DockItem tab = new DockItem(this, content);
         DockPane.getActiveDockPane().addTab(tab);
 
-        // Initial title
+        // Initial title for the tab
         if (file != null)
         {
             String folderName = file.getName().isEmpty() ? file.getPath() : file.getName();
-            tab.setLabel(app.getDisplayName() + " \\" + folderName);
+            tab.setLabel(app.getDisplayName() + " (" + folderName + ")");
         }
 
         // When the user navigates, update the tab name dynamically
@@ -72,7 +72,7 @@ public class FileBrowser implements AppInstance
                 if (newRoot != null)
                 {
                     String folderName = newRoot.getName().isEmpty() ? newRoot.getPath() : newRoot.getName();
-                    tab.setLabel(app.getDisplayName() + " \\" + folderName);
+                    tab.setLabel(app.getDisplayName() + " (" + folderName + ")");
                 }
             });
 

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserApp.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserApp.java
@@ -43,12 +43,6 @@ public class FileBrowserApp implements AppResourceDescriptor {
         return createWithRoot(default_root);
     }
 
-    // @Override
-    // public AppInstance create(final URI resource)
-    // {
-    //     return createWithRoot(new File(resource));
-    // }
-
     @Override
     public AppInstance create(final URI resource)
     {

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserApp.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserApp.java
@@ -2,6 +2,7 @@ package org.phoebus.applications.filebrowser;
 
 import java.io.File;
 import java.net.URI;
+import java.net.URL;
 
 import org.phoebus.framework.preferences.AnnotatedPreferences;
 import org.phoebus.framework.preferences.Preference;
@@ -42,14 +43,37 @@ public class FileBrowserApp implements AppResourceDescriptor {
         return createWithRoot(default_root);
     }
 
+    // @Override
+    // public AppInstance create(final URI resource)
+    // {
+    //     return createWithRoot(new File(resource));
+    // }
+
     @Override
     public AppInstance create(final URI resource)
     {
-        return createWithRoot(new File(resource));
+        try
+        {
+            // Remove query component since File(URI) does not accept it
+            URI clean = new URI(resource.getScheme(), resource.getSchemeSpecificPart(), null);
+            return createWithRoot(new File(clean));
+        }
+        catch (Exception ex)
+        {
+            // Fallback: try using path string
+            return createWithRoot(new File(resource.getPath()));
+        }
     }
+
 
     public AppInstance createWithRoot(final File directory)
     {
         return new FileBrowser(this, directory);
+    }
+
+    @Override
+    public URL getIconURL()
+    {
+        return FileBrowserApp.class.getResource("/icons/filebrowser.png");
     }
 }

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserController.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserController.java
@@ -73,18 +73,20 @@ public class FileBrowserController {
     private final Menu openWith = new Menu(Messages.OpenWith, ImageCache.getImageView(PhoebusApplication.class, "/icons/fldr_obj.png"));
     private final ContextMenu contextMenu = new ContextMenu();
 
+    /**
+     * Create a listener for changes in the selected directory
+     */
     private final List<Consumer<File>> root_change_listeners = new ArrayList<>();
-
-    public void addRootChangeListener(Consumer<File> listener)
-    {
+    public void addRootChangeListener(Consumer<File> listener) {
         root_change_listeners.add(listener);
     }
 
-    private void notifyRootChange(File newRoot)
-    {
+    private void notifyRootChange(File newRoot) {
+        // Notify that the directory has changed
         for (Consumer<File> listener : root_change_listeners)
             listener.accept(newRoot);
     }
+    
 
     private ExpandedCountChangeListener expandedCountChangeListener;
 

--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserController.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileBrowserController.java
@@ -43,9 +43,11 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.function.Consumer;
 
 import static org.phoebus.applications.filebrowser.FileBrowser.logger;
 
@@ -70,6 +72,19 @@ public class FileBrowserController {
     private final MenuItem open = new MenuItem(Messages.Open, ImageCache.getImageView(PhoebusApplication.class, "/icons/fldr_obj.png"));
     private final Menu openWith = new Menu(Messages.OpenWith, ImageCache.getImageView(PhoebusApplication.class, "/icons/fldr_obj.png"));
     private final ContextMenu contextMenu = new ContextMenu();
+
+    private final List<Consumer<File>> root_change_listeners = new ArrayList<>();
+
+    public void addRootChangeListener(Consumer<File> listener)
+    {
+        root_change_listeners.add(listener);
+    }
+
+    private void notifyRootChange(File newRoot)
+    {
+        for (Consumer<File> listener : root_change_listeners)
+            listener.accept(newRoot);
+    }
 
     private ExpandedCountChangeListener expandedCountChangeListener;
 
@@ -461,6 +476,7 @@ public class FileBrowserController {
         monitor.setRoot(directory);
         path.setText(directory.toString());
         treeView.setRoot(new FileTreeItem(monitor, directory));
+        notifyRootChange(directory);
     }
 
     /**


### PR DESCRIPTION
<!-- ^^^ Describe your changes here ^^^ -->
Main change is code to remove the query component before passing the URI to FileBrowserApp. This means the path to the repo can be added to settings.ini, under top_resources. Example: 
```org.phoebus.ui/top_resources= … | file:///path_to_common_folder/Common_PLTs?app=file_browser, Common PLT | … ```

Added a listener to listen to path changes and update the tab name. 
Added the function to get the filebrowser icon to display in top resources. 

Rebuilt using maven and tested that changes work. 

closes #3584  

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
