### PR TITLE
Do not throw exception in indexOf() function if PV has not yet connected

### DIFF
--- a/core/formula/src/main/java/org/csstudio/apputil/formula/enums/IndexOfFunction.java
+++ b/core/formula/src/main/java/org/csstudio/apputil/formula/enums/IndexOfFunction.java
@@ -1,8 +1,10 @@
 package org.csstudio.apputil.formula.enums;
 
 import org.csstudio.apputil.formula.spi.FormulaFunction;
+import org.epics.vtype.Alarm;
 import org.epics.vtype.Display;
 import org.epics.vtype.Time;
+import org.epics.vtype.VDouble;
 import org.epics.vtype.VEnum;
 import org.epics.vtype.VInt;
 import org.epics.vtype.VType;
@@ -52,6 +54,18 @@ public class IndexOfFunction implements FormulaFunction {
                     Display.none());
         } else
         {
+            if (args[0] instanceof VDouble)
+            {
+                final VDouble v = (VDouble)args[0];
+                if (v.getValue().isNaN() &&
+                        (v.getAlarm() == Alarm.none() || v.getAlarm() == Alarm.disconnected()))
+                {
+                    // Connection has not yet been made to the PV
+                    // so don't throw an exception yet
+                    return args[0];
+                }
+            }
+            // Otherwise throw exception
             throw new Exception("Function " + getName() + " requires an enum argument " + Arrays.toString(args));
         }
 

--- a/core/formula/src/test/java/org/csstudio/apputil/formula/FormulaUnitTest.java
+++ b/core/formula/src/test/java/org/csstudio/apputil/formula/FormulaUnitTest.java
@@ -7,11 +7,16 @@
  ******************************************************************************/
 package org.csstudio.apputil.formula;
 
+import org.csstudio.apputil.formula.enums.IndexOfFunction;
+
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.AlarmStatus;
+import org.epics.vtype.Display;
 import org.epics.vtype.Time;
+import org.epics.vtype.VDouble;
 import org.epics.vtype.VString;
+import org.epics.vtype.VType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.phoebus.core.vtypes.VTypeHelper;
@@ -291,6 +296,31 @@ public class FormulaUnitTest {
         } catch (Exception ex) {
             assertThat(ex.getMessage(), containsString("arguments"));
         }
+    }
+
+    @Test
+    public void testEnums() throws Exception {
+        Formula f = new Formula("enumOf(1, arrayOf(1,2,3), arrayOf(\"a\",\"b\",\"c\"))");
+        assertEquals("b", VTypeHelper.toString(f.eval()));
+
+        f = new Formula("indexOf(enumOf(1, arrayOf(1,2,3), arrayOf(\"a\",\"b\",\"c\")))");
+        assertEquals(1, VTypeHelper.toDouble(f.eval()));
+
+        // Exception is thrown
+        IndexOfFunction indexFunc = new IndexOfFunction();
+        try {
+            indexFunc.compute(VDouble.of(3.2, Alarm.none(), Time.now(), Display.none()));
+        } catch (Exception ex) {
+            assertTrue(ex.getMessage().contains("Function indexOf requires an enum argument"));
+        }
+
+        // Disconnected or not set values should not throw an exception
+        // and should return the same input.
+        VType input = VDouble.of(Double.NaN, Alarm.none(), Time.now(), Display.none());
+        assertEquals(indexFunc.compute(input), input);
+
+        input = VDouble.of(Double.NaN, Alarm.disconnected(), Time.now(), Display.none());
+        assertEquals(indexFunc.compute(input), input);
     }
 
     @Test


### PR DESCRIPTION
PR to fix issue described in https://github.com/ControlSystemStudio/phoebus/issues/3755. This PR doesn't change the underlying behavior but does stop misleading exception messages being printed to the logs.

The initial input variable to the `indexOf()` function will be given the value: `VDouble.of(Double.NaN, Alarm.none(), ...)`. The function is then evaluated and because the initial value is not of type `VEnum`, an exception is unnecessarily thrown. 

The variable is then given the value `VDouble.of(Double.NaN, Alarm.disconnected(), ...)` until the PV send its first value. Again, we have not established a connection to the PV yet and so the `indexOf()` function should not throw an exception.

Under these two cases, _value = NaN_ and _alarm = none_ or _disconnected_ we should not throw an exception if the `VType` is not `VEnum`. I have added this logic to the `indexOf()` function in this PR. Under any other condition we expect this function to be passed a `VEnum` type and so it would be correct to throw the exception.

I have also added a few tests to provide coverage for this cases.



<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [X] The feature has automated tests
    - [X] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
