### PR TITLE
Bugfix: disable pvs with enable date indefinitely

### DIFF
--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/ComponentActionHelper.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/tree/ComponentActionHelper.java
@@ -78,6 +78,7 @@ public class ComponentActionHelper {
         });
     }
 
+
     /**
      * @param item Node where to start recursing for PVs that would be affected
      * @param pvs  Array to update with PVs that would be affected
@@ -87,7 +88,7 @@ public class ComponentActionHelper {
             final AlarmClientLeaf pv = (AlarmClientLeaf) item;
             // If pv has different enablement, and wasn't already added
             // because selection contains its parent as well as the PV itself...
-            if (pv.isEnabled() != enable && !pvs.contains(pv)) {
+            if ((pv.isEnabled() != enable || pv.getEnabledDate() != null) && !pvs.contains(pv)) {
                 pvs.add(pv);
             }
         } else {


### PR DESCRIPTION
Alarm tree items with an enable date can now be disabled pemanently without triggering the "PV is already disabled" Message.

- Testing:
    - [ ] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
