### PR TITLE
RDB archive: Fix Oracle time zone problem.

### DIFF
--- a/services/archive-engine/dbd/postgres_schema.txt
+++ b/services/archive-engine/dbd/postgres_schema.txt
@@ -199,7 +199,7 @@ DROP TABLE IF EXISTS sample;
 CREATE TABLE sample
 (
    channel_id BIGINT NOT NULL,
-   smpl_time TIMESTAMP NOT NULL,
+   smpl_time TIMESTAMPTZ NOT NULL,
    nanosecs BIGINT  NOT NULL,
    severity_id BIGINT NOT NULL,
    status_id BIGINT  NOT NULL,

--- a/services/archive-engine/src/main/java/org/csstudio/archive/writer/rdb/RDBArchiveWriter.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/writer/rdb/RDBArchiveWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2024 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2025 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,7 +51,6 @@ import org.phoebus.pv.LongString;
  *  @author Lana Abadie - PostgreSQL for original RDBArchive code. Disable autocommit as needed.
  *  @author Laurent Philippe (Use read-only connection when possible for MySQL load balancing)
  */
-@SuppressWarnings("nls")
 public class RDBArchiveWriter implements ArchiveWriter
 {
     /** Status string for <code>Double.NaN</code> samples */
@@ -430,9 +429,8 @@ public class RDBArchiveWriter implements ArchiveWriter
             final int N = additional.size();
             for (int i = 1; i < N; i++)
             {
-                if (dialect == Dialect.Oracle){
-                    insert_array_sample.setTimestamp(2, stamp);
-                }
+                if (dialect == Dialect.Oracle)
+                    insert_array_sample.setObject(2, TimestampHelper.toOffsetDateTime(stamp));
                 else
                 {
                     // Truncate the time stamp
@@ -498,9 +496,8 @@ public class RDBArchiveWriter implements ArchiveWriter
             final Timestamp stamp, final int severity,
             final Status status) throws Exception
     {
-        if (dialect == Dialect.Oracle){
-            insert_xx.setTimestamp(2, stamp);
-        }
+        if (dialect == Dialect.Oracle)
+            insert_xx.setObject(2, TimestampHelper.toOffsetDateTime(stamp));
         else
         {
             // Truncate the time stamp


### PR DESCRIPTION
The sample.smpl_time is handled differently for MySQL, Postgres, Oracle.

In MySQL, it's stored as UTC. The `Timestamp` passed to `PreparedStatement.setTimestamp(Timestamp)` is converted to UTC and stored as UTC. On retrieval, `ResultSet.getTimestamp` converts back to the local time zone with appropriate GMT offset.

In Postgres, we need to use a `TIMESTAMPTZ` datatype that stores the stamp with timezone info.

Both MySQL and Postgres handle the fall transition from daylight savings time back to standard time just fine.

In Oracle, even if we use `TIMESTAMP WITH TIMEZONE` for smpl_time, Oracle JDBC will second-guess the Timestamp passed to `setTimestamp(Timestamp)` and change the time offset. During the DST change in the fall, time stamps will be written with the wrong GMT offset.
The workaround is to use `setObject(OffsetDateTime)` because OffsetDateTime is passed through and written as received.


<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing: Manual with test database setup. Ultimate test will happen in November 2026.
- 
Data during the last EDT to EST change might look like this:

2025-11-02T00:30-04:00
2025-11-02T01:30-04:00
2025-11-02T01:30-05:00
2025-11-02T02:30-05:00

Note that the local time 01:30 is logged with the correct time zone info during the transition.

Before this change, with Oracle you would get

2025-11-02T00:30-04:00
2025-11-02T01:30-04:00
2025-11-02T01:30-04:00
2025-11-02T02:30-05:00

or

2025-11-02T00:30-04:00
2025-11-02T01:30-05:00
2025-11-02T01:30-05:00
2025-11-02T02:30-05:00

where both instances of 01:30 are erroneously in the same zone offset.

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
