### PR TITLE
Modify maven build to skip tests when building the readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
     - openjdk-25-jdk
   jobs:
     pre_build:
-      - mvn clean install
+      - mvn clean install -DskipTests
 
 # Build from the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
addressing #3773

We don't need to run all the unit tests when building documentation

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
