### PR TITLE
Avoid deprecated from and to parameters for ES range queries

### DIFF
--- a/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/AlarmLogSearchUtil.java
+++ b/services/alarm-logger/src/main/java/org/phoebus/alarm/logging/rest/AlarmLogSearchUtil.java
@@ -11,6 +11,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.WildcardQuery;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.json.JsonData;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -237,8 +238,9 @@ public class AlarmLogSearchUtil {
                     Query.of(q -> q
                             .range(RangeQuery.of(r -> r
                                             .field("message_time")
-                                            .from(formatter.format(finalFromInstant))
-                                            .to(formatter.format(finalToInstant))
+                                            .gte(JsonData.of(finalFromInstant.toEpochMilli()))
+                                            .lte(JsonData.of(finalToInstant.toEpochMilli()))
+                                            .format("epoch_millis")
                                     )
                             )
                     )

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/search/SearchUtil.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/search/SearchUtil.java
@@ -16,6 +16,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.WildcardQuery;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.json.JsonData;
 import org.phoebus.applications.saveandrestore.model.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -240,8 +241,9 @@ public class SearchUtil {
                 DisMaxQuery.Builder temporalQuery = new DisMaxQuery.Builder();
                 RangeQuery.Builder rangeQuery = new RangeQuery.Builder();
                 // Add a query based on the created time
-                rangeQuery.field("node.lastModified").from(Long.toString(1000 * start.toEpochSecond()))
-                        .to(Long.toString(1000 * end.toEpochSecond()));
+                rangeQuery.field("node.lastModified").gte(JsonData.of(start.toEpochSecond()))
+                        .lte(JsonData.of(end.toEpochSecond()))
+                        .format("epoch_second");
                 NestedQuery nestedQuery = NestedQuery.of(n1 -> n1.path("node").query(rangeQuery.build()._toQuery()));
                 temporalQuery.queries(nestedQuery._toQuery());
                 boolQueryBuilder.must(temporalQuery.build()._toQuery());


### PR DESCRIPTION
The `from` and `to` parameters for range queries were deprecated in Elasticsearch 0.90.4, and more than ten years later, they were finally removed in Elasticsearch 9.x. Therefore, the existing code did not work any longer when using modern versions of Elasticsearch.

This is fixed now by using the `gte` and `lte` parameters instead of `from` and `to`. In addition to that, the code is simplified a bit by directly using the values as-is and telling Elasticsearch about the format instead of converting them in the client code. This is the approach that was already taken by `app/eslog/src/main/java/org/phoebus/applications/eslog/archivedjmslog/ElasticsearchModel.java`.

Fixes #3632.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

I tested that with the change, the alarm logger service works correctly with Elasticsearch 9.x: The range query is accepted again and the log view in Phoebus shows the expected results.

As we haven’t deployed the save & restore service yet, I wasn’t able to test the changes there, but as they are essentially the same, I find it very likely that they will have the intended effect.

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
