### PR TITLE
Added Context Menu to Annunciator Table

### DIFF
--- a/app/alarm/ui/doc/index.rst
+++ b/app/alarm/ui/doc/index.rst
@@ -457,7 +457,7 @@ Where the include component is identified in the inclusion file with a DID decla
 Context Menu
 ------------
 
-In the Alarm Tree and the Alarm Table views user may right click on an alarm item to launch a context menu:
+In the Alarm Tree, the Alarm Table views and the Annunciator user may right click on an alarm item to launch a context menu:
 
 .. image:: images/context_menu_new.png
     :width: 20%

--- a/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/annunciator/AnnunciatorTable.java
+++ b/app/alarm/ui/src/main/java/org/phoebus/applications/alarm/ui/annunciator/AnnunciatorTable.java
@@ -10,34 +10,42 @@ package org.phoebus.applications.alarm.ui.annunciator;
 import static org.phoebus.applications.alarm.AlarmSystem.logger;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
+import javafx.collections.ObservableList;
+import javafx.scene.control.*;
 import org.phoebus.applications.alarm.AlarmSystem;
+import org.phoebus.applications.alarm.client.AlarmClientLeaf;
+import org.phoebus.applications.alarm.client.AlarmClientNode;
+import org.phoebus.applications.alarm.model.AlarmTreeItem;
 import org.phoebus.applications.alarm.model.SeverityLevel;
 import org.phoebus.applications.alarm.talk.TalkClient;
 import org.phoebus.applications.alarm.talk.TalkClientListener;
+import org.phoebus.applications.alarm.ui.AlarmContextMenuHelper;
 import org.phoebus.applications.alarm.ui.AlarmUI;
+import org.phoebus.applications.alarm.ui.tree.*;
+import org.phoebus.framework.selection.Selection;
+import org.phoebus.framework.selection.SelectionService;
+import org.phoebus.ui.application.ContextMenuService;
+import org.phoebus.ui.application.SaveSnapshotAction;
 import org.phoebus.ui.dialog.DialogHelper;
+import org.phoebus.ui.docking.DockPane;
 import org.phoebus.ui.javafx.ImageCache;
+import org.phoebus.ui.javafx.PrintAction;
+import org.phoebus.ui.javafx.Screenshot;
 import org.phoebus.ui.javafx.ToolbarHelper;
+import org.phoebus.ui.selection.AppSelection;
+import org.phoebus.ui.spi.ContextMenuEntry;
 import org.phoebus.util.time.TimestampFormats;
 
 import javafx.application.Platform;
 import javafx.geometry.Insets;
-import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.Label;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumn.SortType;
-import javafx.scene.control.TableView;
-import javafx.scene.control.ToggleButton;
-import javafx.scene.control.ToolBar;
-import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Background;
@@ -271,8 +279,40 @@ public class AnnunciatorTable extends VBox implements TalkClientListener
 
         getChildren().setAll(toolbar, table);
 
-        // Annunciate message so that user can determine if annunciator and table are indeed functional.
+        createContextMenu();
+
         messageReceived(SeverityLevel.OK, true, "Annunciator started");
+    }
+
+    private void createContextMenu()
+    {
+        final ContextMenu menu = new ContextMenu();
+
+        table.setOnContextMenuRequested(event ->
+        {
+            final ObservableList<MenuItem> menu_items = menu.getItems();
+            menu_items.clear();
+
+            final Selection originalSelection = SelectionService.getInstance().getSelection();
+            final List<AppSelection> newSelection = Arrays.asList(AppSelection.of(table, "Annunciator Screenshot", "see annunciator screenshot", () -> Screenshot.imageFromNode(table)));
+            SelectionService.getInstance().setSelection("Annunciator", newSelection);
+            List<ContextMenuEntry> supported = ContextMenuService.getInstance().listSupportedContextMenuEntries();
+            supported.stream().forEach(action -> {
+               MenuItem supportedMenuItem = new MenuItem(action.getName(), new ImageView(action.getIcon()));
+               supportedMenuItem.setOnAction((e) -> {
+                   try{
+                       SelectionService.getInstance().setSelection("Annunciator", newSelection);
+                       action.call(table, SelectionService.getInstance().getSelection());
+                   } catch (Exception ex) {
+                       logger.log(Level.WARNING, "Failed to execute " + action.getName() + " from Annunciator.", ex);
+                   }
+               });
+               menu_items.add(supportedMenuItem);
+            });
+            menu_items.add(new SaveSnapshotAction(DockPane.getActiveDockPane()));
+            SelectionService.getInstance().setSelection("Annunciator", originalSelection);
+            menu.show(table.getScene().getWindow(), event.getScreenX(), event.getScreenY());
+        });
     }
 
     ToolBar getToolbar()

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuService.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuService.java
@@ -55,12 +55,13 @@ public class ContextMenuService {
      * @return A list of {@link ContextMenuEntry}'s supported for the current
      *         selection
      */
+
     public List<ContextMenuEntry> listSupportedContextMenuEntries() {
         // List of types of the current selection
         List<Class> selectionTypes = SelectionService.getInstance().getSelection().getSelections().stream().map(s -> {
             return s.getClass();
         }).collect(Collectors.toList());
-
+        System.out.println("selection types: " + selectionTypes);
         // Take into account the types the selected objects can be converted into
         List<Class> allAdaptableSelectionType = new ArrayList<>();
         selectionTypes.forEach(s -> {

--- a/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuService.java
+++ b/core/ui/src/main/java/org/phoebus/ui/application/ContextMenuService.java
@@ -21,7 +21,7 @@ public class ContextMenuService {
 
     private static ContextMenuService contextMenuService;
     private static ServiceLoader<ContextMenuEntry> loader;
-    private List<ContextMenuEntry> contextMenuEntries;
+    private final List<ContextMenuEntry> contextMenuEntries;
 
     private ContextMenuService() {
         loader = ServiceLoader.load(ContextMenuEntry.class);
@@ -61,7 +61,6 @@ public class ContextMenuService {
         List<Class> selectionTypes = SelectionService.getInstance().getSelection().getSelections().stream().map(s -> {
             return s.getClass();
         }).collect(Collectors.toList());
-        System.out.println("selection types: " + selectionTypes);
         // Take into account the types the selected objects can be converted into
         List<Class> allAdaptableSelectionType = new ArrayList<>();
         selectionTypes.forEach(s -> {


### PR DESCRIPTION
The Annunciator has now a context menu to take screenshots and create a Log Entry

<img width="857" height="659" alt="Screenshot 2026-07-27 154204" src="https://github.com/user-attachments/assets/6af83e72-dbd3-4cdd-b8dd-7a2444270b87" />


- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [x] The feature is documented
    - [x] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
