### PR TITLE
improve SaR snapshot UI behavior

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -757,11 +757,16 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
      */
     private void resetMetaData() {
         tabTitleProperty.setValue(Messages.unnamedSnapshot);
-        snapshotNameProperty.setValue(null);
-        snapshotCommentProperty.setValue(null);
         createdDateTextProperty.setValue(null);
         lastModifiedDateTextProperty.setValue(null);
         createdByTextProperty.setValue(null);
+    }
+
+    public static Throwable getRootCause(Throwable throwable) {
+        if (throwable.getCause() != null)
+            return getRootCause(throwable.getCause());
+
+        return throwable;
     }
 
     @SuppressWarnings("unused")
@@ -795,7 +800,8 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
                 Platform.runLater(() -> {
                     Alert alert = new Alert(Alert.AlertType.ERROR);
                     alert.setTitle(Messages.errorActionFailed);
-                    alert.setContentText(e.getMessage());
+                    // get root cause of exception because the nested exception names are not very friendly
+                    alert.setContentText(getRootCause(e).getMessage());
                     alert.setHeaderText(Messages.saveSnapshotErrorContent);
                     DialogHelper.positionDialog(alert, borderPane, -150, -150);
                     alert.showAndWait();
@@ -1101,7 +1107,14 @@ public class SnapshotController extends SaveAndRestoreBaseController implements 
             });
             showTakeSnapshotResult(snapshotItems);
             Snapshot snapshot = new Snapshot();
-            snapshot.setSnapshotNode(Node.builder().nodeType(NodeType.SNAPSHOT).build());
+            snapshot.setSnapshotNode(
+                    Node.builder()
+                        .nodeType(NodeType.SNAPSHOT)
+                        // set name and description to preserve the name / comment fields
+                        .name(snapshotNameProperty.getValue())
+                        .description(snapshotCommentProperty.getValue())
+                        .build()
+            );
             SnapshotData snapshotData = new SnapshotData();
             snapshotData.setSnapshotItems(snapshotItems);
             snapshot.setSnapshotData(snapshotData);


### PR DESCRIPTION
<!-- ^^^ Describe your changes here ^^^ -->

Basically, the SaR snapshot controller was a bit unintuitive. The UI suggested you needed to enter a name / description before hitting take snapshot / save, but hitting take snapshot would clear out the metadata entered by the user. I changed it so that the name and the comment are no longer cleared. However, if you start from an existing snapshot, this would preserve the name / description from that existing snapshot (which would be fine IMO, you can start editing from there) but the name needs to be unique. The error message shown to the user on a non-unique node name contained exception names because it was a nested exception. This is no longer the case.

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing: Tested new behavior locally

- Documentation: I don't think this is significant enough to warrent a release not entry, nor is it breaking