### PR TITLE
Use Oracle JDBC from maven central

### DIFF
--- a/dependencies/install-jars/pom.xml
+++ b/dependencies/install-jars/pom.xml
@@ -14,48 +14,8 @@
          like install the ojdbc jar with the pbraw/pom.xml:
 
    maven-install-plugin:2.5.2:install-file (install-jar-lib) @ install-jars
-   Installing dependencies/install-jars/lib/ojdbc/ojdbc8-12.2.0.1.jar to .m2/repository/com/oracle/jdbc/ojdbc8/12.2.0.1/ojdbc8-12.2.0.1.jar
    Installing dependencies/install-jars/lib/pbraw/pom.xml to .m2/repository/com/oracle/jdbc/ojdbc8/12.2.0.1/ojdbc8-12.2.0.1.pom
       -->
-  <profiles>
-    <!-- Oracle JDBC is only available from an Oracle.
-         If your site uses it, copy it into ${basedir}/lib/ojdbc/ojdbc8-12.2.0.1.jar,
-         from which it will be installed into local maven repo
-      -->
-    <profile>
-      <activation>
-        <file>
-          <exists>${basedir}/lib/ojdbc/ojdbc8-12.2.0.1.jar</exists>
-        </file>
-      </activation>
-	  <build>
-	    <plugins>
-	      <plugin>
-	        <groupId>org.apache.maven.plugins</groupId>
-	        <artifactId>maven-install-plugin</artifactId>
-	        <version>2.5.2</version>
-	        <executions>
-	          <execution>
-	            <id>install-oracle</id>
-	            <configuration>
-	              <groupId>com.oracle.jdbc</groupId>
-	              <artifactId>ojdbc8</artifactId>
-	              <version>12.2.0.1</version>
-	              <packaging>jar</packaging>
-	              <file>${basedir}/lib/ojdbc/ojdbc8-12.2.0.1.jar</file>
-	              <generatePom>true</generatePom>
-	            </configuration>
-	            <goals>
-	              <goal>install-file</goal>
-	            </goals>
-	            <phase>validate</phase>
-	          </execution>
-	        </executions>
-	      </plugin>
-	    </plugins>
-	  </build>
-    </profile>
-  </profiles>
 
   <build>
     <plugins>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -13,21 +13,6 @@
   </properties>
 
   <profiles>
-    <!-- Oracle JDBC is conditionally installed by install-jars -->
-    <profile>
-      <activation>
-        <file>
-          <exists>${basedir}/../install-jars/lib/ojdbc/ojdbc8-12.2.0.1.jar</exists>
-        </file>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.oracle.jdbc</groupId>
-          <artifactId>ojdbc8</artifactId>
-          <version>12.2.0.1</version>
-        </dependency>
-      </dependencies>
-    </profile>
     <!-- Overriding the default release profile to run the pre release script 
       with makes the required modification to .classpath and other manually maintained 
       files -->
@@ -156,7 +141,38 @@
       <artifactId>py4j</artifactId>
       <version>0.10.2.1</version>
     </dependency>
-    <!-- JDBC connectors For Oracle, see ORACLE_JDBC_JAR -->
+    <!-- JDBC connectors For Oracle, MySQL, Postgres -->
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
+      <version>12.2.0.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.oracle.database.jdbc</groupId>
+          <artifactId>ucp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.oracle.database.security</groupId>
+          <artifactId>oraclepki</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.oracle.database.security</groupId>
+          <artifactId>osdt_cert</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.oracle.database.security</groupId>
+          <artifactId>osdt_core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.oracle.database.ha</groupId>
+          <artifactId>simplefan</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.oracle.database.ha</groupId>
+          <artifactId>ons</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>

--- a/services/archive-engine/pom.xml
+++ b/services/archive-engine/pom.xml
@@ -7,26 +7,6 @@
   </parent>
   <artifactId>service-archive-engine</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
-  <profiles>
-    <!-- When Oracle support is needed, set environment variable ORACLE_JDBC_JAR=/path/to/ojdbc8-12.2.0.1.jar -->
-    <profile>
-      <activation>
-        <property>
-          <name>env.ORACLE_JDBC_JAR</name>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.oracle.jdbc</groupId>
-          <artifactId>ojdbc8</artifactId>
-          <version>12.2.0.1</version>
-          <scope>system</scope>
-          <systemPath>${env.ORACLE_JDBC_JAR}</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -68,6 +48,37 @@
       <version>${jackson.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
+      <version>12.2.0.1</version>
+      <exclusions>
+         <exclusion>
+           <groupId>com.oracle.database.jdbc</groupId>
+           <artifactId>ucp</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>com.oracle.database.security</groupId>
+           <artifactId>oraclepki</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>com.oracle.database.security</groupId>
+           <artifactId>osdt_cert</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>com.oracle.database.security</groupId>
+           <artifactId>osdt_core</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>com.oracle.database.ha</groupId>
+           <artifactId>simplefan</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>com.oracle.database.ha</groupId>
+           <artifactId>ons</artifactId>
+         </exclusion>
+       </exclusions>
+    </dependency>
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>


### PR DESCRIPTION
The RDB archive (archive engine, data browser retrieval) can use Oracle, MySQL or Posgres JDBC. 
For the longest time, Oracle's licensing prevented the Oracle JDBC jar from being available in Maven central.
It had to be downloaded by somebody with an Oracle development network account, and the "install-jar" mechanism then placed it in the local maven repo.

Now that the ojdbc jar is available from maven central, the pom.xml can directly refer to it.
I did add exclusions to only fetch the basic ojdbc jar because none of the existing code needs any of the optional dependencies that would otherwise be added.

Once PBRaw is available online, this would remove the need for "install-jar"
#3637

## Checklist

- Testing:
    - [x] Tests were run

This is a change in build system dependencies. A successful build is a successful test.
   

- Documentation:
    - [X] The feature is documented

It's a change to maven files. Maven has plenty of online material to read which could be called documentation.

