### PR TITLE
Create new Log Entry from Selection

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryDisplayController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryDisplayController.java
@@ -38,10 +38,12 @@ import javafx.scene.layout.Region;
 import org.phoebus.logbook.LogEntry;
 import org.phoebus.logbook.olog.ui.write.EditMode;
 import org.phoebus.logbook.olog.ui.write.LogEntryEditorStage;
+import org.phoebus.logbook.olog.ui.write.LogEntryUtils;
 import org.phoebus.olog.es.api.model.LogGroupProperty;
 import org.phoebus.olog.es.api.model.OlogLog;
 import org.phoebus.ui.javafx.ImageCache;
 
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -185,12 +187,6 @@ public class LogEntryDisplayController {
     }
 
     @FXML
-    public void newLogEntry(){
-        // Show a new editor dialog.
-        new LogEntryEditorStage(new OlogLog(),  null, EditMode.NEW_LOG_ENTRY).show();
-    }
-
-    @FXML
     public void goBack() {
         if (logEntryTableViewController.goBackAndGoForwardActions.isPresent()) {
             logEntryTableViewController.goBackAndGoForwardActions.get().goBack();
@@ -201,6 +197,22 @@ public class LogEntryDisplayController {
     public void goForward() {
         if (logEntryTableViewController.goBackAndGoForwardActions.isPresent()) {
             logEntryTableViewController.goBackAndGoForwardActions.get().goForward();
+        }
+    }
+
+    /**
+     * Creates a new Log Entry.
+     * If 2 or more existing Log Entries in the list are selected,
+     * they get linked into the description of the new Log Entry.
+     * */
+    @FXML
+    public void createNewLogEntry(){
+        List<LogEntry> selectedLogEntries = logEntryTableViewController.getSelectedLogEntries();
+        if (selectedLogEntries.size() > 1){
+            LogEntry logEntry = LogEntryUtils.createLogEntryFromList(LogbookUIPreferences.web_client_root_URL, selectedLogEntries);
+            new LogEntryEditorStage(logEntry,null, EditMode.NEW_LOG_ENTRY_FROM_SELECTION).show();
+        } else {
+            new LogEntryEditorStage(new OlogLog(),  null, EditMode.NEW_LOG_ENTRY).show();
         }
     }
 

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryDisplayController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryDisplayController.java
@@ -38,12 +38,10 @@ import javafx.scene.layout.Region;
 import org.phoebus.logbook.LogEntry;
 import org.phoebus.logbook.olog.ui.write.EditMode;
 import org.phoebus.logbook.olog.ui.write.LogEntryEditorStage;
-import org.phoebus.logbook.olog.ui.write.LogEntryUtils;
 import org.phoebus.olog.es.api.model.LogGroupProperty;
 import org.phoebus.olog.es.api.model.OlogLog;
 import org.phoebus.ui.javafx.ImageCache;
 
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -207,13 +205,7 @@ public class LogEntryDisplayController {
      * */
     @FXML
     public void createNewLogEntry(){
-        List<LogEntry> selectedLogEntries = logEntryTableViewController.getSelectedLogEntries();
-        if (selectedLogEntries.size() > 1){
-            LogEntry logEntry = LogEntryUtils.createLogEntryFromList(LogbookUIPreferences.web_client_root_URL, selectedLogEntries);
-            new LogEntryEditorStage(logEntry,null, EditMode.NEW_LOG_ENTRY_FROM_SELECTION).show();
-        } else {
-            new LogEntryEditorStage(new OlogLog(),  null, EditMode.NEW_LOG_ENTRY).show();
-        }
+        new LogEntryEditorStage(new OlogLog(), null, EditMode.NEW_LOG_ENTRY).show();
     }
 
     /**

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -208,7 +208,15 @@ public class LogEntryTableViewController extends LogbookSearchController impleme
 
         MenuItem menuItemNewLogEntry = new MenuItem(Messages.NewLogEntry);
         menuItemNewLogEntry.acceleratorProperty().setValue(new KeyCodeCombination(KeyCode.N, KeyCombination.CONTROL_DOWN));
-        menuItemNewLogEntry.setOnAction(ae -> new LogEntryEditorStage(new OlogLog(), null, EditMode.NEW_LOG_ENTRY).showAndWait());
+        menuItemNewLogEntry.setOnAction(ae  -> {
+            List<LogEntry> selectedLogEntries = getSelectedLogEntries();
+            if (selectedLogEntries.size() > 1){
+                LogEntry logEntry = LogEntryUtils.createLogEntryFromList(LogbookUIPreferences.web_client_root_URL, selectedLogEntries);
+                new LogEntryEditorStage(logEntry,null, EditMode.NEW_LOG_ENTRY_FROM_SELECTION).show();
+            } else {
+                new LogEntryEditorStage(new OlogLog(),  null, EditMode.NEW_LOG_ENTRY).show();
+            }
+        });
 
         MenuItem menuItemUpdateLogEntry = new MenuItem(Messages.UpdateLogEntry);
         menuItemUpdateLogEntry.visibleProperty().bind(Bindings.createBooleanBinding(() -> selectedLogEntries.size() == 1, selectedLogEntries));

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -209,7 +209,6 @@ public class LogEntryTableViewController extends LogbookSearchController impleme
         MenuItem menuItemNewLogEntry = new MenuItem(Messages.NewLogEntry);
         menuItemNewLogEntry.acceleratorProperty().setValue(new KeyCodeCombination(KeyCode.N, KeyCombination.CONTROL_DOWN));
         menuItemNewLogEntry.setOnAction(ae  -> {
-            List<LogEntry> selectedLogEntries = getSelectedLogEntries();
             if (selectedLogEntries.size() > 1){
                 LogEntry logEntry = LogEntryUtils.createLogEntryFromList(LogbookUIPreferences.web_client_root_URL, selectedLogEntries);
                 new LogEntryEditorStage(logEntry,null, EditMode.NEW_LOG_ENTRY_FROM_SELECTION).show();

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -219,7 +219,7 @@ public class LogEntryTableViewController extends LogbookSearchController impleme
         MenuItem menuItemCreateLogEntryFromSelection = new MenuItem(Messages.CreateLogEntryFromSelection);
         menuItemCreateLogEntryFromSelection.setOnAction(pl -> {
             LogEntry logEntry = LogEntryUtils.createLogEntryFromList(LogbookUIPreferences.web_client_root_URL, selectedLogEntries);
-            new LogEntryEditorStage(logEntry, null, EditMode.NEW_LOG_ENTRY).show();
+            new LogEntryEditorStage(logEntry, null, EditMode.NEW_LOG_ENTRY_FROM_SELECTION).show();
         });
 
         contextMenu.getItems().addAll(groupSelectedEntries, menuItemShowHideAll, menuItemNewLogEntry, menuItemCreateLogEntryFromSelection);

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -56,6 +56,7 @@ import org.phoebus.logbook.olog.ui.query.OlogQueryManager;
 import org.phoebus.logbook.olog.ui.spi.Decoration;
 import org.phoebus.logbook.olog.ui.write.EditMode;
 import org.phoebus.logbook.olog.ui.write.LogEntryEditorStage;
+import org.phoebus.logbook.olog.ui.write.LogEntryUtils;
 import org.phoebus.olog.es.api.model.LogGroupProperty;
 import org.phoebus.olog.es.api.model.OlogLog;
 import org.phoebus.security.store.SecureStore;
@@ -214,7 +215,14 @@ public class LogEntryTableViewController extends LogbookSearchController impleme
         menuItemUpdateLogEntry.acceleratorProperty().setValue(new KeyCodeCombination(KeyCode.U, KeyCombination.CONTROL_DOWN));
         menuItemUpdateLogEntry.setOnAction(ae -> new LogEntryEditorStage(selectedLogEntries.get(0), null, EditMode.UPDATE_LOG_ENTRY).show());
 
-        contextMenu.getItems().addAll(groupSelectedEntries, menuItemShowHideAll, menuItemNewLogEntry);
+        //Milena
+        MenuItem menuItemCreateLogEntryFromSelection = new MenuItem(Messages.CreateLogEntryFromSelection);
+        menuItemCreateLogEntryFromSelection.setOnAction(pl -> {
+            LogEntry logEntry = LogEntryUtils.createLogEntryFromList(LogbookUIPreferences.web_client_root_URL, selectedLogEntries);
+            new LogEntryEditorStage(logEntry, null, EditMode.NEW_LOG_ENTRY).show();
+        });
+
+        contextMenu.getItems().addAll(groupSelectedEntries, menuItemShowHideAll, menuItemNewLogEntry, menuItemCreateLogEntryFromSelection);
         if (LogbookUIPreferences.log_entry_update_support) {
             contextMenu.getItems().add(menuItemUpdateLogEntry);
         }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/LogEntryTableViewController.java
@@ -215,14 +215,7 @@ public class LogEntryTableViewController extends LogbookSearchController impleme
         menuItemUpdateLogEntry.acceleratorProperty().setValue(new KeyCodeCombination(KeyCode.U, KeyCombination.CONTROL_DOWN));
         menuItemUpdateLogEntry.setOnAction(ae -> new LogEntryEditorStage(selectedLogEntries.get(0), null, EditMode.UPDATE_LOG_ENTRY).show());
 
-        //Milena
-        MenuItem menuItemCreateLogEntryFromSelection = new MenuItem(Messages.CreateLogEntryFromSelection);
-        menuItemCreateLogEntryFromSelection.setOnAction(pl -> {
-            LogEntry logEntry = LogEntryUtils.createLogEntryFromList(LogbookUIPreferences.web_client_root_URL, selectedLogEntries);
-            new LogEntryEditorStage(logEntry, null, EditMode.NEW_LOG_ENTRY_FROM_SELECTION).show();
-        });
-
-        contextMenu.getItems().addAll(groupSelectedEntries, menuItemShowHideAll, menuItemNewLogEntry, menuItemCreateLogEntryFromSelection);
+        contextMenu.getItems().addAll(groupSelectedEntries, menuItemShowHideAll, menuItemNewLogEntry);
         if (LogbookUIPreferences.log_entry_update_support) {
             contextMenu.getItems().add(menuItemUpdateLogEntry);
         }
@@ -597,6 +590,11 @@ public class LogEntryTableViewController extends LogbookSearchController impleme
                     }
                 });
 
+    }
+
+
+    public List<LogEntry> getSelectedLogEntries(){
+        return selectedLogEntries;
     }
 
     /**

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/Messages.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/Messages.java
@@ -28,6 +28,7 @@ public class Messages
             CloseRequestHeader,
             CloseRequestButtonContinue,
             CloseRequestButtonDiscard,
+            CreateLogEntryFromSelection,
             DownloadSelected,
             DownloadingAttachments,
             EditLogEntry,

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/EditMode.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/EditMode.java
@@ -7,5 +7,6 @@ package org.phoebus.logbook.olog.ui.write;
 public enum EditMode {
 
     NEW_LOG_ENTRY,
-    UPDATE_LOG_ENTRY
+    UPDATE_LOG_ENTRY,
+    NEW_LOG_ENTRY_FROM_SELECTION
 }

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
@@ -388,7 +388,11 @@ public class LogEntryEditorController {
         titleProperty.set(logEntry.getTitle());
 
         textArea.textProperty().bindBidirectional(descriptionProperty);
-        descriptionProperty.set(logEntry.getSource());
+        switch(editMode){
+            case NEW_LOG_ENTRY -> descriptionProperty.set("");
+            case UPDATE_LOG_ENTRY, NEW_LOG_ENTRY_FROM_SELECTION -> descriptionProperty.set(logEntry.getSource());
+        }
+//        descriptionProperty.set(logEntry.getSource());
         descriptionProperty.addListener((observable, oldValue, newValue) -> isDirty = true);
 
         Image tagIcon = ImageCache.getImage(LogEntryEditorController.class, "/icons/add_tag.png");
@@ -743,17 +747,20 @@ public class LogEntryEditorController {
             LogClient logClient =
                     logFactory.getLogClient(new SimpleAuthenticationToken(usernameProperty.get(), passwordProperty.get()));
             try {
-                if(editMode.equals(EditMode.NEW_LOG_ENTRY)){
-                    if (replyTo == null) {
+                switch(editMode){
+                    case NEW_LOG_ENTRY:
+                        if (replyTo == null) {
+                            logEntryResult = Optional.of(logClient.set(ologLog));
+                        } else {
+                            logEntryResult = Optional.of(logClient.reply(ologLog, replyTo));
+                        }
+                        break;
+                    case UPDATE_LOG_ENTRY:
+                        logEntryResult = Optional.of(logClient.update(ologLog));
+                        break;
+                    case NEW_LOG_ENTRY_FROM_SELECTION:
                         logEntryResult = Optional.of(logClient.set(ologLog));
-                    } else {
-                        logEntryResult = Optional.of(logClient.reply(ologLog, replyTo));
-                    }
                 }
-                else{
-                    logEntryResult = Optional.of(logClient.update(ologLog));
-                }
-
                 // Not dirty anymore...
                 isDirty = false;
 

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
@@ -389,8 +389,8 @@ public class LogEntryEditorController {
 
         textArea.textProperty().bindBidirectional(descriptionProperty);
         // When editing an existing entry, set the description to the source of the entry.
-        descriptionProperty.set(editMode.equals(EditMode.UPDATE_LOG_ENTRY) ?  logEntry.getSource() :
-                (logEntry.getDescription() != null ? logEntry.getDescription() : ""));
+        descriptionProperty.set(logEntry.getSource());
+//                (logEntry.getDescription() != null ? logEntry.getDescription() : ""));
         descriptionProperty.addListener((observable, oldValue, newValue) -> isDirty = true);
 
         Image tagIcon = ImageCache.getImage(LogEntryEditorController.class, "/icons/add_tag.png");

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
@@ -388,9 +388,7 @@ public class LogEntryEditorController {
         titleProperty.set(logEntry.getTitle());
 
         textArea.textProperty().bindBidirectional(descriptionProperty);
-        // When editing an existing entry, set the description to the source of the entry.
         descriptionProperty.set(logEntry.getSource());
-//                (logEntry.getDescription() != null ? logEntry.getDescription() : ""));
         descriptionProperty.addListener((observable, oldValue, newValue) -> isDirty = true);
 
         Image tagIcon = ImageCache.getImage(LogEntryEditorController.class, "/icons/add_tag.png");

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUtils.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUtils.java
@@ -1,0 +1,28 @@
+package org.phoebus.logbook.olog.ui.write;
+
+import org.phoebus.logbook.LogEntry;
+import org.phoebus.olog.es.api.model.OlogLog;
+
+import java.util.List;
+
+public class LogEntryUtils {
+
+    public static LogEntry createLogEntryFromList(String baseURL, List<LogEntry> logEntries){
+        // number of log entries
+        // they links should be based on the
+        // instantiate new Log Entry implementatin Olog
+        // interface: type of class that defines a behavior/functionality/data
+        // you cannot instantiate an interface
+        // so we instantiate an OlogLog
+        // public class OlogLog implements LogEntry
+        OlogLog log = new OlogLog();
+        StringBuilder stringBuilder = new StringBuilder();
+        logEntries.forEach(l -> {
+            stringBuilder.append("\n");
+            stringBuilder.append("[").append(l.getTitle()).append("](").append(baseURL).append(l.getId()).append(")\n\n");
+        });
+
+        log.setSource(stringBuilder.toString());
+        return log;
+    }
+}

--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUtils.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryUtils.java
@@ -2,24 +2,16 @@ package org.phoebus.logbook.olog.ui.write;
 
 import org.phoebus.logbook.LogEntry;
 import org.phoebus.olog.es.api.model.OlogLog;
-
 import java.util.List;
 
 public class LogEntryUtils {
 
     public static LogEntry createLogEntryFromList(String baseURL, List<LogEntry> logEntries){
-        // number of log entries
-        // they links should be based on the
-        // instantiate new Log Entry implementatin Olog
-        // interface: type of class that defines a behavior/functionality/data
-        // you cannot instantiate an interface
-        // so we instantiate an OlogLog
-        // public class OlogLog implements LogEntry
         OlogLog log = new OlogLog();
         StringBuilder stringBuilder = new StringBuilder();
         logEntries.forEach(l -> {
             stringBuilder.append("\n");
-            stringBuilder.append("[").append(l.getTitle()).append("](").append(baseURL).append(l.getId()).append(")\n\n");
+            stringBuilder.append("- [").append(l.getTitle()).append("](").append(baseURL).append("/").append(l.getId()).append(")");
         });
 
         log.setSource(stringBuilder.toString());

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/LogEntryDisplay.fxml
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/LogEntryDisplay.fxml
@@ -28,7 +28,7 @@
     <top>
         <ToolBar fx:id="toolBar">
             <items>
-                <Button fx:id="newLogEntryButton" mnemonicParsing="false" onAction="#newLogEntry" text="%NewLogEntry"/>
+                <Button fx:id="newLogEntryButton" mnemonicParsing="false" onAction="#createNewLogEntry" text="%NewLogEntry"/>
                 <Button fx:id="replyButton" mnemonicParsing="false" onAction="#reply" text="%Reply" disable="true"/>
                 <ToggleButton fx:id="showHideLogEntryGroupButton" contentDisplay="RIGHT" mnemonicParsing="false"
                               text="%ShowHideLogEntryGroup" disable="true" onAction="#showHideLogEntryGroup"/>

--- a/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/messages.properties
+++ b/app/logbook/olog/ui/src/main/resources/org/phoebus/logbook/olog/ui/messages.properties
@@ -30,6 +30,8 @@ CloseRequestHeader=Log entry not saved. Do you wish to close?
 CloseRequestButtonContinue=Continue Editing
 CloseRequestButtonDiscard=Close
 CreateLogbookEntry=Create Log Book Entry
+#milena
+CreateLogEntryFromSelection=Create Log Entry From Selection
 CopyMarkdown=Copy Markdown
 CopyURL=Copy URL
 CSSWindow=CSS Window

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/write/LogEntryUtilsTest.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/write/LogEntryUtilsTest.java
@@ -27,7 +27,7 @@ public class LogEntryUtilsTest {
 
         LogEntry testListLog = LogEntryUtils.createLogEntryFromList("someURL", List.of(ologEntry01, ologEntry02, ologEntry03));
 
-        assertEquals("\n[Title01](someURL1)\n\n\n[Title02](someURL2)\n\n\n[Title03](someURL3)\n\n", testListLog.getSource());
+        assertEquals("\n- [Title01](someURL/1)\n- [Title02](someURL/2)\n- [Title03](someURL/3)", testListLog.getSource());
     }
 }
 

--- a/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/write/LogEntryUtilsTest.java
+++ b/app/logbook/olog/ui/src/test/java/org/phoebus/logbook/olog/ui/write/LogEntryUtilsTest.java
@@ -1,0 +1,33 @@
+package org.phoebus.logbook.olog.ui.write;
+
+import org.junit.jupiter.api.Test;
+import org.phoebus.logbook.*;
+import org.phoebus.olog.es.api.model.OlogLog;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LogEntryUtilsTest {
+
+    @Test
+    public void testCreateLogEntryFromList(){
+
+        OlogLog ologEntry01 = new OlogLog();
+        ologEntry01.setTitle("Title01");
+        ologEntry01.setId(1L);
+
+        OlogLog ologEntry02 = new OlogLog();
+        ologEntry02.setTitle("Title02");
+        ologEntry02.setId(2L);
+
+
+        OlogLog ologEntry03 = new OlogLog();
+        ologEntry03.setTitle("Title03");
+        ologEntry03.setId(3L);
+
+        LogEntry testListLog = LogEntryUtils.createLogEntryFromList("someURL", List.of(ologEntry01, ologEntry02, ologEntry03));
+
+        assertEquals("\n[Title01](someURL1)\n\n\n[Title02](someURL2)\n\n\n[Title03](someURL3)\n\n", testListLog.getSource());
+    }
+}
+


### PR DESCRIPTION
By selecting multiple Log Entries and right clicking, there is the option to "Create new Log Entry from Selection", which creates a new Log Entry with a list of links to your selected Log Entries in the description.

<img width="975" height="1613" alt="Screenshot 2026-06-18 125226" src="https://github.com/user-attachments/assets/09e88fb6-0c81-483e-977f-cf73df20de70" />
<img width="1316" height="1539" alt="Screenshot 2026-06-18 125246" src="https://github.com/user-attachments/assets/c6e54a3b-2e91-452c-a99f-17a96a558b40" />


- Testing:
    - [ ] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
