### PR TITLE
CSSTUDIO-3620 Linear Meter Bugfix: Fix setting of range when no range has been specified

### DIFF
--- a/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterRepresentation.java
+++ b/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterRepresentation.java
@@ -344,9 +344,11 @@ public class LinearMeterRepresentation extends RegionBaseRepresentation<Pane, Li
                                 meter.setRange(observedMin - 1, observedMax + 1, false);
                                 newObservedMinAndMaxValues = false;
                                 linearMeterScaleHasChanged = true;
-                            } else if (meter.linearMeterScale.getValueRange().getLow() != 0.0 || meter.linearMeterScale.getValueRange().getHigh() != 100) {
-                                meter.setRange(0.0, 100.0, false);
-                                linearMeterScaleHasChanged = true;
+                            } else if (Double.isNaN(observedMin) || Double.isNaN(observedMax)) {
+                                if (meter.linearMeterScale.getValueRange().getLow() != 0.0 || meter.linearMeterScale.getValueRange().getHigh() != 100) {
+                                    meter.setRange(0.0, 100.0, false);
+                                    linearMeterScaleHasChanged = true;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This pull request implements a bugfix for the Linear Meter widget: before this pull request, when no range was specified by the user and the PV values don't contain information about the range to display, the Linear Meter would erratically switch between the default range of `[0.0, 100.0]` and a dynamically computed range based on observed values. The reason was a missing check for whether values had been observed yet or not by the Linear Meter upon which to compute a scale.

This pull request fixes the erratic switching of the range by only using setting the range to the default range `[0.0, 100.0]` if there are no observed values to base the range on. (If there are observed values to base the range on, the range is set to `[observedMin - 1, obeservedMax  + 1`].)

I have tested the bugfix manually.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
