### PR TITLE
CSSTUDIO-3780 Bugfix: Boolean Button in "Push"/"Push (inverted)" mode should only write to the PV when left-clicking.

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
@@ -37,6 +37,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBase;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.CycleMethod;
@@ -117,8 +118,16 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<Pane, Boo
             else
             {
                 final boolean inverted = model_widget.propMode().getValue() == Mode.PUSH_INVERTED;
-                button.setOnMousePressed(event -> handlePress(! inverted));
-                button.setOnMouseReleased(event -> handlePress(inverted));
+                button.setOnMousePressed(event ->
+                {
+                    if (event.getButton() == MouseButton.PRIMARY)
+                        handlePress(! inverted);
+                });
+                button.setOnMouseReleased(event ->
+                {
+                    if (event.getButton() == MouseButton.PRIMARY)
+                        handlePress(inverted);
+                });
             }
         }
 


### PR DESCRIPTION
Currently, when using a Boolean Button widget in either "Push" or in "Push (inverted)" mode, _right-clicking (or, more generally, any non-primary mouse button) on the Boolean Button will write to the PV connected to the Boolean Button._

This pull request fixes this by checking that the primary mouse button (i.e., usually the left mouse button) was clicked before attempting to write to the PV connected to the Boolean Button.

- Testing:
I have tested the change manually locally.

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
