### PR TITLE
Fix timestamp being invalid if nanoseconds component is zero

### DIFF
--- a/core/pv-pva/src/main/java/org/phoebus/pv/pva/Decoders.java
+++ b/core/pv-pva/src/main/java/org/phoebus/pv/pva/Decoders.java
@@ -172,9 +172,9 @@ public class Decoders
         // In addition, a time stamp of 1990/01/02 00:00:00
         // as used for the Channel Access and IOC time stamp epoch
         // is considered invalid because IOCs send it for never processed records
-        final boolean valid = timestamp.getNano() != 0  &&
-                              (timestamp.getEpochSecond() > 0 &&  timestamp.getEpochSecond() != EPICS_EPOCH);
-        return Time.of(timestamp, usertag, valid);
+        final boolean valid = !(timestamp.getEpochSecond() == 0 && timestamp.getNano() == 0) &&
+                              timestamp.getEpochSecond() != EPICS_EPOCH;
+         return Time.of(timestamp, usertag, valid);
     }
 
     /** @param printfFormat Format from NTScalar display.format


### PR DESCRIPTION
Closes #3463

I am not familiar enough with Java and this project to add a test for it but I verified that it fixed the bug and that all the existing tests passed. Please add them if you think it is needed before merging.

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes
        - Used the PV that I noticed the bug with that always has a 0 nanoseconds component to see if the timestamp shown correctly

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature

