### PR TITLE
Stop scrollbars from flickering on/off when resizing windows

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -225,9 +225,12 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         model_root = new ScrollPane(scroll_body);
         model_root.setId(MODEL_ROOT_ID);
 
-        final InvalidationListener resized = prop -> handleViewportChanges();
-        model_root.widthProperty().addListener(resized);
-        model_root.heightProperty().addListener(resized);
+        // Update background of parent when it changes or, for example,
+        // becomes not null
+        final InvalidationListener background = prop -> {
+            updateBackground();
+        };
+        model_root.parentProperty().addListener(background);
 
         // Middle Button (Wheel press) drag panning started
         final EventHandler<MouseEvent> onMousePressedHandler = evt ->
@@ -647,48 +650,6 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         throw new IllegalStateException("Not implemented");
     }
 
-    /** Handle changes in on-screen size of this representation */
-    private void handleViewportChanges()
-    {
-        final int view_width = (int) model_root.getWidth();
-        final int view_height = (int) model_root.getHeight();
-
-        final int model_width, model_height;
-        final DisplayModel copy = model;
-        if (copy == null)
-            model_width = model_height = 0;
-        else
-        {
-            model_width = copy.propWidth().getValue();
-            model_height = copy.propHeight().getValue();
-        }
-
-        // If on-screen viewport is larger than model,
-        // grow the scroll_body so that the complete area is
-        // filled with the background color
-        // and - in edit mode - the grid.
-        // If the viewport is smaller, use the model's size
-        // to get appropriate scrollbars.
-        final int show_x = view_width >= model_width
-                         ? view_width-SCROLLBAR_ADJUST
-                         : model_width;
-        final int show_y = view_height >= model_height
-                         ? view_height-SCROLLBAR_ADJUST
-                         : model_height;
-
-        // Does not consider zooming.
-        // If the widget_pane is zoomed 'out', e.g. 50%,
-        // the widget_pane will only be half as large
-        // as we specify here in pixels
-        // -> Ignore. If user zooms out a lot, there'll be an
-        //    area a gray area at the right and bottom of the display.
-        //    But user tends to zoom out to see the complete set of widgets,
-        //    so there is very little gray area.
-        //        widget_parent.setMinWidth(show_x / zoom);
-        //        widget_parent.setMinHeight(show_y / zoom);
-        widget_pane.setMinSize(show_x, show_y);
-    }
-
     /** Update lines that indicate model's size in edit mode */
     private void updateModelSizeIndicators()
     {
@@ -992,7 +953,17 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         final WritableImage wimage = new WritableImage(gridStepX, gridStepY);
         SwingFXUtils.toFXImage(image, wimage);
         final ImagePattern pattern = new ImagePattern(wimage, 0, 0, gridStepX, gridStepY, false);
-        widget_pane.setBackground(new Background(new BackgroundFill(pattern, CornerRadii.EMPTY, Insets.EMPTY)));
+        Background bg = new Background(new BackgroundFill(pattern, CornerRadii.EMPTY, Insets.EMPTY));
+        
+        // Set the background of the parent BorderPane 
+        if (model_root.getParent() instanceof Pane)
+            ((Pane) model_root.getParent()).setBackground(bg);
+        // Now make the scroll pane transparent to see the parent background
+        model_root.setStyle("-fx-background: transparent; -fx-background-color: transparent; ");
+        // Also set background of content to workaround JFX bugs (https://bugs.openjdk.org/browse/JDK-8118303
+        // and https://bugs.openjdk.org/browse/JDK-8095008) where text is rendered badly inside a transparent 
+        // ScrollPane.
+        widget_pane.setBackground(bg);
     }
 
     // Future for controlling the audio player

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -895,6 +895,9 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     /** Update background, using background color and grid information from model */
     private void updateBackground()
     {
+        if (model == null)
+            return;
+
         final WidgetColor background = model.propBackgroundColor().getValue();
 
         // Setting the "-fx-background:" of the root node propagates

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
@@ -15,6 +15,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
+import javafx.scene.layout.*;
+import javafx.scene.paint.Color;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.Widget;
@@ -33,9 +35,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.layout.Background;
-import javafx.scene.layout.BackgroundFill;
-import javafx.scene.layout.Pane;
 import javafx.scene.text.Font;
 
 /** Creates JavaFX item for model widget
@@ -295,12 +294,15 @@ public class TabsRepresentation extends JFXBaseRepresentation<TabPane, TabsWidge
             {   // Set the font of the 'graphic' that's used to represent the tab
                 final Label label = (Label) tab.getGraphic();
                 label.setFont(tab_font);
+                label.setTextFill(Color.BLACK);
 
                 // Set colors
                 tab.setStyle(style);
 
                 final Pane content  = (Pane) tab.getContent();
                 content.setBackground(background);
+                content.setBorder(new Border(new BorderStroke(Color.WHITE,
+                        BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderWidths.DEFAULT)));
             }
 
             final Integer width = model_widget.propWidth().getValue();


### PR DESCRIPTION
We noticed that when you resize a window with the mouse you can see scroll bars flicker on and off. See attached screencast showing this:
[scrollbar_flicker.webm](https://github.com/user-attachments/assets/399a12ac-2928-4b22-9e3d-e14004f5491e)

You will also see that even when the window is made smaller than the screen in one direction, you still get scroll bars appear in both x and y even though they are only needed in one. 

The issue is caused by code that attempts to resize the widget pane to fill the parent scroll pane:https://github.com/ControlSystemStudio/phoebus/blob/11eb814d610cf978c41029604d00d8f0170ff689/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java#L651

This is a workaround to another issue of setting the background of a ScrollPane, see comments in code here: https://github.com/ControlSystemStudio/phoebus/blob/11eb814d610cf978c41029604d00d8f0170ff689/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java#L939 Essentially you can not set the background of the ScrollPane without it propagating down to the children node. Instead, the background was set on the widget pane and then a listener is added so that whenever the scrollpane is resized, the widget pane gets resized using its `setMinSize()` method to fill the ScrollPane. This must be causing some race condition where it momentarily thinks the pane is too small for the content and so puts on scroll bars before realising it is not and then removing them. 

The fix for the scroll bar issue described above is to remove this listener and the resizing of the widget pane. However this then leaves us with this problem of setting the background. I have been able to fix this by:
- setting the background on the Scroll pane's parent BorderPane.
- then setting the ScrollPane background to be transparent so we see the BorderPane's background underneath.
- Set the widget pane background as well to work around a JFX bug where a transparent ScrollPane causes text to render differently (see  https://bugs.openjdk.org/browse/JDK-8118303 and https://bugs.openjdk.org/browse/JDK-8095008).

I have tested this with all widgets and noticed some different behavior for the Tabs widget where the tab label text was white, as was the border. I fixed this by explicitly setting them in the code.

I think my implementation also goes some way to fixing https://github.com/ControlSystemStudio/phoebus/issues/3677, or at least when you zoom out the background still gets painted all the way out so you wouldn't see the grey background in this example. 

Manual tests to run:
- Check that you do not see scroll bars flicker on and off as you resize a window
- Check that scroll bars only appear in the dimensions where the window is too small
- Change the background of the display in the editor and check that this is reflected in both the runtime and editor. 
   - Expand the windows to make sure it is still painted out to the boundaries. 
   - Try zooming out - is the background still painted out to the boundaries
- Close Phoebus and open again so that it loads from the memento - is the background still drawn out to the boundaries.
- Open some existing BOB files - are the widgets all visible and look the same.
- Test creating a new BOB with a Tab widget. Does this behave as normal.


<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [X] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
