### PR TITLE
Create directory for secure store if it does not exist

### DIFF
--- a/core/security/src/main/java/org/phoebus/security/store/FileBasedStore.java
+++ b/core/security/src/main/java/org/phoebus/security/store/FileBasedStore.java
@@ -8,6 +8,7 @@ import javax.crypto.spec.PBEKeySpec;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.security.KeyStore;
 import java.util.Collections;
 import java.util.List;
@@ -28,11 +29,10 @@ public class FileBasedStore implements Store<String, String> {
     private final SecretKeyFactory kf = SecretKeyFactory.getInstance("PBE");
     private final KeyStore store;
     private final File secure_file;
-    private byte[] secureStoreByteArray;
     private final char[] store_pass;
     private final KeyStore.ProtectionParameter pp;
 
-    private static final Logger LOGGER = Logger.getLogger(SecureStore.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(FileBasedStore.class.getName());
 
     /**
      * Create with default file in 'user' location
@@ -63,6 +63,14 @@ public class FileBasedStore implements Store<String, String> {
      * @throws Exception on error
      */
     public FileBasedStore(final File secure_file, final char[] store_pass) throws Exception {
+
+        File secureFileDir = secure_file.getParentFile();
+        if (!secureFileDir.exists()) {
+            if(!secureFileDir.mkdirs()){
+                throw new IOException("Cannot create directory for secure store");
+            }
+        }
+
         this.secure_file = secure_file;
         this.store_pass = store_pass;
 


### PR DESCRIPTION
Fixes a corner case: if using file to cache credentials, the ```Locations.user()``` dir must exist when user signs in to a service.

- Testing:
    - [ ] The feature has automated tests
    - [ X] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
