### PR TITLE
CSSTUDIO-3661 Bugfix: Take into account `Range.isReversed()` when computing the alarm limits for the tooltip of a widget

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
@@ -108,12 +108,26 @@ public class TooltipSupport
             if (vtype instanceof DisplayProvider && !Alarm.alarmOf(vtype).equals(Alarm.disconnected()) ) {
 
                 Range alarmRange = display.getAlarmRange();
-                double lolo = alarmRange.getMinimum();
-                double hihi = alarmRange.getMaximum();
+                double lolo;
+                double hihi;
+                if (!alarmRange.isReversed()) {
+                    lolo = alarmRange.getMinimum();
+                    hihi = alarmRange.getMaximum();
+                } else {
+                    lolo = alarmRange.getMaximum();
+                    hihi = alarmRange.getMinimum();
+                }
 
                 Range warningRange = display.getWarningRange();
-                double low = warningRange.getMinimum();
-                double high = warningRange.getMaximum();
+                double low;
+                double high;
+                if (!warningRange.isReversed()) {
+                    low = warningRange.getMinimum();
+                    high = warningRange.getMaximum();
+                }  else {
+                    low = warningRange.getMaximum();
+                    high = warningRange.getMinimum();
+                }
 
                 String pv_alarm_limits = Messages.HIHI + ": " + (Double.isNaN(hihi) ? Messages.NotSet : hihi) + System.lineSeparator() +
                                          Messages.HIGH + ": " + (Double.isNaN(high) ? Messages.NotSet : high) + System.lineSeparator() +


### PR DESCRIPTION
An instance of `Range` may be reversed such that,e.g., in the case of alarm limits, LOW is `Range.getMaximum()` and HIGH is `Range.getMinimum()` instead of the other way around.

This pull request fixes the code that generates the tooltip to consider `Range.isReversed()` when computing the alarm limits shown in the tooltip.

I have tested the change manually.

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
