### PR TITLE
CSSTUDIO-3537 Bugfix: Fix check for non-zero-length array (For ESS-specific navigator)

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
+++ b/core/ui/src/main/java/org/phoebus/ui/docking/DockPane.java
@@ -658,7 +658,7 @@ public class DockPane extends TabPane
             final SplitPane parent = (SplitPane) dock_parent;
             // Remove this dock pane from BorderPane
             Optional<Double> dividerPosition;
-            if (parent.getDividerPositions().length > 1) {
+            if (parent.getDividerPositions().length > 0) {
                 dividerPosition = Optional.of(parent.getDividerPositions()[0]);
             }
             else {


### PR DESCRIPTION
This pull request fixes a bug when detecting the presence of a divider when running "Split Left/Right" when running the ESS-specific Navigator application.