### PR TITLE
CSSTUDIO-3523 Bugfix: Use `layoutBoundsWithoutScrollbars` instead of `layoutBoundsWithScrollbars` in if-condition

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -516,7 +516,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
                 // correct width/height properties.
                 final double zoomXWithoutScrollbars, zoomYWithoutScrollbars;
                 final double zoomXWithScrollbars, zoomYWithScrollbars;
-                if (outline.getWidth() > layoutBoundsWithScrollbars.getWidth()) {
+                if (outline.getWidth() > layoutBoundsWithoutScrollbars.getWidth()) {
                     zoomXWithoutScrollbars = layoutBoundsWithoutScrollbars.getWidth() / outline.getWidth();
                     zoomXWithScrollbars = layoutBoundsWithScrollbars.getWidth() / outline.getWidth();
                 }
@@ -529,7 +529,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
                     zoomXWithScrollbars = 1.0;
                 }
 
-                if (outline.getHeight() > layoutBoundsWithScrollbars.getHeight()) {
+                if (outline.getHeight() > layoutBoundsWithoutScrollbars.getHeight()) {
                     zoomYWithoutScrollbars = layoutBoundsWithoutScrollbars.getHeight() / outline.getHeight();
                     zoomYWithScrollbars = layoutBoundsWithScrollbars.getHeight() / outline.getHeight();
                 }


### PR DESCRIPTION
This pull request fixes a bug introduced in https://github.com/ControlSystemStudio/phoebus/pull/3489: when determining whether the width and height specified in `outline` or in `model` should be used for computing the zoom-level when zooming, `layoutBoundsWithoutScrollbars` should be compared against instead of `layoutBoundsWithoutScrollbars`. I have tested this change manually in the Display Builder.