### PR TITLE
Allow tagging of multiple save-and-restore snapshots in a single operation

### DIFF
--- a/app/save-and-restore/app/doc/index.rst
+++ b/app/save-and-restore/app/doc/index.rst
@@ -489,7 +489,7 @@ that the context menu will only show tags common to all selected nodes.
 Tagging from search view
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The search result table of the Search And Filter view also supports a contect menu for the purpose of managing tags:
+The search result table of the Search And Filter view also supports a context menu for the purpose of managing tags:
 
 .. image:: images/search-result-context-menu.png
 

--- a/app/save-and-restore/app/doc/index.rst
+++ b/app/save-and-restore/app/doc/index.rst
@@ -95,7 +95,7 @@ Brief description of all items in the context menu (details on actions are outli
 * Delete - delete selected items.
 * Compare Snapshots - compare a snapshot in view to the selected.
 * Add Golden Tag - tag a snapshot as "golden".
-* Tags with comment - add/delete tag on a snapshot or composite snapshot.
+* Tags - add/delete tag on a snapshot or composite snapshot.
 * Copy unique id to clipboard - put a nodes unique string id on the clipboard.
 * Import ... from CSV - import configuration or configuration from CSV file.
 * Export ... to CSV - export configuration or snapshot to CSV file.

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
@@ -1392,7 +1392,6 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
         selectedItemsProperty.setAll(selectedItems.stream().map(TreeItem::getValue).toList());
 
         tagWithComment.disableProperty().set(userIdentity.isNull().get() ||
-                selectedItemsProperty.size() != 1 ||
                 (!selectedItemsProperty.get(0).getNodeType().equals(NodeType.SNAPSHOT) &&
                         !selectedItemsProperty.get(0).getNodeType().equals(NodeType.COMPOSITE_SNAPSHOT)));
         configureTagContextMenu(tagWithComment);

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/search/SearchResultTableViewController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/search/SearchResultTableViewController.java
@@ -223,7 +223,6 @@ public class SearchResultTableViewController extends SaveAndRestoreBaseControlle
                 return;
             }
             tagMenuItem.disableProperty().set(userIdentity.isNull().get() ||
-                    selectedItemsProperty.size() != 1 ||
                     (!selectedItemsProperty.get(0).getNodeType().equals(NodeType.SNAPSHOT) &&
                             !selectedItemsProperty.get(0).getNodeType().equals(NodeType.COMPOSITE_SNAPSHOT)));
             NodeType selectedItemType = resultTableView.getSelectionModel().getSelectedItem().getNodeType();
@@ -241,8 +240,9 @@ public class SearchResultTableViewController extends SaveAndRestoreBaseControlle
 
         contextMenu.getItems().addAll(loginMenuItem, tagGoldenMenuItem, tagMenuItem, restoreFromClientMenuItem, restoreFromServiceMenuItem);
 
-        resultTableView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
+        resultTableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         resultTableView.setContextMenu(contextMenu);
+
 
         // Bind search result table to tableEntries observable
         Property<ObservableList<Node>> tableListProperty = new SimpleObjectProperty<>(tableEntries);


### PR DESCRIPTION
User may select multiple snapshots in tree view or search result view in order to apply same tag. This has been possible for golden tags, but is hence now extended to support free text tags as well.

## Checklist

- Testing:
    - [ ] The feature has automated tests
    - [ X] Tests were run

- Documentation:
    - [ X] The feature is documented
    - [ X] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
