### PR TITLE
Add log scaling property to Meter widget

### DIFF
--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
@@ -146,7 +146,7 @@ public class MeterWidget extends PVWidget
         newColorPropertyDescriptor(WidgetPropertyCategory.MISC, "knob_color", Messages.WidgetProperties_KnobColor);
 
     /** Property */
-    public static WidgetPropertyDescriptor<Boolean> propLogarithmicScale =
+    public static final WidgetPropertyDescriptor<Boolean> propLogarithmicScale =
             newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "logScale", Messages.WidgetProperties_LogScale);
 
     private volatile WidgetProperty<WidgetColor> foreground;

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
@@ -146,7 +146,7 @@ public class MeterWidget extends PVWidget
         newColorPropertyDescriptor(WidgetPropertyCategory.MISC, "knob_color", Messages.WidgetProperties_KnobColor);
 
     /** Property */
-    public static WidgetPropertyDescriptor<Boolean> propLogscale =
+    public static WidgetPropertyDescriptor<Boolean> propLogarithmicScale =
             newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "logScale", Messages.WidgetProperties_LogScale);
 
     private volatile WidgetProperty<WidgetColor> foreground;
@@ -200,7 +200,7 @@ public class MeterWidget extends PVWidget
         properties.add(limits_from_pv = propLimitsFromPV.createProperty(this, true));
         properties.add(minimum = propMinimum.createProperty(this, 0.0));
         properties.add(maximum = propMaximum.createProperty(this, 100.0));
-        properties.add(log_scale = propLogscale.createProperty(this, false));
+        properties.add(log_scale = propLogarithmicScale.createProperty(this, false));
     }
 
     /** @return 'foreground_color' property */

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
@@ -107,6 +107,10 @@ public class MeterWidget extends PVWidget
                     ||
                     !XMLUtil.getChildBoolean(xml, "show_markers").orElse(true))
                     meter.propShowLimits().setValue(false);
+
+                // Map log_scale property to logScale
+                XMLUtil.getChildBoolean(xml, "log_scale")
+                        .ifPresent(meter.propLogScale()::setValue);
             }
             else if (xml_version.getMajor() < 3)
             {   // Display Builder meter based on 3rd party JFX lib

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
@@ -146,7 +146,7 @@ public class MeterWidget extends PVWidget
         newColorPropertyDescriptor(WidgetPropertyCategory.MISC, "knob_color", Messages.WidgetProperties_KnobColor);
 
     /** Property */
-    public static WidgetPropertyDescriptor<Boolean> propLogScale =
+    public static WidgetPropertyDescriptor<Boolean> propLogscale =
             newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "logScale", Messages.WidgetProperties_LogScale);
 
     private volatile WidgetProperty<WidgetColor> foreground;
@@ -200,7 +200,7 @@ public class MeterWidget extends PVWidget
         properties.add(limits_from_pv = propLimitsFromPV.createProperty(this, true));
         properties.add(minimum = propMinimum.createProperty(this, 0.0));
         properties.add(maximum = propMaximum.createProperty(this, 100.0));
-        properties.add(log_scale = propLogScale.createProperty(this, false));
+        properties.add(log_scale = propLogscale.createProperty(this, false));
     }
 
     /** @return 'foreground_color' property */

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
@@ -18,6 +18,7 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMinimum;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPrecision;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propShowUnits;
+import static org.csstudio.display.builder.model.widgets.plots.PlotWidgetProperties.propLogscale;
 
 import java.util.Arrays;
 import java.util.List;
@@ -158,6 +159,7 @@ public class MeterWidget extends PVWidget
     private volatile WidgetProperty<Boolean> limits_from_pv;
     private volatile WidgetProperty<Double> minimum;
     private volatile WidgetProperty<Double> maximum;
+    private volatile WidgetProperty<Boolean> log_scale;
 
     /** Constructor */
     public MeterWidget()
@@ -195,6 +197,7 @@ public class MeterWidget extends PVWidget
         properties.add(limits_from_pv = propLimitsFromPV.createProperty(this, true));
         properties.add(minimum = propMinimum.createProperty(this, 0.0));
         properties.add(maximum = propMaximum.createProperty(this, 100.0));
+        properties.add(log_scale = propLogscale.createProperty(this, false));
     }
 
     /** @return 'foreground_color' property */
@@ -273,5 +276,11 @@ public class MeterWidget extends PVWidget
     public WidgetProperty<Double> propMaximum()
     {
         return maximum;
+    }
+
+    /** @return 'log_scale' property */
+    public WidgetProperty<Boolean> propLogScale()
+    {
+        return log_scale;
     }
 }

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
@@ -18,7 +18,6 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMinimum;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPrecision;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propShowUnits;
-import static org.csstudio.display.builder.model.widgets.plots.PlotWidgetProperties.propLogscale;
 
 import java.util.Arrays;
 import java.util.List;
@@ -146,6 +145,10 @@ public class MeterWidget extends PVWidget
     public static final WidgetPropertyDescriptor<WidgetColor> propKnobColor =
         newColorPropertyDescriptor(WidgetPropertyCategory.MISC, "knob_color", Messages.WidgetProperties_KnobColor);
 
+    /** Property */
+    public static WidgetPropertyDescriptor<Boolean> propLogScale =
+            newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "logScale", Messages.WidgetProperties_LogScale);
+
     private volatile WidgetProperty<WidgetColor> foreground;
     private volatile WidgetProperty<WidgetColor> background;
     private volatile WidgetProperty<WidgetFont> font;
@@ -197,7 +200,7 @@ public class MeterWidget extends PVWidget
         properties.add(limits_from_pv = propLimitsFromPV.createProperty(this, true));
         properties.add(minimum = propMinimum.createProperty(this, 0.0));
         properties.add(maximum = propMaximum.createProperty(this, 100.0));
-        properties.add(log_scale = propLogscale.createProperty(this, false));
+        properties.add(log_scale = propLogScale.createProperty(this, false));
     }
 
     /** @return 'foreground_color' property */

--- a/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
+++ b/app/display/model/src/main/java/org/csstudio/display/builder/model/widgets/MeterWidget.java
@@ -107,10 +107,6 @@ public class MeterWidget extends PVWidget
                     ||
                     !XMLUtil.getChildBoolean(xml, "show_markers").orElse(true))
                     meter.propShowLimits().setValue(false);
-
-                // Map log_scale property to logScale
-                XMLUtil.getChildBoolean(xml, "log_scale")
-                        .ifPresent(meter.propLogScale()::setValue);
             }
             else if (xml_version.getMajor() < 3)
             {   // Display Builder meter based on 3rd party JFX lib
@@ -151,7 +147,7 @@ public class MeterWidget extends PVWidget
 
     /** Property */
     public static final WidgetPropertyDescriptor<Boolean> propLogarithmicScale =
-            newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "logScale", Messages.WidgetProperties_LogScale);
+            newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "log_scale", Messages.WidgetProperties_LogScale);
 
     private volatile WidgetProperty<WidgetColor> foreground;
     private volatile WidgetProperty<WidgetColor> background;

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/MeterRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/MeterRepresentation.java
@@ -64,6 +64,7 @@ public class MeterRepresentation extends RegionBaseRepresentation<Pane, MeterWid
         model_widget.propMaximum().addUntypedPropertyListener(valueListener);
         model_widget.propShowValue().addUntypedPropertyListener(valueListener);
         model_widget.runtimePropValue().addUntypedPropertyListener(valueListener);
+        model_widget.propLogScale().addUntypedPropertyListener(valueListener);
         valueChanged(null, null, null);
     }
 
@@ -82,6 +83,7 @@ public class MeterRepresentation extends RegionBaseRepresentation<Pane, MeterWid
         model_widget.propMaximum().removePropertyListener(valueListener);
         model_widget.propShowValue().removePropertyListener(valueListener);
         model_widget.runtimePropValue().removePropertyListener(valueListener);
+        model_widget.propLogScale().removePropertyListener(valueListener);
         super.unregisterListeners();
     }
 
@@ -142,6 +144,8 @@ public class MeterRepresentation extends RegionBaseRepresentation<Pane, MeterWid
         }
         else
             meter.setValue(value, "");
+
+        meter.setLogScale(model_widget.propLogScale().getValue());
     }
 
     @Override

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTMeter.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/RTMeter.java
@@ -61,6 +61,13 @@ public class RTMeter extends ImageView
     /** Area of this meter */
     protected volatile Rectangle area = new Rectangle(0, 0, 0, 0);
 
+    /** @param logscale Use log scale for y-axis? */
+    public void setLogScale(final boolean logscale)
+    {
+        scale.setLogarithmic(logscale);
+        requestUpdate();
+    }
+
     /** Listener to {@link PlotPart}s (scale), triggering refresh of meter */
     protected final PlotPartListener plot_part_listener = new PlotPartListener()
     {

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/MeterScale.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/MeterScale.java
@@ -16,6 +16,8 @@ import java.awt.Stroke;
 import org.csstudio.javafx.rtplot.AxisRange;
 import org.csstudio.javafx.rtplot.internal.util.GraphicsUtils;
 
+import static org.csstudio.javafx.rtplot.internal.util.Log10.log10;
+
 /** 'Round' numeric scale for a meter.
  *  @author Kay Kasemir
  */
@@ -133,7 +135,7 @@ public class MeterScale extends NumericAxis
             final AxisRange<Double> range = getValueRange();
             if (isLogarithmic())
             {
-                return start_angle + Math.log10(value/range.getLow()) * angle_range / Math.log10(range.getHigh()/range.getLow());
+                return start_angle + (log10(value) - log10(range.getLow())) * angle_range / (log10(range.getHigh()) - log10(range.getLow()));
             }
             else
             {

--- a/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/MeterScale.java
+++ b/app/rtplot/src/main/java/org/csstudio/javafx/rtplot/internal/MeterScale.java
@@ -131,7 +131,15 @@ public class MeterScale extends NumericAxis
         if (Double.isFinite(value))
         {
             final AxisRange<Double> range = getValueRange();
-            return start_angle + (value - range.getLow()) * angle_range / (range.getHigh() - range.getLow());
+            if (isLogarithmic())
+            {
+                return start_angle + Math.log10(value/range.getLow()) * angle_range / Math.log10(range.getHigh()/range.getLow());
+            }
+            else
+            {
+                return start_angle + (value - range.getLow()) * angle_range / (range.getHigh() - range.getLow());
+            }
+
         }
         else
             return Double.NaN;


### PR DESCRIPTION
<!-- ^^^ Describe your changes here ^^^ -->
I noticed that the old Meter widget in CS-Studio had the option of using a log scale but that this is missing in the Phoebus Meter widget.

This PR adds the code needed to support log scaling in the meter widget following what is implemented for the RTTank widget. The only real bit of logic needed is in MeterScale.java, otherwise it is pretty much boilerplate. 

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
