### PR TITLE
Workaround to JFX21 bug causing transparent labels

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -229,6 +229,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
         {
             final Color color = JFXUtil.convert(model_widget.propForegroundColor().getValue());
             label.setTextFill(color);
+            setTextFillColorStyle(label, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
             label.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
 
             led.setStyle("-fx-stroke: " + JFXUtil.webRgbOrHex(model_widget.propLineColor().getValue()));
@@ -279,12 +280,21 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
                 {   // Colors of text and LED are very close in brightness.
                     // Make text visible by forcing black resp. white
                     if (brightness > Brightness.BRIGHT_THRESHOLD)
+                    {
                         label.setTextFill(Color.BLACK);
+                        setTextFillColorStyle(label, "#000000");
+                    }
                     else
+                    {
                         label.setTextFill(Color.WHITE);
+                        setTextFillColorStyle(label, "#FFFFFF");
+                    }
                 }
                 else
+                {
                     label.setTextFill(text_color);
+                    setTextFillColorStyle(label, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
+                }
             }
         }
         jfx_node.layout();

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
@@ -143,6 +143,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
                 label.getStyleClass().add("led_label");
                 label.setFont(text_font);
                 label.setTextFill(text_color);
+                setTextFillColorStyle(label, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
                 label.setManaged(false);
             }
             else
@@ -436,12 +437,21 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
                         {   // Colors of text and LED are very close in brightness.
                             // Make text visible by forcing black resp. white
                             if (brightness > Brightness.BRIGHT_THRESHOLD)
+                            {
                                 save_labels[i].setTextFill(Color.BLACK);
+                                setTextFillColorStyle(save_labels[i], "#000000");
+                            }
                             else
+                            {
                                 save_labels[i].setTextFill(Color.WHITE);
+                                setTextFillColorStyle(save_labels[i], "#FFFFFF");
+                            }
                         }
-                        else
+                        else 
+                        {
                             save_labels[i].setTextFill(text_color);
+                            setTextFillColorStyle(save_labels[i], JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
+                        }
                         save_labels[i].layout();
                     }
                 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
@@ -19,7 +19,6 @@ import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.CheckBoxWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.epics.vtype.VType;
-import org.phoebus.ui.javafx.Styles;
 import org.phoebus.ui.javafx.TextUtils;
 
 import javafx.application.Platform;
@@ -223,6 +222,7 @@ public class CheckBoxRepresentation extends RegionBaseRepresentation<CheckBox, C
             jfx_node.setText(label);
             jfx_node.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
             jfx_node.setTextFill(JFXUtil.convert(model_widget.propForegroundColor().getValue()));
+            setTextFillColorStyle(jfx_node, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
 
             // Don't disable the widget, because that would also remove the
             // context menu etc.

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
@@ -215,6 +215,7 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
                     label.setPadding(TITLE_PADDING);
                     label.setPrefSize(width + ( ( !firstUpdate && hasChildren ) ? insets[2] : 0 ), inset);
                     label.setTextFill(foreground_color);
+                    setTextFillColorStyle(label, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
                     label.setBackground(new Background(new BackgroundFill(line_color, CornerRadii.EMPTY, Insets.EMPTY)));
                     break;
                 }
@@ -233,6 +234,7 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
                     label.setPadding(TITLE_PADDING);
                     label.setPrefSize(Label.USE_COMPUTED_SIZE, Label.USE_COMPUTED_SIZE);
                     label.setTextFill(foreground_color);
+                    setTextFillColorStyle(label, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
                     label.setBackground(new Background(new BackgroundFill(background_color, CornerRadii.EMPTY, Insets.EMPTY)));
                     break;
                 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -22,7 +22,6 @@ import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
-import org.csstudio.display.builder.model.widgets.GroupWidget;
 import org.csstudio.display.builder.model.widgets.TabsWidget;
 import org.csstudio.display.builder.model.widgets.TabsWidget.TabItemProperty;
 import org.csstudio.display.builder.representation.WidgetRepresentation;
@@ -34,8 +33,6 @@ import javafx.event.EventHandler;
 import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.Parent;
-import org.phoebus.core.types.ProcessVariable;
-import org.phoebus.ui.dnd.DataFormats;
 import org.phoebus.ui.javafx.Styles;
 
 /** Base class for all JavaFX widget representations
@@ -377,5 +374,20 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
                 }   
             }
         }
+    }
+
+    /**
+     * Set the text fill using inline CSS
+     * TODO Remove this method after moving to JFX25!!
+     *  It is Required in JFX21 to workaround bug https://bugs.openjdk.org/browse/JDK-8336097
+     *  meaning we cannot set the colour using setters after making the parent pane 
+     *  transparent. 
+     *  See Phoebus Github issue https://github.com/ControlSystemStudio/phoebus/issues/3891
+     *  
+     * @param node JFX node
+     * @param color Colour as hex string
+     */
+    public static void setTextFillColorStyle(Node node, String color){
+        node.setStyle("-fx-text-fill: "+ color);
     }
 }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
@@ -180,6 +180,7 @@ public class LabelRepresentation extends RegionBaseRepresentation<Pane, LabelWid
 
             Color color = JFXUtil.convert(model_widget.propForegroundColor().getValue());
             label.setTextFill(color);
+            setTextFillColorStyle(label, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
             if (model_widget.propTransparent().getValue())
                 label.setBackground(null); // No fill
             else

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/RadioRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/RadioRepresentation.java
@@ -24,7 +24,6 @@ import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.epics.vtype.VEnum;
 import org.epics.vtype.VNumber;
 import org.epics.vtype.VType;
-import org.phoebus.ui.javafx.Styles;
 import org.phoebus.ui.vtype.FormatOption;
 import org.phoebus.ui.vtype.FormatOptionHandler;
 
@@ -304,6 +303,7 @@ public class RadioRepresentation extends JFXBaseRepresentation<TilePane, RadioWi
             {
                 final RadioButton rb = (RadioButton) rb_node;
                 rb.setTextFill(fg);
+                setTextFillColorStyle(rb, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
                 rb.setFont(font);
             }
         }

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
@@ -23,7 +23,6 @@ import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.SlideButtonWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.epics.vtype.VType;
-import org.phoebus.ui.javafx.Styles;
 
 import javafx.application.Platform;
 import javafx.geometry.Pos;
@@ -94,6 +93,7 @@ public class SlideButtonRepresentation extends RegionBaseRepresentation<HBox, Sl
             label.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
             label.setText(labelContent);
             label.setTextFill(foreground);
+            setTextFillColorStyle(label, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
 
             // Don't disable the widget, because that would also remove the context menu etc.
             // Just apply a style that matches the disabled look.

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -434,6 +434,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
         indexLabel.setAlignment(Pos.CENTER);
         indexLabel.setFont(Font.font(indexLabel.getFont().getFamily(), FontWeight.BOLD, 16));
         indexLabel.setTextFill(Color.WHITE);
+        setTextFillColorStyle(indexLabel, "#FFFFFF");
         indexLabel.setVisible(model_widget.propShowIndex().getValue());
         indexLabel.textProperty().bind(Bindings.convert(imageIndexProperty()));
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
@@ -295,6 +295,7 @@ public class TabsRepresentation extends JFXBaseRepresentation<TabPane, TabsWidge
                 final Label label = (Label) tab.getGraphic();
                 label.setFont(tab_font);
                 label.setTextFill(Color.BLACK);
+                setTextFillColorStyle(label, "#000000");
 
                 // Set colors
                 tab.setStyle(style);

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextSymbolRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextSymbolRepresentation.java
@@ -223,6 +223,7 @@ public class TextSymbolRepresentation extends RegionBaseRepresentation<Label, Te
         );
         symbol.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
         symbol.setTextFill(JFXUtil.convert(model_widget.propForegroundColor().getValue()));
+        setTextFillColorStyle(symbol, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
         symbol.setText("\u263A");
         symbol.setManaged(false);
 

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
@@ -255,6 +255,7 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
                 final Label label = (Label) jfx_node;
                 Color color = JFXUtil.convert(model_widget.propForegroundColor().getValue());
                 label.setTextFill(color);
+                setTextFillColorStyle(label, JFXUtil.webHex(model_widget.propForegroundColor().getValue()));
                 label.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
                 label.setAlignment(pos);
                 label.setWrapText(model_widget.propWrapWords().getValue());


### PR DESCRIPTION
See description and discussion of bug here: https://github.com/ControlSystemStudio/phoebus/issues/3891.

Bug in JFX21 means that setting the foreground color of the label widget using the setter fails and the label is rendered transparent. 

JFX21 bug: https://bugs.openjdk.org/browse/JDK-8336097

This bug has been fixed in JFX24. 

The workaround is to set the style using inline CSS. 

Once we have moved to JFX25 this workaround should be removed - I have added a TODO for this in the code.


<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [X] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
