### PR TITLE
Use VType display for formatting data browser cursor values

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PlotSample.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/model/PlotSample.java
@@ -10,7 +10,9 @@ package org.csstudio.trends.databrowser3.model;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.csstudio.javafx.rtplot.Trace;
 import org.csstudio.javafx.rtplot.data.PlotDataItem;
+import org.csstudio.javafx.rtplot.internal.YAxisImpl;
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.AlarmStatus;
@@ -23,6 +25,8 @@ import org.epics.vtype.VType;
 import org.epics.vtype.VEnum;
 import org.phoebus.archive.vtype.VTypeHelper;
 import org.phoebus.pv.TimeHelper;
+import org.phoebus.ui.vtype.FormatOption;
+import org.phoebus.ui.vtype.FormatOptionHandler;
 
 /** Data Sample from control system ({@link VType})
  *  with interface for XYGraph
@@ -236,5 +240,10 @@ public class PlotSample implements PlotDataItem<Instant>
     public String toString()
     {
         return VTypeHelper.toString(value);
+    }
+
+    @Override
+    public String format(YAxisImpl<Instant> axis, Trace<Instant> trace) {
+        return FormatOptionHandler.format(value, FormatOption.DEFAULT, -1, true);
     }
 }

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/data/PlotDataItem.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/data/PlotDataItem.java
@@ -7,6 +7,9 @@
  ******************************************************************************/
 package org.csstudio.javafx.rtplot.data;
 
+import org.csstudio.javafx.rtplot.Trace;
+import org.csstudio.javafx.rtplot.internal.YAxisImpl;
+
 import java.time.Instant;
 
 /** One 'point' of a trace in the plot
@@ -48,4 +51,13 @@ public interface PlotDataItem<XTYPE extends Comparable<XTYPE>>
 
     /** @return if this data point is real or just a mechanical point, e.g. the 'now' point. */
     public default boolean isVirtual() { return false; }
+
+    /** @return a formatted string of this plot sample given the axis it is on */
+    public default String format(YAxisImpl<XTYPE> axis, Trace<XTYPE> trace) {
+        String label = axis.getTicks().formatDetailed(getValue());
+        final String units = trace.getUnits();
+        if (! units.isEmpty())
+            label += " " + units;
+        return label;
+    }
 }

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/CursorMarker.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/CursorMarker.java
@@ -136,10 +136,7 @@ class CursorMarker implements Comparable<CursorMarker>
                 final double value = sample.getValue();
                 if (Double.isFinite(value)  &&  axis.getValueRange().contains(value))
                 {
-                    String label = axis.getTicks().formatDetailed(value);
-                    final String units = trace.getUnits();
-                    if (! units.isEmpty())
-                        label += " " + units;
+                    String label = sample.format(axis, trace);
                     final String info = sample.getInfo();
                     if (info != null  &&  info.length() > 0)
                         label += " (" + info + ")";

--- a/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
+++ b/core/ui/src/main/java/org/phoebus/ui/vtype/FormatOptionHandler.java
@@ -36,6 +36,7 @@ import org.epics.vtype.VString;
 import org.epics.vtype.VStringArray;
 import org.epics.vtype.VTable;
 import org.epics.vtype.VType;
+import org.epics.vtype.VStatistics;
 import org.phoebus.pv.LongString;
 import org.phoebus.ui.Preferences;
 
@@ -108,6 +109,13 @@ public class FormatOptionHandler
             final String text = formatNumber(number.getValue(), number.getDisplay(), option, precision);
             if (show_units  &&  !number.getDisplay().getUnit().isEmpty())
                 return text + " " + number.getDisplay().getUnit();
+            return text;
+        }
+        else if (value instanceof VStatistics stats)
+        {
+            String text = formatNumber(stats.getAverage(), stats.getDisplay(), option, precision);
+            if (show_units  &&  !stats.getDisplay().getUnit().isEmpty())
+                return text + " " + stats.getDisplay().getUnit();
             return text;
         }
         else if (value instanceof VString)


### PR DESCRIPTION
<!-- ^^^ Describe your changes here ^^^ -->

Use VType display for formatting data browser cursor marker values. Previously, they were formatted using the formatting specified by the trace (which seemed to be obtained automatically, and depends on the axis labels, which can also not be configured manually it seems). I changed this to where this can be implemented in the `PlotDataItem` implementation. The default one is the same as the one that was implemented before, and I specified it for the `PlotSample` class, where it uses the `FormatOptionHandler` with the `DEFAULT` format to format the VType from the selected sample. This makes it so that the value formatted in the cursor marker and the value in the Traces table are all formatted using the VType's format, which is more consistent with the rest of the UI.

I am however not sure if I missed some configurable option, or if other sites possibly depend on the "old" formatting.  

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - Checked whether the newly formatted values properly showed up in the data browser

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
