### PR TITLE
Add tz request parameter to logbook search requests

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -64,10 +64,12 @@ import org.phoebus.ui.dialog.DialogHelper;
 import org.phoebus.ui.dialog.ExceptionDetailsErrorDialog;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -407,6 +409,8 @@ public class LogEntryTableViewController extends LogbookSearchController impleme
         params.put("sort", advancedSearchViewController.getSortAscending() ? "up" : "down");
         params.put("from", Integer.toString(pagination.getCurrentPageIndex() * pageSizeProperty.get()));
         params.put("size", Integer.toString(pageSizeProperty.get()));
+        params.put("tz", ZoneId.systemDefault().getId());
+
 
         searchInProgress.set(true);
         logger.log(Level.INFO, "Single search: " + queryString);

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/query/OlogQueryManagerTest.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/query/OlogQueryManagerTest.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -104,5 +106,12 @@ public class OlogQueryManagerTest {
         OlogQueryManager ologQueryManager = OlogQueryManager.getInstance(nonEmptyFile);
         List<OlogQuery> queries = ologQueryManager.getQueries();
         assertEquals(1, queries.size());
+    }
+
+    @Test
+    public void testTZ(){
+        System.out.println(ZoneId.systemDefault());
+        System.out.println(TimeZone.getDefault().getID());
+        System.out.println(TimeZone.getDefault().toZoneId().getId());
     }
 }


### PR DESCRIPTION
The time zone of the client is always added to search requests. It is needed to correctly compute the start/end time of temporal search when client is not in the same time zone as service.

## Checklist

- Testing:
    - [ ] The feature has automated tests
    - [ X] Tests were run

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
