### PR TITLE
added date of disabled pvs to structural element

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/Messages.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/Messages.java
@@ -43,6 +43,7 @@ public class Messages
     public static String removeComponentFailed;
     public static String renameItemFailed;
     public static String timer;
+    public static String timers;
     public static String unacknowledgeFailed;
     public static String withEnableDate;
 

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/AlarmTreeViewCell.java
@@ -26,9 +26,7 @@ import org.phoebus.applications.alarm.ui.Messages;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 /** TreeCell for AlarmTreeItem
  *  @author Kay Kasemir
@@ -127,22 +125,27 @@ class AlarmTreeViewCell extends TreeCell<AlarmTreeItem<?>>
             else
             {
                 final AlarmClientNode node = (AlarmClientNode) item;
-
                 Optional<Pair<LeavesDisabledStatus, Boolean>> maybeLeavesDisabledStatusBooleanPair = leavesDisabledStatus(node);
                 if (maybeLeavesDisabledStatusBooleanPair.isPresent() && !maybeLeavesDisabledStatusBooleanPair.get().getKey().equals(LeavesDisabledStatus.AllEnabled)) {
                     Pair<LeavesDisabledStatus, Boolean> leavesDisabledStatusBooleanPair = maybeLeavesDisabledStatusBooleanPair.get();
 
                     if (leavesDisabledStatusBooleanPair.getKey().equals(LeavesDisabledStatus.AllDisabled)) {
                         if (leavesDisabledStatusBooleanPair.getValue()) {
-                            disabledTimerIndicator.setText("(" + Messages.disabled + "; " + Messages.timer + ")");
-                        }
-                        else {
+                            Set<AlarmClientLeaf> withEnableDate = new HashSet<>();
+                            boolean test = DisableAction.checkEnableDates(node.getChildren(), new HashSet<>(), withEnableDate);
+                            if (test){
+                                disabledTimerIndicator.setText("(" + Messages.disabled + "; " + Messages.timer + ": " + withEnableDate.iterator().next().getEnabledDate() + ")");
+                            } else {
+                                disabledTimerIndicator.setText("(" + Messages.disabled + "; " + Messages.timers + ")");
+                            }
+
+                        } else {
                             disabledTimerIndicator.setText("(" + Messages.disabled + ")");
                         }
                     }
                     else if (leavesDisabledStatusBooleanPair.getKey().equals(LeavesDisabledStatus.SomeEnabledSomeDisabled)) {
                         if (leavesDisabledStatusBooleanPair.getValue()) {
-                            disabledTimerIndicator.setText("(" + Messages.partlyDisabled + "; " + Messages.timer + ")");
+                            disabledTimerIndicator.setText("(" + Messages.partlyDisabled + "; " + Messages.timers + ")");
                         }
                         else {
                             disabledTimerIndicator.setText("(" + Messages.partlyDisabled + ")");

--- a/app/alarm/ui/src/main/resources/org/phoebus/applications/alarm/ui/messages.properties
+++ b/app/alarm/ui/src/main/resources/org/phoebus/applications/alarm/ui/messages.properties
@@ -73,6 +73,7 @@ relativeDateTooltip=Select a predefined duration for disabling the alarm
 removeComponentFailed=Failed to remove component
 renameItemFailed=Failed to rename item
 timer=Timer
+timers=Timers
 title=Title
 tooltipAddTableItem=Add a new table item
 tooltipDeleteSelectedItems=Delete selected table items


### PR DESCRIPTION
If all the leafs of a structural element in the alarm tree have the same enable date, it is displayed next to the name of the component

<img width="496" height="327" alt="Screenshot 2026-07-13 093428" src="https://github.com/user-attachments/assets/f4ec2a9a-d2cb-4465-95d8-c810f005e25a" />


- Testing:
    - [ ] The feature has automated tests
    - [x ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
