### PR TITLE
CSSTUDIO-3597 Create a new instance of macros in `EmbeddedDisplayWidget.getEffectiveMacros()`.

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/EmbeddedDisplayWidget.java
@@ -307,6 +307,13 @@ public class EmbeddedDisplayWidget extends MacroWidget
         return super.getProperty(name);
     }
 
+    @Override
+    public Macros getEffectiveMacros()
+    {
+        final Macros macros = new Macros(super.getEffectiveMacros());
+        return macros;
+    }
+
     /** @return 'file' property */
     public WidgetProperty<String> propFile()
     {


### PR DESCRIPTION
In https://github.com/ControlSystemStudio/phoebus/pull/3475/commits/a7e5d4c43121d47dcaee4efa5a41679e22f4e3e9 (part of https://github.com/ControlSystemStudio/phoebus/pull/3475), the `@Override` method `EmbeddedDisplayWidget.getEffectiveMacros()` was removed in order to remove the `LCID` macro.

A side-effect of this was that no new instance of `Macros` was created when calling the function `EmbeddedDisplayWidget.getEffectiveMacros()`. This in turn leads to the `firePropertyChange()`-functionality stopping to work properly, since it contains the optimization that listeners should not be updated if the new value is `equal()` to the old value:

https://github.com/ControlSystemStudio/phoebus/blob/ed9fce4e7f023771923b25bc33d8eb26535faaa5/app/display/model/src/main/java/org/csstudio/display/builder/model/properties/PropertyChangeHandler.java#L167-L169

A concrete example to illustrate the problem is the following: consider an OPI `A.bob` that contains (1) an embedded display Widget of the name `"EmbeddedDisplay"` and (2) a script of the following form:

```
embeddedDisplayWidget = ScriptUtil.findWidgetByName(widget, "EmbeddedDisplay")
macros = embeddedDisplayWidget.getEffectiveMacros()
macros.add("NewMacro", "This is a new macro binding")
embeddedDisplayWidget.propMacros().setValue(macros)
```

This pull request reinstates the creation of a new instance of `Macros` when calling `EmbeddedDisplayWidget.getEffectiveMacros()`, which leads to `firePropertyChange()` notifying the embedded display of the change.

I am not sure if this is the best way to fix the issue, or not. It does seem to me, however, that calling `embeddedDisplayWidget.propMacros().setValue(macros)` with a valid argument should correctly update the embedded display.

I have tested the change manually.