### PR TITLE
Add plot marker visible property

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/XYPlotWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/plots/XYPlotWidget.java
@@ -12,6 +12,7 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propInteractive;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propVisible;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPVName;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.runtimePropConfigure;
 import static org.csstudio.display.builder.model.widgets.plots.PlotWidgetProperties.propGridColor;
@@ -99,7 +100,8 @@ public class XYPlotWidget extends VisibleWidget
                   Arrays.asList(propColor.createProperty(widget, new WidgetColor(0, 0, 255)),
                                 propPVName.createProperty(widget, ""),
                                 propInteractive.createProperty(widget, true),
-                                propValue.createProperty(widget, Double.NaN)
+                                propValue.createProperty(widget, Double.NaN),
+                                propVisible.createProperty(widget, true)
                                ));
         }
 
@@ -111,6 +113,8 @@ public class XYPlotWidget extends VisibleWidget
         public WidgetProperty<Boolean> interactive()   { return getElement(2); }
         /** @return Marker value */
         public WidgetProperty<Double> value()          { return getElement(3); }
+        /** @return Marker visible */
+        public WidgetProperty<Boolean> visible()       { return getElement(4); }
     };
 
     /** 'marker' array */

--- a/app/display/model/src/main/resources/examples/plots_xy.bob
+++ b/app/display/model/src/main/resources/examples/plots_xy.bob
@@ -9,7 +9,7 @@
     <width>181</width>
     <height>31</height>
     <font>
-      <font name="Header 1" family="Source Sans Pro" style="BOLD_ITALIC" size="36.0">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
       </font>
     </font>
   </widget>
@@ -21,7 +21,7 @@ one for the "X" and one for the "Y" axis.</text>
     <width>371</width>
     <height>40</height>
   </widget>
-  <widget type="xyplot" version="2.0.0">
+  <widget type="xyplot" version="3.0.0">
     <name>X/Y Plot_1</name>
     <y>91</y>
     <width>511</width>
@@ -33,6 +33,12 @@ one for the "X" and one for the "Y" axis.</text>
           <value>false</value>
         </exp>
         <pv_name>loc://interactive(1)</pv_name>
+      </rule>
+      <rule name="Visible" prop_id="marker[0].visible" out_exp="false">
+        <exp bool_exp="pv0&lt;1">
+          <value>false</value>
+        </exp>
+        <pv_name>loc://visible(1)</pv_name>
       </rule>
     </rules>
     <traces>
@@ -79,6 +85,7 @@ one for the "X" and one for the "Y" axis.</text>
         </color>
         <pv_name>loc://pos(50)</pv_name>
         <interactive>true</interactive>
+        <visible>true</visible>
       </marker>
     </marker>
   </widget>
@@ -95,7 +102,7 @@ one for the "X" and one for the "Y" axis.</text>
     <y>441</y>
     <width>221</width>
     <font>
-      <font name="Header 2" family="Source Sans Pro" style="BOLD_ITALIC" size="21.0">
+      <font name="Header 2" family="Liberation Sans" style="BOLD" size="18.0">
       </font>
     </font>
   </widget>
@@ -293,7 +300,7 @@ Double-click zooms back out.</text>
     <y>471</y>
     <width>221</width>
     <font>
-      <font name="Header 3" family="Source Sans Pro" style="BOLD_ITALIC" size="18.0">
+      <font name="Header 3" family="Liberation Sans" style="BOLD" size="16.0">
       </font>
     </font>
   </widget>
@@ -304,7 +311,7 @@ Double-click zooms back out.</text>
     <y>711</y>
     <width>70</width>
   </widget>
-  <widget type="xyplot" version="2.0.0">
+  <widget type="xyplot" version="3.0.0">
     <name>RightPlot</name>
     <x>591</x>
     <y>91</y>
@@ -335,11 +342,11 @@ pvs[1].write(err)
       <maximum>10.0</maximum>
       <show_grid>false</show_grid>
       <title_font>
-        <font name="Default Bold" family="Source Sans Pro" style="BOLD" size="16.0">
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
         </font>
       </title_font>
       <scale_font>
-        <font name="Default" family="Source Sans Pro" style="REGULAR" size="16.0">
+        <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
         </font>
       </scale_font>
       <visible>true</visible>
@@ -353,14 +360,19 @@ pvs[1].write(err)
         <maximum>120.0</maximum>
         <show_grid>false</show_grid>
         <title_font>
-          <font name="Default Bold" family="Source Sans Pro" style="BOLD" size="16.0">
+          <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
           </font>
         </title_font>
         <scale_font>
-          <font name="Default" family="Source Sans Pro" style="REGULAR" size="16.0">
+          <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
           </font>
         </scale_font>
+        <on_right>false</on_right>
         <visible>true</visible>
+        <color>
+          <color name="Text" red="0" green="0" blue="0">
+          </color>
+        </color>
       </y_axis>
     </y_axes>
     <traces>
@@ -407,7 +419,7 @@ pvs[1].write(err)
     <y>441</y>
     <width>221</width>
     <font>
-      <font name="Header 2" family="Source Sans Pro" style="BOLD_ITALIC" size="21.0">
+      <font name="Header 2" family="Liberation Sans" style="BOLD" size="18.0">
       </font>
     </font>
   </widget>
@@ -446,7 +458,7 @@ That local PV is then used as the error bar waveform.</text>
     <width>429</width>
     <height>69</height>
     <font>
-      <font name="Comment" family="Source Sans Pro" style="ITALIC" size="16.0">
+      <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
       </font>
     </font>
   </widget>
@@ -464,6 +476,7 @@ Push button to re-enable.</text>
     <name>Action Button</name>
     <actions>
       <action type="execute">
+        <description>Autoscale</description>
         <script file="EmbeddedPy">
           <text><![CDATA[from org.csstudio.display.builder.runtime.script import ScriptUtil
 
@@ -478,7 +491,6 @@ plot.setPropertyValue("y_axes[0].autoscale", False)
 plot.setPropertyValue("y_axes[0].autoscale", True)
 ]]></text>
         </script>
-        <description>Autoscale</description>
       </action>
     </actions>
     <x>1000</x>
@@ -487,7 +499,7 @@ plot.setPropertyValue("y_axes[0].autoscale", True)
     <height>29</height>
     <tooltip>$(actions)</tooltip>
   </widget>
-  <widget type="xyplot" version="2.0.0">
+  <widget type="xyplot" version="3.0.0">
     <name>X/Y Plot</name>
     <y>900</y>
     <x_axis>
@@ -498,11 +510,11 @@ plot.setPropertyValue("y_axes[0].autoscale", True)
       <maximum>22.0</maximum>
       <show_grid>false</show_grid>
       <title_font>
-        <font name="Default Bold" family="Source Sans Pro" style="BOLD" size="16.0">
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
         </font>
       </title_font>
       <scale_font>
-        <font name="Default" family="Source Sans Pro" style="REGULAR" size="16.0">
+        <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
         </font>
       </scale_font>
       <visible>true</visible>
@@ -516,14 +528,19 @@ plot.setPropertyValue("y_axes[0].autoscale", True)
         <maximum>10.0</maximum>
         <show_grid>false</show_grid>
         <title_font>
-          <font name="Default Bold" family="Source Sans Pro" style="BOLD" size="16.0">
+          <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
           </font>
         </title_font>
         <scale_font>
-          <font name="Default" family="Source Sans Pro" style="REGULAR" size="16.0">
+          <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
           </font>
         </scale_font>
+        <on_right>false</on_right>
         <visible>true</visible>
+        <color>
+          <color name="Text" red="0" green="0" blue="0">
+          </color>
+        </color>
       </y_axis>
     </y_axes>
     <traces>
@@ -582,7 +599,7 @@ For a "Line Width" of zero, the bar graph turns into a histogram-type display wi
     <y>900</y>
     <width>221</width>
     <font>
-      <font name="Header 2" family="Source Sans Pro" style="BOLD_ITALIC" size="21.0">
+      <font name="Header 2" family="Liberation Sans" style="BOLD" size="18.0">
       </font>
     </font>
   </widget>
@@ -606,10 +623,16 @@ For a "Line Width" of zero, the bar graph turns into a histogram-type display wi
     <y>500</y>
     <width>140</width>
     <height>60</height>
-    <font>
-      <font name="Comment" family="Source Sans Pro" style="ITALIC" size="16.0">
+    <font use_class="true">
+      <font name="Comment" family="Liberation Sans" style="ITALIC" size="14.0">
       </font>
     </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <wrap_words use_class="true">true</wrap_words>
   </widget>
   <widget type="checkbox" version="2.0.0">
     <name>Check Box</name>
@@ -617,5 +640,12 @@ For a "Line Width" of zero, the bar graph turns into a histogram-type display wi
     <label>  Interactive</label>
     <x>380</x>
     <y>470</y>
+  </widget>
+  <widget type="checkbox" version="2.0.0">
+    <name>Check Box_1</name>
+    <pv_name>loc://visible(1)</pv_name>
+    <label>  Visible</label>
+    <x>380</x>
+    <y>561</y>
   </widget>
 </display>

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -451,7 +451,8 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
     {
         final PlotMarker<Double> plot_marker = plot.addMarker(JFXUtil.convert(model_marker.color().getValue()),
                                                               model_marker.interactive().getValue(),
-                                                              model_marker.value().getValue());
+                                                              model_marker.value().getValue(),
+                                                              model_marker.visible().getValue());
 
         // Listen to model_marker.value(), interactive() .. and update plot_marker
         final UntypedWidgetPropertyListener model_marker_listener = (o, old, value) ->
@@ -461,11 +462,13 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
             changing_marker = true;
             plot_marker.setInteractive(model_marker.interactive().getValue());
             plot_marker.setPosition(model_marker.value().getValue());
+            plot_marker.setVisible(model_marker.visible().getValue());
             changing_marker = false;
             plot.requestUpdate();
         };
         model_marker.value().addUntypedPropertyListener(model_marker_listener);
         model_marker.interactive().addUntypedPropertyListener(model_marker_listener);
+        model_marker.visible().addUntypedPropertyListener(model_marker_listener);
     }
 
     @Override

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/PlotMarker.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/PlotMarker.java
@@ -25,17 +25,20 @@ public class PlotMarker<XTYPE extends Comparable<XTYPE>>
     private final Color color;
     private volatile boolean interactive;
     private volatile XTYPE position;
+    private volatile boolean visible;
 
     /** Not meant to be called by user,
      *  call {@link RTPlot #addMarker()} to create a marker.
      */
     public PlotMarker(final Color color,
                       final boolean interactive,
-                      final XTYPE position)
+                      final XTYPE position,
+                      final boolean visible)
     {
         this.color = color;
         this.interactive = interactive;
         this.position = position;
+        this.visible = visible;
     }
 
     /** @return Color of the marker */
@@ -67,6 +70,18 @@ public class PlotMarker<XTYPE extends Comparable<XTYPE>>
     {
         this.position = position;
         // Caller needs to request update of plot
+    }
+
+    /** @return Is marker visible? */
+    public boolean isVisible()
+    {
+        return visible;
+    }
+
+    /** @param visible Set marker visibility */
+    public void setVisible(final boolean visible)
+    {
+        this.visible = visible;
     }
 
     @Override

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTPlot.java
@@ -497,11 +497,12 @@ public class  RTPlot<XTYPE extends Comparable<XTYPE>> extends BorderPane
     /** Add plot marker
      *  @param color
      *  @param interactive
+     *  @param visible
      *  @return {@link PlotMarker}
      */
-    public PlotMarker<XTYPE> addMarker(final javafx.scene.paint.Color color, final boolean interactive, final XTYPE position)
+    public PlotMarker<XTYPE> addMarker(final javafx.scene.paint.Color color, final boolean interactive, final XTYPE position, final boolean visible)
     {
-        return plot.addMarker(color, interactive, position);
+        return plot.addMarker(color, interactive, position, visible);
     }
 
     /** @return {@link PlotMarker}s */

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/Plot.java
@@ -357,11 +357,12 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends PlotCanvasBase
     /** Add plot marker
      *  @param color
      *  @param interactive
+     *  @param visible
      *  @return {@link PlotMarker}
      */
-    public PlotMarker<XTYPE> addMarker(final javafx.scene.paint.Color color, final boolean interactive, final XTYPE position)
+    public PlotMarker<XTYPE> addMarker(final javafx.scene.paint.Color color, final boolean interactive, final XTYPE position, final boolean visible)
     {   // Return a PlotMarker that triggers a redraw as it's changed
-        final PlotMarker<XTYPE> marker = new PlotMarker<>(color, interactive, position)
+        final PlotMarker<XTYPE> marker = new PlotMarker<>(color, interactive, position, visible)
         {
             @Override
             public void setPosition(XTYPE position)
@@ -721,9 +722,11 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends PlotCanvasBase
         gc.setStroke(AxisPart.TICK_STROKE);
         for (PlotMarker<XTYPE> marker : plot_markers)
         {
-            gc.setColor(GraphicsUtils.convert(marker.getColor()));
-            final int x = x_axis.getScreenCoord(marker.getPosition());
-            gc.drawLine(x, y0, x, y1);
+            if(marker.isVisible()){
+                gc.setColor(GraphicsUtils.convert(marker.getColor()));
+                final int x = x_axis.getScreenCoord(marker.getPosition());
+                gc.drawLine(x, y0, x, y1);
+            }
         }
         gc.setStroke(old_stroke);
     }

--- a/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TimePlotDemo.java
+++ b/app/rtplot/src/test/java/org/csstudio/javafx/rtplot/TimePlotDemo.java
@@ -67,7 +67,7 @@ public class TimePlotDemo extends ApplicationWrapper
         plot.addTrace("Jane", "handbags", data[1], colors.next(), TraceType.AREA, 5, LineStyle.SOLID, PointType.NONE, 5, 1);
         plot.addTrace("Another", "mA", data[2], colors.next(), TraceType.LINES_DIRECT, 1, LineStyle.SOLID, PointType.TRIANGLES, 15, 2);
 
-        plot.addMarker(Color.BLUE, true, Instant.now().plusSeconds(5));
+        plot.addMarker(Color.BLUE, true, Instant.now().plusSeconds(5), true);
 
         final AtomicBoolean run = new AtomicBoolean(true);
         // Update data at 50Hz


### PR DESCRIPTION
We included the marker visible property.
I have updated the example in `app/display/model/src/main/resources/examples/plots_xy.bob` - I added a rule to make the marker visible.

<img width="70%" height="70%" alt="plot_marker_invisible" src="https://github.com/user-attachments/assets/81214913-5fd5-48dd-b857-2be6cc332f54" />

<img width="70%" height="70%" alt="plot_marker_visible" src="https://github.com/user-attachments/assets/26b5e146-bc45-494b-8665-049c8eb65fe3" />

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - To test check example in `app/display/model/src/main/resources/examples/plots_xy.bob`

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
