### PR TITLE
Updatethrottle singleton

### DIFF
--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
@@ -38,6 +38,9 @@ import java.util.logging.Level;
 @SuppressWarnings("nls")
 public class RepresentationUpdateThrottle
 {
+    /** Reference counter to determine when to safely shutdown */
+    private static final AtomicInteger reference_count = new AtomicInteger();
+
     /** Period in seconds for logging update performance */
     private static final int performance_log_period_secs = Preferences.performance_log_period_secs;
 
@@ -83,6 +86,7 @@ public class RepresentationUpdateThrottle
         if(instance == null) {
             instance = new RepresentationUpdateThrottle(gui_executor);
         }
+        reference_count.incrementAndGet();
         return instance;
     }
 
@@ -231,7 +235,13 @@ public class RepresentationUpdateThrottle
     /** Shutdown the throttle thread and wait for it to exit */
     public void shutdown()
     {
+        // Only shutdown if this is the last reference
+        if (reference_count.decrementAndGet() != 0){
+            return;
+        }
+
         run = false;
+        instance = null;
         synchronized (updateable)
         {
             updateable.notifyAll();

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
@@ -38,7 +38,7 @@ import java.util.logging.Level;
 @SuppressWarnings("nls")
 public class RepresentationUpdateThrottle
 {
-    /** Reference counter to determine when to safely shutdown */
+    /** Reference counter to aid in debugging the throttle start/shutdown */
     private static final AtomicInteger reference_count = new AtomicInteger();
 
     /** Period in seconds for logging update performance */
@@ -80,22 +80,22 @@ public class RepresentationUpdateThrottle
      * is a singleton to ensure that only one thread is scheduling jobs on the UI
      * thread.
      *
-     *  @param gui_executor Executor for UI thread
+     *  @param guiExecutor Executor for UI thread
      */
-    public static RepresentationUpdateThrottle getInstance(final Executor gui_executor) {
+    public static synchronized RepresentationUpdateThrottle getInstance(final Executor guiExecutor) {
         if(instance == null) {
-            instance = new RepresentationUpdateThrottle(gui_executor);
+            instance = new RepresentationUpdateThrottle(guiExecutor);
         }
         reference_count.incrementAndGet();
         return instance;
     }
 
-    /** @param gui_executor Executor for UI thread */
-    private RepresentationUpdateThrottle(final Executor gui_executor)
+    /** @param guiExecutor Executor for UI thread */
+    private RepresentationUpdateThrottle(final Executor guiExecutor)
     {
         final String name = "RepresentationUpdateThrottle";
         logger.log(Level.FINE, "Create " + name);
-        this.gui_executor = gui_executor;
+        this.gui_executor = guiExecutor;
         throttle_thread = new Thread(this::doRun);
         throttle_thread.setName(name);
         throttle_thread.setDaemon(true);
@@ -235,26 +235,6 @@ public class RepresentationUpdateThrottle
     /** Shutdown the throttle thread and wait for it to exit */
     public void shutdown()
     {
-        // Only shutdown if this is the last reference
-        if (reference_count.decrementAndGet() != 0){
-            return;
-        }
-
-        run = false;
-        instance = null;
-        synchronized (updateable)
-        {
-            updateable.notifyAll();
-        }
-        try
-        {
-            throttle_thread.join(2000);
-        }
-        catch (final InterruptedException ex)
-        {
-            // Ignore, closing down anyway
-        }
-        if (throttle_thread.isAlive())
-            logger.log(Level.WARNING, "Representation update throttle fails to terminate within 2 seconds");
+        reference_count.decrementAndGet();
     }
 }

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
@@ -38,9 +38,6 @@ import java.util.logging.Level;
 @SuppressWarnings("nls")
 public class RepresentationUpdateThrottle
 {
-    /** Instance counter to aid in debugging the throttle start/shutdown */
-    private static final AtomicInteger instance = new AtomicInteger();
-
     /** Period in seconds for logging update performance */
     private static final int performance_log_period_secs = Preferences.performance_log_period_secs;
 
@@ -54,7 +51,7 @@ public class RepresentationUpdateThrottle
     private static final long update_delay = Preferences.update_delay;
 
     /** Singleton instance of this class */
-    private static RepresentationUpdateThrottle INSTANCE;
+    private static RepresentationUpdateThrottle instance;
 
     /** Executor for UI thread */
     private final Executor gui_executor;
@@ -83,16 +80,16 @@ public class RepresentationUpdateThrottle
      *  @param gui_executor Executor for UI thread
      */
     public static RepresentationUpdateThrottle getInstance(final Executor gui_executor) {
-        if(INSTANCE == null) {
-            INSTANCE = new RepresentationUpdateThrottle(gui_executor);
+        if(instance == null) {
+            instance = new RepresentationUpdateThrottle(gui_executor);
         }
-        return INSTANCE;
+        return instance;
     }
 
     /** @param gui_executor Executor for UI thread */
     private RepresentationUpdateThrottle(final Executor gui_executor)
     {
-        final String name = "RepresentationUpdateThrottle" + instance.incrementAndGet();
+        final String name = "RepresentationUpdateThrottle";
         logger.log(Level.FINE, "Create " + name);
         this.gui_executor = gui_executor;
         throttle_thread = new Thread(this::doRun);

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
@@ -53,6 +53,9 @@ public class RepresentationUpdateThrottle
     /** Pause between updates to prevent flooding the UI thread */
     private static final long update_delay = Preferences.update_delay;
 
+    /** Singleton instance of this class */
+    private static RepresentationUpdateThrottle INSTANCE;
+
     /** Executor for UI thread */
     private final Executor gui_executor;
 
@@ -73,8 +76,21 @@ public class RepresentationUpdateThrottle
      */
     private final Set<WidgetRepresentation<?, ?, ?>> updateable = new LinkedHashSet<>();
 
+    /** Get instance of this class to perform updates on the UI thread. This class
+     * is a singleton to ensure that only one thread is scheduling jobs on the UI
+     * thread.
+     *
+     *  @param gui_executor Executor for UI thread
+     */
+    public static RepresentationUpdateThrottle getInstance(final Executor gui_executor) {
+        if(INSTANCE == null) {
+            INSTANCE = new RepresentationUpdateThrottle(gui_executor);
+        }
+        return INSTANCE;
+    }
+
     /** @param gui_executor Executor for UI thread */
-    public RepresentationUpdateThrottle(final Executor gui_executor)
+    private RepresentationUpdateThrottle(final Executor gui_executor)
     {
         final String name = "RepresentationUpdateThrottle" + instance.incrementAndGet();
         logger.log(Level.FINE, "Create " + name);

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
@@ -86,8 +86,9 @@ public class RepresentationUpdateThrottle
         if(instance == null) {
             instance = new RepresentationUpdateThrottle(guiExecutor);
         }
-        logger.log(Level.FINE, "RepresentationUpdateThrottle getInstance() reference count: "
-                + reference_count.incrementAndGet());
+        reference_count.incrementAndGet();
+        logger.log(Level.FINE, () -> "RepresentationUpdateThrottle getInstance() reference count: "
+                + reference_count.get());
         return instance;
     }
 
@@ -236,7 +237,8 @@ public class RepresentationUpdateThrottle
     /** Shutdown the throttle thread and wait for it to exit */
     public void shutdown()
     {
-        logger.log(Level.FINE, "RepresentationUpdateThrottle shutdown() reference count: "
-                + reference_count.decrementAndGet());
+        reference_count.decrementAndGet();
+        logger.log(Level.FINE, () -> "RepresentationUpdateThrottle shutdown() reference count: "
+                + reference_count.get());
     }
 }

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/RepresentationUpdateThrottle.java
@@ -86,7 +86,8 @@ public class RepresentationUpdateThrottle
         if(instance == null) {
             instance = new RepresentationUpdateThrottle(guiExecutor);
         }
-        reference_count.incrementAndGet();
+        logger.log(Level.FINE, "RepresentationUpdateThrottle getInstance() reference count: "
+                + reference_count.incrementAndGet());
         return instance;
     }
 
@@ -235,6 +236,7 @@ public class RepresentationUpdateThrottle
     /** Shutdown the throttle thread and wait for it to exit */
     public void shutdown()
     {
-        reference_count.decrementAndGet();
+        logger.log(Level.FINE, "RepresentationUpdateThrottle shutdown() reference count: "
+                + reference_count.decrementAndGet());
     }
 }

--- a/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
+++ b/app/display/representation/src/main/java/org/csstudio/display/builder/representation/ToolkitRepresentation.java
@@ -74,7 +74,7 @@ abstract public class ToolkitRepresentation<TWP extends Object, TW> implements E
 
     private final boolean edit_mode;
 
-    private final RepresentationUpdateThrottle throttle = new RepresentationUpdateThrottle(this);
+    private final RepresentationUpdateThrottle throttle = RepresentationUpdateThrottle.getInstance(this);
 
     /**
      * Listener list

--- a/app/display/representation/src/test/java/org/csstudio/display/builder/representation/UpdateThrottleTest.java
+++ b/app/display/representation/src/test/java/org/csstudio/display/builder/representation/UpdateThrottleTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @SuppressWarnings("nls")
 public class UpdateThrottleTest
 {
-    private final RepresentationUpdateThrottle throttle = new RepresentationUpdateThrottle(Executors.newSingleThreadExecutor());
+    private final RepresentationUpdateThrottle throttle = RepresentationUpdateThrottle.getInstance(Executors.newSingleThreadExecutor());
 
     private class TestWidgetRepresentation extends WidgetRepresentation<Object, Object, Widget>
     {

--- a/app/display/representation/src/test/java/org/csstudio/display/builder/representation/UpdateThrottleTest.java
+++ b/app/display/representation/src/test/java/org/csstudio/display/builder/representation/UpdateThrottleTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class UpdateThrottleTest
+class UpdateThrottleTest
 {
     private final RepresentationUpdateThrottle throttle = RepresentationUpdateThrottle.getInstance(Executors.newSingleThreadExecutor());
 
@@ -79,7 +79,7 @@ public class UpdateThrottleTest
     }
 
     @Test
-    public void demonstrateUpdateThrottle() throws Throwable
+    void demonstrateUpdateThrottle() throws Throwable
     {
         final AtomicInteger updates_a = new AtomicInteger();
         final AtomicInteger updates_b = new AtomicInteger();


### PR DESCRIPTION
<!-- ^^^ Describe your changes here ^^^ -->
A little while we were looking at the performance of Phoebus when there are multiple windows open (see issue https://github.com/ControlSystemStudio/phoebus/issues/3169), specifically that CPU usage was very high with multiple windows with PVs updating at 10Hz. 

After some further investigations, including testing a standalone JavaFX application, we found that a lot of the bad performance stems from JavaFX itself and the way it handles repainting multiple windows (as also suggested by Kay in the above issue). 

However, we continued to look for any ways that we could improve performance on the Phoebus side, which we address in this PR. Currently Phoebus creates an `RepresentationUpdateThrottle` instance for _each_ window. This class is in charge of collecting updates and running them on the UI thread. This means that in the case of 10 windows, there are 10 `RepresentationUpdateThrottle` all scheduling jobs on the single UI thread. 

Instead we found that it was slightly more efficient to turn the `RepresentationUpdateThrottle` class into a singleton and only have this one thread to collect updates across all windows and hence there is only one thread trying to run jobs on the UI thread. In testing, with this change, we saw CPU usage drop by about 10%, e.g. from 165% to 155%. 

There is only one UI thread that can repaint the display and so I can't see any ill effects of only having one thread to collect updates and call this UI thread, but I would appreciate some further thoughts on this. Is there anything we haven't thought of that this might affect? 

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [X] The feature has automated tests
    - [X] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [X] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
