### PR TITLE
Add support for DBEMask

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/FieldRequest.java
+++ b/core/pva/src/main/java/org/epics/pva/client/FieldRequest.java
@@ -53,74 +53,45 @@ class FieldRequest
      */
     public FieldRequest(final String request)
     {
-        this(0, false, request);
+        this(RecordOptions.DEFAULT, request);
     }
 
-    /** Parse field request for "monitor" with optional pipeline
-     *  @param pipeline Number of elements for 'pipeline' mode, 0 to disable
+    /** Parse plain field request for "get"
+     *  @param pipeline pipeline flag
      *  @param request Examples:
      *                 "", "field()",
      *                 "value", "field(value)",
      *                 "field(value, timeStamp.userTag)"
      */
-    public FieldRequest(final int pipeline, final String request)
+    public FieldRequest(final int pipeline, String request)
     {
-        this(pipeline, false, request);
+        this(RecordOptions.builder().pipeline(pipeline).build(), request);
     }
 
-    /** Parse field request for "put" with optional completion
-     *  @param completion Perform a write that triggers processing and only returns on completion?
+    /** Parse plain field request for "get"
+     *  @param completion Completion flag
      *  @param request Examples:
      *                 "", "field()",
      *                 "value", "field(value)",
      *                 "field(value, timeStamp.userTag)"
      */
-    public FieldRequest(final boolean completion, final String request)
+    public FieldRequest(final boolean completion, String request)
     {
-        this(0, completion, request);
+        this(RecordOptions.builder().completion(completion).build(), request);
     }
 
 
     /** Parse field request
-     *  @param pipeline Number of elements for 'pipeline' mode, 0 to disable
-     *  @param completion Perform a write that triggers processing and only returns on completion?
+     *  @param recordOptions Options for record monitoring
      *  @param request Examples:
      *                 "", "field()",
      *                 "value", "field(value)",
      *                 "field(value, timeStamp.userTag)"
      */
-    private FieldRequest(final int pipeline, final boolean completion, final String request)
+    public FieldRequest(final RecordOptions recordOptions, final String request)
     {
-        if (pipeline > 0  &&  completion)
-            throw new IllegalStateException("Cannot use both 'pipeline' (for get) " +
-                                            "and 'completion' (for put) within same request");
-        final List<PVAData> items = new ArrayList<>();
 
-        if (pipeline > 0)
-        {
-            // record._options.pipeline=true
-            // 'pvmonitor' encodes as PVAString 'true', not PVABool
-            items.add(
-                new PVAStructure("record", "",
-                    new PVAStructure("_options", "",
-                        new PVABool("pipeline", true),
-                        new PVAInt("queueSize", pipeline)
-                        )));
-        }
-        else if (completion)
-        {
-            // Similar to Channel Access put-callback:
-            // Process passive record (could also use "true" to always process),
-            // then block until processing completes
-            // record._options.process="passive"
-            // record._options.block=true
-            items.add(
-                new PVAStructure("record", "",
-                    new PVAStructure("_options", "",
-                        new PVAString("process", "passive"),
-                        new PVABool("block", true)
-                        )));
-        }
+        final List<PVAData> items = new ArrayList<>(recordOptions.structureItems());
 
         // XXX Not using any client type registry,
         //     but (re-)defining from 1 each time

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -336,10 +336,28 @@ public class PVAChannel extends SearchRequest.Channel implements AutoCloseable
      */
     public AutoCloseable subscribe(final String request, final int pipeline, final MonitorListener listener) throws Exception
     {
+        return subscribe(request, RecordOptions.builder().pipeline(pipeline).build(), listener);
+    }
+
+    /** Start a subscription with different record options
+     *
+     *  <p>Asks the server to send a certain number of 'pipelined' updates.
+     *  Client automatically requests more updates as soon as half the pipelined updates
+     *  are received. In case the client gets overloaded and cannot do this,
+     *  the server will thus pause after sending the pipelined updates.
+     *
+     *  @param request Request, "" for all fields, or "field_a, field_b.subfield"
+     *  @param recordOptions Number of updates to recordOptions
+     *  @param listener Will be invoked with channel and latest value
+     *  @return {@link AutoCloseable}, used to close the subscription
+     *  @throws Exception on error
+     */
+    public AutoCloseable subscribe(final String request, final RecordOptions recordOptions, final MonitorListener listener) throws Exception
+    {
         // MonitorRequest submits itself to TCPHandler
         // and registers as response handler,
         // so we can later retrieve it via its requestID
-        final MonitorRequest subscription = new MonitorRequest(this, request, pipeline, listener);
+        final MonitorRequest subscription = new MonitorRequest(this, request, recordOptions, listener);
         subscriptions.add(subscription);
         return subscription;
     }

--- a/core/pva/src/main/java/org/epics/pva/client/RecordOptions.java
+++ b/core/pva/src/main/java/org/epics/pva/client/RecordOptions.java
@@ -1,0 +1,108 @@
+package org.epics.pva.client;
+
+import org.epics.pva.data.PVABool;
+import org.epics.pva.data.PVAData;
+import org.epics.pva.data.PVAInt;
+import org.epics.pva.data.PVAString;
+import org.epics.pva.data.PVAStructure;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RecordOptions {
+    private static final String STRUCTURE_RECORD_NAME = "record";
+    private static final String STRUCTURE_OPTIONS_NAME = "_options";
+
+    public static final RecordOptions DEFAULT = new RecordOptions(false, 0, null);
+    private final boolean completion;
+    private final int pipeline;
+    private final DBEMask dbeMask;
+
+    /** DBE mask to use for monitoring
+     * */
+    public enum DBEMask {
+        DBE_NOTHING(0),
+        DBE_VALUE(1),
+        DBE_ARCHIVE(2),
+        DBE_ALARM(4);
+
+        private final int mask;
+        DBEMask(final int mask) { this.mask = mask; }
+        public int getMask() { return mask; }
+    }
+
+    private RecordOptions(boolean completion, int pipeline, DBEMask dbeMask) {
+        if (pipeline > 0  &&  completion)
+            throw new IllegalStateException("Cannot use both 'pipeline' (for get) " +
+                "and 'completion' (for put) within same request");
+
+        this.completion = completion;
+        this.pipeline = pipeline;
+        this.dbeMask = dbeMask;
+
+    }
+    public static Builder builder() { return new Builder(); }
+
+    public static class Builder {
+        private boolean completion;
+        private int pipeline;
+        private DBEMask dbeMask = null;
+        public Builder() {
+        }
+
+        Builder  completion(boolean completion) {
+            this.completion = completion;
+            return this;
+        }
+        Builder pipeline(int pipeline) {
+            this.pipeline = pipeline;
+            return this;
+        }
+        Builder dbeMask(DBEMask dbeMask) {
+            this.dbeMask = dbeMask;
+            return this;
+        }
+        public RecordOptions build() {
+            return new RecordOptions(completion, pipeline, dbeMask);
+        }
+    }
+
+    public boolean completion() { return completion; }
+    public int pipeline() { return pipeline; }
+    public DBEMask dbeMask() { return dbeMask; }
+
+    public List<PVAData> structureItems() {
+        List<PVAData> items = new ArrayList<>();
+
+        if (pipeline > 0) {
+            // record._options.pipeline=true
+            // 'pvmonitor' encodes as PVAString 'true', not PVABool
+            items.add(
+                new PVAStructure(STRUCTURE_RECORD_NAME, "",
+                    new PVAStructure(STRUCTURE_OPTIONS_NAME, "",
+                        new PVABool("pipeline", true),
+                        new PVAInt("queueSize", pipeline)
+                    )));
+        } else if (completion) {
+            // Similar to Channel Access put-callback:
+            // Process passive record (could also use "true" to always process),
+            // then block until processing completes
+            // record._options.process="passive"
+            // record._options.block=true
+            items.add(
+                new PVAStructure(STRUCTURE_RECORD_NAME, "",
+                    new PVAStructure(STRUCTURE_OPTIONS_NAME, "",
+                        new PVAString("process", "passive"),
+                        new PVABool("block", true)
+                    )));
+        }
+        if (dbeMask != null) {
+            items.add(
+                new PVAStructure(STRUCTURE_RECORD_NAME, "",
+                    new PVAStructure(STRUCTURE_OPTIONS_NAME, "",
+                        new PVAInt("DBE", dbeMask.getMask())
+                    )));
+        }
+        return items;
+    }
+}

--- a/core/pva/src/test/resources/demo.db
+++ b/core/pva/src/test/resources/demo.db
@@ -14,6 +14,24 @@ record(calc, "ramp$(N)")
   field(DESC, "ramp going up")
 }
 
+record(calc, "demo$(N)") {
+field(SCAN, "1 second")
+field(INPA, "demo$(N).VAL")
+field(CALC, "(A<100)?A+1:0")
+field(HIHI, "90")
+field(HHSV, "MAJOR")
+field(HIGH, "60")
+field(HSV, "MINOR")
+field(LOW, "30")
+field(LSV, "MINOR")
+field(LOLO, "10")
+field(LLSV, "MAJOR")
+field(HOPR, "125")
+field(ADEL, "0")
+field(MDEL, "0")
+}
+
+
 record(calc, "saw$(N)")
 {
   field(SCAN, "1 second")


### PR DESCRIPTION
Allows opening different MonitorRequests
In particular for use in the archiver using DBE_ARCHIVE

Added a new pv to the demo.db that changes alarm frequently to test the DBE_ALARM in ClientDemo

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [x ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
