### PR TITLE
Fix CA certificate extraction from PKCS12 key entry chains in SecureSockets

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
@@ -113,6 +113,29 @@ public class SecureSockets
                     final String principal = x509.getSubjectX500Principal().toString();
                     logger.log(Level.FINE, "Keychain alias '" + alias + "' is X509 key and certificate for " + principal);
                     keychain_x509_certificates.put(principal, x509);
+
+                    // Add CA certs from the key entry's chain as trusted entries.
+                    // Java's TrustManagerFactory only trusts trustedCertEntry aliases,
+                    // not the CA chain attached to a keyEntry.
+                    // PVXS does the equivalent in extractCAs() (openssl.cpp).
+                    final Certificate[] chain = key_store.getCertificateChain(alias);
+                    if (chain != null)
+                    {
+                        for (int i = 1; i < chain.length; i++)
+                        {
+                            if (chain[i] instanceof X509Certificate ca_cert)
+                            {
+                                final String ca_alias = "ca-chain-" + alias + "-" + i;
+                                if (! key_store.containsAlias(ca_alias))
+                                {
+                                    key_store.setCertificateEntry(ca_alias, ca_cert);
+                                    final String ca_name = ca_cert.getSubjectX500Principal().toString();
+                                    logger.log(Level.FINE, "Added CA from chain as trusted: " + ca_name);
+                                    keychain_x509_certificates.put(ca_name, ca_cert);
+                                }
+                            }
+                        }
+                    }
                 }
                 // Could print 'key', but jdk.event.security logger already logs the cert at FINE level
                 // and logging the key would show the private key


### PR DESCRIPTION
## Problem

Java's `TrustManagerFactory` only trusts entries with alias type `trustedCertEntry`. CA certificates embedded in the certificate chain of a `PrivateKeyEntry` are not automatically trusted — unless Oracle's proprietary OID (`1.2.840.113556.1.8000.2554.43570`) is present in the keystore metadata. PVXS-created `.p12` files do not include this OID, so the `TrustManager` cannot verify server certificates and TLS connections fail.

## Fix

After loading the PKCS12 keystore, iterate over every `PrivateKeyEntry` and walk its certificate chain. Any `X509Certificate` that is its own issuer (i.e. a self-signed CA root) or any intermediate CA is re-added to the keystore as a dedicated `trustedCertEntry`. This matches the behaviour of PVXS's `extractCAs()` function and ensures interoperability with PVXS-generated keystores.

## Files Changed

- `core/pva/src/main/java/org/epics/pva/common/SecureSockets.java`