### PR TITLE
Fix TLS connection mismatch in PVAClient tcp_handlers map

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java
@@ -187,6 +187,9 @@ class ChannelSearch
 
     private final ClientUDPHandler udp;
 
+    /** When true, TLS is excluded from search requests and ignored in responses */
+    private final boolean tls_disabled;
+
     /** Create ClientTCPHandler from IP address and 'tls' flag */
     private final BiFunction<InetSocketAddress, Boolean, ClientTCPHandler> tcp_provider;
 
@@ -206,15 +209,18 @@ class ChannelSearch
      *  @param udp_addresses UDP addresses to search
      *  @param tcp_provider Function that creates ClientTCPHandler for IP address and 'tls' flag
      *  @param name_server_addresses TCP addresses to search
+     *  @param tls_disabled When true, exclude TLS from search protocol list
      *  @throws Exception on error
      */
     public ChannelSearch(final ClientUDPHandler udp,
                          final List<AddressInfo> udp_addresses,
                          final BiFunction<InetSocketAddress, Boolean, ClientTCPHandler> tcp_provider,
-                         final List<AddressInfo> name_server_addresses) throws Exception
+                         final List<AddressInfo> name_server_addresses,
+                         final boolean tls_disabled) throws Exception
     {
         this.udp = udp;
         this.tcp_provider = tcp_provider;
+        this.tls_disabled = tls_disabled;
 
         // Each bucket holds set of channels to search in that time slot
         for (int i=0; i<MAX_SEARCH_PERIOD+2; ++i)
@@ -434,7 +440,7 @@ class ChannelSearch
     /** Issue a PVA server list request */
     public void list()
     {
-        final boolean tls = !PVASettings.EPICS_PVA_TLS_KEYCHAIN.isBlank();
+        final boolean tls = !tls_disabled && !PVASettings.EPICS_PVA_TLS_KEYCHAIN.isBlank();
 
         // Search is invoked for new SearchedChannel(channel, now)
         // as well as by regular, timed search.
@@ -452,8 +458,9 @@ class ChannelSearch
     private void search(final Collection<SearchRequest.Channel> channels)
     {
         // Do we support TLS? This will be encoded in the search requests
-        // to tell server if we can support TLS?
-        final boolean tls = !PVASettings.EPICS_PVA_TLS_KEYCHAIN.isBlank();
+        // to tell server if we can support TLS.
+        // When tls_disabled, never advertise TLS so servers respond with TCP only.
+        final boolean tls = !tls_disabled && !PVASettings.EPICS_PVA_TLS_KEYCHAIN.isBlank();
 
         // Search via TCP
         for (AddressInfo name_server : name_server_addresses)

--- a/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAClient.java
@@ -62,6 +62,9 @@ public class PVAClient implements AutoCloseable
     /** TCP handlers by server address */
     private final ConcurrentHashMap<InetSocketAddress, ClientTCPHandler> tcp_handlers = new ConcurrentHashMap<>();
 
+    /** When true, all connections use plain TCP, ignoring TLS flags from search responses */
+    private final boolean tls_disabled;
+
     private final AtomicInteger request_ids = new AtomicInteger();
 
     /** Create a new PVAClient
@@ -80,6 +83,21 @@ public class PVAClient implements AutoCloseable
      */
     public PVAClient() throws Exception
     {
+        this(false);
+    }
+
+    /** Create a new PVAClient
+     *
+     *  @param tls_disabled When <code>true</code>, all connections use plain TCP,
+     *                      ignoring the TLS flag in search responses.
+     *                      Used by the {@link org.epics.pva.common.CertificateStatusMonitor}
+     *                      to avoid infinite recursion: monitoring cert status requires a
+     *                      PVA connection, which must not itself require cert status monitoring.
+     * @throws Exception on error
+     */
+    public PVAClient(final boolean tls_disabled) throws Exception
+    {
+        this.tls_disabled = tls_disabled;
         final List<AddressInfo> name_server_addresses = Network.parseAddresses(PVASettings.EPICS_PVA_NAME_SERVERS, PVASettings.EPICS_PVA_SERVER_PORT);
 
         final List<AddressInfo> udp_search_addresses = Network.parseAddresses(PVASettings.EPICS_PVA_ADDR_LIST, PVASettings.EPICS_PVA_BROADCAST_PORT);
@@ -91,13 +109,14 @@ public class PVAClient implements AutoCloseable
 
         // TCP traffic is handled by one ClientTCPHandler per address (IP, socket).
         // Pass helper to channel search for getting such a handler.
+        // When tls_disabled, force use_tls=false regardless of what the server advertises.
         final BiFunction<InetSocketAddress, Boolean, ClientTCPHandler> tcp_provider = (the_addr, use_tls) ->
             tcp_handlers.computeIfAbsent(the_addr, addr ->
             {
                 try
                 {
                     // If absent, create with initial empty GUID
-                    return new ClientTCPHandler(this, addr, Guid.EMPTY, use_tls);
+                    return new ClientTCPHandler(this, addr, Guid.EMPTY, tls_disabled ? false : use_tls);
                 }
                 catch (Exception ex)
                 {
@@ -106,7 +125,7 @@ public class PVAClient implements AutoCloseable
                 return null;
 
             });
-        search = new ChannelSearch(udp, udp_search_addresses, tcp_provider, name_server_addresses);
+        search = new ChannelSearch(udp, udp_search_addresses, tcp_provider, name_server_addresses, tls_disabled);
 
         udp.start();
         search.start();
@@ -243,6 +262,14 @@ public class PVAClient implements AutoCloseable
             return;
         }
 
+        // When TLS is disabled (e.g. inner cert-status client), skip TLS search responses.
+        // The server also listens on a plain TCP port and will send a separate response for that.
+        if (tls_disabled && tls)
+        {
+            logger.log(Level.FINE, () -> "Skipping TLS search response from " + server + " (TLS disabled)");
+            return;
+        }
+
         // Reply for specific channel
         final PVAChannel channel = search.unregister(channel_id);
         // Late reply for search that was already satisfied?
@@ -268,11 +295,12 @@ public class PVAClient implements AutoCloseable
         channel.setState(ClientChannelState.FOUND);
         logger.log(Level.FINE, () -> "Reply for " + channel + " from " + (tls ? "TLS " : "TCP ") + server + " " + guid);
 
+        final boolean use_tls = tls_disabled ? false : tls;
         final ClientTCPHandler tcp = tcp_handlers.computeIfAbsent(server, addr ->
         {
             try
             {
-                return new ClientTCPHandler(this, addr, guid, tls);
+                return new ClientTCPHandler(this, addr, guid, use_tls);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Problem

`PVAClient.tcp_handlers` is a `ConcurrentHashMap` keyed by `InetSocketAddress` alone. When a plain-TCP search response arrives for the same `address:port` before the TLS response, `computeIfAbsent` returns the stale plain-TCP handler and the connection is permanently stuck on plain TCP for that address — even after the TLS search response arrives.

## Root Cause

The map key does not encode the TLS flag, so a plain-TCP entry silently shadows any later request to open a TLS connection to the same socket address.

## Fix

- Add a `tls_disabled` flag to `PVAClient` (default `false`).
- When `tls_disabled=true`, force `use_tls=false` in the `computeIfAbsent` lambda so the map is always populated with a plain-TCP handler, regardless of what the search response advertises.
- Thread `tls_disabled` through to `ChannelSearch` so search requests never advertise TLS support when disabled, preventing servers from ever replying with a TLS flag.
- Add a `PVAClient(boolean tls_disabled)` constructor for callers that need a plain-TCP client (e.g., the `CertificateStatusMonitor`, which must avoid infinite recursion).

## Files Changed

- `core/pva/src/main/java/org/epics/pva/client/PVAClient.java`
- `core/pva/src/main/java/org/epics/pva/client/ChannelSearch.java`