### PR TITLE
add preference : epics_pva_enable_ipv6

### DIFF
--- a/core/pv-pva/src/main/java/org/phoebus/pv/pva/PVA_Preferences.java
+++ b/core/pv-pva/src/main/java/org/phoebus/pv/pva/PVA_Preferences.java
@@ -62,6 +62,7 @@ public class PVA_Preferences
                                 "epics_pva_addr_list",
                                 "epics_pva_auto_addr_list",
                                 "epics_pva_name_servers",
+                                "epics_pva_enable_ipv6",
                                 "epics_pva_server_port",
                                 "epics_pva_broadcast_port",
                                 "epics_pva_conn_tmo",

--- a/core/pv-pva/src/main/resources/pv_pva_preferences.properties
+++ b/core/pv-pva/src/main/resources/pv_pva_preferences.properties
@@ -26,6 +26,11 @@ epics_pva_auto_addr_list=
 # Name servers used for TCP name resolution.
 epics_pva_name_servers=
 
+# PVAccess enable IPv6.
+#
+# :format: `true` or `false`
+epics_pva_enable_ipv6=
+
 # :::{caution}
 # The following parameters should best be left
 # at their default.


### PR DESCRIPTION
The environment variable `EPICS_PVA_ENABLE_IPV6` exists since https://github.com/ControlSystemStudio/phoebus/pull/2826, but is not available as a preference. 

With this new feature, one can now add the following line to their `settings.ini` to configure the `EPICS_PVA_ENABLE_IPV6` environement variable : 
```
org.phoebus.pv.pva/epics_pva_enable_ipv6=false
```

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [x] The feature is documented
    - [x] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
