### PR TITLE
Add EPICS_PVA_TLS_KEYCHAIN_PWD_FILE for file-based keychain password

### DIFF
--- a/core/pva/src/main/java/org/epics/pva/PVASettings.java
+++ b/core/pva/src/main/java/org/epics/pva/PVASettings.java
@@ -153,6 +153,22 @@ public class PVASettings
      */
     public static String EPICS_PVAS_TLS_KEYCHAIN = "";
 
+    /** Path to a file containing the password for the PVA server keychain.
+     *
+     *  <p>Alternative to embedding the password in {@link #EPICS_PVAS_TLS_KEYCHAIN}
+     *  using the "/path/to/file;password" syntax.
+     *  When set, the password is read from this file instead, with leading and trailing
+     *  whitespace stripped.
+     *  Takes precedence over an inline password in {@link #EPICS_PVAS_TLS_KEYCHAIN}
+     *  when no ";" separator is present in that setting.
+     *
+     *  <p>Intended for environments where secrets are mounted as files,
+     *  for example Kubernetes pods using a {@code Secret} volume.
+     *
+     *  <p>When empty, no password file is used.
+     */
+    public static String EPICS_PVAS_TLS_KEYCHAIN_PWD_FILE = "";
+
     /** Secure server options
      *
      *  <ul>
@@ -182,6 +198,22 @@ public class PVASettings
      *  and searches via EPICS_PVA_NAME_SERVERS will also use TLS.
      */
     public static String EPICS_PVA_TLS_KEYCHAIN = "";
+
+    /** Path to a file containing the password for the PVA client keychain.
+     *
+     *  <p>Alternative to embedding the password in {@link #EPICS_PVA_TLS_KEYCHAIN}
+     *  using the "/path/to/file;password" syntax.
+     *  When set, the password is read from this file instead, with leading and trailing
+     *  whitespace stripped.
+     *  Takes precedence over an inline password in {@link #EPICS_PVA_TLS_KEYCHAIN}
+     *  when no ";" separator is present in that setting.
+     *
+     *  <p>Intended for environments where secrets are mounted as files,
+     *  for example Kubernetes pods using a {@code Secret} volume.
+     *
+     *  <p>When empty, no password file is used.
+     */
+    public static String EPICS_PVA_TLS_KEYCHAIN_PWD_FILE = "";
 
     /** TCP buffer size for sending data
      *
@@ -281,9 +313,11 @@ public class PVASettings
         EPICS_PVA_TCP_SOCKET_TMO = get("EPICS_PVA_TCP_SOCKET_TMO", EPICS_PVA_TCP_SOCKET_TMO);
         EPICS_PVA_MAX_ARRAY_FORMATTING = get("EPICS_PVA_MAX_ARRAY_FORMATTING", EPICS_PVA_MAX_ARRAY_FORMATTING);
         EPICS_PVAS_TLS_KEYCHAIN = get("EPICS_PVAS_TLS_KEYCHAIN", EPICS_PVAS_TLS_KEYCHAIN);
+        EPICS_PVAS_TLS_KEYCHAIN_PWD_FILE = get("EPICS_PVAS_TLS_KEYCHAIN_PWD_FILE", EPICS_PVAS_TLS_KEYCHAIN_PWD_FILE);
         EPICS_PVAS_TLS_OPTIONS = get("EPICS_PVAS_TLS_OPTIONS", EPICS_PVAS_TLS_OPTIONS);
         require_client_cert =  EPICS_PVAS_TLS_OPTIONS.contains("client_cert=require");
         EPICS_PVA_TLS_KEYCHAIN = get("EPICS_PVA_TLS_KEYCHAIN", EPICS_PVA_TLS_KEYCHAIN);
+        EPICS_PVA_TLS_KEYCHAIN_PWD_FILE = get("EPICS_PVA_TLS_KEYCHAIN_PWD_FILE", EPICS_PVA_TLS_KEYCHAIN_PWD_FILE);
         if (EPICS_PVA_TLS_KEYCHAIN.isEmpty()  &&  !EPICS_PVAS_TLS_KEYCHAIN.isEmpty())
         {
             EPICS_PVA_TLS_KEYCHAIN = EPICS_PVAS_TLS_KEYCHAIN;

--- a/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
@@ -14,6 +14,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.Principal;
 import java.security.cert.Certificate;
@@ -63,16 +65,18 @@ public class SecureSockets
     /** X509 certificates loaded from the keychain mapped by principal name of the certificate */
     public static Map<String, X509Certificate> keychain_x509_certificates = new ConcurrentHashMap<>();
 
-    /** @param keychain_setting "/path/to/keychain;password"
+    /** @param keychain_setting "/path/to/keychain", "/path/to/keychain;password",
+     *         or just "/path/to/keychain" with password in a separate *_PWD_FILE
+     *  @param is_server true for server keychain (uses EPICS_PVAS_TLS_KEYCHAIN_PWD_FILE),
+     *                   false for client (uses EPICS_PVA_TLS_KEYCHAIN_PWD_FILE)
      *  @return {@link SSLContext} with 'keystore' and 'truststore' set to content of keystore
      *  @throws Exception on error
      */
-    private static SSLContext createContext(final String keychain_setting) throws Exception
+    private static SSLContext createContext(final String keychain_setting, final boolean is_server) throws Exception
     {
         final String path;
         final char[] pass;
 
-        // We support the default "" empty as well as actual passwords, but not null for no password
         final int sep = keychain_setting.indexOf(';');
         if (sep > 0)
         {
@@ -82,7 +86,7 @@ public class SecureSockets
         else
         {
             path = keychain_setting;
-            pass = "".toCharArray();
+            pass = readKeychainPassword(is_server);
         }
 
         logger.log(Level.FINE, () -> "Loading keychain '" + path + "'");
@@ -131,6 +135,29 @@ public class SecureSockets
         return context;
     }
 
+    private static char[] readKeychainPassword(final boolean is_server)
+    {
+        final String env_name = is_server ? "EPICS_PVAS_TLS_KEYCHAIN_PWD_FILE"
+                                          : "EPICS_PVA_TLS_KEYCHAIN_PWD_FILE";
+        final String pwd_file = PVASettings.get(env_name, "");
+        if (! pwd_file.isEmpty())
+        {
+            try
+            {
+                final String password = Files.readString(Path.of(pwd_file)).trim();
+                logger.log(Level.FINE, () -> "Read keychain password from " + pwd_file);
+                return password.toCharArray();
+            }
+            catch (Exception ex)
+            {
+                logger.log(Level.WARNING, "Error reading password file " + pwd_file, ex);
+            }
+        }
+        // Java PKCS12: null skips encrypted sections (loses CA certs).
+        // Empty array attempts decryption with retry via NUL char fallback.
+        return new char[0];
+    }
+
     private static synchronized void initialize() throws Exception
     {
         if (initialized)
@@ -138,13 +165,13 @@ public class SecureSockets
 
         if (! PVASettings.EPICS_PVAS_TLS_KEYCHAIN.isBlank())
         {
-            final SSLContext context = createContext(PVASettings.EPICS_PVAS_TLS_KEYCHAIN);
+            final SSLContext context = createContext(PVASettings.EPICS_PVAS_TLS_KEYCHAIN, true);
             tls_server_sockets = context.getServerSocketFactory();
         }
 
         if (! PVASettings.EPICS_PVA_TLS_KEYCHAIN.isBlank())
         {
-            final SSLContext context = createContext(PVASettings.EPICS_PVA_TLS_KEYCHAIN);
+            final SSLContext context = createContext(PVASettings.EPICS_PVA_TLS_KEYCHAIN, false);
             tls_client_sockets = context.getSocketFactory();
         }
         initialized = true;

--- a/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
+++ b/core/pva/src/main/java/org/epics/pva/common/SecureSockets.java
@@ -137,9 +137,8 @@ public class SecureSockets
 
     private static char[] readKeychainPassword(final boolean is_server)
     {
-        final String env_name = is_server ? "EPICS_PVAS_TLS_KEYCHAIN_PWD_FILE"
-                                          : "EPICS_PVA_TLS_KEYCHAIN_PWD_FILE";
-        final String pwd_file = PVASettings.get(env_name, "");
+        final String pwd_file = is_server ? PVASettings.EPICS_PVAS_TLS_KEYCHAIN_PWD_FILE
+                                          : PVASettings.EPICS_PVA_TLS_KEYCHAIN_PWD_FILE;
         if (! pwd_file.isEmpty())
         {
             try


### PR DESCRIPTION
## Motivation

The existing `EPICS_PVA_TLS_KEYCHAIN` setting embeds the keystore password directly in the path string (e.g. `path/to/client.p12|password`). This is convenient for development but unsuitable for production environments where secrets must not appear in environment variables, process listings, or configuration files.

Container orchestration platforms such as Kubernetes mount secrets as files (e.g. via `Secret` volumes or external secret operators like Vault Agent). There was no way to supply the keychain password via a file path.

## Change

Two new environment variables are introduced:

| Variable | Purpose |
|---|---|
| `EPICS_PVA_TLS_KEYCHAIN_PWD_FILE` | Path to a file containing the client keychain password |
| `EPICS_PVAS_TLS_KEYCHAIN_PWD_FILE` | Path to a file containing the server keychain password |

When set, `SecureSockets` reads the password from the referenced file instead of parsing it from the keychain path string. The inline `path|password` syntax continues to work; the `_PWD_FILE` variable takes precedence when both are present.

This enables secure password injection for Kubernetes deployments using `secretKeyRef` volume mounts without patching the keychain path.

## Files Changed

- `core/pva/src/main/java/org/epics/pva/common/SecureSockets.java`