### PR TITLE
Add section detailing performance improvements to documentation

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -124,11 +124,11 @@ will contact the already running instance and have it open the requested file.
 Performance
 -----------
 
-Phoebus displays are built on JavaFX, which will use hardware acceleration wherever possible. If your screens display PVs with high update rates but you notice that the displayed update rates are not keeping up, you may benefit from using the following environment and Java options::
+Phoebus displays are built on JavaFX, which will use hardware acceleration wherever possible. If your screen contains PVs with high update rates and you notice that the display is not keeping up then you may benefit from using the following environment and Java options::
 
    export __GL_SYNC_TO_VBLANK=0 
    export _JAVA_OPTIONS="-Dprism.vsync=false"
 
-These settings allow the display to update without waiting for the vblank, which is to say it is not synchronized with the monitor display rate and hence display updates can occur as fast as we need them to.
+These settings allow the display to update without waiting for the :abbr:`vblank (vertical blanking interval)` meaning that the monitor's refresh rate is ignored and display updates occur as fast as possible.
 
-Note: these environment variables will only make a difference when running on a dedicated GPU
+Note: these options will only make a difference when running on a dedicated GPU.

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -9,17 +9,17 @@ From the command-line, invoke ``phoebus.sh -help``, which will look
 similar to this, but check your copy of CS-Studio/Phoebus
 for the complete list::
 
-      _______           _______  _______  ______            _______ 
+      _______           _______  _______  ______            _______
      (  ____ )|\     /|(  ___  )(  ____ \(  ___ \ |\     /|(  ____ \
      | (    )|| )   ( || (   ) || (    \/| (   ) )| )   ( || (    \/
-     | (____)|| (___) || |   | || (__    | (__/ / | |   | || (_____ 
+     | (____)|| (___) || |   | || (__    | (__/ / | |   | || (_____
      |  _____)|  ___  || |   | ||  __)   |  __ (  | |   | |(_____  )
      | (      | (   ) || |   | || (      | (  \ \ | |   | |      ) |
      | )      | )   ( || (___) || (____/\| )___) )| (___) |/\____) |
      |/       |/     \|(_______)(_______/|/ \___/ (_______)\_______)
-     
+
      Command-line arguments:
-     
+
         -help                                   -  This text
         -splash                                 -  Show splash screen
         -nosplash                               -  Suppress the splash screen
@@ -74,12 +74,12 @@ be interpreted by the Linux shell, best enclose all resources in quotes.
 
 Open probe with a PV name::
 
-    phoebus.sh -resource "pv://?sim://sine&app=probe"              
+    phoebus.sh -resource "pv://?sim://sine&app=probe"
 
 
 Open PV Table with some PVs::
 
-    phoebus.sh -resource "pv://?MyPV&AnotherPV&YetAnotherPV&app=pv_table"              
+    phoebus.sh -resource "pv://?MyPV&AnotherPV&YetAnotherPV&app=pv_table"
 
 Note that all these examples use the internal name of the application feature,
 for example "pv_table", and not the name that is displayed the user interface,
@@ -112,7 +112,7 @@ For this scenario, invoke ``phoebus.sh`` with the ``-server`` option, using
 a TCP port that you reserve for this use on that computer, for example::
 
    phoebus.sh -server 4918
-   
+
 The first time you start phoebus this way, it will actually open the main window.
 Follow-up invocations, for example::
 
@@ -126,7 +126,7 @@ Performance
 
 Phoebus displays are built on JavaFX, which will use hardware acceleration wherever possible. If your screen contains PVs with high update rates and you notice that the display is not keeping up then you may benefit from using the following environment and Java options::
 
-   export __GL_SYNC_TO_VBLANK=0 
+   export __GL_SYNC_TO_VBLANK=0
    export _JAVA_OPTIONS="-Dprism.vsync=false"
 
 These settings allow the display to update without waiting for the :abbr:`vblank (vertical blanking interval)` meaning that the monitor's refresh rate is ignored and display updates occur as fast as possible.

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -119,3 +119,16 @@ Follow-up invocations, for example::
    phoebus.sh -server 4918 -resource "/path/to/some/file.pvs"
 
 will contact the already running instance and have it open the requested file.
+
+
+Performance
+-----------
+
+Phoebus displays are built on JavaFX, which will use hardware acceleration wherever possible. If your screens display PVs with high update rates but you notice that the displayed update rates are not keeping up, you may benefit from using the following environment and Java options::
+
+   export __GL_SYNC_TO_VBLANK=0 
+   export _JAVA_OPTIONS="-Dprism.vsync=false"
+
+These settings allow the display to update without waiting for the vblank, which is to say it is not synchronized with the monitor display rate and hence display updates can occur as fast as we need them to.
+
+Note: these environment variables will only make a difference when running on a dedicated GPU

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -131,4 +131,4 @@ Phoebus displays are built on JavaFX, which will use hardware acceleration where
 
 These settings allow the display to update without waiting for the :abbr:`vblank (vertical blanking interval)` meaning that the monitor's refresh rate is ignored and display updates occur as fast as possible.
 
-Note: these options will only make a difference when running on a dedicated GPU.
+Note: these options will only make a difference when running on a dedicated GPU and have only been tested on Linux operating systems.


### PR DESCRIPTION
<!-- ^^^ Describe your changes here ^^^ -->
We ran some performance tests on Phoebus using multiple windows displaying 100s of PVs updating at 10Hz. We discovered that the displayed update rate was much slower than the actual PV update rate. After some further investigations we found that there are 2 environment variables that can be set which drastically improved the performance of the displays when running using hardware acceleration. 

I have added a section to the Phoebus documentation detailing these variables and how to use them, just in case others should come across this issue and might benefit from this advice.

I think having this in the 'Starting CS-Studio/Phoebus' makes sense but if anyone has other ideas then please just let me know and I can move it.


## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [X] The feature is documented
    - [X] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
