### PR TITLE
Fix ant build after 3796

### DIFF
--- a/app/display/runtime/build.xml
+++ b/app/display/runtime/build.xml
@@ -12,6 +12,7 @@
         <pathelement path="../representation/${build}/app-display-representation-${version}.jar"/>
         <pathelement path="../representation-javafx/${build}/app-display-representation-javafx-${version}.jar"/>
         <pathelement path="../actions/${build}/app-display-actions-${version}.jar"/>
+        <pathelement path="../../databrowser/${build}/app-databrowser-${version}.jar"/>
       </classpath>
     </javac>
   	
@@ -29,6 +30,7 @@
         <pathelement path="../representation/${build}/app-display-representation-${version}.jar"/>
         <pathelement path="${build}/app-display-runtime-${version}.jar"/>
         <pathelement path="../actions/${build}/app-display-actions-${version}.jar"/>
+        <pathelement path="../../databrowser/${build}/app-databrowser-${version}.jar"/>
       </classpath>
       <batchtest>
         <zipfileset src="${build}/app-display-runtime-${version}.jar" includes="**/*Test.class"/>
@@ -46,6 +48,7 @@
         <pathelement path="../representation/${build}/app-display-representation-${version}.jar"/>
         <pathelement path="../representation-javafx/${build}/app-display-representation-javafx-${version}.jar"/>
         <pathelement path="../actions/${build}/app-display-actions-${version}.jar"/>
+        <pathelement path="../../databrowser/${build}/app-databrowser-${version}.jar"/>
         <pathelement path="${build}/app-display-runtime-${version}.jar"/>
       </classpath>
     </java>


### PR DESCRIPTION
PR 3796 added a dependency from display-runtime to the databrowser

- Testing:
Before this fix, ant build fails with
```
app-display-runtime:
    [javac] ...OpenDataBrowserActionHandler.java:9: error:
            package org.csstudio.trends.databrowser3 does not exist
    [javac] import org.csstudio.trends.databrowser3.DataBrowserApp;
```
   With this fix, it completes the build process.
