### PR TITLE
Update jetty to jakarta.* version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <postgresql.driver.version>42.6.2</postgresql.driver.version>
     <!-- When connections to older MySQL server fail because of CLIENT_PLUGIN_AUTH, downgrade to 5.1.45 -->
     <mysql.version>8.4.0</mysql.version>
-    <jetty.version>9.4.30.v20200611</jetty.version>
+    <jetty.version>11.0.26</jetty.version>
     <apache.commons.math.version>3.6.1</apache.commons.math.version>
     <junit.version>5.8.2</junit.version>
     <elasticsearch.version>8.2.0</elasticsearch.version>

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/ChannelServlet.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/ChannelServlet.java
@@ -9,10 +9,10 @@ package org.csstudio.archive.engine.server;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.Engine;
 import org.csstudio.archive.engine.model.ArchiveChannel;

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/DisconnectedServlet.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/DisconnectedServlet.java
@@ -9,10 +9,10 @@ package org.csstudio.archive.engine.server;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.Engine;
 import org.csstudio.archive.engine.model.ArchiveChannel;

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/GroupServlet.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/GroupServlet.java
@@ -9,10 +9,10 @@ package org.csstudio.archive.engine.server;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.Engine;
 import org.csstudio.archive.engine.model.ArchiveChannel;

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/GroupsServlet.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/GroupsServlet.java
@@ -9,10 +9,10 @@ package org.csstudio.archive.engine.server;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.Engine;
 import org.csstudio.archive.engine.model.ArchiveChannel;

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/HTMLWriter.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/HTMLWriter.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.Instant;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.writer.rdb.TimestampHelper;
 

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/JSONWriter.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/JSONWriter.java
@@ -11,8 +11,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.Instant;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.engine.model.ArchiveChannel;
 import org.csstudio.archive.engine.model.BufferStats;

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/MainServlet.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/MainServlet.java
@@ -11,10 +11,10 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.Engine;
 import org.csstudio.archive.Preferences;

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/RestartServlet.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/RestartServlet.java
@@ -9,10 +9,10 @@ package org.csstudio.archive.engine.server;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.Engine;
 

--- a/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/StopServlet.java
+++ b/services/archive-engine/src/main/java/org/csstudio/archive/engine/server/StopServlet.java
@@ -9,10 +9,10 @@ package org.csstudio.archive.engine.server;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.Engine;
 

--- a/services/scan-server/build.xml
+++ b/services/scan-server/build.xml
@@ -30,6 +30,7 @@
         <include name="dependencies/**/org.eclipse.paho.client.mqttv*.jar"/>
         <include name="dependencies/**/epics-jackie*.jar"/>
         <include name="dependencies/**/commons-lang*.jar"/>
+        <include name="dependencies/**/slf4j-api-*.jar"/>
       	
       	<include name="core/**/core-framework-*.jar"/>
       	<include name="core/**/core-formula-*.jar"/>

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/RequestPath.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/RequestPath.java
@@ -7,7 +7,7 @@
  ******************************************************************************/
 package org.csstudio.scan.server.httpd;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 /** Helper for analyzing the request path
  *  @author Kay Kasemir

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ScanServlet.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ScanServlet.java
@@ -16,11 +16,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.logging.Level;
 
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.csstudio.scan.data.ScanData;

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ScansServlet.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ScansServlet.java
@@ -13,10 +13,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.csstudio.scan.info.ScanInfo;

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ServerServlet.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ServerServlet.java
@@ -12,10 +12,10 @@ import static org.csstudio.scan.server.ScanServerInstance.logger;
 import java.io.IOException;
 import java.util.logging.Level;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.csstudio.scan.info.ScanServerInfo;

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ServletHelper.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/ServletHelper.java
@@ -14,8 +14,8 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.logging.Level;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
 

--- a/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/SimulateServlet.java
+++ b/services/scan-server/src/main/java/org/csstudio/scan/server/httpd/SimulateServlet.java
@@ -14,10 +14,10 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.logging.Level;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.csstudio.scan.info.SimulationResult;
 import org.csstudio.scan.server.ScanServer;

--- a/services/scan-server/src/test/java/org/csstudio/scan/server/httpd/WebServerDemo.java
+++ b/services/scan-server/src/test/java/org/csstudio/scan/server/httpd/WebServerDemo.java
@@ -12,9 +12,9 @@ import java.io.PrintWriter;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;

--- a/services/scan-server/src/test/java/org/csstudio/scan/server/httpd/WebServletsDemo.java
+++ b/services/scan-server/src/test/java/org/csstudio/scan/server/httpd/WebServletsDemo.java
@@ -12,10 +12,10 @@ import java.io.PrintWriter;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;


### PR DESCRIPTION
Moving to newer version of jetty. Similar to tomcat and JEE in general, jetty changed from javax.servlet to jakarta.servlet, requiring corresponding updates to the jetty-based web servers in the archive engine and scan server.

