### PR TITLE
ArchiveFetchJob timeout message

### DIFF
--- a/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/archive/ArchiveFetchJob.java
+++ b/app/databrowser/src/main/java/org/csstudio/trends/databrowser3/archive/ArchiveFetchJob.java
@@ -302,10 +302,16 @@ public class ArchiveFetchJob implements JobRunnable
                 final String info = MessageFormat.format(Messages.ArchiveFetchProgressFmt,
                                                          currentMessage, seconds);
                 monitor.updateTaskName(info);
-                if (monitor.isCanceled()
-                        || (Preferences.archive_read_timeout_ms > 0
-                            && System.currentTimeMillis() - sourceStartTime > Preferences.archive_read_timeout_ms))
+                if (monitor.isCanceled())
                     worker.cancel();
+                else if (Preferences.archive_read_timeout_ms > 0
+                            && System.currentTimeMillis() - sourceStartTime > Preferences.archive_read_timeout_ms)
+                {
+                    if (! worker.cancelled)
+                        logger.log(Level.WARNING,
+                                   () -> this + " cancelled because of " + Preferences.archive_read_timeout_ms + " ms timeout");
+                    worker.cancel();
+                }
             }
         }
         finally


### PR DESCRIPTION
#3807 added a `archive_read_timeout_ms`.
This adds a log message when that timeout is reached, because a silent timeout can be confusing: No error, yet then no data?!