### PR TITLE
Fix search response port preservation for name-server (gateway) replies

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/client/SearchResponseHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/SearchResponseHandler.java
@@ -47,15 +47,14 @@ class SearchResponseHandler implements CommandHandler<ClientTCPHandler>
             throw new Exception("PVA Server " + tcp + " sent invalid search reply", ex);
         }
 
-        // If reply is "*:port", then use this TCP connection's address.
-        // Client will find existing TCP connection via that address and re-use it.
-        // This is the expected case when directly connecting to a PVA server via
-        // its TCP port.
-        // Otherwise, in case we queried a name server which then points to the actual PVA server,
-        // use address as provided, and connect to it or re-use in case we already have a TCP connection to that address:port.
+        // If reply is "*:port", then use this TCP connection's address
+        // but preserve the port from the response.
+        // The port matters because the server may advertise a TLS port (e.g. 5075)
+        // that differs from the name server's TCP port (e.g. 5175).
+        // This matches the UDP handler behavior in ClientUDPHandler.handleSearchReply.
         InetSocketAddress server = response.server;
         if (server.getAddress().isAnyLocalAddress())
-            server = tcp.getRemoteAddress();
+            server = new InetSocketAddress(tcp.getRemoteAddress().getAddress(), server.getPort());
 
         if (response.found)
         {


### PR DESCRIPTION
## Problem

When a name server / gateway returns a search response containing `0.0.0.0:port`, the `SearchResponseHandler` (TCP path) replaced **both** the IP address *and* the port with the remote address of the TCP connection. This correctly resolved the wildcard IP, but silently discarded the server's advertised port.

In a gateway scenario where the name server listens on port 5175 (plain PVA) but the actual data server listens on TLS port 5075, the response arrived with `0.0.0.0:5075`. After the replacement, the client connected to port 5175 (the name server's port) instead of 5075 (the data server's TLS port), causing the connection to fail or land on the wrong service.

The UDP handler already handled this case correctly by only replacing the IP when the address is a wildcard, leaving the port untouched.

## Fix

Align the TCP search response handler with the UDP handler: when the response address is a wildcard (`0.0.0.0` / `::`), substitute only the IP portion from the remote connection address; preserve the port from the search response.

## Files Changed

- `core/pva/src/main/java/org/epics/pva/client/SearchResponseHandler.java`