### PR TITLE
fix (filebrowser): clear selection and expand target after drag-and-drop move

### DIFF
--- a/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileTreeCell.java
+++ b/app/filebrowser/src/main/java/org/phoebus/applications/filebrowser/FileTreeCell.java
@@ -191,13 +191,13 @@ final class FileTreeCell extends TreeTableCell<FileInfo, File> {
                 {
                     // System.out.println("Add tree item for " + new_name + " to " + target_item.getValue());
                     final ObservableList<TreeItem<FileInfo>> siblings = target_item.getChildren();
-                    final FileTreeItem new_item = new FileTreeItem(mon, new_name);
-                    siblings.add(new_item);
+                    final FileTreeItem newItem = new FileTreeItem(mon, new_name);
+                    siblings.add(newItem);
                     FileTreeItem.sortSiblings(siblings);
                     // Expand the target folder so the moved/copied file is
                     // immediately visible, then select it.
                     target_item.setExpanded(true);
-                    final int idx = getTreeTableView().getRow(new_item);
+                    final int idx = getTreeTableView().getRow(newItem);
                     if (idx >= 0)
                         getTreeTableView().getSelectionModel().select(idx);
                 });


### PR DESCRIPTION
After a MOVE drag-and-drop, the removed TreeItem was left in the SelectionModel, leaving the tree highlighted in a confused state until the file browser was closed and reopened.

Two fixes in FileTreeCell:
- onDragDone: call clearSelection() after removing the moved item so the tree view returns to a clean state immediately.
- move_or_copy: expand the target folder and select the newly added item so the moved/copied file is immediately visible without requiring the user to manually expand the destination directory.