### PR TITLE
Handle long values in EPICS Jackie PV support

### DIFF
--- a/core/pv-jackie/pom.xml
+++ b/core/pv-jackie/pom.xml
@@ -23,6 +23,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.epics</groupId>
       <artifactId>vtype</artifactId>
       <version>${vtype.version}</version>

--- a/core/pv-jackie/src/main/java/org/phoebus/pv/jackie/JackiePV.java
+++ b/core/pv-jackie/src/main/java/org/phoebus/pv/jackie/JackiePV.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2024 aquenos GmbH.
+ * Copyright (c) 2017-2025 aquenos GmbH.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -261,10 +261,12 @@ public class JackiePV extends PV {
                 // Use ca_put_callback.
                 final var listenable_future = channel.put(
                         ValueConverter.objectToChannelAccessSimpleOnlyValue(
+                                channel.getName(),
                                 new_value,
                                 channel.getClient().getConfiguration()
                                         .getCharset(),
-                                treat_char_as_long_string));
+                                treat_char_as_long_string,
+                                preferences.long_conversion_mode()));
                 final var completable_future = new CompletableFuture<Void>();
                 listenable_future.addCompletionListener((future) -> {
                     try {
@@ -304,10 +306,12 @@ public class JackiePV extends PV {
                 // Use ca_put without a callback.
                 channel.putNoCallback(
                         ValueConverter.objectToChannelAccessSimpleOnlyValue(
+                                channel.getName(),
                                 new_value,
                                 channel.getClient().getConfiguration()
                                         .getCharset(),
-                                treat_char_as_long_string));
+                                treat_char_as_long_string,
+                                preferences.long_conversion_mode()));
             }
             case YES -> {
                 // Wait for the write operation to complete. This allows code

--- a/core/pv-jackie/src/main/resources/pv_jackie_preferences.properties
+++ b/core/pv-jackie/src/main/resources/pv_jackie_preferences.properties
@@ -119,6 +119,18 @@ honor_zero_precision=true
 # hostname is determined automatically.
 hostname=
 
+# How to process write operations specifying a long value that is greater than
+# 2147483647 or less than -2147483648. Possible settings are:
+#
+# - COERCE
+# - COERCE_AND_WARN
+# - CONVERT
+# - CONVERT_AND_WARN
+# - FAIL
+# - TRUNCATE
+# - TRUNCATE_AND_WARN
+long_conversion_mode=COERCE_AND_WARN
+
 # Mask that shall be used when registering monitors for DBR_TIME_* values.
 #
 # This can be a combination of DBE_ALARM, DBE_ARCHIVE, DBE_PROPERTY, and


### PR DESCRIPTION
This PR adds support for writing values of types `Long` and `long[]` to the EPICS Jackie PV support (`core-pv-jackie`). Support for these data types is needed because at least some widgets (e.g. Text Entry) use them.

Closes #3603.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [X] The feature has automated tests
    - [X] Tests were run

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
