### PR TITLE
enable protocol choice, so we can enable https

### DIFF
--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/config/ElasticConfig.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/config/ElasticConfig.java
@@ -91,6 +91,9 @@ public class ElasticConfig {
     @Value("${elasticsearch.authorization.password}")
     private String password;
 
+    @Value("${elasticsearch.http.protocol:http}")
+    private String protocol;
+
 
     private ElasticsearchClient client;
     private static final AtomicBoolean esInitialized = new AtomicBoolean();
@@ -112,7 +115,7 @@ public class ElasticConfig {
     public ElasticsearchClient getClient() {
         if (client == null) {
             // Create the low-level client
-            RestClientBuilder clientBuilder = RestClient.builder(new HttpHost(host, port));
+            RestClientBuilder clientBuilder = RestClient.builder(new HttpHost(host, port, protocol));
 
             // Configure authentication
             if (!authorizationHeader.isEmpty()) {

--- a/services/save-and-restore/src/main/resources/application.properties
+++ b/services/save-and-restore/src/main/resources/application.properties
@@ -8,6 +8,7 @@ server.port=8080
 # Elasticsearch connection parameters
 elasticsearch.network.host=localhost
 elasticsearch.http.port=9200
+elasticsearch.http.protocol=http
 
 # The value for the `Authorization` header used in requests to the Elasticsearch server.
 # This header supports token-based or API key-based authentication.


### PR DESCRIPTION
This simple patch adds support for selecting the HTTP protocol when connecting to Elasticsearch. It enables connections over HTTPS, which is the default in newer Elasticsearch versions.