### PR TITLE
XYPlot: When autoscale is disabled, apply axis range from model

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/plots/XYPlotRepresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2022 Oak Ridge National Laboratory.
+ * Copyright (c) 2015-2026 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -719,18 +719,9 @@ public class XYPlotRepresentation extends RegionBaseRepresentation<Pane, XYPlotW
             plot_axis.setAutoscale(true);
         }
         else
-        {   // No auto-scale requested.
-            if (plot_axis.setAutoscale(false))
-            {   // Autoscale was on.
-                // Turn off, and update model to the last range used by the plot
-                final AxisRange<Double> range = plot_axis.getValueRange();
-                changing_range = true;
-                model_axis.minimum().setValue(range.getLow());
-                model_axis.maximum().setValue(range.getHigh());
-                changing_range = false;
-            }
-            else
-                plot_axis.setValueRange(model_axis.minimum().getValue(), model_axis.maximum().getValue());
+        {   // No auto-scale requested. Apply axis range from model to plot
+            plot_axis.setAutoscale(false);
+            plot_axis.setValueRange(model_axis.minimum().getValue(), model_axis.maximum().getValue());
         }
     }
 


### PR DESCRIPTION
Used to first update model with last plot range, overriding what's in the model. This complicates scripts or rules because their values are ignored.

Fixes #3824.


Note that source file was found in git with CRLF line endings.
This also updates to LF line endings.
"Hide whitespace" shows actual code change.

- Testing:
  Example file
  [xy_plot_bob.txt](https://github.com/user-attachments/files/28642215/xy_plot_bob.txt) 
  now allows switching autoscale on/off and manually configured min..max range is
  applied as soon as autoscale is turned off


