### PR TITLE
Change how AlarmTableUI handles selecting items when state changes to no longer clear manually selected items

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/table/AlarmTableUI.java
@@ -357,7 +357,7 @@ public class AlarmTableUI extends BorderPane
         });
 
         search.setTooltip(new Tooltip("Enter pattern ('vac', 'amp*trip')\nfor PV Name or Description,\npress RETURN to select"));
-        search.textProperty().addListener(prop -> selectRows(true));
+        search.textProperty().addListener(prop -> selectRows());
 
     	if (AlarmSystem.disable_notify_visible)
     	    return new ToolBar(active_count,ToolbarHelper.createStrut(), ToolbarHelper.createSpring(), server_mode, server_notify, acknowledge, unacknowledge, search);
@@ -662,12 +662,12 @@ public class AlarmTableUI extends BorderPane
         update(active_rows, active);
         update(acknowledged_rows, acknowledged);
 
+        /* Move this up here out of update(), doesn't need to be ran twice */
+        selectRows();
+
         /* Now that the table has been appropriately updated, select any still valid pvs */
         selectPvs(this.active, active_selection);
         selectPvs(this.acknowledged, acknowledged_selection);
-
-        /* Move this up here out of update(), doesn't need to be ran twice */
-        selectRows(false);
     }
 
     /** Limit the number of alarms
@@ -716,14 +716,10 @@ public class AlarmTableUI extends BorderPane
     }
 
     /** Select all rows that match the current 'search' pattern */
-    private void selectRows(boolean clearSelection)
+    private void selectRows()
     {
-
-        if(clearSelection)
-        {
-            active.getSelectionModel().clearSelection();
-            acknowledged.getSelectionModel().clearSelection();
-        }
+        active.getSelectionModel().clearSelection();
+        acknowledged.getSelectionModel().clearSelection();
 
         final String glob = search.getText().trim();
         if(glob.isEmpty())


### PR DESCRIPTION
Currently, whenever the alarm table state changes or when the user searches for something, any selected rows get cleared and it creates a new selection based of the search input. If there is no search input, then all selections are cleared. This means that any items selected with a users mouse get cleared when an alarm is added, removed, or is modified (such as the pv severity changing). This can cause user frustration, particularly when a pv severity is flickering in and out of different states.


This PR attempts to fix this by recording all the pv's that were previously selected that are still in the new alarm list when the state changes. After the rows are updated with the new alarms, create a new selection with this pv list.