### PR TITLE
Scan server: Enforce loop limits

### DIFF
--- a/services/scan-server/.classpath
+++ b/services/scan-server/.classpath
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/phoebus-target"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-framework"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-util"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-pv"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-pv-ca"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/core-pv-pva"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/core-vtype"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/core-vtype"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/app-scan-model"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/phoebus-target"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2018 Oak Ridge National Laboratory.
+ * Copyright (c) 2011-2026 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -111,15 +111,20 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
         return device_names.toArray(new String[device_names.size()]);
     }
 
-    private double getLoopStart()
+    /** @return Lower loop limit */
+    double getLoopStart()
     {
         return Math.min(command.getStart(), command.getEnd());
     }
-    private double getLoopEnd()
+
+    /** @return Upper loop limit */
+    double getLoopEnd()
     {
         return Math.max(command.getStart(), command.getEnd());
     }
-    private double getLoopStep()
+
+    /** @return Loop step, might toggle direction */
+    double getLoopStep()
     {
         final double step  = direction * command.getStepSize();
         // Revert direction for next iteration of the complete loop?
@@ -128,8 +133,25 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
         return step;
     }
 
-    public int getNumSteps() {
+    /** @return Number of loop steps */
+    int getNumSteps()
+    {
         return (int)Math.ceil(Math.abs(((command.getEnd() - command.getStart()) / command.getStepSize()))) + 1;
+    }
+
+    /** @param start Start value, might be upper or lower limit
+     *  @param step Loop step value, positive or negative
+     *  @param i Loop index
+     *  @return Loop value
+     */
+    double computeStep(double start, double step, int i)
+    {
+        // Compute loop value, but limit to upper or lower
+        // end depending on step direction
+        if (step >= 0)
+            return Math.min(start + i * step, getLoopEnd());
+        else
+            return Math.max(start + i * step, getLoopStart());
     }
 
     /** {@inheritDoc} */
@@ -143,7 +165,7 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
         double start = step < 0 ? getLoopEnd() : getLoopStart();
         int num_steps = getNumSteps();
         for (int i = 0; i < num_steps; i++)
-            simulateStep(context, device, start + i * step);
+            simulateStep(context, device, computeStep(start, step, i));
     }
 
     /** Simulate one step in the loop iteration
@@ -211,7 +233,7 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
         int num_steps = getNumSteps();
 
         for (int i = 0; i < num_steps; i++)
-            executeStep(context, device, condition, readback, start + i * step);
+            executeStep(context, device, condition, readback, computeStep(start, step, i));
     }
 
     /** Execute one step of the loop

--- a/services/scan-server/src/test/java/org/csstudio/scan/server/command/LoopTest.java
+++ b/services/scan-server/src/test/java/org/csstudio/scan/server/command/LoopTest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The scan engine idea is based on the "ScanEngine" developed
+ * by the Software Services Group (SSG),  Advanced Photon Source,
+ * Argonne National Laboratory,
+ * Copyright (c) 2011 , UChicago Argonne, LLC.
+ *
+ * This implementation, however, contains no SSG "ScanEngine" source code
+ * and is not endorsed by the SSG authors.
+ ******************************************************************************/
+package org.csstudio.scan.server.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.csstudio.scan.command.LoopCommand;
+import org.junit.jupiter.api.Test;
+
+/** JUnit test for loop */
+public class LoopTest
+{
+    @Test
+    void testNormalLoop() throws Exception
+    {
+        LoopCommand cmd = new LoopCommand("loc://x(0)", 1.0, 10.0, 0.5, List.of());
+        LoopCommandImpl impl = new LoopCommandImpl(cmd);
+
+        System.out.println(cmd);
+
+        double step = impl.getLoopStep();
+        double start = step < 0 ? impl.getLoopEnd() : impl.getLoopStart();
+        int num_steps = impl.getNumSteps();
+
+        double last = Double.NaN;
+        for (int i = 0; i < num_steps; i++)
+        {
+            last = impl.computeStep(start, step, i);
+            System.out.println(last);
+        }
+        assertEquals(10.0, last);
+    }
+
+    @Test
+    void testUpwardsLoop() throws Exception
+    {
+        LoopCommand cmd = new LoopCommand("loc://x(0)", 1.0, 1.1, 5.0, List.of());
+        LoopCommandImpl impl = new LoopCommandImpl(cmd);
+
+        System.out.println(cmd);
+
+        double step = impl.getLoopStep();
+        double start = step < 0 ? impl.getLoopEnd() : impl.getLoopStart();
+        int num_steps = impl.getNumSteps();
+
+        double last = Double.NaN;
+        for (int i = 0; i < num_steps; i++)
+        {
+            last = impl.computeStep(start, step, i);
+            System.out.println(last);
+        }
+        assertEquals(1.1, last);
+    }
+
+    @Test
+    void testDownwardsLoop() throws Exception
+    {
+        LoopCommand cmd = new LoopCommand("loc://x(0)", 1.1, 1.0, -5.0, List.of());
+        LoopCommandImpl impl = new LoopCommandImpl(cmd);
+
+        System.out.println(cmd);
+
+        double step = impl.getLoopStep();
+        double start = step < 0 ? impl.getLoopEnd() : impl.getLoopStart();
+        int num_steps = impl.getNumSteps();
+
+        double last = Double.NaN;
+        for (int i = 0; i < num_steps; i++)
+        {
+            last = impl.computeStep(start, step, i);
+            System.out.println(last);
+        }
+        assertEquals(1.0, last);
+    }
+
+    @Test
+    void testTogglingLoop() throws Exception
+    {
+        LoopCommand cmd = new LoopCommand("loc://x(0)", 1.0, 1.1, -5.0, List.of());
+        LoopCommandImpl impl = new LoopCommandImpl(cmd);
+
+        System.out.println(cmd);
+
+        double step = impl.getLoopStep();
+        double start = step < 0 ? impl.getLoopEnd() : impl.getLoopStart();
+        int num_steps = impl.getNumSteps();
+
+        double last = Double.NaN;
+        for (int i = 0; i < num_steps; i++)
+        {
+            last = impl.computeStep(start, step, i);
+            System.out.println(last);
+        }
+        assertEquals(1.0, last);
+
+        // Run loop again, expect toggled direction
+        step = impl.getLoopStep();
+        start = step < 0 ? impl.getLoopEnd() : impl.getLoopStart();
+        num_steps = impl.getNumSteps();
+        for (int i = 0; i < num_steps; i++)
+        {
+            last = impl.computeStep(start, step, i);
+            System.out.println(last);
+        }
+        assertEquals(1.1, last);
+    }
+}


### PR DESCRIPTION
Fixes #3794

The scan server loop command started out as basically
`for (double value=start; value<=end; value += step)`.
While this is quite a normal loop, with equivalent loops available in every programming language, there can be subtle rounding errors. A loop from 0 to 10.0 for example might end at 9.9999 instead of exactly 1.0, with details depending on the step size.
In PR #3305, commits  30964db684d0844dad76ef34f87b7a21d3b55884 and 0e2df3abc6abdd67a91bdaf06b6baa87cc5743fb tried to make it more predictable by avoiding rounding errors. Unfortunately, this disregarded the loop end points. A loop from `1.0` to '2.0' in steps of `2.0` would now yield values `1.0` and `3.0`, with the latter clearly being beyond the loop end of `2.0`.

A basic `for (double value=1.0; value<=2.0; value += 2.0)` loop would only give a value of `1.0` and then end because the next potential value of `1.0+2.0=3.0` is beyond the loop end condition.
I could argue that this original loop command behavior was good and didn't need to be "fixed" in the first place, but in keeping with the spirit of 0e2df3abc6abdd67a91bdaf06b6baa87cc5743fb to include the bounds, this update will will enforce the loop limits, resulting in a loop with values `1.0` and `2.0`.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist
- Testing:
    - [X] The feature has automated tests
    - [X] Tests were run
