### PR TITLE
Optimizations in ScaledSlider

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
@@ -7,10 +7,12 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.widgets;
 
+import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.scene.Node;
+import javafx.scene.control.Skin;
 import javafx.scene.control.Slider;
 import javafx.scene.control.skin.SliderSkin;
 import javafx.scene.input.KeyEvent;
@@ -37,7 +39,6 @@ import org.epics.vtype.VType;
 
 import java.text.DecimalFormat;
 import java.time.Instant;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
@@ -75,14 +76,12 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
     private final Slider slider;
     private final SliderMarkers markers;
 
-    private final AtomicBoolean isHorizontal = new AtomicBoolean(true);
-
     private static final double THUMB_PADDING_DEFAULT = 7.6;
     private static final double THUMB_PADDING_MAX = 20.0;
-    private static final double THUMB_SCALING_FACTOR = 0.3;
+    private static final double THUMB_SCALING_FACTOR = 0.16;
     private static final double TRACK_PADDING_DEFAULT = 3.3;
     private static final double TRACK_PADDING_MAX = 13.0;
-    private static final double TRACK_SCALING_FACTOR = 0.2;
+    private static final double TRACK_SCALING_FACTOR = 0.1;
     private static final double MAJOR_TICK_LENGTH_DEFAULT = 8.0;
     private static final double MAJOR_TICK_LENGTH_MAX = 20.0;
     private static final double MAJOR_TICK_LENGTH_SCALING_FACTOR = 0.1;
@@ -136,6 +135,9 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
         // because otherwise for example border changes would trigger
         // expensive Node.notifyParentOfBoundsChange() recursing up the scene graph
         pane.setManaged(false);
+
+        // Adjust sizes when a skin is available. Handles initial resizing of slider UI elements.
+        slider.skinProperty().addListener(new SkinChangeListener());
 
         return pane;
     }
@@ -247,7 +249,6 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
             model_widget.propWidth().setValue(h);
             model_widget.propHeight().setValue(w);
         }
-        isHorizontal.set(horizontal);
         layoutChanged(prop, old, horizontal);
     }
 
@@ -534,6 +535,8 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
 
             if (any_markers)
                 markers.setAlarmMarkers(lolo, low, high, hihi);
+
+            adjustSizes();
         }
         if (dirty_value.checkAndClear())
         {
@@ -569,7 +572,6 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
             }
         }
 
-        adjustSizes();
         jfx_node.layout();
     }
 
@@ -595,24 +597,39 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
      * </p>
      */
     private void adjustSizes(){
-        SliderSkin skin = (SliderSkin) slider.getSkin();
-        if (skin == null) {
+        if(slider.getSkin() == null){
             return;
         }
-        double size = isHorizontal.get() ? jfx_node.getHeight() : jfx_node.getWidth();
+
+        double size = model_widget.propHorizontal().getValue() ?
+                jfx_node.getHeight() :
+                jfx_node.getWidth();
+
+        SliderSkin skin = (SliderSkin) slider.getSkin();
         for (Node node : skin.getChildren()) {
             if (node.getStyleClass().contains("thumb")) {
                 node.setStyle("-fx-padding: " + Math.clamp(size * THUMB_SCALING_FACTOR,
-                        THUMB_PADDING_DEFAULT,
-                        THUMB_PADDING_MAX));
+                        THUMB_PADDING_DEFAULT, THUMB_PADDING_MAX));
             } else if (node.getStyleClass().contains("track")) {
                 node.setStyle("-fx-padding: " + Math.clamp(size * TRACK_SCALING_FACTOR,
-                        TRACK_PADDING_DEFAULT,
-                        TRACK_PADDING_MAX));
+                        TRACK_PADDING_DEFAULT, TRACK_PADDING_MAX));
             } else if (node.getStyleClass().contains("axis")) {
                 node.setStyle("-fx-tick-length: " + Math.clamp(size * MAJOR_TICK_LENGTH_SCALING_FACTOR,
-                        MAJOR_TICK_LENGTH_DEFAULT,
-                        MAJOR_TICK_LENGTH_MAX));
+                        MAJOR_TICK_LENGTH_DEFAULT, MAJOR_TICK_LENGTH_MAX));
+            }
+        }
+    }
+
+    /**
+     * Custom {@link ChangeListener} for the purpose of setting slider sizes once there is a {@link Skin}
+     * available to manipulate.
+     */
+    private class SkinChangeListener implements ChangeListener<Skin<?>>{
+        @Override
+        public void changed(ObservableValue<? extends Skin<?>> observableValue, Skin<?> oldValue, Skin<?> newValue) {
+            if(oldValue == null && newValue != null){
+                adjustSizes();
+                slider.skinProperty().removeListener(this);
             }
         }
     }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
@@ -597,7 +597,9 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
      * </p>
      */
     private void adjustSizes(){
-        if(slider.getSkin() == null){
+
+        Skin<?> skin = slider.getSkin();
+        if(skin == null){
             return;
         }
 
@@ -605,8 +607,7 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
                 jfx_node.getHeight() :
                 jfx_node.getWidth();
 
-        SliderSkin skin = (SliderSkin) slider.getSkin();
-        for (Node node : skin.getChildren()) {
+        for (Node node : ((SliderSkin) skin).getChildren()) {
             if (node.getStyleClass().contains("thumb")) {
                 node.setStyle("-fx-padding: " + Math.clamp(size * THUMB_SCALING_FACTOR,
                         THUMB_PADDING_DEFAULT, THUMB_PADDING_MAX));


### PR DESCRIPTION
As suggested by Mr Claude: do not adjust sizes of the slider UI elements on value change, only on size change.

Also tweaked default sizes a bit to make a fresh ScaledSlider resemble the native JavaFX slider with default paddings.

- Testing:
    - [ ] The feature has automated tests
    - [ X] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
