### PR TITLE
Vertical progress bar causes Group widget to extend further than it should

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.widgets;
 
+import javafx.scene.layout.Pane;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -28,7 +29,7 @@ import javafx.scene.transform.Translate;
  *  @author Amanda Carpenter
  */
 @SuppressWarnings("nls")
-public class ProgressBarRepresentation extends RegionBaseRepresentation<ProgressBar, ProgressBarWidget>
+public class ProgressBarRepresentation extends RegionBaseRepresentation<Pane, ProgressBarWidget>
 {
     private final DirtyFlag dirty_look = new DirtyFlag();
     private final DirtyFlag dirty_value = new DirtyFlag();
@@ -39,11 +40,13 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
 
     private volatile double percentage = 0.0;
 
+    private ProgressBar bar;
+
     @Override
-    public ProgressBar createJFXNode() throws Exception
+    public Pane createJFXNode() throws Exception
     {
-        final ProgressBar bar = new ProgressBar();
-        return bar;
+        bar = new ProgressBar();
+        return new Pane(bar);
     }
 
     @Override
@@ -172,6 +175,9 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
         toolkit.scheduleUpdate(this);
     }
 
+    protected boolean isFilteringEditModeClicks() {
+        return true;
+    }
 
     @Override
     public void updateChanges()
@@ -187,29 +193,31 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
 
             if (!horizontal)
             {
-                jfx_node.getTransforms().setAll(
+                bar.getTransforms().setAll(
                     new Translate(0, height),
                     new Rotate(-90, 0, 0));
-                jfx_node.setPrefSize(height, width);
+                bar.setPrefSize(height, width);
+                jfx_node.setPrefSize(width, height);
 
                 if (min_val > max_val) 
                 {
-                    jfx_node.getTransforms().setAll(
+                    bar.getTransforms().setAll(
                         new Translate(0, height),
                         new Rotate(-90, 0, 0, 0),
                         new Translate(height, 0),
                         new Rotate(180, 0, 0, 0, Rotate.Y_AXIS));
-                    jfx_node.setPrefSize(height, width);
+                    bar.setPrefSize(height, width);
                 }
             }
             else
             {
-                jfx_node.getTransforms().clear();
+                bar.getTransforms().clear();
+                bar.setPrefSize(width, height);
                 jfx_node.setPrefSize(width, height);
 
                 if (min_val > max_val)
                 {
-                    jfx_node.getTransforms().setAll(
+                    bar.getTransforms().setAll(
                         new Translate(width, 0),
                         new Rotate(180, 0, 0, 0, Rotate.Y_AXIS));
                 }
@@ -259,6 +267,6 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
             jfx_node.setStyle(style.toString());
         }
         if (dirty_value.checkAndClear())
-            jfx_node.setProgress(percentage);
+            bar.setProgress(percentage);
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
@@ -175,6 +175,7 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Pane, Pr
         toolkit.scheduleUpdate(this);
     }
 
+    @Override
     protected boolean isFilteringEditModeClicks() {
         return true;
     }


### PR DESCRIPTION
We discovered a fairly obscure bug when placing a vertical progress bar in a Group widget positioned on the far right edge of a screen. We were opening the window from the command line specifying the height and width so that it opening at the exact size of the screen, however we continued to get scroll bars on the window. We also found that if you right clicked to the right of the group, i.e. outside of the group, you would still get the option to view 'Group' information indicating that the Group had been drawn beyond its defined size.

I found that the cause of this was the vertical progress bar, which by default is horizontal and so a translation is applied to the node. However the width of the Progress bar node before the translation (i.e. the length of the bar) seems to remain the same width after the translation. So when it is placed in a Group widget it thinks that the width of the progress bar is much larger than it is and draws the Group out to the length of the progress bar.

E.g. Maybe easier to see in this example - note the right click menu option and the scroll bars

<img width="437" height="459" alt="Screenshot from 2026-06-15 16-00-01" src="https://github.com/user-attachments/assets/2d4d3fe9-58dd-4f13-b87d-ec2907c382ee" />



I have also attached an example BOB file: 
[progressbar_group.bob.txt](https://github.com/user-attachments/files/28966843/progressbar_group.bob.txt)

If you open this with
```
phoebus.sh  -resource "file:/path/to/bob/progressbar_group.bob?target=window@210x370+50+50"
```
you will see that the right click menu extends to the right beyond the group and that you continued to get scroll bars even when the window is large enough to encompass the visible screen.

Something similar has been seen before as a potential bug in the JFX Progress bar, see https://bugs.openjdk.org/browse/JDK-8295341. 

I have found a workaround for this issue which involves wrapping the progress bar in a JFX Pane() allowing us to rotate the progress bar as before but then set the correct width/height of the pane so that the Group widget doesn't think that this child element is bigger than it is. This fix gives the desired effect in that we can open the window to fit the screen without scroll bars appearing, e.g. 
<img width="218" height="421" alt="Screenshot from 2026-06-15 16-03-00" src="https://github.com/user-attachments/assets/4d151883-d7df-4225-adea-1db0b4da36f1" />


<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
