### PR TITLE
Do not invoke disconnect callbacks on non-critical web socket transport error

### DIFF
--- a/core/websocket/client/src/main/java/org/phoebus/core/websocket/client/WebSocketClientService.java
+++ b/core/websocket/client/src/main/java/org/phoebus/core/websocket/client/WebSocketClientService.java
@@ -242,12 +242,12 @@ public class WebSocketClientService {
         public void handleTransportError(StompSession session, Throwable exception) {
             if (exception instanceof ConnectionLostException) {
                 logger.log(Level.WARNING, "Connection lost, will attempt to reconnect", exception);
+                if (disconnectCallback != null) {
+                    disconnectCallback.run();
+                }
                 connect();
             } else {
-                logger.log(Level.WARNING, "Handling transport exception", exception);
-            }
-            if (disconnectCallback != null) {
-                disconnectCallback.run();
+                logger.log(Level.WARNING, "Got transport exception", exception);
             }
         }
     }


### PR DESCRIPTION
When ```StompSessionHandler``` encounters transport error it should only re-attempt connection and invoke disconnect callback when connection is lost. In other cases the error is logged.

"Non-critical" errors may occur if the server is unable to respond to heartbeat requests because it is busy. This can be seen for instance when debugging server side.


