### PR TITLE
PreferenceReader: Log undefined properties at FINE level

### DIFF
--- a/core/framework/src/main/java/org/phoebus/framework/preferences/PreferencesReader.java
+++ b/core/framework/src/main/java/org/phoebus/framework/preferences/PreferencesReader.java
@@ -65,7 +65,7 @@ public class PreferencesReader
             if (prop == null)
             {
                 Logger.getLogger(PreferencesReader.class.getPackageName())
-                      .log(Level.SEVERE, "Reading Preferences: Java system property or Environment variable'" + prop_spec + "' is not defined");
+                      .log(Level.FINE, "Reading Preferences: Java system property or Environment variable '" + prop_spec + "' is not defined");
                 break;
             }
             else

--- a/core/launcher/src/main/resources/logging.properties
+++ b/core/launcher/src/main/resources/logging.properties
@@ -51,6 +51,7 @@ org.postgresql.level = WARNING
 # Core packages
 org.phoebus.framework.rdb.level = WARNING
 org.phoebus.framework.workbench.level = WARNING
+org.phoebus.framework.preferences.level = WARNING
 org.phoebus.security.level = WARNING
 org.phoebus.ui.javafx.BufferUtil.level = WARNING
 org.phoebus.ui.docking.level = WARNING


### PR DESCRIPTION
... instead of SEVERE because it tends to not be a fatal issue. For example, the current initialization of `Locations` routinely logs missing `phoebus.folder.name.preference` and `phoebus.user` properties without any ill outcome, whereas a SEVERE log message would suggest that the application cannot continue in this state.

```
CONFIG [org.phoebus.product] Loading logging configuration from /.../phoebus/core/launcher/target/classes/logging.properties
SEVERE [org.phoebus.framework.preferences] Reading Preferences: Java system property or Environment variable'$(phoebus.folder.name.preference)' is not defined
SEVERE [org.phoebus.framework.preferences] Reading Preferences: Java system property or Environment variable'$(phoebus.user)' is not defined
CONFIG [org.phoebus.framework.workbench] phoebus_install is set to .... found from $(phoebus.install) system property
CONFIG [org.phoebus.framework.workbench] folder_name_preference is set to .phoebus found from  default value
CONFIG [org.phoebus.framework.workbench] user home is set to ..... found from $(user.home) system property
CONFIG [org.phoebus.framework.workbench] phoebus_user folder is set to ...../.phoebus
```

This does fix the immediately visible part of #3810: The SEVERE messages are gone, the CONFIG messages remain, and if one is interested in details, one can enable FINE level logging.

