### PR TITLE
Erroneous properties

### DIFF
--- a/core/launcher/src/main/java/org/phoebus/product/Launcher.java
+++ b/core/launcher/src/main/java/org/phoebus/product/Launcher.java
@@ -96,11 +96,11 @@ public class Launcher {
         Locations.initialize();
         // Check for site-specific settings.ini bundled into distribution
         // before potentially adding command-line settings.
-        final File site_settings = new File(Locations.install(), "settings.ini");
-        if (site_settings.canRead())
+        final File siteSettings = new File(Locations.install(), "settings.ini");
+        if (siteSettings.canRead())
         {
-            logger.info("Loading bundled settings from " + site_settings.getAbsolutePath());
-            LoadSettings(site_settings.getName());
+            logger.info("Loading bundled settings from " + siteSettings.getAbsolutePath());
+            loadSettings(siteSettings.getName());
         }
 
         // Handle arguments, potentially not even starting the UI
@@ -137,7 +137,7 @@ public class Launcher {
                     iter.remove();
 
                     logger.info("Loading settings from " + location);
-                    LoadSettings(location);
+                    loadSettings(location);
                 } else if (cmd.equals("-export_settings")) {
                     if (!iter.hasNext())
                         throw new Exception("Missing -export_settings file name");
@@ -213,24 +213,24 @@ public class Launcher {
         Application.launch(PhoebusApplication.class, args.toArray(new String[args.size()]));
     }
 
-    private static void LoadSettings(String location) throws Exception {
+    private static void loadSettings(String location) throws Exception {
         if (location.endsWith(".xml"))
             Preferences.importPreferences(new FileInputStream(location));
         else
             PropertyPreferenceLoader.load(location);
 
         // Preference settings
-        final ByteArrayOutputStream prefs_buf = new ByteArrayOutputStream();
+        final ByteArrayOutputStream prefsBuf = new ByteArrayOutputStream();
         try
         {
-            PropertyPreferenceWriter.save(prefs_buf);
+            PropertyPreferenceWriter.save(prefsBuf);
         }
         catch (Exception ex)
         {
             logger.log(Level.WARNING, "Cannot list preferences", ex);
         }
 
-        Preferences.userRoot().put(SETTINGS_SNAPSHOT, prefs_buf.toString());
+        Preferences.userRoot().put(SETTINGS_SNAPSHOT, prefsBuf.toString());
     }
 
     private static void help() {

--- a/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
+++ b/core/ui/src/main/java/org/phoebus/ui/help/OpenAbout.java
@@ -191,12 +191,12 @@ public class OpenAbout implements MenuEntry
         area.setEditable(false);
         final Tab props = new Tab(Messages.HelpAboutSysFea, area);
 
-        String settings_snapshot = Preferences.userRoot().get(SETTINGS_SNAPSHOT, "");
+        String settingsSnapshot = Preferences.userRoot().get(SETTINGS_SNAPSHOT, "");
         WebView webView = new WebView();
         String content = "<html><head><style>" +
         	    "body {font-family: monospace;}" +
         	    "</style></head><body>";
-        content += settings_snapshot;
+        content += settingsSnapshot;
         content += "</body></html>";
         webView.getEngine().loadContent(content);
 


### PR DESCRIPTION
The settings displayed in the dialog box were not just the ones from the settings.ini but also all the parameters saved in memory after Pheobus start.
To avoid this problem, the solution is to chech the settings at the start instead of at the help dialobox opening.
Other advantage, the property files with the "reference" settings are only loaded once whereas it was done every time the dialog box was open.

- Testing:
    - manual test
