### PR TITLE
Extend Alt+drag rubberband to all container widgets

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -115,13 +115,12 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
                     // Clicking with the primary (left) button selects the widget ..
                     if (event.isPrimaryButtonDown())
                     {
-                        // .. but ignore the group widget when Alt key is held.
-                        // This allows 'rubberbanding' within a group while Alt is held.
-                        // Without Alt, a click within a group would select-click the group,
-                        // consuming the event and preventing a any rubberband selection.
+                        // .. but ignore container widgets when Alt key is held.
+                        // This allows 'rubberbanding' within a group/tab/array/etc. while Alt is held.
+                        // Without Alt, a click within a container would select-click it,
+                        // consuming the event and preventing any rubberband selection.
                         if (event.isAltDown()  &&
-                            (model_widget instanceof GroupWidget ||
-                             model_widget instanceof TabsWidget))
+                            ChildrenProperty.getChildren(model_widget) != null)
                         {
                             // System.out.println("Ignoring click in " + model_widget);
                             return;


### PR DESCRIPTION
Previously, Alt+left-click-drag to start a rubberband selection inside a container only worked for GroupWidget and TabsWidget (hard-coded instanceof checks). Any other container (e.g. ArrayWidget) would still consume the click and select itself instead.

Replace the specific instanceof checks with ChildrenProperty.getChildren() != null, which returns non-null for any widget that has a children property. This covers GroupWidget, TabsWidget, ArrayWidget, and any future container types automatically.