### PR TITLE
Rotated Label causes Group widget to extend further than it should

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.widgets;
 
+import javafx.scene.layout.Pane;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -32,13 +33,14 @@ import javafx.scene.transform.Translate;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWidget>
+public class LabelRepresentation extends RegionBaseRepresentation<Pane, LabelWidget>
 {
     private final DirtyFlag dirty_style = new DirtyFlag();
     private final DirtyFlag dirty_content = new DirtyFlag();
     private final UntypedWidgetPropertyListener contentChangedListener = this::contentChanged;
     private final UntypedWidgetPropertyListener styleChangedListener = this::styleChanged;
     private volatile Pos pos;
+    private Label label;
 
     /** Was there ever any transformation applied to the jfx_node?
      *
@@ -49,11 +51,11 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
     private boolean was_ever_transformed = false;
 
     @Override
-    public Label createJFXNode() throws Exception
+    public Pane createJFXNode() throws Exception
     {
-        final Label label = new Label();
+        label = new Label();
         label.getStyleClass().add("text_update");
-        return label;
+        return new Pane(label);
     }
 
     @Override
@@ -119,7 +121,7 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
         if (dirty_content.checkAndClear())
         {
             final String text = model_widget.propText().getValue();
-            jfx_node.setText(text);
+            label.setText(text);
             if (model_widget.propAutoSize().getValue())
             {
                 final Dimension2D size = TextUtils.computeTextSize(JFXUtil.convert(model_widget.propFont().getValue()), text);
@@ -140,14 +142,16 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
                 jfx_node.setPrefSize(width, height);
                 jfx_node.setMinSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.setMaxSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
+                label.setPrefSize(width, height);
                 if (was_ever_transformed)
-                    jfx_node.getTransforms().clear();
+                    label.getTransforms().clear();
                 break;
             case NINETY:
-                jfx_node.setPrefSize(height, width);
+                jfx_node.setPrefSize(width, height);
                 jfx_node.setMinSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.setMaxSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
-                jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()),
+                label.setPrefSize(height, width);
+                label.getTransforms().setAll(new Rotate(-rotation.getAngle()),
                                                 new Translate(-height, 0));
                 was_ever_transformed = true;
                 break;
@@ -155,33 +159,35 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
                 jfx_node.setPrefSize(width, height);
                 jfx_node.setMinSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.setMaxSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
-                jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()),
+                label.setPrefSize(width, height);
+                label.getTransforms().setAll(new Rotate(-rotation.getAngle()),
                                                 new Translate(-width, -height));
                 was_ever_transformed = true;
                                break;
             case MINUS_NINETY:
-                jfx_node.setPrefSize(height, width);
+                jfx_node.setPrefSize(width, height);
                 jfx_node.setMinSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
                 jfx_node.setMaxSize(Control.USE_PREF_SIZE, Control.USE_PREF_SIZE);
-                jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()),
+                label.setPrefSize(height, width);
+                label.getTransforms().setAll(new Rotate(-rotation.getAngle()),
                                                 new Translate(0, -width));
                 was_ever_transformed = true;
                 break;
             }
-            jfx_node.setAlignment(pos);
-            jfx_node.setTextAlignment(TextAlignment.values()[model_widget.propHorizontalAlignment().getValue().ordinal()]);
-            jfx_node.setWrapText(model_widget.propWrapWords().getValue());
+            label.setAlignment(pos);
+            label.setTextAlignment(TextAlignment.values()[model_widget.propHorizontalAlignment().getValue().ordinal()]);
+            label.setWrapText(model_widget.propWrapWords().getValue());
 
             Color color = JFXUtil.convert(model_widget.propForegroundColor().getValue());
-            jfx_node.setTextFill(color);
+            label.setTextFill(color);
             if (model_widget.propTransparent().getValue())
-                jfx_node.setBackground(null); // No fill
+                label.setBackground(null); // No fill
             else
             {   // Fill background
                 color = JFXUtil.convert(model_widget.propBackgroundColor().getValue());
-                jfx_node.setBackground(new Background(new BackgroundFill(color, CornerRadii.EMPTY, Insets.EMPTY)));
+                label.setBackground(new Background(new BackgroundFill(color, CornerRadii.EMPTY, Insets.EMPTY)));
             }
-            jfx_node.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
+            label.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
         }
     }
 }


### PR DESCRIPTION
This is the same issue as seen with a vertical progress bar in PR: https://github.com/ControlSystemStudio/phoebus/pull/3833. 

Essentially when the JFX label widget gets rotated, the width and height properties do not get switched and so the group containing the label gets drawn out further than it should be. 
<img width="445" height="497" alt="Screenshot from 2026-07-06 14-24-32" src="https://github.com/user-attachments/assets/99577201-0819-407a-9d98-981f60f3c5f7" />


Another impact of this is that it can cause widgets next to the group to become un-clickable due to the group being painted wider than it should be and covering neighboring widgets without users noticing. I am attaching an example BOB screen to reproduce this issue:
[label_group.bob.txt](https://github.com/user-attachments/files/29706294/label_group.bob.txt)


The fix for this is the same as that for the progress bar, e.g. wrap the JFX label widget in a JFX pane 

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [X] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
