### PR TITLE
CSSTUDIO-3605 Always use the type "long" when converting to hexadecimal notation

### DIFF
--- a/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
+++ b/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
@@ -18,6 +18,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.epics.util.array.ListNumber;
+import org.epics.util.number.UByte;
+import org.epics.util.number.UInteger;
+import org.epics.util.number.ULong;
+import org.epics.util.number.UShort;
 import org.epics.vtype.Display;
 import org.epics.vtype.DisplayProvider;
 import org.epics.vtype.VBoolean;
@@ -219,7 +223,30 @@ public class FormatOptionHandler
         if (option == FormatOption.HEX)
         {
             final StringBuilder buf = new StringBuilder();
-            long longValue = value.longValue();
+            long longValue;
+            if (value instanceof Byte valueByte) {
+                longValue = Byte.toUnsignedLong(valueByte);
+            } else if (value instanceof Short valueShort) {
+                longValue = Short.toUnsignedLong(valueShort);
+            } else if (value instanceof Integer valueInt) {
+                longValue = Integer.toUnsignedLong(valueInt);
+            } else if (value instanceof Long valueLong) {
+                longValue = valueLong;
+            } else if (value instanceof Float valueFloat) {
+                longValue = valueFloat.longValue();
+            } else if (value instanceof Double valueDouble) {
+                longValue = valueDouble.longValue();
+            } else if (value instanceof UByte valueUByte) {
+                longValue = valueUByte.longValue();
+            } else if (value instanceof UShort valueUShort) {
+                longValue = valueUShort.longValue();
+            } else if (value instanceof UInteger valueUInteger) {
+                longValue = valueUInteger.longValue();
+            } else if (value instanceof ULong valueULong) {
+                longValue = valueULong.longValue();
+            } else {
+                longValue = value.longValue();
+            }
             String hexString = Long.toHexString(longValue);
             buf.append(hexString.toUpperCase());
             for (int i=buf.length(); i<precision; ++i)

--- a/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
+++ b/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
@@ -223,8 +223,7 @@ public class FormatOptionHandler
         }
         if (option == FormatOption.HEX)
         {
-            final StringBuilder buf = new StringBuilder();
-            Optional<Long> maybeLongValue;
+            final Optional<Long> maybeLongValue;
             if (value instanceof Byte valueByte) {
                 maybeLongValue = Optional.of(Byte.toUnsignedLong(valueByte));
             } else if (value instanceof Short valueShort) {
@@ -248,17 +247,18 @@ public class FormatOptionHandler
             } else {
                 maybeLongValue = Optional.empty();
             }
-            
+
             if (maybeLongValue.isPresent()) {
                 long longValue = maybeLongValue.get();
-                String hexString = Long.toHexString(longValue);
+                final String hexString = Long.toHexString(longValue);
+                final StringBuilder buf = new StringBuilder();
                 buf.append(hexString.toUpperCase());
                 for (int i=buf.length(); i<precision; ++i)
                     buf.insert(0, '0');
                 buf.insert(0, "0x");
                 return buf.toString();
             } else {
-                String numberFormat = value.getClass().getSimpleName();
+                final String numberFormat = value.getClass().getSimpleName();
                 Logger.getLogger(FormatOptionHandler.class.getPackageName())
                         .log(Level.WARNING, "Error: Number format is unsupported for conversion to HEX format: " + numberFormat);
                 return "ERROR: Unsupported number format: " + numberFormat;

--- a/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
+++ b/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
@@ -13,6 +13,7 @@ import java.text.NumberFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -223,36 +224,46 @@ public class FormatOptionHandler
         if (option == FormatOption.HEX)
         {
             final StringBuilder buf = new StringBuilder();
-            long longValue;
+            Optional<Long> maybeLongValue;
             if (value instanceof Byte valueByte) {
-                longValue = Byte.toUnsignedLong(valueByte);
+                maybeLongValue = Optional.of(Byte.toUnsignedLong(valueByte));
             } else if (value instanceof Short valueShort) {
-                longValue = Short.toUnsignedLong(valueShort);
+                maybeLongValue = Optional.of(Short.toUnsignedLong(valueShort));
             } else if (value instanceof Integer valueInt) {
-                longValue = Integer.toUnsignedLong(valueInt);
+                maybeLongValue = Optional.of(Integer.toUnsignedLong(valueInt));
             } else if (value instanceof Long valueLong) {
-                longValue = valueLong;
+                maybeLongValue = Optional.of(valueLong);
             } else if (value instanceof Float valueFloat) {
-                longValue = valueFloat.longValue();
+                maybeLongValue = Optional.of(valueFloat.longValue());
             } else if (value instanceof Double valueDouble) {
-                longValue = valueDouble.longValue();
+                maybeLongValue = Optional.of(valueDouble.longValue());
             } else if (value instanceof UByte valueUByte) {
-                longValue = valueUByte.longValue();
+                maybeLongValue = Optional.of(valueUByte.longValue());
             } else if (value instanceof UShort valueUShort) {
-                longValue = valueUShort.longValue();
+                maybeLongValue = Optional.of(valueUShort.longValue());
             } else if (value instanceof UInteger valueUInteger) {
-                longValue = valueUInteger.longValue();
+                maybeLongValue = Optional.of(valueUInteger.longValue());
             } else if (value instanceof ULong valueULong) {
-                longValue = valueULong.longValue();
+                maybeLongValue = Optional.of(valueULong.longValue());
             } else {
-                longValue = value.longValue();
+                maybeLongValue = Optional.empty();
             }
-            String hexString = Long.toHexString(longValue);
-            buf.append(hexString.toUpperCase());
-            for (int i=buf.length(); i<precision; ++i)
-                buf.insert(0, '0');
-            buf.insert(0, "0x");
-            return buf.toString();
+            
+            if (maybeLongValue.isPresent()) {
+                long longValue = maybeLongValue.get();
+                String hexString = Long.toHexString(longValue);
+                buf.append(hexString.toUpperCase());
+                for (int i=buf.length(); i<precision; ++i)
+                    buf.insert(0, '0');
+                buf.insert(0, "0x");
+                return buf.toString();
+            } else {
+                String numberFormat = value.getClass().getSimpleName();
+                Logger.getLogger(FormatOptionHandler.class.getPackageName())
+                        .log(Level.WARNING, "Error: Number format is unsupported for conversion to HEX format: " + numberFormat);
+                return "ERROR: Unsupported number format: " + numberFormat;
+            }
+
         }
         if (option == FormatOption.STRING)
             return new String(new byte[] { value.byteValue() });

--- a/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
+++ b/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
@@ -219,10 +219,9 @@ public class FormatOptionHandler
         if (option == FormatOption.HEX)
         {
             final StringBuilder buf = new StringBuilder();
-            if (precision <= 8)
-                buf.append(Integer.toHexString(value.intValue()).toUpperCase());
-            else
-                buf.append(Long.toHexString(value.longValue()).toUpperCase());
+            long longValue = value.longValue();
+            String hexString = Long.toHexString(longValue);
+            buf.append(hexString.toUpperCase());
             for (int i=buf.length(); i<precision; ++i)
                 buf.insert(0, '0');
             buf.insert(0, "0x");

--- a/core/ui/src/test/java/org/phoebus/ui/vtype/FormatOptionHandlerTest.java
+++ b/core/ui/src/test/java/org/phoebus/ui/vtype/FormatOptionHandlerTest.java
@@ -15,14 +15,22 @@ import org.epics.vtype.Alarm;
 import org.epics.vtype.Display;
 import org.epics.vtype.EnumDisplay;
 import org.epics.vtype.Time;
+import org.epics.vtype.VByte;
 import org.epics.vtype.VDouble;
 import org.epics.vtype.VEnum;
+import org.epics.vtype.VFloat;
+import org.epics.vtype.VInt;
 import org.epics.vtype.VIntArray;
 import org.epics.vtype.VLong;
 import org.epics.vtype.VNumberArray;
+import org.epics.vtype.VShort;
 import org.epics.vtype.VString;
 import org.epics.vtype.VStringArray;
 import org.epics.vtype.VType;
+import org.epics.vtype.VUByte;
+import org.epics.vtype.VUInt;
+import org.epics.vtype.VULong;
+import org.epics.vtype.VUShort;
 import org.junit.jupiter.api.Test;
 
 import java.text.DecimalFormat;
@@ -167,19 +175,245 @@ public class FormatOptionHandlerTest
     @Test
     public void testHexFormat()
     {
-        VType number = VDouble.of(65535.0, Alarm.none(), Time.now(), display);
+        {
+            VType number = VDouble.of(65535.0, Alarm.none(), Time.now(), display);
 
-        String text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
-        System.out.println(text);
-        assertThat(text, equalTo("0xFFFF V"));
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFF V"));
 
-        text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
-        System.out.println(text);
-        assertThat(text, equalTo("0x0000FFFF V"));
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x0000FFFF V"));
 
-        text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
-        System.out.println(text);
-        assertThat(text, equalTo("0x000000000000FFFF V"));
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x000000000000FFFF V"));
+        }
+
+        {
+            // Test with VDouble representing 0xFFFFFFFF
+            VType number = VDouble.of(4294967295.0, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFFF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFFF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00000000FFFFFFFF V"));
+        }
+
+        {
+            // Test with VFloat representing 0xFFFF
+            VType number = VFloat.of(65535.0, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x0000FFFF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x000000000000FFFF V"));
+        }
+
+        {
+            // Test with VInt representing 0x00
+            VType number = VInt.of(0x00, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x0000 V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00000000 V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x0000000000000000 V"));
+        }
+
+        {
+            // Test with VByte representing 0xFF
+            VType number = VByte.of(0xFF, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 2, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00FF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x000000FF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00000000000000FF V"));
+        }
+
+        {
+            // Test with VByte representing 0xFF
+            VType number = VUByte.of(0xFF, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 2, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00FF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x000000FF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00000000000000FF V"));
+        }
+
+        {
+            // Test with VShort representing 0xFFAA
+            VType number = VShort.of(0xFFAA, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 2, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x0000FFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x000000000000FFAA V"));
+        }
+
+        {
+            // Test with VUShort representing 0xFFAA
+            VType number = VUShort.of(0xFFAA, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 2, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x0000FFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x000000000000FFAA V"));
+        }
+
+        {
+            // Test with VInt representing 0xFF
+            VType number = VInt.of(0xFF, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 2, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00FF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x000000FF V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00000000000000FF V"));
+        }
+
+        {
+            // Test with VInt representing 0xFFFFFFAA
+            VType number = VInt.of(0xFFFFFFAA, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00000000FFFFFFAA V"));
+        }
+
+        {
+            // Test with VUInt representing 0xFFFFFFAA
+            VType number = VUInt.of(0xFFFFFFAA, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0x00000000FFFFFFAA V"));
+        }
+
+        {
+            // Test with VLong representing 0xFFFFFFAA
+            VType number = VLong.of(0xFFFFFFFFFFFFFFAAL, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFFFFFFFFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFFFFFFFFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFFFFFFFFFAA V"));
+        }
+
+        {
+            // Test with VULong representing 0xFFFFFFAA
+            VType number = VULong.of(0xFFFFFFFFFFFFFFAAL, Alarm.none(), Time.now(), display);
+
+            String text = FormatOptionHandler.format(number, FormatOption.HEX, 4, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFFFFFFFFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 8, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFFFFFFFFFAA V"));
+
+            text = FormatOptionHandler.format(number, FormatOption.HEX, 16, true);
+            System.out.println(text);
+            assertThat(text, equalTo("0xFFFFFFFFFFFFFFAA V"));
+        }
     }
 
     @Test


### PR DESCRIPTION
This pull request changes the method `FormatOptionHandler.formatNumber()` so that the type `long` is always used when converting a number to hexadecimal notation.

`FormatOptionHandler.formatNumber()` is used by the Text Entry widget and the Text Update widget when the widget property "Format" is set to "Hexadecimal". If, furthermore, the widget property "Precision" is set to `-1` (the default value), then `FormatOptionHandler.formatNumber()` will be called with its argument `precision` set to `3` when called with a value of type `double`, with the consequence that, prior to this pull request, the type (signed) `int` would be used to convert a number represented by a `double` to hexadecimal notation, potentially truncating the input.

To me, it seems incorrect that the argument `precision` is used to determine the number of digits. For the decimal notation, the parameter refers to the number of digits after the period, and in this context, the default value of `3` makes sense for a value of type `double`. I think that for the property to mean something different for the hexadecimal notation is confusing, and I think the default (if any) should be a different value. Should this be changed, e.g., by introducing a new widget property for the number of digits before the period to display?