### PR TITLE
More efficient check of references in save&restore

### DIFF
--- a/app/save-and-restore/app/doc/index.rst
+++ b/app/save-and-restore/app/doc/index.rst
@@ -51,12 +51,6 @@ tags is indicated with a symbol to the right of the node name:
 
 .. image:: images/snapshot-with-tag.png
 
-Similarly, snapshots and composite snapshots referenced in other composite snapshots are annotated with a symbol to the
-right of the node name:
-
-.. image:: images/snapshot-with-references.png
-
-
 
 Node names and ordering
 -----------------------
@@ -279,7 +273,7 @@ The composite snapshot can be saved when a case sensitive name and a description
 
 * The combined list of PV names in the referenced snapshots must not contain duplicates. This is checked for each item dropped into the list when editing a composite snapshot. If duplicates are detected, an error dialog is shown.
 
-* Snapshots and composite snapshots cannot be deleted if referenced in a composite snapshot.
+* Snapshots and composite snapshots cannot be deleted if referenced in any composite snapshot. This is indicated by disabling the Delete context menu item.
 
 Edit Composite Snapshot using drag-n-drop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/BrowserTreeCell.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/BrowserTreeCell.java
@@ -18,7 +18,6 @@
 
 package org.phoebus.applications.saveandrestore.ui;
 
-import javafx.application.Platform;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.TreeCell;
@@ -39,13 +38,9 @@ import org.phoebus.applications.saveandrestore.SaveAndRestoreApplication;
 import org.phoebus.applications.saveandrestore.model.Node;
 import org.phoebus.applications.saveandrestore.model.NodeType;
 import org.phoebus.applications.saveandrestore.model.Tag;
-import org.phoebus.applications.saveandrestore.model.search.SearchResult;
-import org.phoebus.framework.jobs.JobManager;
 import org.phoebus.ui.javafx.ImageCache;
 import org.phoebus.util.time.TimestampFormats;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -188,7 +183,6 @@ public class BrowserTreeCell extends TreeCell<Node> {
                     tagImage.setPreserveRatio(true);
                     hBox.getChildren().add(tagImage);
                 }
-                annotateContainedInCompositeSnapshot(node, hBox);
                 break;
             case COMPOSITE_SNAPSHOT:
                 hBox.getChildren().add(new ImageView(ImageRepository.COMPOSITE_SNAPSHOT));
@@ -199,7 +193,6 @@ public class BrowserTreeCell extends TreeCell<Node> {
                     tagImage.setPreserveRatio(true);
                     getChildren().add(tagImage);
                 }
-                annotateContainedInCompositeSnapshot(node, hBox);
                 break;
             case CONFIGURATION:
                 hBox.getChildren().add(new ImageView(ImageRepository.CONFIGURATION));
@@ -215,18 +208,5 @@ public class BrowserTreeCell extends TreeCell<Node> {
         }
 
         setGraphic(hBox);
-    }
-
-    private void annotateContainedInCompositeSnapshot(Node node, HBox hbox) {
-        JobManager.schedule("Annotate contained in snapshot", monitor -> {
-            MultivaluedMap<String, String> multivaluedMap = new MultivaluedHashMap<>();
-            multivaluedMap.put("referenced", List.of(node.getUniqueId()));
-            SearchResult searchResult = saveAndRestoreController.saveAndRestoreService.search(multivaluedMap);
-            if (searchResult.getHitCount() > 0) {
-                Platform.runLater(() -> {
-                    hbox.getChildren().add(new ImageView(ImageRepository.LINK));
-                });
-            }
-        });
     }
 }

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
@@ -134,6 +134,8 @@ import java.util.ResourceBundle;
 import java.util.ServiceLoader;
 import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -1405,8 +1407,35 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
         compareSnapshotsMenuItem.disableProperty().set(!compareSnapshotsPossible());
         deleteNodeMenuItem.disableProperty().set(getUserIdentity().isNull().get() ||
                 selectedItemsProperty.stream().anyMatch(n -> n.getUniqueId().equals(Node.ROOT_FOLDER_UNIQUE_ID)) ||
-                !hasSameParent());
+                !hasSameParent() ||
+                hasReferences(selectedItemsProperty.get(0)));
         pasteMenuItem.disableProperty().set(!mayPaste());
+    }
+
+    /**
+     * Queries service if the specified {@link Node} is referenced in any composite snapshot.
+     *
+     * @param node The node to check.
+     * @return <code>true</code> if the {@link Node} is referenced.
+     */
+    private boolean hasReferences(Node node) {
+        if (node.getNodeType().equals(NodeType.FOLDER) || node.getNodeType().equals(NodeType.CONFIGURATION)) {
+            return false;
+        }
+        AtomicBoolean hasReferences = new AtomicBoolean(false);
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        JobManager.schedule("Find references", monitor -> {
+            MultivaluedMap<String, String> multivaluedMap = new MultivaluedHashMap<>();
+            multivaluedMap.put("referenced", List.of(node.getUniqueId()));
+            hasReferences.set(saveAndRestoreService.search(multivaluedMap).getHitCount() > 0);
+            countDownLatch.countDown();
+        });
+        try {
+            countDownLatch.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.log(Level.WARNING, "Timeout when checking references for node " + node.getUniqueId(), e);
+        }
+        return hasReferences.get();
     }
 
     /**

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
@@ -1427,7 +1427,11 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
         JobManager.schedule("Find references", monitor -> {
             MultivaluedMap<String, String> multivaluedMap = new MultivaluedHashMap<>();
             multivaluedMap.put("referenced", List.of(node.getUniqueId()));
-            hasReferences.set(saveAndRestoreService.search(multivaluedMap).getHitCount() > 0);
+            try {
+                hasReferences.set(saveAndRestoreService.search(multivaluedMap).getHitCount() > 0);
+            } catch (Exception e) {
+                logger.log(Level.WARNING, "Failed to check for references for node " + node.getUniqueId(), e);
+            }
             countDownLatch.countDown();
         });
         try {


### PR DESCRIPTION
Recently added: annotation of save&restore snapshot and composite snapshots referenced in any composite snapshot. The implementation however is very inefficient as it generates queries to the service whenever JavaFX determines that the ```TreeCell``` must be re-rendered.

This PR abandons the annotation strategy to instead disable the Delete menu item if references are found. This way the call to the service happens only when context menu is launched, and only for the selected node, so user will be able to determine if a snapshot or composite snapshot can be deleted before attempting the operation.

- Testing:
    - [ ] The feature has automated tests
    - [ X] Tests were run

- Documentation:
    - [ ] The feature is documented
    - [ X] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
