### PR TITLE
CSSTUDIO-3653 Linear Meter widget tooltip improvements

### DIFF
--- a/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterRepresentation.java
+++ b/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterRepresentation.java
@@ -105,7 +105,7 @@ public class LinearMeterRepresentation extends RegionBaseRepresentation<Pane, Li
         TooltipSupport.attach(jfx_node, model_widget.propTooltip(), () ->
             FormatOptionHandler.format(model_widget.runtimePropValue().getValue(),
                                        model_widget.propFormat().getValue(),
-                                       -1,
+                                       model_widget.propPrecision().getValue(),
                                        model_widget.propShowUnits().getValue()));
     }
 

--- a/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterWidget.java
+++ b/app/display/linearmeter/src/main/java/org/csstudio/display/extra/widgets/linearmeter/LinearMeterWidget.java
@@ -217,6 +217,7 @@ public class LinearMeterWidget extends PVWidget {
     private WidgetProperty<WidgetColor> background;
     private WidgetProperty<WidgetFont> font;
     private WidgetProperty<FormatOption> format;
+    private WidgetProperty<Integer> precision;
     private WidgetProperty<Boolean> show_units;
     private WidgetProperty<Boolean> show_limits;
     private WidgetProperty<Boolean> show_warnings;
@@ -260,6 +261,7 @@ public class LinearMeterWidget extends PVWidget {
         properties.add(logScale = propLogScale.createProperty(this, false));
         properties.add(font = propFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.DEFAULT)));
         properties.add(format = propFormat.createProperty(this, FormatOption.DEFAULT));
+        properties.add(precision = propPrecision.createProperty(this, -1));
         properties.add(show_units = propShowUnits.createProperty(this, true));
         properties.add(scale_visible = propScaleVisible.createProperty(this, true));
         properties.add(show_limits = propShowLimits.createProperty(this, true));
@@ -323,6 +325,13 @@ public class LinearMeterWidget extends PVWidget {
      */
     public WidgetProperty<FormatOption> propFormat() {
         return format;
+    }
+
+    /**
+     * @return 'precision' property
+     */
+    public WidgetProperty<Integer> propPrecision() {
+        return precision;
     }
 
     /**


### PR DESCRIPTION
This pull request improves the tooltip of the Linear Meter widget by:

1. Overriding the method `JFXBaseRepresentation.attachTooltip()` in order to format the current value in a nicer way than the default. Before the changes in this PR, the current value was formatted in the following way:<img width="503" height="118" alt="screenshot1" src="https://github.com/user-attachments/assets/efcfe99c-2078-4bc2-a414-57c60d5ae419" />
In contrast, with the change in this PR, the current value is formatted as follows:<img width="394" height="130" alt="screenshot2" src="https://github.com/user-attachments/assets/460927f8-4767-4ae6-83ed-8c4eab398abe" />
2. Adding the widget property "Precision" to the Linear Meter widget, that allows one to specify the number of decimal places of the current value to display in the tooltip:
<img width="572" height="301" alt="screenshot3" src="https://github.com/user-attachments/assets/002170e3-c996-46e2-93df-5c8ec8c7a17a" /><img width="346" height="133" alt="screenshot4" src="https://github.com/user-attachments/assets/6d77d58b-976b-4a79-83cc-dfcbdbfefbda" />

I have tested the improvements manually.


- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
