### PR TITLE
Expose TLS connection details through PV → Channel → TCPHandler chain

### DIFF
--- a/core/pv-pva/src/main/java/org/phoebus/pv/pva/PVA_PV.java
+++ b/core/pv-pva/src/main/java/org/phoebus/pv/pva/PVA_PV.java
@@ -207,6 +207,36 @@ public class PVA_PV extends PV
         return channel.write(true, name_helper.getRequest(), new_value);
     }
 
+    /** @return <code>true</code> if the connection to the server uses TLS */
+    public boolean isTLS()
+    {
+        return channel.isTLS();
+    }
+
+    /** @return Common Name from the server's X.509 certificate, or <code>null</code> */
+    public String getServerX509Name()
+    {
+        return channel.getServerX509Name();
+    }
+
+    /** @return Common Name from the client's X.509 certificate, or <code>null</code> */
+    public String getClientX509Name()
+    {
+        return channel.getClientX509Name();
+    }
+
+    /** @return Authentication method description, or <code>null</code> when disconnected */
+    public String getAuthenticationInfo()
+    {
+        return channel.getAuthenticationInfo();
+    }
+
+    /** @return Server address as host:port, or <code>null</code> when disconnected */
+    public String getRemoteAddress()
+    {
+        return channel.getRemoteAddress();
+    }
+
     @Override
     protected void close()
     {

--- a/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
+++ b/core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java
@@ -61,6 +61,9 @@ class ClientTCPHandler extends TCPHandler
     /** Is this a TLS connection or plain TCP? */
     private final boolean tls;
 
+    /** Authentication method negotiated during connection validation */
+    private volatile ClientAuthentication authentication;
+
     /** Client context */
     private final PVAClient client;
 
@@ -160,10 +163,16 @@ class ClientTCPHandler extends TCPHandler
         return client;
     }
 
+    /** @return <code>true</code> if this connection uses TLS */
+    public boolean isTLS()
+    {
+        return tls;
+    }
+
     /** When using TLS, the socket has a peer (server, IOC) certificate
      *  @return Name from server's certificate, or <code>null</code>
      */
-    String getServerX509Name()
+    public String getServerX509Name()
     {
         try
         {
@@ -180,10 +189,17 @@ class ClientTCPHandler extends TCPHandler
     /** When using TLS, the socket may come with a local (client) certificate
      *  that TLS uses to authenticate to the server.
      *  @return Name from client's certificate, or <code>null</code> */
-    String getClientX509Name()
+    public String getClientX509Name()
     {
         return tls ? SecureSockets.getPrincipalCN(((SSLSocket) socket).getSession().getLocalPrincipal())
                    : null;
+    }
+
+    /** @return Authentication method description, e.g. "x509", "ca(user@host)", or "anonymous". Null before validation. */
+    public String getAuthenticationInfo()
+    {
+        final ClientAuthentication auth = authentication;
+        return auth != null ? auth.toString() : null;
     }
 
     /** @param channel Channel that uses this TCP connection */
@@ -406,6 +422,7 @@ class ClientTCPHandler extends TCPHandler
         // it will send a CMD_VALIDATED = 9 message with StatusOK and close the TCP connection.
 
         // Reply to Connection Validation request.
+        this.authentication = auth;
         logger.log(Level.FINE, () -> "Sending connection validation response, auth = " + auth);
         // Since send thread is not running, yet, send directly
         PVAHeader.encodeMessageHeader(send_buffer, PVAHeader.FLAG_NONE, PVAHeader.CMD_CONNECTION_VALIDATION, 4+2+2+1);

--- a/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
+++ b/core/pva/src/main/java/org/epics/pva/client/PVAChannel.java
@@ -111,6 +111,44 @@ public class PVAChannel extends SearchRequest.Channel implements AutoCloseable
         return copy;
     }
 
+    /** @return <code>true</code> if the connection uses TLS, <code>false</code> for plain TCP or when disconnected */
+    public boolean isTLS()
+    {
+        final ClientTCPHandler handler = tcp.get();
+        return handler != null && handler.isTLS();
+    }
+
+    /** @return Common Name from the server's X.509 certificate, or <code>null</code> if not using TLS or disconnected */
+    public String getServerX509Name()
+    {
+        final ClientTCPHandler handler = tcp.get();
+        return handler != null ? handler.getServerX509Name() : null;
+    }
+
+    /** @return Common Name from the client's X.509 certificate used for authentication, or <code>null</code> */
+    public String getClientX509Name()
+    {
+        final ClientTCPHandler handler = tcp.get();
+        return handler != null ? handler.getClientX509Name() : null;
+    }
+
+    /** @return Authentication method description, or <code>null</code> when disconnected */
+    public String getAuthenticationInfo()
+    {
+        final ClientTCPHandler handler = tcp.get();
+        return handler != null ? handler.getAuthenticationInfo() : null;
+    }
+
+    /** @return Server address as host:port, or <code>null</code> when disconnected */
+    public String getRemoteAddress()
+    {
+        final ClientTCPHandler handler = tcp.get();
+        if (handler == null)
+            return null;
+        final java.net.InetSocketAddress addr = handler.getRemoteAddress();
+        return addr.getAddress().getHostAddress() + ":" + addr.getPort();
+    }
+
     /** @return Server channel ID */
     int getSID()
     {


### PR DESCRIPTION
## Motivation

There was no API for applications or display widgets to inspect TLS connection details (whether TLS is active, the authenticated server identity, the client identity, and the remote address) for a live PVA connection. This information is needed both for diagnostics and for the PVA Security Widget.

## Change

Adds read-only accessors through the full PVA client stack:

| Class | New methods |
|---|---|
| `ClientTCPHandler` | `isTLS()`, `getServerX509Name()`, `getClientX509Name()`, `getAuthenticationInfo()`, `getRemoteAddress()` |
| `PVAChannel` | Delegates the above through to its `ClientTCPHandler` |
| `PVA_PV` (core/pv-pva) | Delegates the above through to its `PVAChannel` |

All methods are safe to call at any point in the channel lifecycle; they return `false` / `null` / empty string when the connection is not established or TLS is not in use.

## Files Changed

- `core/pva/src/main/java/org/epics/pva/client/ClientTCPHandler.java`
- `core/pva/src/main/java/org/epics/pva/client/PVAChannel.java`
- `core/pv-pva/src/main/java/org/phoebus/pv/pva/PVA_PV.java`