### PR TITLE
Remove 'State' topic from delete_topics script

### DIFF
--- a/app/alarm/examples/delete_alarm_topics.sh
+++ b/app/alarm/examples/delete_alarm_topics.sh
@@ -24,7 +24,7 @@ config=$1
 
 # ...State was used earlier.
 # With recent setups, you might get a "... does not exist" error which can be ignored
-for topic in "$1" "${1}State" "${1}Command" "${1}Talk"
+for topic in "$1" "${1}Command" "${1}Talk"
 do
     kafka/bin/kafka-topics.sh  --bootstrap-server localhost:9092 --delete --topic $topic
 done


### PR DESCRIPTION
fix https://github.com/ControlSystemStudio/phoebus/issues/3711
Removes 'State' parameter from the delete script

Tested manually.
No more error message when deleting topics with the script
