### PR TITLE
add validation when loosing focus

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/TitleDetailTable.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/TitleDetailTable.java
@@ -30,7 +30,6 @@ import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.Tooltip;
-import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.VBox;
 import javafx.util.converter.DefaultStringConverter;
@@ -83,27 +82,25 @@ public class TitleDetailTable extends BorderPane
 
         TableColumn<TitleDetail, String> col = new TableColumn<>("Title");
         col.setCellValueFactory(cell -> new SimpleStringProperty(cell.getValue().title));
-        col.setCellFactory(column -> new TextFieldTableCell<>(new DefaultStringConverter()));
+        col.setCellFactory(ValidatingTextFieldTableCell.forTableColumn(new DefaultStringConverter()));
         col.setOnEditCommit(event ->
         {
             final int row = event.getTablePosition().getRow();
             items.set(row, new TitleDetail(event.getNewValue(), items.get(row).detail));
 
             // Trigger editing the detail
-            UpdateThrottle.TIMER.schedule(() ->
-                Platform.runLater(() ->
-                {
-                    table.getSelectionModel().clearAndSelect(row);
-                    table.edit(row, table.getColumns().get(1));
-                }),
-                200, TimeUnit.MILLISECONDS);
+            Platform.runLater(() ->
+            {
+                table.getSelectionModel().clearAndSelect(row);
+                table.edit(row, table.getColumns().get(1));
+            });
         });
         col.setSortable(false);
         table.getColumns().add(col);
 
         col = new TableColumn<>("Detail");
         col.setCellValueFactory(cell -> new SimpleStringProperty(cell.getValue().detail.replace("\n", "\\n")));
-        col.setCellFactory(column -> new TextFieldTableCell<>(new DefaultStringConverter()));
+        col.setCellFactory(ValidatingTextFieldTableCell.forTableColumn(new DefaultStringConverter()));
         col.setOnEditCommit(event ->
         {
             final int row = event.getTablePosition().getRow();

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/ValidatingTextFieldTableCell.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/ValidatingTextFieldTableCell.java
@@ -1,0 +1,47 @@
+package org.phoebus.applications.alarm.ui.tree;
+
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TextField;
+import javafx.scene.control.cell.TextFieldTableCell;
+import javafx.util.Callback;
+import javafx.util.StringConverter;
+
+public class ValidatingTextFieldTableCell<S, T> extends TextFieldTableCell<S, T> {
+
+    private TextField textField;
+
+    public ValidatingTextFieldTableCell(StringConverter<T> converter) {
+        super(converter);
+    }
+
+    @Override
+    public void startEdit() {
+        super.startEdit();
+        if (isEditing() && getGraphic() instanceof TextField tf) {
+            textField = tf;
+            // add listener
+            textField.focusedProperty().addListener((obs, wasFocused, isNowFocused) -> {
+            	if (!isNowFocused && textField != null) {
+                    T newValue = getConverter().fromString(textField.getText());
+                    if (newValue.equals(getItem())) {
+                        // nothing changed so cancel
+                        cancelEdit();
+                    } else {
+                        // changed so validate
+                        commitEdit(newValue);
+                    }
+                }
+            });
+        }
+    }
+    
+    // utility method to simplify usage in column
+    public static <S> Callback<TableColumn<S, String>, TableCell<S, String>> forTableColumn() {
+        return forTableColumn(new javafx.util.converter.DefaultStringConverter());
+    }
+
+    public static <S, T> Callback<TableColumn<S, T>, TableCell<S, T>> forTableColumn(StringConverter<T> converter) {
+        return column -> new ValidatingTextFieldTableCell<>(converter);
+    }
+}


### PR DESCRIPTION
In the alarm configuration "Enter" key must be pressed to validate the text in the guidance, displays, commands and actions tables.
This way to validate could be annoying because if we forget to press the "Enter" key, all the text typed is lost.

This PR add another way to validation when the focus is lost.

It has been tested manually as it's a GUI change by @achoqt and @lcaouen 

Issue related : https://github.com/ControlSystemStudio/phoebus/issues/3656