### PR TITLE
Add jdk-jsobject so javafx.web (WebView) builds on JDK 26

### DIFF
--- a/core/ui/pom.xml
+++ b/core/ui/pom.xml
@@ -46,6 +46,13 @@
       <artifactId>javafx-web</artifactId>
       <version>${openjfx.version}</version>
     </dependency>
+    <!-- netscape.javascript for javafx.web; previously provided by the JDK's
+         jdk.jsobject module, which was removed in JDK 26. -->
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>jdk-jsobject</artifactId>
+      <version>${jsobject.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-swing</artifactId>

--- a/core/ui/pom.xml
+++ b/core/ui/pom.xml
@@ -46,13 +46,6 @@
       <artifactId>javafx-web</artifactId>
       <version>${openjfx.version}</version>
     </dependency>
-    <!-- netscape.javascript for javafx.web; previously provided by the JDK's
-         jdk.jsobject module, which was removed in JDK 26. -->
-    <dependency>
-      <groupId>org.openjfx</groupId>
-      <artifactId>jdk-jsobject</artifactId>
-      <version>${jsobject.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-swing</artifactId>
@@ -112,4 +105,22 @@
       </resource>
     </resources>
   </build>
+
+  <profiles>
+    <!-- netscape.javascript (javafx.web/WebView) moved out of the JDK in 26;
+         supply it as a jar only on 26+ (<= 25 have the jdk.jsobject module). -->
+    <profile>
+      <id>jdk-jsobject</id>
+      <activation>
+        <jdk>[26,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.openjfx</groupId>
+          <artifactId>jdk-jsobject</artifactId>
+          <version>${jsobject.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -41,6 +41,22 @@
         </plugins>
       </build>
     </profile>
+
+    <!-- netscape.javascript (javafx.web/WebView) moved out of the JDK in 26;
+         supply it as a jar only on 26+ (<= 25 have the jdk.jsobject module). -->
+    <profile>
+      <id>jdk-jsobject</id>
+      <activation>
+        <jdk>[26,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.openjfx</groupId>
+          <artifactId>jdk-jsobject</artifactId>
+          <version>${jsobject.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <dependencies>
@@ -80,13 +96,6 @@
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-web</artifactId>
       <version>${openjfx.version}</version>
-    </dependency>
-    <!-- netscape.javascript for javafx.web; previously provided by the JDK's
-         jdk.jsobject module, which was removed in JDK 26. -->
-    <dependency>
-      <groupId>org.openjfx</groupId>
-      <artifactId>jdk-jsobject</artifactId>
-      <version>${jsobject.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>

--- a/dependencies/phoebus-target/pom.xml
+++ b/dependencies/phoebus-target/pom.xml
@@ -81,6 +81,13 @@
       <artifactId>javafx-web</artifactId>
       <version>${openjfx.version}</version>
     </dependency>
+    <!-- netscape.javascript for javafx.web; previously provided by the JDK's
+         jdk.jsobject module, which was removed in JDK 26. -->
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>jdk-jsobject</artifactId>
+      <version>${jsobject.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-swing</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,8 @@
     <epics.util.version>1.0.8</epics.util.version>
     <vtype.version>1.0.8</vtype.version>
     <openjfx.version>21.0.7</openjfx.version>
-    <!-- Supplies netscape.javascript (used by javafx.web's WebView), which lived
-         in the JDK's jdk.jsobject module until that module was removed in JDK 26.
-         Versioned independently of openjfx because the standalone artifact only
-         exists from 25 onwards. -->
+    <!-- netscape.javascript jar for the JDK 26+ profiles; versioned separately
+         from openjfx as it's only published for 25+. -->
     <jsobject.version>26.0.1</jsobject.version>
     <jackson.version>2.12.3</jackson.version>
     <batik.version>1.17</batik.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
     <epics.util.version>1.0.8</epics.util.version>
     <vtype.version>1.0.8</vtype.version>
     <openjfx.version>21.0.7</openjfx.version>
+    <!-- Supplies netscape.javascript (used by javafx.web's WebView), which lived
+         in the JDK's jdk.jsobject module until that module was removed in JDK 26.
+         Versioned independently of openjfx because the standalone artifact only
+         exists from 25 onwards. -->
+    <jsobject.version>26.0.1</jsobject.version>
     <jackson.version>2.12.3</jackson.version>
     <batik.version>1.17</batik.version>
     <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
`MergedLogEntryDisplayController` uses `netscape.javascript.JSObject` to bridge the
Olog WebView to Java. That class was provided by the JDK's `jdk.jsobject` module,
which is removed in JDK 26, so `javafx.web` no longer compiles or resolves there.

Since JavaFX 24 that module is shipped with JavaFX as the upgradable
`org.openjfx:jdk-jsobject` artifact; this adds it to the classpath. It is versioned
independently of `openjfx.version` because the standalone artifact only exists from
25 onwards. On JDK 25 and earlier the platform module still takes precedence, so the
dependency is inert; on JDK 26 it supplies `netscape.javascript`.

Together with #3851 (which replaces the removed `Thread.stop()`), this clears the
second and final compile blocker, so the project builds and runs on JDK 26.

## Checklist
- Testing:
    - [ ] The feature has automated tests
    - [X] Tests were run
    - If not, explain how you tested your changes
        - Built the full reactor and ran the test suite on both the JDK 21 target
          and JDK 26 (2332 tests, 0 failures on each). On JDK 21 the JDK's own
          `jdk.jsobject` still takes precedence (behavior unchanged); on JDK 26
          `netscape.javascript` resolves from the bundled artifact and the embedded
          `WebView` renders a page.
- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
