### PR TITLE
Support simplified access to save&restore root node

### DIFF
--- a/services/save-and-restore/doc/index.rst
+++ b/services/save-and-restore/doc/index.rst
@@ -127,6 +127,14 @@ A special case is the root node as it has a fixed unique id:
 
 **.../node/44bef5de-e8e6-4014-af37-b8f6c8a939a2**
 
+The root node may also be retrieved using:
+
+**.../root**
+
+or
+
+**.../node/root***
+
 Retrieve multiple nodes
 """""""""""""""""""""""
 Method: GET
@@ -264,6 +272,10 @@ The a list of all the children nodes of the node with id `{uniqueNodeId}`
             "tags": []
         }
     ]
+
+One may retrieve the child nodes of the root node using:
+
+**.../node/root/children**
 
 .. _Get a configuration:
 

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchDAO.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/persistence/dao/impl/elasticsearch/ElasticsearchDAO.java
@@ -95,6 +95,9 @@ public class ElasticsearchDAO implements NodeDAO {
 
     @Override
     public List<Node> getChildNodes(String uniqueNodeId) {
+        if("root".equals(uniqueNodeId)) {
+            uniqueNodeId = ROOT_FOLDER_UNIQUE_ID;
+        }
         Optional<ESTreeNode> elasticsearchNode =
                 elasticsearchTreeRepository.findById(uniqueNodeId);
         if (elasticsearchNode.isEmpty()) {
@@ -111,6 +114,9 @@ public class ElasticsearchDAO implements NodeDAO {
 
     @Override
     public Node getNode(String uniqueNodeId) {
+        if("root".equals(uniqueNodeId)) {
+            uniqueNodeId = ROOT_FOLDER_UNIQUE_ID;
+        }
         Optional<ESTreeNode> optional =
                 elasticsearchTreeRepository.findById(uniqueNodeId);
         if (optional.isEmpty()) {

--- a/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/web/controllers/NodeController.java
+++ b/services/save-and-restore/src/main/java/org/phoebus/service/saveandrestore/web/controllers/NodeController.java
@@ -99,6 +99,9 @@ public class NodeController extends BaseController {
     @SuppressWarnings("unused")
     @GetMapping(value = "/node/{uniqueNodeId}", produces = JSON)
     public Node getNode(@PathVariable final String uniqueNodeId) {
+        if("root".equals(uniqueNodeId)) {
+            return nodeDAO.getRootNode();
+        }
         return nodeDAO.getNode(uniqueNodeId);
     }
 
@@ -158,7 +161,7 @@ public class NodeController extends BaseController {
     public void deleteNodes(@RequestBody List<String> nodeIds) {
         nodeDAO.deleteNodes(nodeIds);
         nodeIds.forEach(id ->
-                webSocketService.sendMessageToClients(new WebSocketMessage(SaveAndRestoreMessageType.NODE_REMOVED, id)));
+                webSocketService.sendMessageToClients(new WebSocketMessage<>(SaveAndRestoreMessageType.NODE_REMOVED, id)));
     }
 
     /**
@@ -220,8 +223,17 @@ public class NodeController extends BaseController {
         }
         nodeToUpdate.setUserName(principal.getName());
         Node updatedNode = nodeDAO.updateNode(nodeToUpdate, Boolean.parseBoolean(customTimeForMigration));
-        webSocketService.sendMessageToClients(new WebSocketMessage(SaveAndRestoreMessageType.NODE_UPDATED, updatedNode));
+        webSocketService.sendMessageToClients(new WebSocketMessage<>(SaveAndRestoreMessageType.NODE_UPDATED, updatedNode));
         return updatedNode;
+    }
+
+    /**
+     * Endpoint for the sake of convenience, i.e. client need not know the unique id of the root {@link Node}
+     * @return The root {@link Node}
+     */
+    @GetMapping("/root")
+    public Node getRoot() {
+        return nodeDAO.getRootNode();
     }
 
     /**
@@ -235,11 +247,7 @@ public class NodeController extends BaseController {
             return true;
         }
 
-        if (!node.getNodeType().equals(NodeType.SNAPSHOT) &&
-                node.getTags().stream().anyMatch(t -> t.getName().equalsIgnoreCase(Tag.GOLDEN))) {
-            return false;
-        }
-
-        return true;
+        return node.getNodeType().equals(NodeType.SNAPSHOT) ||
+                node.getTags().stream().noneMatch(t -> t.getName().equalsIgnoreCase(Tag.GOLDEN));
     }
 }

--- a/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/persistence/dao/impl/DAOTestIT.java
+++ b/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/persistence/dao/impl/DAOTestIT.java
@@ -719,7 +719,25 @@ public class DAOTestIT {
 
         List<Node> childNodes = nodeDAO.getChildNodes(rootNode.getUniqueId());
         assertTrue(nodeDAO.getChildNodes(folder1.getUniqueId()).isEmpty());
+    }
 
+    @Test
+    public void testGetChildNodesFromRoot() {
+        Node rootNode = nodeDAO.getRootNode();
+
+        Node folder1 = Node.builder().name("SomeFolder").build();
+
+        // Create folder1 in the root folder
+        folder1 = nodeDAO.createNode(rootNode.getUniqueId(), folder1);
+
+        List<Node> childNodes = nodeDAO.getChildNodes("root");
+        assertTrue(nodeDAO.getChildNodes(folder1.getUniqueId()).isEmpty());
+    }
+
+    @Test
+    public void testGetRootNode() {
+        Node rootNode = nodeDAO.getNode("root");
+        assertEquals(Node.ROOT_FOLDER_UNIQUE_ID, rootNode.getUniqueId());
     }
 
     @Test

--- a/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/web/controllers/NodeControllerTest.java
+++ b/services/save-and-restore/src/test/java/org/phoebus/service/saveandrestore/web/controllers/NodeControllerTest.java
@@ -810,4 +810,23 @@ public class NodeControllerTest {
         mockMvc.perform(request).andExpect(status().isOk());
 
     }
+
+    @Test
+    public void testGetRootNode() throws Exception {
+        when(nodeDAO.getRootNode()).thenReturn(Node.builder().uniqueId(Node.ROOT_FOLDER_UNIQUE_ID).build());
+        MockHttpServletRequestBuilder request = get("/root");
+        MvcResult mvcResult = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
+        Node node = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), Node.class);
+        assertEquals(Node.ROOT_FOLDER_UNIQUE_ID, node.getUniqueId());
+    }
+
+    @Test
+    public void testRootNodeChildNodes() throws Exception {
+        when(nodeDAO.getChildNodes("root")).thenReturn(List.of(Node.builder().uniqueId("foo").build()));
+        MockHttpServletRequestBuilder request = get("/node/root/children");
+        MvcResult mvcResult = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
+        List<Node> nodes = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() {
+        });
+        assertEquals(1, nodes.size());
+    }
 }


### PR DESCRIPTION
The save&restore root node is created with a hard coded unique ID. Clients cannot be expected to know the value of this id, so this PR adds the ability to query for the root node using a GET call to ```<context>/root``` or ```<context>/node/root```. To get child nodes of the root client may use a GET call to ```<context>/node/root/children```.

- Testing:
    - [X] The feature has automated tests
    - [X] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [X] The feature is documented
    - [X] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
