### PR TITLE
EDM parser/converter: Fix `"` handling

### DIFF
--- a/app/display/convert-edm/src/main/java/org/csstudio/opibuilder/converter/model/EdmAttribute.java
+++ b/app/display/convert-edm/src/main/java/org/csstudio/opibuilder/converter/model/EdmAttribute.java
@@ -96,7 +96,7 @@ public class EdmAttribute {
      * @return        Actual value appended (without quotations).
      */
     public String appendValue(String value) {
-        if(value.startsWith("\"")&&value.endsWith("\"")){
+        if(value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2){
             value=value.substring(1, value.length()-1);
         }
 


### PR DESCRIPTION
If a (slightly buggy) EDM edl file provides just `"` for an attribute value, missing the closing quote, the parser would run into an index error.

Fixes #3846

- Testing:
Open the file shown in #3846 before and after this fix.
