### PR TITLE
Launcher: Fix loading bundled settings

### DIFF
--- a/core/launcher/src/main/java/org/phoebus/product/Launcher.java
+++ b/core/launcher/src/main/java/org/phoebus/product/Launcher.java
@@ -100,7 +100,7 @@ public class Launcher {
         if (siteSettings.canRead())
         {
             logger.info("Loading bundled settings from " + siteSettings.getAbsolutePath());
-            loadSettings(siteSettings.getName());
+            loadSettings(siteSettings.getAbsolutePath());
         }
 
         // Handle arguments, potentially not even starting the UI


### PR DESCRIPTION
To detect bundled settings, that is a `settings.ini` file in the "install" location,
we check if a file with the expected absolute path is readable.
Next, however, we're loading just the "name", which results in this type of error:

```
INFO [org.phoebus.product] Loading bundled settings from
/Applications/CSS_Phoebus.app/product-xxxx/settings.ini
Exception in thread "main" java.lang.RuntimeException: Unable to locate
settings file: settings.ini
	at org.phoebus.framework.preferences.PropertyPreferenceLoader.load(PropertyPreferenceLoader.java:88)
	at org.phoebus.product.Launcher.loadSettings(Launcher.java:220)
	at org.phoebus.product.Launcher.main(Launcher.java:103)
```

Now it loads `/Applications/CSS_Phoebus.app/product-xxxx/settings.ini` as intended.


## Checklist
- Testing:
    - If not, explain how you tested your changes

SNS product recently failed with the error message shown above.
Works again after the fix.
