### PR TITLE
Archive: Support for UTC-related Oracle issues

### DIFF
--- a/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/rdb/RDBPreferences.java
+++ b/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/rdb/RDBPreferences.java
@@ -19,6 +19,8 @@ public class RDBPreferences
     @Preference static String user, password, prefix;
     @Preference static int timeout_secs;
     @Preference static boolean use_array_blob;
+    @Preference static String raw_query;
+    @Preference static boolean use_utc_in_raw_query;
     @Preference static String stored_procedure;
     @Preference static String starttime_function;
     @Preference static int fetch_size;

--- a/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/rdb/RawSampleIterator.java
+++ b/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/rdb/RawSampleIterator.java
@@ -13,6 +13,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.logging.Level;
 
 import org.epics.vtype.VType;
@@ -66,6 +68,9 @@ public class RawSampleIterator extends AbstractRDBValueIterator
             value = null;
         }
     }
+
+    // UTC time zone
+    private static final ZoneId UTC = ZoneId.of("UTC");
 
     /** Get the samples: <code>result_set</code> will have the samples,
      *  <code>value</code> will contain the first sample
@@ -132,8 +137,20 @@ public class RawSampleIterator extends AbstractRDBValueIterator
 
         reader.addForCancellation(sel_samples);
         sel_samples.setInt(1, channel_id);
-        sel_samples.setTimestamp(2, start_stamp);
-        sel_samples.setTimestamp(3, end_stamp);
+
+        if (RDBPreferences.use_utc_in_raw_query)
+        {   // Send a 'local' time stamp, no time zone info, with UTC-based values
+            Timestamp start_utc = Timestamp.valueOf(LocalDateTime.ofInstant(start_stamp.toInstant(), UTC));
+            Timestamp end_utc   = Timestamp.valueOf(LocalDateTime.ofInstant(end_stamp.toInstant(), UTC));
+            sel_samples.setTimestamp(2, start_utc);
+            sel_samples.setTimestamp(3, end_utc);
+        }
+        else
+        {   // Send time stamp that's based on EPOCH.
+            // All but Oracle will properly deal with local/UTC conversions
+            sel_samples.setTimestamp(2, start_stamp);
+            sel_samples.setTimestamp(3, end_stamp);
+        }
         result_set = sel_samples.executeQuery();
         // Get first sample
         if (result_set.next())

--- a/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/rdb/SQL.java
+++ b/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/rdb/SQL.java
@@ -87,12 +87,13 @@ class SQL
                 "   WHERE channel_id=?" +
                 "     AND smpl_time BETWEEN ? AND ?" +
                 "   ORDER BY smpl_time";
-            sample_sel_by_id_start_end_with_blob =
-                "SELECT smpl_time, severity_id, status_id, num_val, float_val, str_val, datatype, array_val" +
+            sample_sel_by_id_start_end_with_blob = RDBPreferences.raw_query.isEmpty()
+              ? "SELECT smpl_time, severity_id, status_id, num_val, float_val, str_val, datatype, array_val" +
                 "   FROM " + prefix + "sample" +
                 "   WHERE channel_id=?" +
                 "     AND smpl_time>=? AND smpl_time<=?" +
-                "   ORDER BY smpl_time";
+                "   ORDER BY smpl_time"
+              : RDBPreferences.raw_query;
         sample_sel_array_vals = "SELECT float_val FROM " + prefix + "array_val" +
                 " WHERE channel_id=? AND smpl_time=? ORDER BY seq_nbr";
         }

--- a/app/trends/archive-reader/src/main/resources/archive_reader_rdb_preferences.properties
+++ b/app/trends/archive-reader/src/main/resources/archive_reader_rdb_preferences.properties
@@ -38,6 +38,15 @@ timeout_secs=120
 # When running against an old database, this parameter must be set to false.
 use_array_blob=true
 
+# Optional replacement for the built-in raw data query.
+# When empty, default to `SQL.sample_sel_by_id_start_end_with_blob`
+raw_query=
+
+# Use a UTC-based local time stamp for the raw data query?
+# Necessary when Oracle doesn't properly convert
+# the epoch-based sql.Timestamp to/from local time zone.
+use_utc_in_raw_query=false
+
 # Use stored procedures and functions for 'optimized' data readout?
 #
 # Set to procedure name, or nothing to disable stored procedure.


### PR DESCRIPTION
The `sql.Timestamp`, just like `Instant`, `Date`, ... internally holds seconds-since-epoch.
There are various ways to convert between local time zones, and RDBs like MySQL or Postgres handle this well.

Oracle, however, may treat the `Timestamp` as a local time zone reading. This PR allows customization of the raw data query, with an option to pass the start and end time of the raw data query as a UTC-based "local" time.

