### PR TITLE
Minor UI fix in save&restore snapshot view

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/snapshot/SnapshotController.java
@@ -463,8 +463,8 @@ public class SnapshotController extends SaveAndRestoreBaseController
         showLiveReadbackButton.setGraphic(new ImageView(new Image(getClass().getResourceAsStream("/icons/show_live_readback_column.png"))));
         showLiveReadbackButton.selectedProperty()
                 .addListener((a, o, n) -> {
-                    this.showReadbacks.set(n);
-                    actionResultReadbackColumn.visibleProperty().setValue(actionResultReadbackColumn.getGraphic() != null);
+                    showReadbacks.set(n);
+                    actionResultReadbackColumn.visibleProperty().setValue(actionResultReadbackColumn.getGraphic() != null && showReadbacks.get());
                 });
 
         ImageView showHideDeltaPercentageButtonImageView = new ImageView(new Image(getClass().getResourceAsStream("/icons/show_hide_delta_percentage.png")));


### PR DESCRIPTION
The "status" column for read-back items remained in view when user clicks "hide readback" (upper left).

This PR fixes it.

- Testing:
    - [ ] The feature has automated tests
    - [X ] Tests were run
   
