### PR TITLE
don't re-expand SaR tree nodes if they are already expanded

### DIFF
--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreController.java
@@ -463,6 +463,10 @@ public class SaveAndRestoreController extends SaveAndRestoreBaseController
      * @param targetItem {@link TreeItem<Node>} on which the operation is performed.
      */
     protected void expandTreeNode(TreeItem<Node> targetItem) {
+        // don't do anything is we are already expanded
+        if (targetItem.isExpanded())
+            return;
+
         List<Node> childNodes = saveAndRestoreService.getChildNodes(targetItem.getValue());
         List<TreeItem<Node>> list =
                 childNodes.stream().map(this::createTreeItem).toList();


### PR DESCRIPTION
<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

Before: opening a save and restore snapshot through a display builder OPEN_SAR_NODE action would (on first click) open the folders up to the snapshot's parent, but NOT the snapshot's parent itself. On second click, it would open the proper node. The issue was that both `locateNode` and the treeview event handler:

```
treeView.getRoot().addEventHandler(TreeItem.<Node>branchExpandedEvent(), e -> expandTreeNode(e.getTreeItem()));
```

called the `expandTreeNode` handler, which caused it to "expand" the parent folder twice, making it closed on the second call.

(Example trying to open `acc/accelerator/oper`)

<img width="1229" height="1336" alt="image" src="https://github.com/user-attachments/assets/1f31de59-9d12-4fb6-af65-d4cb12d6839a" />

After: this is fixed, now the node is opened right away.

<img width="1238" height="1337" alt="image" src="https://github.com/user-attachments/assets/023136e6-7c4d-4d83-ba1a-cc24fdd06a02" />

- Testing:

The bug is no longer present
