### PR TITLE
Allow symlinks to phoebus.sh

### DIFF
--- a/phoebus-product/phoebus.sh
+++ b/phoebus-product/phoebus.sh
@@ -5,7 +5,8 @@
 # When deploying, change "TOP"
 # to the absolute installation path
 # TOP="."
-TOP="$( cd "$(dirname "$0")" ; pwd -P )"
+realpath=$(realpath "$0")
+TOP=$(dirname "$realpath")
 
 # Ideally, assert that Java is found
 # export JAVA_HOME=/opt/jdk-9

--- a/phoebus-product/phoebus.sh
+++ b/phoebus-product/phoebus.sh
@@ -20,7 +20,7 @@ fi
 if [ -d "${TOP}/update" ]
 then
   echo "Installing update..."
-  cd ${TOP}
+  cd "${TOP}"
   rm -rf doc lib
   mv update/* .
   rmdir update
@@ -28,7 +28,7 @@ then
 fi
 
 
-JAR=`echo ${TOP}/product-*.jar`
+JAR=`echo "${TOP}"/product-*.jar`
 
 # To get one instance, use server mode
 OPT="-server 4918"
@@ -41,10 +41,10 @@ firstarg=$1;
 
 if test "${firstarg#*$filter1}" != "$firstarg"; then
   # Run MEDM converter etc. in foreground
-  java -Dfile.encoding=UTF-8 -jar $JAR $OPT "$@"
+  java -Dfile.encoding=UTF-8 -jar "$JAR" $OPT "$@"
 elif test "${firstarg#*$filter2}" != "$firstarg"; then
-    java -Dfile.encoding=UTF-8 -jar $JAR $OPT "$@"
+    java -Dfile.encoding=UTF-8 -jar "$JAR" $OPT "$@"
 else
   # Run UI as separate thread
-  java -Dfile.encoding=UTF-8 -jar $JAR $OPT "$@" &
+  java -Dfile.encoding=UTF-8 -jar "$JAR" $OPT "$@" &
 fi


### PR DESCRIPTION
Starting Phoebus using a symlink to `phoebus.sh` is not possible because the detection where Phoebus was installed fails which means the `.jar` cannot be found.

This PR uses `realpath` instead of the `cd` and `pwd -P` pair to resolve symlinks and convert the path to absolute.

There is another problem if the installation path contains spaces; we need to put `${TOP}` inside quotes.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - Used phoebus.sh to check if it works for symlinks and paths containing spaces
- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
