### PR TITLE
Use Kafka properties when creating AdminClient

### DIFF
--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -28,10 +28,10 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.phoebus.applications.alarm.AlarmSystemConstants;
 import org.phoebus.applications.alarm.client.ClientState;
+import org.phoebus.applications.alarm.client.KafkaHelper;
 import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.applications.alarm.model.AlarmTreeLeaf;
 import org.phoebus.applications.alarm.model.SeverityLevel;
@@ -93,7 +93,9 @@ public class AlarmServerMain implements ServerModelListener
      * @throws Exception
      */
     private static void ensureKafkaTopics(String server, String topic, String kafka_props_file) throws Exception {
-        try (AdminClient admin = AdminClient.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, server))) {
+        var kafka_props = KafkaHelper.loadPropsFromFile(kafka_props_file);
+        kafka_props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, server);
+        try (AdminClient admin = AdminClient.create(kafka_props)) {
             Set<String> topics = admin.listTopics().names().get(60, TimeUnit.SECONDS);
             // Compacted topic
             String compactedTopic = topic;


### PR DESCRIPTION
This PR changes `AlarmServerMain.ensureKafkaTopics` to actually make use of the `kafka_props_file` parameter, so that custom Kafka properties are used when creating the `AdminClient`.

Fixes #3625.

@shroffk As you wrote the original code that introduced this problem, you might be the right one to review this PR.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

I started the alarm server with the changes and found that the `AdminClient` now correctly uses the settings set in the Kafka properties file. I checked this by increasing the log level for `org.apache.kafka` to `INFO`, so that configuration settings are logged.

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
