### PR TITLE
Fix missin screenshots from log created from OPIs

### DIFF
--- a/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogClient.java
+++ b/app/logbook/elog/src/main/java/org/phoebus/elog/api/ElogClient.java
@@ -1,11 +1,20 @@
 package org.phoebus.elog.api;
 
-import org.phoebus.logbook.*;
+import org.phoebus.logbook.Attachment;
+import org.phoebus.logbook.AttachmentImpl;
+import org.phoebus.logbook.LogClient;
+import org.phoebus.logbook.LogEntry;
+import org.phoebus.logbook.LogEntryImpl;
 import org.phoebus.logbook.LogEntryImpl.LogEntryBuilder;
+import org.phoebus.logbook.Logbook;
+import org.phoebus.logbook.LogbookException;
+import org.phoebus.logbook.LogbookImpl;
+import org.phoebus.logbook.SearchResult;
+import org.phoebus.logbook.Tag;
+import org.phoebus.logbook.TagImpl;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.net.FileNameMap;
 import java.net.URI;
@@ -15,7 +24,12 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -25,7 +39,7 @@ import java.util.logging.Logger;
  * @author kingspride
  *
  */
-public class ElogClient implements LogClient{
+public class ElogClient implements LogClient {
     private final ElogApi service;
     private final Collection<Tag> categories;
     private final Collection<Logbook> types;
@@ -47,7 +61,7 @@ public class ElogClient implements LogClient{
         private final ElogProperties properties = new ElogProperties();
 
         private ElogClientBuilder() {
-            this.elogURI = URI.create( this.properties.getPreferenceValue("elog_url") );
+            this.elogURI = URI.create(this.properties.getPreferenceValue("elog_url"));
         }
 
         /**
@@ -82,13 +96,13 @@ public class ElogClient implements LogClient{
             for (int i = 0; i < password.length(); i++) {
                 ch[i] = password.charAt(i);
             }
-            this.password = Sha256.sha256( ch, 5000 );
+            this.password = Sha256.sha256(ch, 5000);
             return this;
         }
 
         /**
          * Create new instance of <code>ElogClient</code>
-         * 
+         *
          * @return {@link ElogClient}
          */
         public ElogClient create() {
@@ -97,23 +111,23 @@ public class ElogClient implements LogClient{
 
             List<Logbook> types = null;
             String types_prop = this.properties.getPreferenceValue("types");
-            if( !types_prop.isEmpty() ) {
+            if (!types_prop.isEmpty()) {
                 types = new ArrayList<>();
-                for( String s: types_prop.split("\\s*,\\s*") ){
-                    types.add( LogbookImpl.of( s ) );
+                for (String s : types_prop.split("\\s*,\\s*")) {
+                    types.add(LogbookImpl.of(s));
                 }
             }
 
             List<Tag> categories = null;
             String categories_prop = this.properties.getPreferenceValue("categories");
-            if( !categories_prop.isEmpty() ) {
+            if (!categories_prop.isEmpty()) {
                 categories = new ArrayList<>();
-                for( String s: categories_prop.split("\\s*,\\s*") ){
-                    categories.add( TagImpl.of( s ) );
+                for (String s : categories_prop.split("\\s*,\\s*")) {
+                    categories.add(TagImpl.of(s));
                 }
             }
-            ElogApi service = new ElogApi( this.elogURI, this.username, this.password );
-            return new ElogClient( service, categories, types );
+            ElogApi service = new ElogApi(this.elogURI, this.username, this.password);
+            return new ElogClient(service, categories, types);
         }
 
 
@@ -127,27 +141,27 @@ public class ElogClient implements LogClient{
     }
 
 
-    private ElogClient( ElogApi service, Collection<Tag> categories, Collection<Logbook> types ) {
+    private ElogClient(ElogApi service, Collection<Tag> categories, Collection<Logbook> types) {
         this.service = service;
-        if( types == null ) {
+        if (types == null) {
             this.types = new ArrayList<>();
             try {
-                for( String t : service.getTypes() ) {
-                    this.types.add( LogbookImpl.of( t ));
+                for (String t : service.getTypes()) {
+                    this.types.add(LogbookImpl.of(t));
                 }
-            } catch(LogbookException e){
+            } catch (LogbookException e) {
                 e.printStackTrace();
             }
         } else {
             this.types = types;
         }
-        if( categories == null ) {
+        if (categories == null) {
             this.categories = new ArrayList<>();
             try {
-                for( String c : service.getCategories() ) {
-                    this.categories.add( TagImpl.of( c ));
+                for (String c : service.getCategories()) {
+                    this.categories.add(TagImpl.of(c));
                 }
-            } catch(LogbookException e){
+            } catch (LogbookException e) {
                 e.printStackTrace();
             }
         } else {
@@ -160,38 +174,38 @@ public class ElogClient implements LogClient{
     public LogEntry set(LogEntry log) throws LogbookException {
         Map<String, String> attributes = new HashMap<>();
 
-        for( Logbook l: log.getLogbooks() ) {
-            if( !l.getName().isEmpty() ) {
-                attributes.put( "Type", l.getName() );
+        for (Logbook l : log.getLogbooks()) {
+            if (!l.getName().isEmpty()) {
+                attributes.put("Type", l.getName());
                 break;
             }
         }
-        if( !attributes.containsKey("Type") ) {
-            Logger.getLogger( ElogClient.class.getPackageName()).severe( "No valid type selected. Cannot submit log entry" );
+        if (!attributes.containsKey("Type")) {
+            Logger.getLogger(ElogClient.class.getPackageName()).severe("No valid type selected. Cannot submit log entry");
             return null;
         }
 
-        for( Tag t: log.getTags() ) {
-            if( !t.getName().isEmpty() ) {
-                attributes.put( "Category", t.getName() );
+        for (Tag t : log.getTags()) {
+            if (!t.getName().isEmpty()) {
+                attributes.put("Category", t.getName());
                 break;
             }
         }
 
-        attributes.put( "Subject", log.getTitle() );
-        attributes.put( "Text", log.getDescription() );
+        attributes.put("Subject", log.getTitle());
+        attributes.put("Text", log.getDescription());
 
         List<File> files = new ArrayList<>();
-        for( Attachment att: log.getAttachments() ) {
-          files.add( att.getFile() );
+        for (Attachment att : log.getAttachments()) {
+            files.add(att.getFile());
         }
 
-        long msgId = service.post( attributes, files );
+        long msgId = service.post(attributes, files);
 
-        LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log( log );
-        logBuilder.id( msgId );
-        logBuilder.createdDate( Instant.now() );
-        logBuilder.modifiedDate( Instant.now() );
+        LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log(log);
+        logBuilder.id(msgId);
+        logBuilder.createdDate(Instant.now());
+        logBuilder.modifiedDate(Instant.now());
         return logBuilder.build();
     }
 
@@ -199,43 +213,43 @@ public class ElogClient implements LogClient{
     @Override
     public LogEntry getLog(Long logId) {
         ElogEntry entry = null;
-        try{
-            entry = service.read( logId );
-        } catch(LogbookException e){
+        try {
+            entry = service.read(logId);
+        } catch (LogbookException e) {
             e.printStackTrace();
         }
 
         LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
-        logBuilder.id( logId );
-        logBuilder.description( entry.getAttribute("Text") );
-        logBuilder.title( entry.getAttribute("Subject") );
+        logBuilder.id(logId);
+        logBuilder.description(entry.getAttribute("Text"));
+        logBuilder.title(entry.getAttribute("Subject"));
         try {
             LocalDateTime date = LocalDateTime.parse(entry.getAttribute("Date"), formatter);
-            logBuilder.createdDate( date.atZone(ZoneId.systemDefault()).toInstant() );
-            logBuilder.modifiedDate( date.atZone(ZoneId.systemDefault()).toInstant() );
+            logBuilder.createdDate(date.atZone(ZoneId.systemDefault()).toInstant());
+            logBuilder.modifiedDate(date.atZone(ZoneId.systemDefault()).toInstant());
         } catch (DateTimeParseException e) {
             e.printStackTrace();
             return null;
         }
-        logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
-        logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+        logBuilder.appendTag(TagImpl.of(entry.getAttribute("Category")));
+        logBuilder.appendToLogbook(LogbookImpl.of(entry.getAttribute("Type")));
 
-        try{
-            for( String s : entry.getAttachments() ) {
+        try {
+            for (String s : entry.getAttachments()) {
                 String mimeType = fileNameMap.getContentTypeFor(s);
-                if( mimeType == null ) {
-                    if( s.endsWith(".py") ){
-                        logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
-                    } else if( s.endsWith(".pyc") ){
-                        logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
+                if (mimeType == null) {
+                    if (s.endsWith(".py")) {
+                        logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "text/x-python", false));
+                    } else if (s.endsWith(".pyc")) {
+                        logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "application/x-python-code", false));
                     } else {
-                        logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unknown", false ));
+                        logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "unknown", false));
                     }
                 } else {
-                    logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                    logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), mimeType, false));
                 }
             }
-        } catch(LogbookException | FileNotFoundException e){
+        } catch (LogbookException e) {
             e.printStackTrace();
         }
 
@@ -246,23 +260,23 @@ public class ElogClient implements LogClient{
     @Override
     public Collection<Attachment> listAttachments(Long logId) {
         List<Attachment> attlist = new ArrayList<>();
-        try{
-            ElogEntry entry = service.read( logId );
-            for( String s : entry.getAttachments() ) {
+        try {
+            ElogEntry entry = service.read(logId);
+            for (String s : entry.getAttachments()) {
                 String mimeType = fileNameMap.getContentTypeFor(s);
-                if( mimeType == null ) {
-                    if( s.endsWith(".py") ){
-                        attlist.add( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
-                    } else if( s.endsWith(".pyc") ){
-                        attlist.add( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
+                if (mimeType == null) {
+                    if (s.endsWith(".py")) {
+                        attlist.add(AttachmentImpl.of(service.getAttachment(s), "text/x-python", false));
+                    } else if (s.endsWith(".pyc")) {
+                        attlist.add(AttachmentImpl.of(service.getAttachment(s), "application/x-python-code", false));
                     } else {
-                        attlist.add( AttachmentImpl.of( service.getAttachment(s), "unknown", false ));
+                        attlist.add(AttachmentImpl.of(service.getAttachment(s), "unknown", false));
                     }
                 } else {
-                    attlist.add( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                    attlist.add(AttachmentImpl.of(service.getAttachment(s), mimeType, false));
                 }
             }
-        } catch(LogbookException | FileNotFoundException e){
+        } catch (LogbookException e) {
             e.printStackTrace();
         }
         return attlist;
@@ -279,58 +293,58 @@ public class ElogClient implements LogClient{
         Map<String, String> query = new HashMap<>(map);
         DateTimeFormatter simple_datetime_formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS", Locale.ENGLISH);
 
-        if( query.containsKey( "start" ) ) {
+        if (query.containsKey("start")) {
             try {
-                LocalDateTime date = LocalDateTime.parse(map.get( "start" ), simple_datetime_formatter);
-                query.put("ma", String.valueOf( date.getMonthValue() ));
+                LocalDateTime date = LocalDateTime.parse(map.get("start"), simple_datetime_formatter);
+                query.put("ma", String.valueOf(date.getMonthValue()));
                 query.put("da", String.valueOf(date.getDayOfMonth()));
-                query.put("ya", String.valueOf( date.getYear() ));
-                query.put("ha", String.valueOf( date.getHour() ));
-                query.put("na", String.valueOf( date.getMinute() ));
-                query.put("ca", String.valueOf( date.getSecond() ));
+                query.put("ya", String.valueOf(date.getYear()));
+                query.put("ha", String.valueOf(date.getHour()));
+                query.put("na", String.valueOf(date.getMinute()));
+                query.put("ca", String.valueOf(date.getSecond()));
             } catch (DateTimeParseException e) {
                 e.printStackTrace();
                 return null;
             }
             query.remove("start");
         }
-        if( query.containsKey( "end" ) ) {
+        if (query.containsKey("end")) {
             try {
-                LocalDateTime date = LocalDateTime.parse(map.get( "end" ), simple_datetime_formatter);
-                query.put("mb", String.valueOf( date.getMonthValue() ));
+                LocalDateTime date = LocalDateTime.parse(map.get("end"), simple_datetime_formatter);
+                query.put("mb", String.valueOf(date.getMonthValue()));
                 query.put("db", String.valueOf(date.getDayOfMonth()));
-                query.put("yb", String.valueOf( date.getYear() ));
-                query.put("hb", String.valueOf( date.getHour() ));
-                query.put("nb", String.valueOf( date.getMinute() ));
-                query.put("cb", String.valueOf( date.getSecond() ));
+                query.put("yb", String.valueOf(date.getYear()));
+                query.put("hb", String.valueOf(date.getHour()));
+                query.put("nb", String.valueOf(date.getMinute()));
+                query.put("cb", String.valueOf(date.getSecond()));
             } catch (DateTimeParseException e) {
                 e.printStackTrace();
                 return null;
             }
             query.remove("end");
         }
-        if( query.containsKey( "desc" ) ) {
-            String subtext = map.get( "desc" );
-            if( !subtext.equals("*") ) {
-                query.put("subtext", subtext );
+        if (query.containsKey("desc")) {
+            String subtext = map.get("desc");
+            if (!subtext.equals("*")) {
+                query.put("subtext", subtext);
             }
             query.remove("desc");
         }
-        if( query.containsKey( "logbook" ) ) {
-            String type = map.get( "logbook" );
-            if( type.contains(",") ) {
-                query.put("Type", type.substring( 0, type.indexOf(",") ) );
+        if (query.containsKey("logbook")) {
+            String type = map.get("logbook");
+            if (type.contains(",")) {
+                query.put("Type", type.substring(0, type.indexOf(",")));
             } else {
-                query.put("Type", type );
+                query.put("Type", type);
             }
             query.remove("logbook");
         }
-        if( query.containsKey( "tag" ) ) {
-            String category = map.get( "tag" );
-            if( category.contains(",") ) {
-                query.put("Category", category.substring( 0, category.indexOf(",") ) );
+        if (query.containsKey("tag")) {
+            String category = map.get("tag");
+            if (category.contains(",")) {
+                query.put("Category", category.substring(0, category.indexOf(",")));
             } else {
-                query.put("Category", category );
+                query.put("Category", category);
             }
             query.remove("tag");
         }
@@ -338,7 +352,7 @@ public class ElogClient implements LogClient{
         Integer from = null;
         Integer size = null;
 
-        if(map.containsKey("from")) {
+        if (map.containsKey("from")) {
             try {
                 from = Integer.parseInt(map.get("from"));
             } catch (NumberFormatException e) {
@@ -346,7 +360,7 @@ public class ElogClient implements LogClient{
             }
         }
 
-        if(map.containsKey("size")) {
+        if (map.containsKey("size")) {
             try {
                 size = Integer.parseInt(map.get("size"));
             } catch (NumberFormatException e) {
@@ -357,45 +371,40 @@ public class ElogClient implements LogClient{
         List<LogEntry> entries = new ArrayList<>();
         ElogSearchResult result = null;
         try {
-            result = service.search( query, from, size );
-            for( ElogEntry entry : result.getLogs() ) {
+            result = service.search(query, from, size);
+            for (ElogEntry entry : result.getLogs()) {
                 LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
-                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
-                logBuilder.description( entry.getAttribute("Text") );
-                logBuilder.title( entry.getAttribute("Subject") );
+                logBuilder.id(Long.valueOf(entry.getAttribute("$@MID@$")));
+                logBuilder.description(entry.getAttribute("Text"));
+                logBuilder.title(entry.getAttribute("Subject"));
                 try {
                     LocalDateTime date = LocalDateTime.parse(entry.getAttribute("Date"), formatter);
-                    logBuilder.createdDate( date.atZone(ZoneId.systemDefault()).toInstant() );
-                    logBuilder.modifiedDate( date.atZone(ZoneId.systemDefault()).toInstant() );
+                    logBuilder.createdDate(date.atZone(ZoneId.systemDefault()).toInstant());
+                    logBuilder.modifiedDate(date.atZone(ZoneId.systemDefault()).toInstant());
                 } catch (DateTimeParseException e) {
                     e.printStackTrace();
                     return null;
                 }
-                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
-                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+                logBuilder.appendTag(TagImpl.of(entry.getAttribute("Category")));
+                logBuilder.appendToLogbook(LogbookImpl.of(entry.getAttribute("Type")));
 
-                try {
-                    for( String s : entry.getAttachments() ) {
-                        String mimeType = fileNameMap.getContentTypeFor(s);
-                        if( mimeType == null ) {
-                            if( s.endsWith(".py") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
-                            } else if( s.endsWith(".pyc") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
-                            } else {
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unknown", false ));
-                            }
+                for (String s : entry.getAttachments()) {
+                    String mimeType = fileNameMap.getContentTypeFor(s);
+                    if (mimeType == null) {
+                        if (s.endsWith(".py")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "text/x-python", false));
+                        } else if (s.endsWith(".pyc")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "application/x-python-code", false));
                         } else {
-                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "unknown", false));
                         }
+                    } else {
+                        logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), mimeType, false));
                     }
-                } catch(FileNotFoundException e){
-                    e.printStackTrace();
                 }
-
-                entries.add( logBuilder.build() );
+                entries.add(logBuilder.build());
             }
-        } catch(LogbookException e){
+        } catch (LogbookException e) {
             e.printStackTrace();
         }
         return SearchResult.of(entries, result.getHitCount());
@@ -404,46 +413,41 @@ public class ElogClient implements LogClient{
 
     @Override
     public Collection<LogEntry> listLogs() {
-          List<LogEntry> entries = new ArrayList<>();
-          try{
-            for( ElogEntry entry : service.getMessages() ) {
+        List<LogEntry> entries = new ArrayList<>();
+        try {
+            for (ElogEntry entry : service.getMessages()) {
                 LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
-                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
-                logBuilder.description( entry.getAttribute("Text") );
-                logBuilder.title( entry.getAttribute("Subject") );
+                logBuilder.id(Long.valueOf(entry.getAttribute("$@MID@$")));
+                logBuilder.description(entry.getAttribute("Text"));
+                logBuilder.title(entry.getAttribute("Subject"));
                 try {
                     LocalDateTime date = LocalDateTime.parse(entry.getAttribute("Date"), formatter);
-                    logBuilder.createdDate( date.atZone(ZoneId.systemDefault()).toInstant() );
-                    logBuilder.modifiedDate( date.atZone(ZoneId.systemDefault()).toInstant() );
+                    logBuilder.createdDate(date.atZone(ZoneId.systemDefault()).toInstant());
+                    logBuilder.modifiedDate(date.atZone(ZoneId.systemDefault()).toInstant());
                 } catch (DateTimeParseException e) {
                     e.printStackTrace();
                     return null;
                 }
-                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
-                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+                logBuilder.appendTag(TagImpl.of(entry.getAttribute("Category")));
+                logBuilder.appendToLogbook(LogbookImpl.of(entry.getAttribute("Type")));
 
-                try{
-                    for( String s : entry.getAttachments() ) {
-                        String mimeType = fileNameMap.getContentTypeFor(s);
-                        if( mimeType == null ) {
-                            if( s.endsWith(".py") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
-                            } else if( s.endsWith(".pyc") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
-                            } else {
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unknown", false ));
-                            }
+                for (String s : entry.getAttachments()) {
+                    String mimeType = fileNameMap.getContentTypeFor(s);
+                    if (mimeType == null) {
+                        if (s.endsWith(".py")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "text/x-python", false));
+                        } else if (s.endsWith(".pyc")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "application/x-python-code", false));
                         } else {
-                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "unknown", false));
                         }
+                    } else {
+                        logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), mimeType, false));
                     }
-                } catch(FileNotFoundException e){
-                    e.printStackTrace();
                 }
-
-                entries.add( logBuilder.build() );
+                entries.add(logBuilder.build());
             }
-        } catch(LogbookException e){
+        } catch (LogbookException e) {
             e.printStackTrace();
         }
         return entries;
@@ -464,32 +468,32 @@ public class ElogClient implements LogClient{
 
     @Override
     public InputStream getAttachment(Long logId, Attachment attachment) throws LogbookException {
-        return getAttachment( logId, attachment.getName() );
+        return getAttachment(logId, attachment.getName());
     }
 
 
     @Override
     public InputStream getAttachment(Long logId, String attachmentName) throws LogbookException {
-        ElogEntry entry = service.read( logId );
+        ElogEntry entry = service.read(logId);
         try {
-            for( String s : entry.getAttachments() ) {
-                if( s.equals( attachmentName ) ) {
-                    return new FileInputStream( service.getAttachment(s) );
+            for (String s : entry.getAttachments()) {
+                if (s.equals(attachmentName)) {
+                    return new FileInputStream(service.getAttachment(s));
                 }
             }
-        } catch( java.io.FileNotFoundException e ) {
-            throw new LogbookException( e.getMessage() );
+        } catch (java.io.FileNotFoundException e) {
+            throw new LogbookException(e.getMessage());
         }
-        throw new LogbookException( "Message " + logId + " has no matching attachment" );
+        throw new LogbookException("Message " + logId + " has no matching attachment");
     }
 
 
     @Override
-    public Tag set(Tag tag){
+    public Tag set(Tag tag) {
         // there is no HTTP request to add new Categories to the Elog.
         // This can only be done by posting a new entry with a new Category value
         // This only works if "Extendable Options = Category" is set in Elog config
-        this.categories.add( tag );
+        this.categories.add(tag);
         return tag;
     }
 
@@ -499,7 +503,7 @@ public class ElogClient implements LogClient{
         // there is no HTTP request to add new Types to the Elog.
         // This can only be done by posting a new entry with a new Type value
         // This only works if "Extendable Options = Type" is set in Elog config
-        this.types.add( Logbook );
+        this.types.add(Logbook);
         return Logbook;
     }
 
@@ -508,44 +512,44 @@ public class ElogClient implements LogClient{
     public LogEntry update(LogEntry log) throws LogbookException {
         Map<String, String> attributes = new HashMap<>();
 
-        for( Logbook l: log.getLogbooks() ) {
-            if( !l.getName().isEmpty() ) {
-                attributes.put( "Type", l.getName() );
+        for (Logbook l : log.getLogbooks()) {
+            if (!l.getName().isEmpty()) {
+                attributes.put("Type", l.getName());
                 break;
             }
         }
-        if( !attributes.containsKey("Type") ) {
-            Logger.getLogger( ElogClient.class.getPackageName()).severe( "No valid type selected. Cannot submit log entry" );
+        if (!attributes.containsKey("Type")) {
+            Logger.getLogger(ElogClient.class.getPackageName()).severe("No valid type selected. Cannot submit log entry");
             return null;
         }
 
-        for( Tag t: log.getTags() ) {
-            if( !t.getName().isEmpty() ) {
-                attributes.put( "Category", t.getName() );
+        for (Tag t : log.getTags()) {
+            if (!t.getName().isEmpty()) {
+                attributes.put("Category", t.getName());
                 break;
             }
         }
 
-        attributes.put( "Subject", log.getTitle() );
-        attributes.put( "Text", log.getDescription() );
+        attributes.put("Subject", log.getTitle());
+        attributes.put("Text", log.getDescription());
 
         List<File> files = new ArrayList<>();
-        for( Attachment att: log.getAttachments() ) {
-          files.add( att.getFile() );
+        for (Attachment att : log.getAttachments()) {
+            files.add(att.getFile());
         }
 
-        long msgId = service.post( attributes, files, log.getId() );
+        long msgId = service.post(attributes, files, log.getId());
 
-        LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log( log );
-        logBuilder.modifiedDate( Instant.now() );
+        LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log(log);
+        logBuilder.modifiedDate(Instant.now());
         return logBuilder.build();
     }
 
     @Override
     public Collection<LogEntry> update(Collection<LogEntry> logs) throws LogbookException {
         List<LogEntry> entries = new ArrayList<>();
-        for( LogEntry entry : logs ) {
-            entries.add( this.update( entry ));
+        for (LogEntry entry : logs) {
+            entries.add(this.update(entry));
         }
         return entries;
     }
@@ -553,50 +557,46 @@ public class ElogClient implements LogClient{
     @Override
     public List<LogEntry> findLogsBySearch(String pattern) {
         Map<String, String> query = new HashMap<>();
-        query.put( "subtext", pattern );
-        query.put( "sall", "1" );
+        query.put("subtext", pattern);
+        query.put("sall", "1");
 
         List<LogEntry> entries = new ArrayList<>();
-        try{
-            ElogSearchResult result = service.search( query, null, null );
-            for( ElogEntry entry : result.getLogs() ) {
+        try {
+            ElogSearchResult result = service.search(query, null, null);
+            for (ElogEntry entry : result.getLogs()) {
                 LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
-                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
-                logBuilder.description( entry.getAttribute("Text") );
-                logBuilder.title( entry.getAttribute("Subject") );
+                logBuilder.id(Long.valueOf(entry.getAttribute("$@MID@$")));
+                logBuilder.description(entry.getAttribute("Text"));
+                logBuilder.title(entry.getAttribute("Subject"));
                 try {
                     LocalDateTime date = LocalDateTime.parse(entry.getAttribute("Date"), formatter);
-                    logBuilder.createdDate( date.atZone(ZoneId.systemDefault()).toInstant() );
-                    logBuilder.modifiedDate( date.atZone(ZoneId.systemDefault()).toInstant() );
+                    logBuilder.createdDate(date.atZone(ZoneId.systemDefault()).toInstant());
+                    logBuilder.modifiedDate(date.atZone(ZoneId.systemDefault()).toInstant());
                 } catch (DateTimeParseException e) {
                     e.printStackTrace();
                     return null;
                 }
-                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
-                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+                logBuilder.appendTag(TagImpl.of(entry.getAttribute("Category")));
+                logBuilder.appendToLogbook(LogbookImpl.of(entry.getAttribute("Type")));
 
-                try{
-                    for( String s : entry.getAttachments() ) {
-                        String mimeType = fileNameMap.getContentTypeFor(s);
-                        if( mimeType == null ) {
-                            if( s.endsWith(".py") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
-                            } else if( s.endsWith(".pyc") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
-                            } else {
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unknown", false ));
-                            }
+                for (String s : entry.getAttachments()) {
+                    String mimeType = fileNameMap.getContentTypeFor(s);
+                    if (mimeType == null) {
+                        if (s.endsWith(".py")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "text/x-python", false));
+                        } else if (s.endsWith(".pyc")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "application/x-python-code", false));
                         } else {
-                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "unknown", false));
                         }
+                    } else {
+                        logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), mimeType, false));
                     }
-                } catch(FileNotFoundException e){
-                    e.printStackTrace();
                 }
 
-                entries.add( logBuilder.build() );
+                entries.add(logBuilder.build());
             }
-        } catch(LogbookException e){
+        } catch (LogbookException e) {
             e.printStackTrace();
         }
         return entries;
@@ -606,49 +606,44 @@ public class ElogClient implements LogClient{
     @Override
     public List<LogEntry> findLogsByTag(String pattern) {
         Map<String, String> query = new HashMap<>();
-        query.put( "Category", pattern );
+        query.put("Category", pattern);
 
         List<LogEntry> entries = new ArrayList<>();
-        try{
-            ElogSearchResult result = service.search( query, null, null );
-            for( ElogEntry entry : result.getLogs() ) {
+        try {
+            ElogSearchResult result = service.search(query, null, null);
+            for (ElogEntry entry : result.getLogs()) {
                 LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
-                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
-                logBuilder.description( entry.getAttribute("Text") );
-                logBuilder.title( entry.getAttribute("Subject") );
+                logBuilder.id(Long.valueOf(entry.getAttribute("$@MID@$")));
+                logBuilder.description(entry.getAttribute("Text"));
+                logBuilder.title(entry.getAttribute("Subject"));
                 try {
                     LocalDateTime date = LocalDateTime.parse(entry.getAttribute("Date"), formatter);
-                    logBuilder.createdDate( date.atZone(ZoneId.systemDefault()).toInstant() );
-                    logBuilder.modifiedDate( date.atZone(ZoneId.systemDefault()).toInstant() );
+                    logBuilder.createdDate(date.atZone(ZoneId.systemDefault()).toInstant());
+                    logBuilder.modifiedDate(date.atZone(ZoneId.systemDefault()).toInstant());
                 } catch (DateTimeParseException e) {
                     e.printStackTrace();
                     return null;
                 }
-                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
-                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+                logBuilder.appendTag(TagImpl.of(entry.getAttribute("Category")));
+                logBuilder.appendToLogbook(LogbookImpl.of(entry.getAttribute("Type")));
 
-                try{
-                    for( String s : entry.getAttachments() ) {
-                        String mimeType = fileNameMap.getContentTypeFor(s);
-                        if( mimeType == null ) {
-                            if( s.endsWith(".py") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
-                            } else if( s.endsWith(".pyc") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
-                            } else {
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unknown", false ));
-                            }
+                for (String s : entry.getAttachments()) {
+                    String mimeType = fileNameMap.getContentTypeFor(s);
+                    if (mimeType == null) {
+                        if (s.endsWith(".py")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "text/x-python", false));
+                        } else if (s.endsWith(".pyc")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "application/x-python-code", false));
                         } else {
-                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "unknown", false));
                         }
+                    } else {
+                        logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), mimeType, false));
                     }
-                } catch(FileNotFoundException e){
-                    e.printStackTrace();
                 }
-
-                entries.add( logBuilder.build() );
+                entries.add(logBuilder.build());
             }
-        } catch(LogbookException e){
+        } catch (LogbookException e) {
             e.printStackTrace();
         }
         return entries;
@@ -658,49 +653,45 @@ public class ElogClient implements LogClient{
     @Override
     public List<LogEntry> findLogsByLogbook(String logbook) {
         Map<String, String> query = new HashMap<>();
-        query.put( "Type", logbook );
+        query.put("Type", logbook);
 
         List<LogEntry> entries = new ArrayList<>();
-        try{
-            ElogSearchResult result = service.search( query, null, null );
-            for( ElogEntry entry : result.getLogs() ) {
+        try {
+            ElogSearchResult result = service.search(query, null, null);
+            for (ElogEntry entry : result.getLogs()) {
                 LogEntryBuilder logBuilder = LogEntryImpl.LogEntryBuilder.log();
-                logBuilder.id( Long.valueOf( entry.getAttribute("$@MID@$") ));
-                logBuilder.description( entry.getAttribute("Text") );
-                logBuilder.title( entry.getAttribute("Subject") );
+                logBuilder.id(Long.valueOf(entry.getAttribute("$@MID@$")));
+                logBuilder.description(entry.getAttribute("Text"));
+                logBuilder.title(entry.getAttribute("Subject"));
                 try {
                     LocalDateTime date = LocalDateTime.parse(entry.getAttribute("Date"), formatter);
-                    logBuilder.createdDate( date.atZone(ZoneId.systemDefault()).toInstant() );
-                    logBuilder.modifiedDate( date.atZone(ZoneId.systemDefault()).toInstant() );
+                    logBuilder.createdDate(date.atZone(ZoneId.systemDefault()).toInstant());
+                    logBuilder.modifiedDate(date.atZone(ZoneId.systemDefault()).toInstant());
                 } catch (DateTimeParseException e) {
                     e.printStackTrace();
                     return null;
                 }
-                logBuilder.appendTag( TagImpl.of( entry.getAttribute("Category") ));
-                logBuilder.appendToLogbook( LogbookImpl.of( entry.getAttribute("Type") ));
+                logBuilder.appendTag(TagImpl.of(entry.getAttribute("Category")));
+                logBuilder.appendToLogbook(LogbookImpl.of(entry.getAttribute("Type")));
 
-                try{
-                    for( String s : entry.getAttachments() ) {
-                        String mimeType = fileNameMap.getContentTypeFor(s);
-                        if( mimeType == null ) {
-                            if( s.endsWith(".py") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "text/x-python", false ));
-                            } else if( s.endsWith(".pyc") ){
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "application/x-python-code", false ));
-                            } else {
-                                logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), "unknown", false ));
-                            }
+                for (String s : entry.getAttachments()) {
+                    String mimeType = fileNameMap.getContentTypeFor(s);
+                    if (mimeType == null) {
+                        if (s.endsWith(".py")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "text/x-python", false));
+                        } else if (s.endsWith(".pyc")) {
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "application/x-python-code", false));
                         } else {
-                            logBuilder.attach( AttachmentImpl.of( service.getAttachment(s), mimeType, false ));
+                            logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), "unknown", false));
                         }
+                    } else {
+                        logBuilder.attach(AttachmentImpl.of(service.getAttachment(s), mimeType, false));
                     }
-                } catch(FileNotFoundException e){
-                    e.printStackTrace();
                 }
 
-                entries.add( logBuilder.build() );
+                entries.add(logBuilder.build());
             }
-        } catch(LogbookException e){
+        } catch (LogbookException e) {
             e.printStackTrace();
         }
         return entries;
@@ -709,20 +700,20 @@ public class ElogClient implements LogClient{
 
     @Override
     public void delete(LogEntry log) throws LogbookException {
-        service.delete( log.getId() );
+        service.delete(log.getId());
     }
 
 
     @Override
     public void delete(Long logId) throws LogbookException {
-        service.delete( logId );
+        service.delete(logId);
     }
 
 
     @Override
     public void delete(Collection<LogEntry> logIds) throws LogbookException {
-        for( LogEntry entry : logIds ) {
-            service.delete( entry.getId() );
+        for (LogEntry entry : logIds) {
+            service.delete(entry.getId());
         }
     }
 

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/menu/SendLogbookAction.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/menu/SendLogbookAction.java
@@ -78,14 +78,10 @@ public class SendLogbookAction extends MenuItem {
         ologLog.setDescription(body != null ? body : "");
 
         if (image_file != null) {
-            try {
-                final Attachment attachment = AttachmentImpl.of(image_file, "image", false);
-                List<Attachment> attachments = new ArrayList<>();
-                attachments.add(attachment);
-                ologLog.setAttachments(attachments);
-            } catch (FileNotFoundException ex) {
-                logger.log(Level.WARNING, "Cannot attach " + image_file, ex);
-            }
+            final Attachment attachment = AttachmentImpl.of(image_file, "image", false);
+            List<Attachment> attachments = new ArrayList<>();
+            attachments.add(attachment);
+            ologLog.setAttachments(attachments);
         }
         new LogEntryEditorStage(ologLog).show();
     }

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogEntryCalenderDemo.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogEntryCalenderDemo.java
@@ -99,11 +99,7 @@ public class LogEntryCalenderDemo extends ApplicationWrapper {
             }
             lb.appendDescription(sb.toString());
             listOfFiles.forEach(file -> {
-                try {
-                    lb.attach(AttachmentImpl.of(file));
-                } catch (FileNotFoundException e) {
-                    e.printStackTrace();
-                }
+                lb.attach(AttachmentImpl.of(file));
             });
             logs.add(lb.build());
         }

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogEntryCellDemo.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogEntryCellDemo.java
@@ -119,11 +119,7 @@ public class LogEntryCellDemo extends ApplicationWrapper {
                         .inLogbooks(new HashSet<Logbook>(Arrays.asList(LogbookImpl.of("Operations", "active"), LogbookImpl.of("Electrical", "active"))))
                         .owner("nsls2-user");
                 listOfFiles.forEach(file -> {
-                    try {
-                        lb.attach(AttachmentImpl.of(file));
-                    } catch (FileNotFoundException e) {
-                        e.printStackTrace();
-                    }
+                    lb.attach(AttachmentImpl.of(file));
                 });
                 controller.setLogEntry(new TableViewListItem(lb.build(), true));
             });

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogEntrySearchDemo.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogEntrySearchDemo.java
@@ -117,11 +117,7 @@ public class LogEntrySearchDemo extends ApplicationWrapper {
             }
             lb.appendDescription(sb.toString());
             listOfFiles.forEach(file -> {
-                try {
-                    lb.attach(AttachmentImpl.of(file));
-                } catch (FileNotFoundException e) {
-                    e.printStackTrace();
-                }
+                lb.attach(AttachmentImpl.of(file));
             });
             logs.add(lb.build());
         }

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogEntryTableDemo.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/LogEntryTableDemo.java
@@ -135,11 +135,7 @@ public class LogEntryTableDemo extends ApplicationWrapper {
             lb.appendDescription(sb.toString());
             if (i % 2 != 0) {
                 listOfFiles.forEach(file -> {
-                    try {
-                        lb.attach(AttachmentImpl.of(file));
-                    } catch (FileNotFoundException e) {
-                        e.printStackTrace();
-                    }
+                    lb.attach(AttachmentImpl.of(file));
                 });
                 lb.appendProperty(experimentProperty);
                 lb.appendProperty(track);

--- a/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/menu/SendLogbookAction.java
+++ b/app/logbook/ui/src/main/java/org/phoebus/logbook/ui/menu/SendLogbookAction.java
@@ -95,15 +95,8 @@ public class SendLogbookAction extends MenuItem
 
         if (image_file != null)
         {
-            try
-            {
-                final Attachment attachment = AttachmentImpl.of(image_file, "image", false);
-                logEntryBuilder.attach(attachment);
-            }
-            catch (FileNotFoundException ex)
-            {
-                logger.log(Level.WARNING, "Cannot attach " + image_file, ex);
-            }
+            final Attachment attachment = AttachmentImpl.of(image_file, "image", false);
+            logEntryBuilder.attach(attachment);
         }
 
         final LogEntryModel model = new LogEntryModel(logEntryBuilder.createdDate(Instant.now()).build());

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryCalenderDemo.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryCalenderDemo.java
@@ -92,11 +92,7 @@ public class LogEntryCalenderDemo extends ApplicationWrapper {
             }
             lb.appendDescription(sb.toString());
             listOfFiles.forEach(file -> {
-                try {
-                    lb.attach(AttachmentImpl.of(file));
-                } catch (FileNotFoundException e) {
-                    e.printStackTrace();
-                }
+                lb.attach(AttachmentImpl.of(file));
             });
             logs.add(lb.build());
         }

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryDisplayDemo.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryDisplayDemo.java
@@ -98,11 +98,7 @@ public class LogEntryDisplayDemo extends ApplicationWrapper {
                         .withTags(new HashSet<Tag>(Arrays.asList(TagImpl.of("Orbit", "active"), TagImpl.of("Studies", "active"))))
                         .inLogbooks(new HashSet<Logbook>(Arrays.asList(LogbookImpl.of("Operations", "active"))));
                 listOfFiles.forEach(file -> {
-                    try {
-                        lb.attach(AttachmentImpl.of(file));
-                    } catch (FileNotFoundException e) {
-                        e.printStackTrace();
-                    }
+                    lb.attach(AttachmentImpl.of(file));
                 });
                 controller.setLogEntry(lb.build());
             });

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntrySearchDemo.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntrySearchDemo.java
@@ -92,11 +92,7 @@ public class LogEntrySearchDemo extends ApplicationWrapper {
             }
             lb.appendDescription(sb.toString());
             listOfFiles.forEach(file -> {
-                try {
-                    lb.attach(AttachmentImpl.of(file));
-                } catch (FileNotFoundException e) {
-                    e.printStackTrace();
-                }
+                lb.attach(AttachmentImpl.of(file));
             });
             logs.add(lb.build());
         }

--- a/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryTableDemo.java
+++ b/app/logbook/ui/src/test/java/org/phoebus/logbook/ui/LogEntryTableDemo.java
@@ -93,11 +93,7 @@ public class LogEntryTableDemo extends ApplicationWrapper {
             }
             lb.appendDescription(sb.toString());
             listOfFiles.forEach(file -> {
-                try {
-                    lb.attach(AttachmentImpl.of(file));
-                } catch (FileNotFoundException e) {
-                    e.printStackTrace();
-                }
+                lb.attach(AttachmentImpl.of(file));
             });
             logs.add(lb.build());
 

--- a/core/logbook/src/main/java/org/phoebus/logbook/AttachmentImpl.java
+++ b/core/logbook/src/main/java/org/phoebus/logbook/AttachmentImpl.java
@@ -1,13 +1,12 @@
 package org.phoebus.logbook;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.net.FileNameMap;
 import java.net.URLConnection;
 
-
 /**
  * A default implementation of {@link Attachment}
+ *
  * @author Kunal Shroff
  *
  */
@@ -17,10 +16,9 @@ public class AttachmentImpl implements Attachment {
     private final Boolean thumbnail;
     private String id;
 
-    private static FileNameMap fileNameMap = URLConnection.getFileNameMap();
+    private static final FileNameMap fileNameMap = URLConnection.getFileNameMap();
 
     private AttachmentImpl(File file, String contentType, Boolean thumbnail) {
-        super();
         this.file = file;
         this.contentType = contentType;
         this.thumbnail = thumbnail;
@@ -47,51 +45,55 @@ public class AttachmentImpl implements Attachment {
     }
 
     @Override
-    public String getId(){
+    public String getId() {
         return id;
     }
 
     @Override
-    public void setId(String id){
+    public void setId(String id) {
         this.id = id;
+    }
+
+    @Override
+    public String getUniqueFilename() {
+        return getName();
     }
 
     /**
      * Create a new instance of a default implementation of the {@link Attachment} interface using the given file
+     *
      * @param file - the attachment file
      * @return a {@link Attachment} based on the given file
-     * @throws FileNotFoundException 
      */
-    public static Attachment of(File file) throws FileNotFoundException {
+    public static Attachment of(File file) {
         String mimeType = fileNameMap.getContentTypeFor(file.getName());
         return new AttachmentImpl(file, mimeType, null);
     }
-    
+
     /**
      * Create a new instance of a default implementation of the {@link Attachment} interface using the given file
-     * @param file - the attachment file
+     *
+     * @param file        - the attachment file
      * @param contentType - the type of the attached content ("image", "file", etc...)
-     * @param thumbnail - Whether the attachment has a thumbnail.
+     * @param thumbnail   - Whether the attachment has a thumbnail.
      * @return a {@link Attachment} based on the given file
-     * @throws FileNotFoundException 
      */
-    public static Attachment of(File file, String contentType, boolean thumbnail) throws FileNotFoundException {
+    public static Attachment of(File file, String contentType, boolean thumbnail) {
         return new AttachmentImpl(file, contentType, thumbnail);
     }
 
     /**
      * Create a new instance of a default implementation of the {@link Attachment} interface using the given file
-     * @param id A unique id
-     * @param file - the attachment file
+     *
+     * @param id          A unique id
+     * @param file        - the attachment file
      * @param contentType - the type of the attached content ("image", "file", etc...)
-     * @param thumbnail - Whether the attachment has a thumbnail.
+     * @param thumbnail   - Whether the attachment has a thumbnail.
      * @return a {@link Attachment} based on the given file
-     * @throws FileNotFoundException
      */
-    public static Attachment of(String id, File file, String contentType, boolean thumbnail) throws FileNotFoundException {
+    public static Attachment of(String id, File file, String contentType, boolean thumbnail) {
         AttachmentImpl attachment = new AttachmentImpl(file, contentType, thumbnail);
         attachment.setId(id);
-        return  attachment;
+        return attachment;
     }
-
 }


### PR DESCRIPTION
Fixes a regression issue in Olog: attachments automatically added when creating olog entry from OPI or Data Browser were not persisted by service.

@shroffk, I'd say this justifies a 5.0.5 release. Sorry.

- Testing:
    - [ ] The feature has automated tests
    - [ X] Tests were run

- Documentation:
    - [x] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
