### PR TITLE
Add preference to use the 'optimized with last sample' AA postprocessor

### DIFF
--- a/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/appliance/ApplianceArchiveReaderConstants.java
+++ b/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/appliance/ApplianceArchiveReaderConstants.java
@@ -52,6 +52,8 @@ public class ApplianceArchiveReaderConstants {
     public static final String OP_MEAN = "mean_";
     /** Operator for the optimized post processor */
     public static final String OP_OPTIMIZED = "optimized_";
+    /** Operator for the optimized with last sample post processor */
+    public static final String OP_OPTIMIZED_WITH_LAST_SAMPLE = "optimLastSample_";
 
     /** The schema delimiter: ca://pvName or pva://pvname */
     static final String SCHEMA_DELIMITER = "://";

--- a/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/appliance/ApplianceOptimizedValueIterator.java
+++ b/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/appliance/ApplianceOptimizedValueIterator.java
@@ -69,7 +69,7 @@ public class ApplianceOptimizedValueIterator extends ApplianceValueIterator {
         String optimizedOperator = ApplianceArchiveReaderConstants.OP_OPTIMIZED;
         if (AppliancePreferences.ppOptimizedWithLastSample)
             optimizedOperator = ApplianceArchiveReaderConstants.OP_OPTIMIZED_WITH_LAST_SAMPLE;
-        
+
         String optimized = new StringBuilder().append(optimizedOperator)
                 .append(requestedPoints).append('(').append(pvName).append(')').toString();
         super.fetchDataInternal(optimized);

--- a/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/appliance/ApplianceOptimizedValueIterator.java
+++ b/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/appliance/ApplianceOptimizedValueIterator.java
@@ -66,7 +66,11 @@ public class ApplianceOptimizedValueIterator extends ApplianceValueIterator {
      */
     @Override
     protected void fetchDataInternal(String pvName) throws ArchiverApplianceException {
-        String optimized = new StringBuilder().append(ApplianceArchiveReaderConstants.OP_OPTIMIZED)
+        String optimizedOperator = ApplianceArchiveReaderConstants.OP_OPTIMIZED;
+        if (AppliancePreferences.ppOptimizedWithLastSample)
+            optimizedOperator = ApplianceArchiveReaderConstants.OP_OPTIMIZED_WITH_LAST_SAMPLE;
+        
+        String optimized = new StringBuilder().append(optimizedOperator)
                 .append(requestedPoints).append('(').append(pvName).append(')').toString();
         super.fetchDataInternal(optimized);
     }

--- a/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/appliance/AppliancePreferences.java
+++ b/app/trends/archive-reader/src/main/java/org/phoebus/archive/reader/appliance/AppliancePreferences.java
@@ -20,6 +20,7 @@ public class AppliancePreferences {
     @Preference static boolean useStatisticsForOptimizedData;
     @Preference static boolean useNewOptimizedOperator;
     @Preference static boolean useHttps;
+    @Preference static boolean ppOptimizedWithLastSample;
 
     static {
     	AnnotatedPreferences.initialize(AppliancePreferences.class, "/appliance_preferences.properties");

--- a/app/trends/archive-reader/src/main/resources/appliance_preferences.properties
+++ b/app/trends/archive-reader/src/main/resources/appliance_preferences.properties
@@ -10,5 +10,5 @@ useHttps=false
 
 # Query the AA using the 'Optimized With Last Sample' post processor.
 # Setting to false means that the 'Optimized' post processor will be 
-# used. 
+# used.
 ppOptimizedWithLastSample=false

--- a/app/trends/archive-reader/src/main/resources/appliance_preferences.properties
+++ b/app/trends/archive-reader/src/main/resources/appliance_preferences.properties
@@ -7,3 +7,8 @@ useNewOptimizedOperator=true
 
 # Use 'https://..' instead of plain 'http://..'?
 useHttps=false
+
+# Query the AA using the 'Optimized With Last Sample' post processor.
+# Setting to false means that the 'Optimized' post processor will be 
+# used. 
+ppOptimizedWithLastSample=false

--- a/app/trends/archive-reader/src/main/resources/appliance_preferences.properties
+++ b/app/trends/archive-reader/src/main/resources/appliance_preferences.properties
@@ -9,6 +9,6 @@ useNewOptimizedOperator=true
 useHttps=false
 
 # Query the AA using the 'Optimized With Last Sample' post processor.
-# Setting to false means that the 'Optimized' post processor will be 
+# Setting to false means that the 'Optimized' post processor will be
 # used.
 ppOptimizedWithLastSample=false

--- a/app/trends/archive-reader/src/main/resources/appliance_preferences.properties
+++ b/app/trends/archive-reader/src/main/resources/appliance_preferences.properties
@@ -11,4 +11,4 @@ useHttps=false
 # Query the AA using the 'Optimized With Last Sample' post processor.
 # Setting to false means that the 'Optimized' post processor will be
 # used.
-ppOptimizedWithLastSample=false
+ppOptimizedWithLastSample=true

--- a/app/trends/archive-reader/src/test/java/org/phoebus/archive/reader/appliance/ApplianceOptimizedValueIteratorTest.java
+++ b/app/trends/archive-reader/src/test/java/org/phoebus/archive/reader/appliance/ApplianceOptimizedValueIteratorTest.java
@@ -38,13 +38,13 @@ class ApplianceOptimizedValueIteratorTest {
     @Test
     void fetchUrlContainsOptimizedNOperator() throws Exception {
         FakeDataRetrieval dr = new FakeDataRetrieval(probeStream(PayloadType.SCALAR_DOUBLE));
-        dr.whenPvContains("optimized_", emptyStream());
+        dr.whenPvContains("optimLastSample_", emptyStream());
 
         FakeApplianceArchiveReader reader = new FakeApplianceArchiveReader(dr);
         new ApplianceOptimizedValueIterator(reader, "TEST:PV", START, END, POINTS, false);
 
-        assertTrue(dr.pvsCalled.stream().anyMatch(pv -> pv.startsWith("optimized_") && pv.endsWith("(TEST:PV)")),
-                "Expected optimized_<N>(TEST:PV) call, got: " + dr.pvsCalled);
+        assertTrue(dr.pvsCalled.stream().anyMatch(pv -> pv.startsWith("optimLastSample_") && pv.endsWith("(TEST:PV)")),
+                "Expected optimLastSample__<N>(TEST:PV) call, got: " + dr.pvsCalled);
     }
 
     @Test
@@ -78,7 +78,7 @@ class ApplianceOptimizedValueIteratorTest {
         when(dataStream.getPayLoadInfo()).thenReturn(waveformInfo);
 
         FakeDataRetrieval dr = new FakeDataRetrieval(probeStream(PayloadType.SCALAR_DOUBLE));
-        dr.whenPvContains("optimized_", dataStream);
+        dr.whenPvContains("optimLastSample_", dataStream);
 
         FakeApplianceArchiveReader reader = new FakeApplianceArchiveReader(dr);
         return new ApplianceOptimizedValueIterator(reader, "TEST:PV", START, END, POINTS, useStatistics);


### PR DESCRIPTION
<!-- ^^^ Describe your changes here ^^^ -->
A while back we introduced a new post processor to the Archive Appliance that better represents the data called 'Optimized with last sample'.

The history and detailed discussion of why this pp was required is here: https://github.com/ControlSystemStudio/cs-studio/issues/2483. 

In brief, say a PV has a flurry of activity, then goes to a value (say 0) and does not change for some time. With the Optimized PP, you would get the average during this flurry, say 50 and then the next bins will have no events, in which case the Optimized algorithm just returns the mean value of the last bin that had events, e.g. it would return 50. This means that data browser would show the value '50' for the entire duration that the PV does not change, even though the PV's last value was 0. 

The optimized with last sample algorithm is based on the optimized one but if a bin does not have any events then it uses the last value in the previous bin that had events and hence in this example would return 0 as desired.

This new post processor was introduce to the CS-Studio data browser as a preference that could be switched on. In this PR I have added a similar preference to use the `optimLastSample_` option.

At the moment I have left the default as 'false', i.e. it is not used but I wonder, given that this post processor gives a better representation of the data, whether it should be the default to use (i.e. make the variable true) - thoughts?  
## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [X] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
