### PR TITLE
various services: exit with non-zero exit code on failure

### DIFF
--- a/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLoggingService.java
+++ b/services/alarm-config-logger/src/main/java/org/phoebus/alarm/logging/AlarmConfigLoggingService.java
@@ -152,7 +152,7 @@ public class AlarmConfigLoggingService {
             ex.printStackTrace();
 	    System.out.println("\n>>>> Please check available arguments of alarm-config-logger as follows:");
 	    help();
-            return;
+			System.exit(-1);
         }
 
         logger.info("Alarm Logging Service (PID " + ProcessHandle.current().pid() + ")");

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/aggregate/AggregateTopics.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/aggregate/AggregateTopics.java
@@ -72,6 +72,7 @@ public class AggregateTopics
         } catch (IOException ex)
         {
             logger.log(Level.WARNING, "Reading input from stdin failed.", ex);
+			System.exit(-1);
         }
 
         // Exit the program. The shutdown hook will clean up the stream.

--- a/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
+++ b/services/alarm-server/src/main/java/org/phoebus/applications/alarm/server/AlarmServerMain.java
@@ -121,6 +121,7 @@ public class AlarmServerMain implements ServerModelListener {
             }
         } catch (final Throwable ex) {
             logger.log(Level.SEVERE, "Alarm Server main loop error", ex);
+			System.exit(-1);
         }
 
         logger.info("Done.");
@@ -613,7 +614,7 @@ public class AlarmServerMain implements ServerModelListener {
             help();
             System.out.println();
             ex.printStackTrace();
-            return;
+			System.exit(-1);
         }
 
         logger.info("Alarm Server (PID " + ProcessHandle.current().pid() + ")");

--- a/services/archive-engine/src/main/java/org/csstudio/archive/Engine.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/Engine.java
@@ -390,7 +390,7 @@ public class Engine
             catch (Exception ex)
             {
                 logger.log(Level.SEVERE, "Cannot start", ex);
-                run = false;
+				System.exit(-1);
             }
             httpd.shutdown();
         }

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/ScanServerInstance.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/ScanServerInstance.java
@@ -246,7 +246,7 @@ public class ScanServerInstance
             help();
             System.out.println();
             ex.printStackTrace();
-            return;
+			System.exit(-1);
         }
 
         logger.info("Scan Server (PID " + ProcessHandle.current().pid() + ")");
@@ -283,6 +283,7 @@ public class ScanServerInstance
         catch (Exception ex)
         {
             logger.log(Level.SEVERE, "Cannot start", ex);
+			System.exit(-1);
         }
         httpd.shutdown();
 


### PR DESCRIPTION
This enables various systems, for example systemd, to see that the service didn't exit normally.

This makes systemd's `Restart=on-failure` feature work more reliably.


<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
