### PR TITLE
Use authenticated user name when creating log entries from save&restore

### DIFF
--- a/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
+++ b/app/logbook/olog/ui/src/main/java/org/phoebus/logbook/olog/ui/write/LogEntryEditorController.java
@@ -388,10 +388,9 @@ public class LogEntryEditorController {
 
         textArea.textProperty().bindBidirectional(descriptionProperty);
         switch(editMode){
-            case NEW_LOG_ENTRY -> descriptionProperty.set("");
+            case NEW_LOG_ENTRY -> descriptionProperty.set(logEntry.getDescription()!= null ? logEntry.getDescription(): "");
             case UPDATE_LOG_ENTRY, NEW_LOG_ENTRY_FROM_SELECTION -> descriptionProperty.set(logEntry.getSource());
         }
-//        descriptionProperty.set(logEntry.getSource());
         descriptionProperty.addListener((observable, oldValue, newValue) -> isDirty = true);
 
         Image tagIcon = ImageCache.getImage(LogEntryEditorController.class, "/icons/add_tag.png");

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/authentication/SaveAndRestoreAuthenticationProvider.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/authentication/SaveAndRestoreAuthenticationProvider.java
@@ -19,6 +19,7 @@
 
 package org.phoebus.applications.saveandrestore.authentication;
 
+import org.phoebus.applications.saveandrestore.model.authentication.SaveAndRestoreAuthenticationScope;
 import org.phoebus.applications.saveandrestore.ui.SaveAndRestoreService;
 import org.phoebus.security.authorization.AuthenticationStatus;
 import org.phoebus.security.authorization.ServiceAuthenticationProvider;

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/client/SaveAndRestoreClientImpl.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/client/SaveAndRestoreClientImpl.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.phoebus.applications.saveandrestore.Messages;
 import org.phoebus.applications.saveandrestore.SaveAndRestoreClientException;
-import org.phoebus.applications.saveandrestore.authentication.SaveAndRestoreAuthenticationScope;
+import org.phoebus.applications.saveandrestore.model.authentication.SaveAndRestoreAuthenticationScope;
 import org.phoebus.applications.saveandrestore.model.CompositeSnapshot;
 import org.phoebus.applications.saveandrestore.model.Configuration;
 import org.phoebus.applications.saveandrestore.model.ConfigurationData;

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/ContextMenuCreateSaveset.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/ContextMenuCreateSaveset.java
@@ -27,7 +27,7 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import org.phoebus.applications.saveandrestore.Messages;
 import org.phoebus.applications.saveandrestore.SaveAndRestoreApplication;
-import org.phoebus.applications.saveandrestore.authentication.SaveAndRestoreAuthenticationScope;
+import org.phoebus.applications.saveandrestore.model.authentication.SaveAndRestoreAuthenticationScope;
 import org.phoebus.applications.saveandrestore.model.Node;
 import org.phoebus.applications.saveandrestore.model.NodeType;
 import org.phoebus.applications.saveandrestore.ui.configuration.ConfigurationFromSelectionController;

--- a/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreBaseController.java
+++ b/app/save-and-restore/app/src/main/java/org/phoebus/applications/saveandrestore/ui/SaveAndRestoreBaseController.java
@@ -20,7 +20,7 @@
 package org.phoebus.applications.saveandrestore.ui;
 
 import javafx.beans.property.SimpleStringProperty;
-import org.phoebus.applications.saveandrestore.authentication.SaveAndRestoreAuthenticationScope;
+import org.phoebus.applications.saveandrestore.model.authentication.SaveAndRestoreAuthenticationScope;
 import org.phoebus.security.store.SecureStore;
 import org.phoebus.security.tokens.ScopedAuthenticationToken;
 

--- a/app/save-and-restore/app/src/test/java/org/phoebus/applications/saveandrestore/client/HttpClientTestIT.java
+++ b/app/save-and-restore/app/src/test/java/org/phoebus/applications/saveandrestore/client/HttpClientTestIT.java
@@ -11,7 +11,7 @@ import org.epics.vtype.VInt;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.phoebus.applications.saveandrestore.authentication.SaveAndRestoreAuthenticationScope;
+import org.phoebus.applications.saveandrestore.model.authentication.SaveAndRestoreAuthenticationScope;
 import org.phoebus.applications.saveandrestore.model.CompositeSnapshot;
 import org.phoebus.applications.saveandrestore.model.CompositeSnapshotData;
 import org.phoebus.applications.saveandrestore.model.ConfigPv;
@@ -30,12 +30,10 @@ import org.phoebus.applications.saveandrestore.model.search.SearchResult;
 import org.phoebus.security.PhoebusSecurity;
 import org.phoebus.security.store.SecureStore;
 import org.phoebus.security.store.SecureStoreTarget;
-import org.phoebus.security.tokens.AuthenticationScope;
 import org.phoebus.security.tokens.ScopedAuthenticationToken;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
-import java.net.ConnectException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/app/save-and-restore/logging/src/main/java/org/phoebus/applications/saveandrestore/logging/SaveAndRestoreEventLogger.java
+++ b/app/save-and-restore/logging/src/main/java/org/phoebus/applications/saveandrestore/logging/SaveAndRestoreEventLogger.java
@@ -22,14 +22,18 @@ import javafx.application.Platform;
 import org.phoebus.applications.saveandrestore.model.Node;
 import org.phoebus.applications.saveandrestore.model.RestoreResult;
 import org.phoebus.applications.saveandrestore.model.Tag;
+import org.phoebus.applications.saveandrestore.model.authentication.SaveAndRestoreAuthenticationScope;
 import org.phoebus.applications.saveandrestore.model.event.SaveAndRestoreEventReceiver;
 import org.phoebus.framework.selection.SelectionService;
 import org.phoebus.framework.workbench.ApplicationService;
 import org.phoebus.logbook.LogEntry;
 import org.phoebus.logbook.LogbookPreferences;
+import org.phoebus.security.store.SecureStore;
+import org.phoebus.security.tokens.ScopedAuthenticationToken;
 
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -59,7 +63,7 @@ public class SaveAndRestoreEventLogger implements SaveAndRestoreEventReceiver {
         SaveSnapshotActionInfo saveSnapshotActionInfo = new SaveSnapshotActionInfo();
         saveSnapshotActionInfo.setSnapshotUniqueId(node.getUniqueId());
         saveSnapshotActionInfo.setSnapshotCreatedDate(node.getCreated());
-        saveSnapshotActionInfo.setActionPerformedBy(System.getProperty("user.name"));
+        saveSnapshotActionInfo.setActionPerformedBy(getUser());
         saveSnapshotActionInfo.setComment(node.getDescription());
         saveSnapshotActionInfo.setSnapshotName(node.getName());
         SelectionService.getInstance().setSelection("SaveAndRestoreLogging", List.of(saveSnapshotActionInfo));
@@ -84,12 +88,25 @@ public class SaveAndRestoreEventLogger implements SaveAndRestoreEventReceiver {
         RestoreSnapshotActionInfo restoreSnapshotActionInfo = new RestoreSnapshotActionInfo();
         restoreSnapshotActionInfo.setSnapshotUniqueId(node.getUniqueId());
         restoreSnapshotActionInfo.setSnapshotCreatedDate(node.getCreated());
-        restoreSnapshotActionInfo.setActionPerformedBy(System.getProperty("user.name"));
+        restoreSnapshotActionInfo.setActionPerformedBy(getUser());
         restoreSnapshotActionInfo.setComment(node.getDescription());
         restoreSnapshotActionInfo.setGolden(node.hasTag(Tag.GOLDEN));
         restoreSnapshotActionInfo.setSnapshotName(node.getName());
         restoreSnapshotActionInfo.setFailedPVs(failedPVs.stream().map(restoreResult -> restoreResult.getSnapshotItem().getConfigPv().getPvName()).toList());
         SelectionService.getInstance().setSelection("SaveAndRestoreLogging", List.of(restoreSnapshotActionInfo));
         Platform.runLater(() -> ApplicationService.createInstance("logbook"));
+    }
+
+    private String getUser(){
+        try {
+            SecureStore store = new SecureStore();
+            ScopedAuthenticationToken scopedAuthenticationToken = store.getScopedAuthenticationToken(new SaveAndRestoreAuthenticationScope());
+            if (scopedAuthenticationToken != null) {
+                return scopedAuthenticationToken.getUsername();
+            }
+        } catch (Exception e){
+            logger.log(Level.WARNING, "Unable to get Authentication Token.", e);
+        }
+        return "<Not Available>";
     }
 }

--- a/app/save-and-restore/model/pom.xml
+++ b/app/save-and-restore/model/pom.xml
@@ -17,6 +17,12 @@
 			<version>6.0.0-SNAPSHOT</version>
 		</dependency>
 
+      <dependency>
+          <groupId>org.phoebus</groupId>
+          <artifactId>core-security</artifactId>
+          <version>6.0.0-SNAPSHOT</version>
+      </dependency>
+
 	  <dependency>
 		  <groupId>org.phoebus</groupId>
 		  <artifactId>core-websocket-common</artifactId>

--- a/app/save-and-restore/model/src/main/java/org/phoebus/applications/saveandrestore/model/authentication/SaveAndRestoreAuthenticationScope.java
+++ b/app/save-and-restore/model/src/main/java/org/phoebus/applications/saveandrestore/model/authentication/SaveAndRestoreAuthenticationScope.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2025 European Spallation Source ERIC.
  */
 
-package org.phoebus.applications.saveandrestore.authentication;
+package org.phoebus.applications.saveandrestore.model.authentication;
 
 import org.phoebus.security.tokens.AuthenticationScope;
 


### PR DESCRIPTION
moved SaveAndRestoreAuthenticationScope to model module and fixed user name for restored log entry

- Testing:
    - [ ] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
