### PR TITLE
Let save&restore connect to WS off UI thread

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
@@ -371,8 +371,7 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
         saveAndRestoreService.addSaveAndRestoreWebSocketMessageHandler(this);
         saveAndRestoreService.setConnectCallback(this::handleWebSocketConnected);
         saveAndRestoreService.setDisconnectCallback(this::handleWebSocketDisconnected);
-        saveAndRestoreService.connectWebSocket();
-
+        JobManager.schedule("Connect to save&restore WS", monitor -> saveAndRestoreService.connectWebSocket());
     }
 
     /**


### PR DESCRIPTION
Seeing side effects with save&restore not being able to connect to service. Hypothesis is that it should not do it on JavaFX thread....

- Testing:
    - [ ] The feature has automated tests
    - [ X] Tests were run

