### PR TITLE
Revert "Stop scrollbars from flickering on/off when resizing windows"

### DIFF
--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -225,12 +225,9 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         model_root = new ScrollPane(scroll_body);
         model_root.setId(MODEL_ROOT_ID);
 
-        // Update background of parent when it changes or, for example,
-        // becomes not null
-        final InvalidationListener background = prop -> {
-            updateBackground();
-        };
-        model_root.parentProperty().addListener(background);
+        final InvalidationListener resized = prop -> handleViewportChanges();
+        model_root.widthProperty().addListener(resized);
+        model_root.heightProperty().addListener(resized);
 
         // Middle Button (Wheel press) drag panning started
         final EventHandler<MouseEvent> onMousePressedHandler = evt ->
@@ -650,6 +647,48 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         throw new IllegalStateException("Not implemented");
     }
 
+    /** Handle changes in on-screen size of this representation */
+    private void handleViewportChanges()
+    {
+        final int view_width = (int) model_root.getWidth();
+        final int view_height = (int) model_root.getHeight();
+
+        final int model_width, model_height;
+        final DisplayModel copy = model;
+        if (copy == null)
+            model_width = model_height = 0;
+        else
+        {
+            model_width = copy.propWidth().getValue();
+            model_height = copy.propHeight().getValue();
+        }
+
+        // If on-screen viewport is larger than model,
+        // grow the scroll_body so that the complete area is
+        // filled with the background color
+        // and - in edit mode - the grid.
+        // If the viewport is smaller, use the model's size
+        // to get appropriate scrollbars.
+        final int show_x = view_width >= model_width
+                         ? view_width-SCROLLBAR_ADJUST
+                         : model_width;
+        final int show_y = view_height >= model_height
+                         ? view_height-SCROLLBAR_ADJUST
+                         : model_height;
+
+        // Does not consider zooming.
+        // If the widget_pane is zoomed 'out', e.g. 50%,
+        // the widget_pane will only be half as large
+        // as we specify here in pixels
+        // -> Ignore. If user zooms out a lot, there'll be an
+        //    area a gray area at the right and bottom of the display.
+        //    But user tends to zoom out to see the complete set of widgets,
+        //    so there is very little gray area.
+        //        widget_parent.setMinWidth(show_x / zoom);
+        //        widget_parent.setMinHeight(show_y / zoom);
+        widget_pane.setMinSize(show_x, show_y);
+    }
+
     /** Update lines that indicate model's size in edit mode */
     private void updateModelSizeIndicators()
     {
@@ -895,9 +934,6 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     /** Update background, using background color and grid information from model */
     private void updateBackground()
     {
-        if (model == null)
-            return;
-
         final WidgetColor background = model.propBackgroundColor().getValue();
 
         // Setting the "-fx-background:" of the root node propagates
@@ -956,17 +992,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         final WritableImage wimage = new WritableImage(gridStepX, gridStepY);
         SwingFXUtils.toFXImage(image, wimage);
         final ImagePattern pattern = new ImagePattern(wimage, 0, 0, gridStepX, gridStepY, false);
-        Background bg = new Background(new BackgroundFill(pattern, CornerRadii.EMPTY, Insets.EMPTY));
-        
-        // Set the background of the parent BorderPane 
-        if (model_root.getParent() instanceof Pane)
-            ((Pane) model_root.getParent()).setBackground(bg);
-        // Now make the scroll pane transparent to see the parent background
-        model_root.setStyle("-fx-background: transparent; -fx-background-color: transparent; ");
-        // Also set background of content to workaround JFX bugs (https://bugs.openjdk.org/browse/JDK-8118303
-        // and https://bugs.openjdk.org/browse/JDK-8095008) where text is rendered badly inside a transparent 
-        // ScrollPane.
-        widget_pane.setBackground(bg);
+        widget_pane.setBackground(new Background(new BackgroundFill(pattern, CornerRadii.EMPTY, Insets.EMPTY)));
     }
 
     // Future for controlling the audio player

--- a/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
+++ b/app/display/representation-javafx/src/main/java/org/csstudio/display/builder/representation/javafx/widgets/TabsRepresentation.java
@@ -15,8 +15,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
-import javafx.scene.layout.*;
-import javafx.scene.paint.Color;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.Widget;
@@ -35,6 +33,9 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.Pane;
 import javafx.scene.text.Font;
 
 /** Creates JavaFX item for model widget
@@ -294,15 +295,12 @@ public class TabsRepresentation extends JFXBaseRepresentation<TabPane, TabsWidge
             {   // Set the font of the 'graphic' that's used to represent the tab
                 final Label label = (Label) tab.getGraphic();
                 label.setFont(tab_font);
-                label.setTextFill(Color.BLACK);
 
                 // Set colors
                 tab.setStyle(style);
 
                 final Pane content  = (Pane) tab.getContent();
                 content.setBackground(background);
-                content.setBorder(new Border(new BorderStroke(Color.WHITE,
-                        BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderWidths.DEFAULT)));
             }
 
             final Integer width = model_widget.propWidth().getValue();


### PR DESCRIPTION
Reverts ControlSystemStudio/phoebus#3887

See discussion: https://github.com/ControlSystemStudio/phoebus/issues/3891 and https://github.com/ControlSystemStudio/phoebus/pull/3892

These changes need to be merged after Phoebus has moved to JFX25 as there is a bug in JFX21 that causes all widget text to become transparent as a consequence of the changes made in 3387. Reverting for now and will PR changes again when this has happened